### PR TITLE
fix: use absolute path for git repository discovery in worktrees

### DIFF
--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -24,7 +24,8 @@ pub struct GitBackend {
 impl GitBackend {
     /// Discover a git repository from the current directory
     pub fn discover() -> Result<Self> {
-        let repo = Repository::discover(".").map_err(|_| TuicrError::NotARepository)?;
+        let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
+        let repo = Repository::discover(&cwd).map_err(|_| TuicrError::NotARepository)?;
 
         let root_path = repo
             .workdir()


### PR DESCRIPTION
## Summary

- Fixes incorrect diff display when running tuicr inside a git worktree
- Files were appearing as "deleted" and diffs compared against the wrong commit

## Root Cause

`Repository::discover(".")` with a relative path can cause git2 to resolve paths incorrectly in worktrees, where `.git` is a file pointing to the main repo's gitdir.

## Solution

Use `std::env::current_dir()` to get the canonical path before calling `Repository::discover()`, ensuring git2 properly follows worktree gitdir references.

Fixes #119