### PR TITLE
feat: Add hierarchical file tree with expand/collapse

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
@@ -6,6 +7,19 @@ use crate::git::{
 };
 use crate::model::{Comment, CommentType, DiffFile, LineSide, ReviewSession};
 use crate::persistence::{find_session_for_repo, load_session};
+
+#[derive(Debug, Clone)]
+pub enum FileTreeItem {
+    Directory {
+        path: String,
+        depth: usize,
+        expanded: bool,
+    },
+    File {
+        file_idx: usize,
+        depth: usize,
+    },
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
@@ -84,7 +98,7 @@ pub struct App {
     pub pending_confirm: Option<ConfirmAction>,
     pub supports_keyboard_enhancement: bool,
     pub show_file_list: bool,
-    pub group_by_directory: bool,
+    pub expanded_dirs: HashSet<String>,
 }
 
 #[derive(Default)]
@@ -152,7 +166,7 @@ impl App {
                     session.add_file(path, file.status);
                 }
 
-                Ok(Self {
+                let mut app = Self {
                     repo_info,
                     session,
                     diff_files,
@@ -178,8 +192,11 @@ impl App {
                     pending_confirm: None,
                     supports_keyboard_enhancement: false,
                     show_file_list: true,
-                    group_by_directory: false,
-                })
+                    expanded_dirs: HashSet::new(),
+                };
+                app.sort_files_by_directory(true);
+                app.expand_all_dirs();
+                Ok(app)
             }
             Err(TuicrError::NoChanges) => {
                 // No unstaged changes - try to get recent commits
@@ -218,7 +235,7 @@ impl App {
                     pending_confirm: None,
                     supports_keyboard_enhancement: false,
                     show_file_list: true,
-                    group_by_directory: false,
+                    expanded_dirs: HashSet::new(),
                 })
             }
             Err(e) => Err(e),
@@ -272,9 +289,8 @@ impl App {
 
         self.diff_files = diff_files;
 
-        if self.group_by_directory {
-            self.sort_files_by_directory(false);
-        }
+        self.sort_files_by_directory(false);
+        self.expand_all_dirs();
 
         if self.diff_files.is_empty() {
             self.diff_state.current_file_idx = 0;
@@ -430,33 +446,79 @@ impl App {
     }
 
     pub fn file_list_down(&mut self, n: usize) {
-        let max_idx = self.diff_files.len().saturating_sub(1);
-        let new_idx = (self.diff_state.current_file_idx + n).min(max_idx);
-        self.jump_to_file(new_idx);
+        let visible_items = self.build_visible_items();
+        let max_idx = visible_items.len().saturating_sub(1);
+        let new_idx = (self.file_list_state.selected() + n).min(max_idx);
+        self.file_list_state.select(new_idx);
     }
 
     pub fn file_list_up(&mut self, n: usize) {
-        let new_idx = self.diff_state.current_file_idx.saturating_sub(n);
-        self.jump_to_file(new_idx);
+        let new_idx = self.file_list_state.selected().saturating_sub(n);
+        self.file_list_state.select(new_idx);
     }
 
     pub fn jump_to_file(&mut self, idx: usize) {
+        use std::path::Path;
+
         if idx < self.diff_files.len() {
             self.diff_state.current_file_idx = idx;
             self.diff_state.cursor_line = self.calculate_file_scroll_offset(idx);
             self.diff_state.scroll_offset = self.diff_state.cursor_line;
+
+            let file_path = self.diff_files[idx].display_path().clone();
+            let mut current = file_path.parent();
+            while let Some(parent) = current {
+                if parent != Path::new("") {
+                    self.expanded_dirs
+                        .insert(parent.to_string_lossy().to_string());
+                }
+                current = parent.parent();
+            }
+
+            if let Some(tree_idx) = self.file_idx_to_tree_idx(idx) {
+                self.file_list_state.select(tree_idx);
+            }
         }
     }
 
     pub fn next_file(&mut self) {
-        let next =
-            (self.diff_state.current_file_idx + 1).min(self.diff_files.len().saturating_sub(1));
-        self.jump_to_file(next);
+        let visible_items = self.build_visible_items();
+        let current_file_idx = self.diff_state.current_file_idx;
+
+        for item in &visible_items {
+            if let FileTreeItem::File { file_idx, .. } = item
+                && *file_idx > current_file_idx
+            {
+                self.jump_to_file(*file_idx);
+                return;
+            }
+        }
     }
 
     pub fn prev_file(&mut self) {
-        let prev = self.diff_state.current_file_idx.saturating_sub(1);
-        self.jump_to_file(prev);
+        let visible_items = self.build_visible_items();
+        let current_file_idx = self.diff_state.current_file_idx;
+
+        for item in visible_items.iter().rev() {
+            if let FileTreeItem::File { file_idx, .. } = item
+                && *file_idx < current_file_idx
+            {
+                self.jump_to_file(*file_idx);
+                return;
+            }
+        }
+    }
+
+    fn file_idx_to_tree_idx(&self, target_file_idx: usize) -> Option<usize> {
+        let visible_items = self.build_visible_items();
+        for (tree_idx, item) in visible_items.iter().enumerate() {
+            if let FileTreeItem::File { file_idx, .. } = item
+                && *file_idx == target_file_idx
+            {
+                return Some(tree_idx);
+            }
+        }
+        None
     }
 
     pub fn next_hunk(&mut self) {
@@ -1023,58 +1085,6 @@ impl App {
         self.set_message(format!("File list: {}", status));
     }
 
-    pub fn toggle_directory_grouping(&mut self) {
-        self.group_by_directory = !self.group_by_directory;
-
-        if self.group_by_directory {
-            self.sort_files_by_directory(true);
-        }
-    }
-
-    fn sort_files_by_directory(&mut self, reset_position: bool) {
-        use std::collections::BTreeMap;
-        use std::path::Path;
-
-        let current_path = if !reset_position {
-            self.current_file_path().cloned()
-        } else {
-            None
-        };
-
-        let mut dir_map: BTreeMap<String, Vec<DiffFile>> = BTreeMap::new();
-
-        for file in self.diff_files.drain(..) {
-            let path = file.display_path();
-            let dir = if let Some(parent) = path.parent() {
-                if parent == Path::new("") {
-                    ".".to_string()
-                } else {
-                    parent.to_string_lossy().to_string()
-                }
-            } else {
-                ".".to_string()
-            };
-
-            dir_map.entry(dir).or_default().push(file);
-        }
-
-        for (_dir, files) in dir_map {
-            self.diff_files.extend(files);
-        }
-
-        if let Some(path) = current_path
-            && let Some(idx) = self
-                .diff_files
-                .iter()
-                .position(|f| f.display_path() == &path)
-        {
-            self.jump_to_file(idx);
-            return;
-        }
-
-        self.jump_to_file(0);
-    }
-
     // Commit selection methods
 
     pub fn commit_select_up(&mut self) {
@@ -1138,6 +1148,372 @@ impl App {
         self.diff_state = DiffState::default();
         self.file_list_state = FileListState::default();
 
+        self.sort_files_by_directory(true);
+        self.expand_all_dirs();
+
         Ok(())
+    }
+
+    fn sort_files_by_directory(&mut self, reset_position: bool) {
+        use std::collections::BTreeMap;
+        use std::path::Path;
+
+        let current_path = if !reset_position {
+            self.current_file_path().cloned()
+        } else {
+            None
+        };
+
+        let mut dir_map: BTreeMap<String, Vec<DiffFile>> = BTreeMap::new();
+
+        for file in self.diff_files.drain(..) {
+            let path = file.display_path();
+            let dir = if let Some(parent) = path.parent() {
+                if parent == Path::new("") {
+                    ".".to_string()
+                } else {
+                    parent.to_string_lossy().to_string()
+                }
+            } else {
+                ".".to_string()
+            };
+
+            dir_map.entry(dir).or_default().push(file);
+        }
+
+        for (_dir, files) in dir_map {
+            self.diff_files.extend(files);
+        }
+
+        if let Some(path) = current_path
+            && let Some(idx) = self
+                .diff_files
+                .iter()
+                .position(|f| f.display_path() == &path)
+        {
+            self.jump_to_file(idx);
+            return;
+        }
+
+        self.jump_to_file(0);
+    }
+
+    pub fn expand_all_dirs(&mut self) {
+        use std::path::Path;
+
+        self.expanded_dirs.clear();
+        for file in &self.diff_files {
+            let path = file.display_path();
+            let mut current = path.parent();
+            while let Some(parent) = current {
+                if parent != Path::new("") {
+                    self.expanded_dirs
+                        .insert(parent.to_string_lossy().to_string());
+                }
+                current = parent.parent();
+            }
+        }
+        self.ensure_valid_tree_selection();
+    }
+
+    pub fn collapse_all_dirs(&mut self) {
+        self.expanded_dirs.clear();
+        self.ensure_valid_tree_selection();
+    }
+
+    pub fn toggle_directory(&mut self, dir_path: &str) {
+        if self.expanded_dirs.contains(dir_path) {
+            self.expanded_dirs.remove(dir_path);
+            self.ensure_valid_tree_selection();
+        } else {
+            self.expanded_dirs.insert(dir_path.to_string());
+        }
+    }
+
+    fn ensure_valid_tree_selection(&mut self) {
+        use std::path::Path;
+
+        let visible_items = self.build_visible_items();
+        if visible_items.is_empty() {
+            self.file_list_state.select(0);
+            return;
+        }
+
+        let current_file_idx = self.diff_state.current_file_idx;
+        let file_visible = visible_items.iter().any(|item| {
+            matches!(item, FileTreeItem::File { file_idx, .. } if *file_idx == current_file_idx)
+        });
+
+        if file_visible {
+            if let Some(tree_idx) = self.file_idx_to_tree_idx(current_file_idx) {
+                self.file_list_state.select(tree_idx);
+            }
+        } else {
+            if let Some(file) = self.diff_files.get(current_file_idx) {
+                let file_path = file.display_path();
+                let mut current = file_path.parent();
+                while let Some(parent) = current {
+                    if parent != Path::new("") {
+                        let parent_str = parent.to_string_lossy().to_string();
+                        for (tree_idx, item) in visible_items.iter().enumerate() {
+                            if let FileTreeItem::Directory { path, .. } = item
+                                && *path == parent_str
+                            {
+                                self.file_list_state.select(tree_idx);
+                                return;
+                            }
+                        }
+                    }
+                    current = parent.parent();
+                }
+            }
+            self.file_list_state.select(0);
+        }
+    }
+
+    pub fn build_visible_items(&self) -> Vec<FileTreeItem> {
+        use std::path::Path;
+
+        let mut items = Vec::new();
+        let mut seen_dirs: HashSet<String> = HashSet::new();
+
+        for (file_idx, file) in self.diff_files.iter().enumerate() {
+            let path = file.display_path();
+
+            let mut ancestors: Vec<String> = Vec::new();
+            let mut current = path.parent();
+            while let Some(parent) = current {
+                if parent != Path::new("") {
+                    ancestors.push(parent.to_string_lossy().to_string());
+                }
+                current = parent.parent();
+            }
+            ancestors.reverse();
+
+            let mut visible = true;
+            for (depth, dir) in ancestors.iter().enumerate() {
+                if !seen_dirs.contains(dir) && visible {
+                    let expanded = self.expanded_dirs.contains(dir);
+                    items.push(FileTreeItem::Directory {
+                        path: dir.clone(),
+                        depth,
+                        expanded,
+                    });
+                    seen_dirs.insert(dir.clone());
+                }
+
+                if !self.expanded_dirs.contains(dir) {
+                    visible = false;
+                }
+            }
+
+            if visible {
+                items.push(FileTreeItem::File {
+                    file_idx,
+                    depth: ancestors.len(),
+                });
+            }
+        }
+
+        items
+    }
+
+    pub fn get_selected_tree_item(&self) -> Option<FileTreeItem> {
+        let visible_items = self.build_visible_items();
+        let selected_idx = self.file_list_state.selected();
+        visible_items.get(selected_idx).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tree_tests {
+    use super::*;
+    use crate::model::{DiffFile, FileStatus};
+
+    fn make_file(path: &str) -> DiffFile {
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from(path)),
+            status: FileStatus::Modified,
+            hunks: vec![],
+            is_binary: false,
+        }
+    }
+
+    struct TreeTestHarness {
+        diff_files: Vec<DiffFile>,
+        expanded_dirs: HashSet<String>,
+    }
+
+    impl TreeTestHarness {
+        fn new(paths: &[&str]) -> Self {
+            Self {
+                diff_files: paths.iter().map(|p| make_file(p)).collect(),
+                expanded_dirs: HashSet::new(),
+            }
+        }
+
+        fn expand_all(&mut self) {
+            use std::path::Path;
+            for file in &self.diff_files {
+                let path = file.display_path();
+                let mut current = path.parent();
+                while let Some(parent) = current {
+                    if parent != Path::new("") {
+                        self.expanded_dirs
+                            .insert(parent.to_string_lossy().to_string());
+                    }
+                    current = parent.parent();
+                }
+            }
+        }
+
+        fn collapse_all(&mut self) {
+            self.expanded_dirs.clear();
+        }
+
+        fn toggle(&mut self, dir: &str) {
+            if self.expanded_dirs.contains(dir) {
+                self.expanded_dirs.remove(dir);
+            } else {
+                self.expanded_dirs.insert(dir.to_string());
+            }
+        }
+
+        fn build_visible_items(&self) -> Vec<FileTreeItem> {
+            use std::path::Path;
+            let mut items = Vec::new();
+            let mut seen_dirs: HashSet<String> = HashSet::new();
+
+            for (file_idx, file) in self.diff_files.iter().enumerate() {
+                let path = file.display_path();
+                let mut ancestors: Vec<String> = Vec::new();
+                let mut current = path.parent();
+                while let Some(parent) = current {
+                    if parent != Path::new("") {
+                        ancestors.push(parent.to_string_lossy().to_string());
+                    }
+                    current = parent.parent();
+                }
+                ancestors.reverse();
+
+                let mut visible = true;
+                for (depth, dir) in ancestors.iter().enumerate() {
+                    if !seen_dirs.contains(dir) && visible {
+                        let expanded = self.expanded_dirs.contains(dir);
+                        items.push(FileTreeItem::Directory {
+                            path: dir.clone(),
+                            depth,
+                            expanded,
+                        });
+                        seen_dirs.insert(dir.clone());
+                    }
+                    if !self.expanded_dirs.contains(dir) {
+                        visible = false;
+                    }
+                }
+
+                if visible {
+                    items.push(FileTreeItem::File {
+                        file_idx,
+                        depth: ancestors.len(),
+                    });
+                }
+            }
+            items
+        }
+
+        fn visible_file_count(&self) -> usize {
+            self.build_visible_items()
+                .iter()
+                .filter(|i| matches!(i, FileTreeItem::File { .. }))
+                .count()
+        }
+
+        fn visible_dir_count(&self) -> usize {
+            self.build_visible_items()
+                .iter()
+                .filter(|i| matches!(i, FileTreeItem::Directory { .. }))
+                .count()
+        }
+    }
+
+    #[test]
+    fn test_expand_all_shows_all_files() {
+        let mut h = TreeTestHarness::new(&["src/ui/app.rs", "src/ui/help.rs", "src/main.rs"]);
+        h.expand_all();
+
+        assert_eq!(h.visible_file_count(), 3);
+    }
+
+    #[test]
+    fn test_collapse_all_hides_all_files() {
+        let mut h = TreeTestHarness::new(&["src/ui/app.rs", "src/main.rs"]);
+        h.expand_all();
+        h.collapse_all();
+
+        assert_eq!(h.visible_file_count(), 0);
+        assert_eq!(h.visible_dir_count(), 1); // only "src" visible
+    }
+
+    #[test]
+    fn test_collapse_parent_hides_nested_dirs() {
+        let mut h = TreeTestHarness::new(&["src/ui/components/button.rs"]);
+        h.expand_all();
+        assert_eq!(h.visible_dir_count(), 3); // src, src/ui, src/ui/components
+
+        h.toggle("src");
+        let items = h.build_visible_items();
+        assert_eq!(items.len(), 1); // only collapsed "src" dir
+        assert!(matches!(
+            &items[0],
+            FileTreeItem::Directory {
+                expanded: false,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_root_files_always_visible() {
+        let mut h = TreeTestHarness::new(&["README.md", "Cargo.toml"]);
+        h.collapse_all();
+
+        assert_eq!(h.visible_file_count(), 2);
+    }
+
+    #[test]
+    fn test_tree_depth_correct() {
+        let mut h = TreeTestHarness::new(&["a/b/c/file.rs"]);
+        h.expand_all();
+
+        let items = h.build_visible_items();
+        assert!(matches!(&items[0], FileTreeItem::Directory { depth: 0, path, .. } if path == "a"));
+        assert!(
+            matches!(&items[1], FileTreeItem::Directory { depth: 1, path, .. } if path == "a/b")
+        );
+        assert!(
+            matches!(&items[2], FileTreeItem::Directory { depth: 2, path, .. } if path == "a/b/c")
+        );
+        assert!(matches!(&items[3], FileTreeItem::File { depth: 3, .. }));
+    }
+
+    #[test]
+    fn test_toggle_expands_collapsed_dir() {
+        let mut h = TreeTestHarness::new(&["src/main.rs"]);
+        h.collapse_all();
+        assert_eq!(h.visible_file_count(), 0);
+
+        h.toggle("src");
+        assert_eq!(h.visible_file_count(), 1);
+    }
+
+    #[test]
+    fn test_sibling_dirs_independent() {
+        let mut h = TreeTestHarness::new(&["src/app.rs", "tests/test.rs"]);
+        h.expand_all();
+        h.toggle("src"); // collapse src
+
+        assert_eq!(h.visible_file_count(), 1); // only tests/test.rs
     }
 }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -33,7 +33,6 @@ pub enum Action {
     EditComment,
     PendingDCommand,
     ToggleDiffView,
-    ToggleDirectoryGrouping,
 
     // Session
     Quit,
@@ -65,6 +64,10 @@ pub enum Action {
     CommitSelectDown,
     ToggleCommitSelect,
     ConfirmCommitSelect,
+
+    ToggleExpand,
+    ExpandAll,
+    CollapseAll,
 
     // No-op
     None,
@@ -116,7 +119,6 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('i'), KeyModifiers::NONE) => Action::EditComment,
         (KeyCode::Char('d'), KeyModifiers::NONE) => Action::PendingDCommand,
         (KeyCode::Char('v'), KeyModifiers::NONE) => Action::ToggleDiffView,
-        (KeyCode::Char('t'), KeyModifiers::NONE) => Action::ToggleDirectoryGrouping,
         (KeyCode::Char('y'), KeyModifiers::NONE) => Action::ExportToClipboard,
 
         // Mode changes (use _ for shifted characters like : and ?)
@@ -126,6 +128,10 @@ fn map_normal_mode(key: KeyEvent) -> Action {
 
         // Quick quit
         (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
+
+        (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleExpand,
+        (KeyCode::Char('o'), KeyModifiers::NONE) => Action::ExpandAll,
+        (KeyCode::Char('O'), _) => Action::CollapseAll,
 
         _ => Action::None,
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use app::App;
+use app::{App, FileTreeItem};
 use input::{Action, map_key_to_action};
 use output::export_to_clipboard;
 use persistence::save_session;
@@ -178,7 +178,6 @@ fn main() -> anyhow::Result<()> {
                 Action::PrevHunk => app.prev_hunk(),
                 Action::ToggleReviewed => app.toggle_reviewed(),
                 Action::ToggleDiffView => app.toggle_diff_view_mode(),
-                Action::ToggleDirectoryGrouping => app.toggle_directory_grouping(),
                 Action::ToggleFocus => {
                     app.focused_panel = match app.focused_panel {
                         app::FocusedPanel::FileList => app::FocusedPanel::Diff,
@@ -186,9 +185,40 @@ fn main() -> anyhow::Result<()> {
                     };
                 }
                 Action::SelectFile => {
-                    if app.focused_panel == app::FocusedPanel::FileList {
-                        app.jump_to_file(app.file_list_state.selected());
+                    if app.focused_panel == app::FocusedPanel::FileList
+                        && let Some(item) = app.get_selected_tree_item()
+                    {
+                        match item {
+                            FileTreeItem::Directory { path, .. } => {
+                                app.toggle_directory(&path);
+                            }
+                            FileTreeItem::File { file_idx, .. } => {
+                                app.jump_to_file(file_idx);
+                            }
+                        }
                     }
+                }
+                Action::ToggleExpand => {
+                    if app.focused_panel == app::FocusedPanel::FileList
+                        && let Some(item) = app.get_selected_tree_item()
+                    {
+                        match item {
+                            FileTreeItem::Directory { path, .. } => {
+                                app.toggle_directory(&path);
+                            }
+                            FileTreeItem::File { file_idx, .. } => {
+                                app.jump_to_file(file_idx);
+                            }
+                        }
+                    }
+                }
+                Action::ExpandAll => {
+                    app.expand_all_dirs();
+                    app.set_message("All directories expanded");
+                }
+                Action::CollapseAll => {
+                    app.collapse_all_dirs();
+                    app.set_message("All directories collapsed");
                 }
                 Action::ToggleHelp => app.toggle_help(),
                 Action::EnterCommandMode => app.enter_command_mode(),

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -93,6 +93,40 @@ pub fn render_help(frame: &mut Frame) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
+            "File Tree",
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  Space     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Toggle expand directory"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Enter     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Expand dir / Jump to file"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  o         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Expand all directories"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  O         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Collapse all directories"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
             "Review Actions",
             Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )),
@@ -145,13 +179,6 @@ pub fn render_help(frame: &mut Frame) {
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle unified/side-by-side diff view"),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  t         ",
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("Toggle directory grouping in file list"),
         ]),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -63,9 +63,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     let mode_span = Span::styled(mode_str, styles::mode_style());
 
     let hints = match app.input_mode {
-        InputMode::Normal => {
-            " j/k:scroll  {/}:file  r:reviewed  c:comment  t:tree  ?:help  :q:quit "
-        }
+        InputMode::Normal => " j/k:scroll  {/}:file  r:reviewed  c:comment  ?:help  :q:quit ",
         InputMode::Command => " Enter:execute  Esc:cancel ",
         InputMode::Comment => " Ctrl-S:save  Esc:cancel ",
         InputMode::Help => " q/?/Esc:close ",

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -117,3 +117,7 @@ pub fn current_line_indicator_style() -> Style {
 pub fn hash_style() -> Style {
     Style::default().fg(Color::Yellow)
 }
+
+pub fn dir_icon_style() -> Style {
+    Style::default().fg(DIFF_HUNK_HEADER)
+}


### PR DESCRIPTION
## Summary
- Add hierarchical file tree view with expand/collapse functionality
- Use Space to select files and toggle directory expansion
- Use `o`/`O` to expand/collapse all directories
- Underline styling for selected items in file list
- Tree structure with ▾/▸ icons for expanded/collapsed directories
- Auto-expand parent directories when jumping to file
- Sync selection between file list and diff panels
- Add 7 unit tests for tree functionality