### PR TITLE
fix: Replace tabs with space

### DIFF
--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -136,6 +136,7 @@ fn parse_hunks(
                 let content = String::from_utf8_lossy(line.content())
                     .trim_end_matches('\n')
                     .trim_end_matches('\r')
+                    .replace('\t', "    ")
                     .to_string();
 
                 line_contents.push(content);


### PR DESCRIPTION
When reviewing diffs in languages which use tabs instead of space like
golang, tabs are not rendered which makes it hard to review the diff.
This change attempts to fix this by replacing tabs with 4 spaces.
Possible future extension could be to let users customize the tab
width via configuration.

Before
<img width="921" height="723" alt="Screenshot 2026-01-16 at 13 40 33" src="https://github.com/user-attachments/assets/fe1efa25-2c8b-42bc-b6d3-934ba1300031" />

After
<img width="921" height="723" alt="Screenshot 2026-01-16 at 13 40 59" src="https://github.com/user-attachments/assets/2772a2eb-ae5c-4819-9e42-77fc975f315b" />
