### PR TITLE
#15 Fix double keystroke bug in Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 
 use crossterm::{
     event::{
-        self, Event, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+        self, Event, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
         PushKeyboardEnhancementFlags,
     },
     execute,
@@ -91,6 +91,7 @@ fn main() -> anyhow::Result<()> {
         // Handle events
         if event::poll(Duration::from_millis(100))?
             && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
         {
             // Handle pending z command for zz centering
             if pending_z {


### PR DESCRIPTION
Added a check for KeyEventKind::Press to ensure that only key press events are processed, since Windows also sends KeyEventKind::Release, which will results in another keystroke. 

fixes #15 