### PR TITLE
change comment behavior to use "enter" to save and "shift+enter" for newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ tuicr
 | Key | Action |
 |-----|--------|
 | `Tab` | Cycle comment type Note/Suggestion/Issue/Praise |
-| `Ctrl-S` | Save comment |
+| `Enter` | Save comment |
+| `Shift-Enter` / `Ctrl-J` | Insert newline |
 | `Ctrl-C/Esc` | Cancel |
 
 #### Commands

--- a/src/app.rs
+++ b/src/app.rs
@@ -46,6 +46,7 @@ pub struct App {
     pub dirty: bool,
     pub message: Option<String>,
     pub pending_confirm: Option<ConfirmAction>,
+    pub supports_keyboard_enhancement: bool,
 }
 
 #[derive(Debug, Default)]
@@ -127,6 +128,7 @@ impl App {
             dirty: false,
             message: None,
             pending_confirm: None,
+            supports_keyboard_enhancement: false,
         })
     }
 

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -133,10 +133,13 @@ fn map_comment_mode(key: KeyEvent) -> Action {
         // Cancel: Esc, Ctrl+C
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Char('c'), KeyModifiers::CONTROL) => Action::ExitMode,
-        // Submit: Ctrl+Enter, Ctrl+S, Shift+Enter
+        // Submit: Enter without shift (Ctrl+Enter and Ctrl+S also work)
+        (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
         (KeyCode::Enter, KeyModifiers::CONTROL) => Action::SubmitInput,
         (KeyCode::Char('s'), KeyModifiers::CONTROL) => Action::SubmitInput,
-        (KeyCode::Enter, KeyModifiers::SHIFT) => Action::SubmitInput,
+        // Newline: Shift+Enter (modern terminals) or Ctrl+J (universal fallback)
+        (KeyCode::Enter, mods) if mods.contains(KeyModifiers::SHIFT) => Action::InsertChar('\n'),
+        (KeyCode::Char('j'), KeyModifiers::CONTROL) => Action::InsertChar('\n'),
         // Comment type: Tab to cycle
         (KeyCode::Tab, KeyModifiers::NONE) => Action::CycleCommentType,
         // Cursor movement
@@ -147,7 +150,6 @@ fn map_comment_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('w'), KeyModifiers::CONTROL) => Action::DeleteWord,
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::ClearLine,
         (KeyCode::Char(c), _) => Action::InsertChar(c),
-        (KeyCode::Enter, KeyModifiers::NONE) => Action::InsertChar('\n'),
         _ => Action::None,
     }
 }

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -24,11 +24,17 @@ pub fn render_comment_input(frame: &mut Frame, app: &App) {
         }
     };
 
+    let newline_hint = if app.supports_keyboard_enhancement {
+        "Shift-Enter"
+    } else {
+        "Ctrl-J"
+    };
     let block = Block::default()
         .title(format!(
-            " {} [{}] (Ctrl-S to save, Ctrl-C/Esc to cancel) ",
+            " {} [{}] (Enter to save, {} for newline) ",
             comment_kind,
-            app.comment_type.as_str()
+            app.comment_type.as_str(),
+            newline_hint
         ))
         .borders(Borders::ALL)
         .border_style(styles::border_style(true));


### PR DESCRIPTION
fixes #18 