### PR TITLE
feat: add vim-style warning on exit with unsaved changes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -150,6 +150,7 @@ pub struct App {
 
     pub should_quit: bool,
     pub dirty: bool,
+    pub quit_warned: bool,
     pub message: Option<Message>,
     pub pending_confirm: Option<ConfirmAction>,
     pub supports_keyboard_enhancement: bool,
@@ -290,6 +291,7 @@ impl App {
                     commit_selection_range: None,
                     should_quit: false,
                     dirty: false,
+                    quit_warned: false,
                     message: None,
                     pending_confirm: None,
                     supports_keyboard_enhancement: false,
@@ -345,6 +347,7 @@ impl App {
                     commit_selection_range: None,
                     should_quit: false,
                     dirty: false,
+                    quit_warned: false,
                     message: None,
                     pending_confirm: None,
                     supports_keyboard_enhancement: false,


### PR DESCRIPTION
## Summary
- `:q` shows error "No write since last change (add \! to override)" when there are unsaved changes
- `:q!` forces quit regardless of dirty state  
- Pressing `q` in normal mode warns once ("Unsaved changes. Press q again to quit."), second `q` quits
- Warning resets when any other action is taken

Closes #61

## Test plan
- [ ] Add a comment, press `q` → should show warning
- [ ] Press `q` again → should quit
- [ ] Add a comment, type `:q` → should show error message
- [ ] Type `:q!` → should quit immediately
- [ ] Add a comment, save with `:w`, press `q` → should quit without warning