### PR TITLE
fix(ui): status bar not appearing on commit panel

### DIFF
--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -141,8 +141,36 @@ fn render_commit_select(frame: &mut Frame, app: &App) {
     let list = Paragraph::new(items);
     frame.render_widget(list, inner);
 
-    // Footer hints with status bar and selection count
-    status_bar::render_status_bar(frame, app, chunks[2]);
+    // Footer with mode, hints, and right-aligned message
+    let theme = &app.theme;
+    let mode_span = Span::styled(" SELECT ", styles::mode_style(theme));
+
+    let selected_count = match app.commit_selection_range {
+        Some((start, end)) => end - start + 1,
+        None => 0,
+    };
+    let selection_info = if selected_count > 0 {
+        format!(" ({selected_count} selected)")
+    } else {
+        String::new()
+    };
+    let hints = format!(" j/k:navigate  Space:select range  Enter:confirm  q:quit{selection_info}");
+    let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
+
+    let left_spans = vec![mode_span, hints_span];
+
+    let (message_span, message_width) = status_bar::build_message_span(app.message.as_ref(), theme);
+    let spans = status_bar::build_right_aligned_spans(
+        left_spans,
+        message_span,
+        message_width,
+        chunks[2].width as usize,
+    );
+
+    let footer = Paragraph::new(Line::from(spans))
+        .style(styles::status_bar_style(theme))
+        .block(Block::default());
+    frame.render_widget(footer, chunks[2]);
 }
 
 fn truncate_str(s: &str, max_len: usize) -> String {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -6,8 +6,47 @@ use ratatui::{
     widgets::{Block, Paragraph},
 };
 
-use crate::app::{App, DiffSource, InputMode, MessageType};
+use crate::app::{App, DiffSource, InputMode, Message, MessageType};
+use crate::theme::Theme;
 use crate::ui::styles;
+
+pub fn build_message_span(message: Option<&Message>, theme: &Theme) -> (Span<'static>, usize) {
+    if let Some(msg) = message {
+        let (fg, bg) = match msg.message_type {
+            MessageType::Info => (Color::Black, Color::Cyan),
+            MessageType::Warning => (Color::Black, theme.pending),
+            MessageType::Error => (Color::White, theme.comment_issue),
+        };
+        let content = format!(" {} ", msg.content);
+        let width = content.len();
+        (
+            Span::styled(
+                content,
+                Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
+            ),
+            width,
+        )
+    } else {
+        (Span::raw(""), 0)
+    }
+}
+
+pub fn build_right_aligned_spans<'a>(
+    mut left_spans: Vec<Span<'a>>,
+    message_span: Span<'a>,
+    message_width: usize,
+    total_width: usize,
+) -> Vec<Span<'a>> {
+    let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();
+    let padding_width = total_width.saturating_sub(left_width + message_width);
+    let padding = Span::raw(" ".repeat(padding_width));
+
+    left_spans.push(padding);
+    if message_width > 0 {
+        left_spans.push(message_span);
+    }
+    left_spans
+}
 
 pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
@@ -99,28 +138,16 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         let hints = match app.input_mode {
             InputMode::Normal => {
                 " j/k:scroll  {/}:file  r:reviewed  c:comment  V:visual  /:search  ?:help  :q:quit "
-                    .to_string()
             }
-            InputMode::Command => " Enter:execute  Esc:cancel ".to_string(),
-            InputMode::Search => " Enter:search  Esc:cancel ".to_string(),
-            InputMode::Comment => " Ctrl-S:save  Esc:cancel ".to_string(),
-            InputMode::Help => " q/?/Esc:close ".to_string(),
-            InputMode::Confirm => " y:yes  n:no ".to_string(),
+            InputMode::Command => " Enter:execute  Esc:cancel ",
+            InputMode::Search => " Enter:search  Esc:cancel ",
+            InputMode::Comment => " Ctrl-S:save  Esc:cancel ",
+            InputMode::Help => " q/?/Esc:close ",
+            InputMode::Confirm => " y:yes  n:no ",
             InputMode::CommitSelect => {
-                let selected_count = match app.commit_selection_range {
-                    Some((start, end)) => end - start + 1,
-                    None => 0,
-                };
-                if selected_count > 0 {
-                    format!(
-                        " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit ({} selected) ",
-                        selected_count
-                    )
-                } else {
-                    " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit ".to_string()
-                }
+                " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit "
             }
-            InputMode::VisualSelect => " j/k:extend  c/Enter:comment  Esc/V:cancel ".to_string(),
+            InputMode::VisualSelect => " j/k:extend  c/Enter:comment  Esc/V:cancel ",
         };
         let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 
@@ -133,38 +160,10 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         vec![mode_span, hints_span, dirty_indicator]
     };
 
-    let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();
-
-    // Build message span for right side with highlighted background
-    let (message_span, message_width) = if let Some(msg) = &app.message {
-        let (fg, bg) = match msg.message_type {
-            MessageType::Info => (Color::Black, Color::Cyan),
-            MessageType::Warning => (Color::Black, theme.pending),
-            MessageType::Error => (Color::White, theme.comment_issue),
-        };
-        let content = format!(" {} ", msg.content);
-        let width = content.len();
-        (
-            Span::styled(
-                content,
-                Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD),
-            ),
-            width,
-        )
-    } else {
-        (Span::raw(""), 0)
-    };
-
-    // Calculate padding to push message to the right
+    // Build message span and create right-aligned layout
+    let (message_span, message_width) = build_message_span(app.message.as_ref(), theme);
     let total_width = area.width as usize;
-    let padding_width = total_width.saturating_sub(left_width + message_width);
-    let padding = Span::raw(" ".repeat(padding_width));
-
-    let mut spans = left_spans;
-    spans.push(padding);
-    if message_width > 0 {
-        spans.push(message_span);
-    }
+    let spans = build_right_aligned_spans(left_spans, message_span, message_width, total_width);
 
     let line = Line::from(spans);
 


### PR DESCRIPTION
This pull request resolves issue #101.

- Adds the selected commit count to the `render_status_bar` function, which required converting the hint to a `String`.
- Removes the previous selected commit count implementation and use the `render_status_bar`. 