### PR TITLE
feat: add commit selection when no unstaged changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,15 +933,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.4+3.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,7 +940,6 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,5 +1,5 @@
 pub mod diff;
 pub mod repository;
 
-pub use diff::get_working_tree_diff;
-pub use repository::RepoInfo;
+pub use diff::{get_commit_range_diff, get_working_tree_diff};
+pub use repository::{CommitInfo, RepoInfo, get_recent_commits};

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -58,6 +58,12 @@ pub enum Action {
     ConfirmYes,
     ConfirmNo,
 
+    // Commit selection
+    CommitSelectUp,
+    CommitSelectDown,
+    ToggleCommitSelect,
+    ConfirmCommitSelect,
+
     // No-op
     None,
 }
@@ -69,6 +75,7 @@ pub fn map_key_to_action(key: KeyEvent, mode: InputMode) -> Action {
         InputMode::Comment => map_comment_mode(key),
         InputMode::Help => map_help_mode(key),
         InputMode::Confirm => map_confirm_mode(key),
+        InputMode::CommitSelect => map_commit_select_mode(key),
     }
 }
 
@@ -169,6 +176,17 @@ fn map_confirm_mode(key: KeyEvent) -> Action {
     match key.code {
         KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => Action::ConfirmYes,
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => Action::ConfirmNo,
+        _ => Action::None,
+    }
+}
+
+fn map_commit_select_mode(key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => Action::CommitSelectDown,
+        KeyCode::Char('k') | KeyCode::Up => Action::CommitSelectUp,
+        KeyCode::Char(' ') => Action::ToggleCommitSelect,
+        KeyCode::Enter => Action::ConfirmCommitSelect,
+        KeyCode::Char('q') | KeyCode::Esc => Action::Quit,
         _ => Action::None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,10 +276,12 @@ fn main() -> anyhow::Result<()> {
                                     app.set_error(format!("Reload failed: {}", e));
                                 }
                             },
-                            "clip" | "export" => match export_to_clipboard(&app.session) {
-                                Ok(msg) => app.set_message(msg),
-                                Err(e) => app.set_warning(format!("{}", e)),
-                            },
+                            "clip" | "export" => {
+                                match export_to_clipboard(&app.session, &app.diff_source) {
+                                    Ok(msg) => app.set_message(msg),
+                                    Err(e) => app.set_warning(format!("{}", e)),
+                                }
+                            }
                             _ => {
                                 app.set_message(format!("Unknown command: {}", cmd));
                             }
@@ -292,7 +294,7 @@ fn main() -> anyhow::Result<()> {
                 Action::ConfirmYes => {
                     if app.input_mode == app::InputMode::Confirm {
                         if let Some(app::ConfirmAction::CopyAndQuit) = app.pending_confirm {
-                            match export_to_clipboard(&app.session) {
+                            match export_to_clipboard(&app.session, &app.diff_source) {
                                 Ok(msg) => app.set_message(msg),
                                 Err(e) => app.set_warning(format!("{}", e)),
                             }
@@ -307,10 +309,20 @@ fn main() -> anyhow::Result<()> {
                         app.should_quit = true;
                     }
                 }
-                Action::ExportToClipboard => match export_to_clipboard(&app.session) {
-                    Ok(msg) => app.set_message(msg),
-                    Err(e) => app.set_warning(format!("{}", e)),
-                },
+                Action::ExportToClipboard => {
+                    match export_to_clipboard(&app.session, &app.diff_source) {
+                        Ok(msg) => app.set_message(msg),
+                        Err(e) => app.set_warning(format!("{}", e)),
+                    }
+                }
+                Action::CommitSelectUp => app.commit_select_up(),
+                Action::CommitSelectDown => app.commit_select_down(),
+                Action::ToggleCommitSelect => app.toggle_commit_selection(),
+                Action::ConfirmCommitSelect => {
+                    if let Err(e) = app.confirm_commit_selection() {
+                        app.set_error(format!("Failed to load commits: {}", e));
+                    }
+                }
                 _ => {}
             }
         }

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -113,3 +113,7 @@ pub fn file_status_style(status: char) -> Style {
 pub fn current_line_indicator_style() -> Style {
     Style::default().fg(BORDER_FOCUSED)
 }
+
+pub fn hash_style() -> Style {
+    Style::default().fg(Color::Yellow)
+}


### PR DESCRIPTION
fixes #6 #35 

When starting tuicr on a repo with no unstaged changes, show a commit selection screen allowing users to select recent commits (up to 5) to review as a combined diff. Users can navigate with j/k, toggle selection with Space, and confirm with Enter.

- Add CommitInfo struct and get_recent_commits() in repository.rs
- Add get_commit_range_diff() to get diff for selected commit range
- Add CommitSelect input mode with dedicated keybindings
- Add commit selection UI with checkbox-style multi-select
- Update header to show commit info when reviewing commits