### PR TITLE
feat: add horizontal scroll to file list and ;h/;l panel navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ tuicr
 | Key | Action |
 |-----|--------|
 | `Tab` | Toggle focus between file list and diff |
+| `;h` | Focus file list (left panel) |
+| `;l` | Focus diff view (right panel) |
 | `;e` | Toggle file list visibility |
 | `Enter` | Select file (when file list is focused) |
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -89,6 +89,7 @@ pub struct App {
 #[derive(Default)]
 pub struct FileListState {
     pub list_state: ratatui::widgets::ListState,
+    pub scroll_x: usize,
 }
 
 impl FileListState {
@@ -98,6 +99,14 @@ impl FileListState {
 
     pub fn select(&mut self, index: usize) {
         self.list_state.select(Some(index));
+    }
+
+    pub fn scroll_left(&mut self, cols: usize) {
+        self.scroll_x = self.scroll_x.saturating_sub(cols);
+    }
+
+    pub fn scroll_right(&mut self, cols: usize) {
+        self.scroll_x = self.scroll_x.saturating_add(cols);
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,12 +111,23 @@ fn main() -> anyhow::Result<()> {
                 // Otherwise fall through to normal handling
             }
 
-            // Handle pending ; command for ;e toggle file list
+            // Handle pending ; command for ;e toggle file list, ;h/;l panel focus
             if pending_semicolon {
                 pending_semicolon = false;
-                if key.code == crossterm::event::KeyCode::Char('e') {
-                    app.toggle_file_list();
-                    continue;
+                match key.code {
+                    crossterm::event::KeyCode::Char('e') => {
+                        app.toggle_file_list();
+                        continue;
+                    }
+                    crossterm::event::KeyCode::Char('h') => {
+                        app.focused_panel = app::FocusedPanel::FileList;
+                        continue;
+                    }
+                    crossterm::event::KeyCode::Char('l') => {
+                        app.focused_panel = app::FocusedPanel::Diff;
+                        continue;
+                    }
+                    _ => {}
                 }
                 // Otherwise fall through to normal handling
             }
@@ -139,8 +150,14 @@ fn main() -> anyhow::Result<()> {
                 Action::HalfPageUp => app.scroll_up(15),
                 Action::PageDown => app.scroll_down(30),
                 Action::PageUp => app.scroll_up(30),
-                Action::ScrollLeft(n) => app.scroll_left(n),
-                Action::ScrollRight(n) => app.scroll_right(n),
+                Action::ScrollLeft(n) => match app.focused_panel {
+                    app::FocusedPanel::FileList => app.file_list_state.scroll_left(n),
+                    app::FocusedPanel::Diff => app.scroll_left(n),
+                },
+                Action::ScrollRight(n) => match app.focused_panel {
+                    app::FocusedPanel::FileList => app.file_list_state.scroll_right(n),
+                    app::FocusedPanel::Diff => app.scroll_right(n),
+                },
                 Action::PendingZCommand => {
                     pending_z = true;
                 }

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -176,6 +176,8 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         app.file_list_state.select(current_idx);
     }
 
+    let scroll_x = app.file_list_state.scroll_x;
+
     let items: Vec<ListItem> = app
         .diff_files
         .iter()
@@ -195,7 +197,7 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                 Style::default()
             };
 
-            ListItem::new(Line::from(vec![
+            let line = Line::from(vec![
                 Span::styled(pointer.to_string(), style),
                 Span::styled(
                     format!("[{}]", review_mark),
@@ -207,7 +209,9 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                 ),
                 Span::styled(format!(" {} ", status), styles::file_status_style(status)),
                 Span::styled(filename.to_string(), style),
-            ]))
+            ]);
+
+            ListItem::new(apply_horizontal_scroll(line, scroll_x))
         })
         .collect();
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -79,6 +79,13 @@ pub fn render_help(frame: &mut Frame) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  ;h/;l     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Focus file list/diff"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  ;e        ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
fixes #52 

- Add scroll_x to FileListState for horizontal scrolling
- h/l now scrolls file list when focused, diff view when diff focused
- Add ;h/;l shortcuts for NERDTree-style panel navigation
- Update README and help popup with new keybindings