### PR TITLE
support toggling file browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ tuicr
 | Key | Action |
 |-----|--------|
 | `Tab` | Toggle focus between file list and diff |
+| `;e` | Toggle file list visibility |
 | `Enter` | Select file (when file list is focused) |
 
 #### Review Actions

--- a/src/app.rs
+++ b/src/app.rs
@@ -83,6 +83,7 @@ pub struct App {
     pub message: Option<Message>,
     pub pending_confirm: Option<ConfirmAction>,
     pub supports_keyboard_enhancement: bool,
+    pub show_file_list: bool,
 }
 
 #[derive(Default)]
@@ -166,6 +167,7 @@ impl App {
                     message: None,
                     pending_confirm: None,
                     supports_keyboard_enhancement: false,
+                    show_file_list: true,
                 })
             }
             Err(TuicrError::NoChanges) => {
@@ -204,6 +206,7 @@ impl App {
                     message: None,
                     pending_confirm: None,
                     supports_keyboard_enhancement: false,
+                    show_file_list: true,
                 })
             }
             Err(e) => Err(e),
@@ -993,6 +996,16 @@ impl App {
             DiffViewMode::SideBySide => "side-by-side",
         };
         self.set_message(format!("Diff view mode: {}", mode_name));
+    }
+
+    pub fn toggle_file_list(&mut self) {
+        self.show_file_list = !self.show_file_list;
+        let status = if self.show_file_list {
+            "visible"
+        } else {
+            "hidden"
+        };
+        self.set_message(format!("File list: {}", status));
     }
 
     // Commit selection methods

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -18,6 +18,7 @@ pub enum Action {
     NextHunk,
     PrevHunk,
     PendingZCommand,
+    PendingSemicolonCommand,
     ScrollLeft(usize),
     ScrollRight(usize),
 
@@ -91,6 +92,7 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('g'), KeyModifiers::NONE) => Action::GoToTop,
         (KeyCode::Char('G'), _) => Action::GoToBottom,
         (KeyCode::Char('z'), KeyModifiers::NONE) => Action::PendingZCommand,
+        (KeyCode::Char(';'), _) => Action::PendingSemicolonCommand,
 
         // File navigation (use _ for modifiers since shift is implicit in the character)
         (KeyCode::Char('}'), _) => Action::NextFile,

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,8 @@ fn main() -> anyhow::Result<()> {
     let mut pending_z = false;
     // Track pending d command for dd delete
     let mut pending_d = false;
+    // Track pending ; command for ;e toggle file list
+    let mut pending_semicolon = false;
 
     // Main loop
     loop {
@@ -109,6 +111,16 @@ fn main() -> anyhow::Result<()> {
                 // Otherwise fall through to normal handling
             }
 
+            // Handle pending ; command for ;e toggle file list
+            if pending_semicolon {
+                pending_semicolon = false;
+                if key.code == crossterm::event::KeyCode::Char('e') {
+                    app.toggle_file_list();
+                    continue;
+                }
+                // Otherwise fall through to normal handling
+            }
+
             let action = map_key_to_action(key, app.input_mode);
 
             match action {
@@ -134,6 +146,9 @@ fn main() -> anyhow::Result<()> {
                 }
                 Action::PendingDCommand => {
                     pending_d = true;
+                }
+                Action::PendingSemicolonCommand => {
+                    pending_semicolon = true;
                 }
                 Action::GoToTop => app.jump_to_file(0),
                 Action::GoToBottom => {

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -147,16 +147,20 @@ fn truncate_str(s: &str, max_len: usize) -> String {
 }
 
 fn render_main_content(frame: &mut Frame, app: &mut App, area: Rect) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([
-            Constraint::Percentage(20), // File list
-            Constraint::Percentage(80), // Diff view
-        ])
-        .split(area);
+    if app.show_file_list {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage(20), // File list
+                Constraint::Percentage(80), // Diff view
+            ])
+            .split(area);
 
-    render_file_list(frame, app, chunks[0]);
-    render_diff_view(frame, app, chunks[1]);
+        render_file_list(frame, app, chunks[0]);
+        render_diff_view(frame, app, chunks[1]);
+    } else {
+        render_diff_view(frame, app, area);
+    }
 }
 
 fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -77,6 +77,13 @@ pub fn render_help(frame: &mut Frame) {
             ),
             Span::raw("Toggle focus file list/diff"),
         ]),
+        Line::from(vec![
+            Span::styled(
+                "  ;e        ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Toggle file list visibility"),
+        ]),
         Line::from(""),
         Line::from(Span::styled(
             "Review Actions",


### PR DESCRIPTION
fixes #12 - this commit adds support for toggling the file browser with `;e` (taking inspiration from NerdTree)