### PR TITLE
feat(cli): add --stdout flag to output export to stdout

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -164,6 +164,10 @@ pub struct App {
     pub expanded_content: HashMap<GapId, Vec<DiffLine>>,
     /// Cached annotations describing what each rendered line represents
     pub line_annotations: Vec<AnnotatedLine>,
+    /// Output to stdout instead of clipboard when exporting
+    pub output_to_stdout: bool,
+    /// Pending output to print to stdout after TUI exits
+    pub pending_stdout_output: Option<String>,
 }
 
 #[derive(Default)]
@@ -247,7 +251,7 @@ enum CommentLocation {
 }
 
 impl App {
-    pub fn new(theme: Theme) -> Result<Self> {
+    pub fn new(theme: Theme, output_to_stdout: bool) -> Result<Self> {
         let vcs = detect_vcs()?;
         let vcs_info = vcs.info().clone();
         let highlighter = theme.syntax_highlighter();
@@ -306,6 +310,8 @@ impl App {
                     expanded_gaps: HashSet::new(),
                     expanded_content: HashMap::new(),
                     line_annotations: Vec::new(),
+                    output_to_stdout,
+                    pending_stdout_output: None,
                 };
                 app.sort_files_by_directory(true);
                 app.expand_all_dirs();
@@ -362,6 +368,8 @@ impl App {
                     expanded_gaps: HashSet::new(),
                     expanded_content: HashMap::new(),
                     line_annotations: Vec::new(),
+                    output_to_stdout,
+                    pending_stdout_output: None,
                 })
             }
             Err(e) => Err(e),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,3 @@
 pub mod markdown;
 
-pub use markdown::export_to_clipboard;
+pub use markdown::{export_to_clipboard, generate_export_content};


### PR DESCRIPTION
## Summary

When `--stdout` is passed, the export command (`E` key or `:clip`/`:export`) prints the review markdown to stdout and exits, instead of copying to the clipboard. This is useful for piping to other tools or redirecting to a file.

### Motivation

This enables running `tuicr` programmatically from AI coding assistants like Claude Code, leveraging tmux to open a split pane for the interactive review while capturing the exported comments via stdout. I'll be raising a follow-up PR with a complementary Claude Code skill that uses this feature.

First of all, kudos on this tool - it's incredibly handy for reviewing AI-generated diffs in a structured way. The GitHub PR-style interface makes it easy to leave contextual comments, and the vim-like keybindings feel natural. This `--stdout` flag is a small addition that opens up powerful automation possibilities.

## Changes

- Add `CliArgs` struct and `parse_cli_args()` for CLI argument handling
- Add `output_to_stdout` and `pending_stdout_output` fields to `App`
- Extract `generate_export_content()` from `export_to_clipboard()` 
- Render TUI to `/dev/tty` when `--stdout` is used (keeps stdout clean for capture)
- Skip the "Copy to clipboard?" confirmation dialog when `--stdout` is set
- Print pending output after TUI cleanup

## Usage

```bash
# Export review to stdout instead of clipboard
tuicr --stdout > review.md

# Pipe to another tool
tuicr --stdout | pbcopy

# Use from tmux (e.g., from an AI assistant)
tmux split-window -h "tuicr --stdout > /tmp/review.md"
```

## Test plan

- [x] `tuicr --help` shows the new `--stdout` option
- [x] Running with `--stdout`, adding comments, and pressing `E` outputs markdown to stdout
- [x] TUI renders correctly (to `/dev/tty`) while stdout captures only the export
- [x] Without `--stdout`, behavior unchanged (copies to clipboard)

---

🤖 Generated with [Claude Code](https://claude.ai/code)