### PR TITLE
feat(skill): add Claude Code skill for interactive review

### DIFF
--- a/.claude/skill/.claude-plugin/plugin.json
+++ b/.claude/skill/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tuicr",
+  "version": "1.0.0",
+  "description": "Review local git changes with tuicr TUI via tmux split pane",
+  "author": "tuicr contributors",
+  "type": "skill",
+  "entrypoint": "SKILL.md"
+}

--- a/.claude/skill/SKILL.md
+++ b/.claude/skill/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: tuicr
+description: Review local git changes with tuicr TUI via tmux split pane
+---
+
+# tuicr - TUI Change Reviewer
+
+Launch the `tuicr` TUI tool in a tmux split pane to interactively review local git changes.
+
+## Usage
+
+```
+/tuicr [directory]
+```
+
+Or simply mention wanting to review changes with tuicr.
+
+## How It Works
+
+Since Claude Code cannot run interactive TUI applications directly, this skill uses a tmux workaround:
+
+1. Detects if Claude is running inside tmux
+2. If yes: Creates a split pane with tuicr running in it
+3. If no: Provides instructions to restart Claude inside tmux
+
+## Determining the Directory
+
+**Important:** You must determine the correct git repository directory based on context.
+
+Consider:
+- The user's current working directory
+- Any repository they've been working in during the session
+- Explicit directory mentioned in their request
+- The git status output if available
+
+Common patterns:
+- "review my changes" → use current working directory
+- "review changes in myproject" → find that repo path
+- After editing files → use the directory of those files
+
+## Workflow
+
+1. **Determine target directory**:
+   - Check current working directory
+   - Consider recent file operations
+   - Ask user if ambiguous
+
+2. **Run the wrapper script** with a 10-minute timeout:
+   ```bash
+   <skill-directory>/tuicr-wrapper.sh [directory]
+   ```
+
+   **IMPORTANT:** Always set `timeout: 600000` (10 minutes) on the Bash tool call.
+   The script waits for tuicr to exit, and without the extended timeout Claude will
+   background the command after 2 minutes.
+
+3. **Handle the result**:
+   - If successful: tuicr opens in a split pane and blocks until user exits
+   - If not in tmux: relay the instructions to the user
+   - If not a git repo: inform user and ask for correct path
+
+4. **Process instructions from tuicr output**:
+
+   The script output may contain instructions between markers:
+   ```
+   === TUICR INSTRUCTIONS ===
+   <instructions here>
+   === END TUICR INSTRUCTIONS ===
+   ```
+
+   **If instructions are present:** Parse and execute them. These are typically
+   code changes or actions the user approved during the review.
+
+   **If no instructions in output:** The script will say "No instructions exported"
+   or mention clipboard. Tell the user:
+   > "No instructions were exported from tuicr. If you exported to clipboard,
+   > paste the instructions here and I'll execute them."
+
+## Configuration
+
+The wrapper script supports environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TUICR_PANE_POSITION` | `top` | Pane position: `top` or `bottom` |
+| `TUICR_PANE_SIZE` | `80` | Pane size as percentage of screen |
+
+Example with custom settings:
+```bash
+TUICR_PANE_SIZE=70 TUICR_PANE_POSITION=bottom <skill-directory>/tuicr-wrapper.sh /path/to/repo
+```
+
+## Example Invocations
+
+User says: "review my changes"
+→ Run tuicr-wrapper.sh with current working directory
+
+User says: "let me review the changes in myproject"
+→ Find myproject path based on context
+→ Run tuicr-wrapper.sh with that path
+
+User says: "/tuicr ~/projects/myapp"
+→ Run tuicr-wrapper.sh with `~/projects/myapp`
+
+## Tmux Tips (relay to user if needed)
+
+- Switch between panes: `Ctrl-b` then arrow keys
+- Close tuicr: Press `q` in tuicr (pane closes automatically)
+- Resize panes: `Ctrl-b` then `Ctrl-arrow`
+- Zoom current pane: `Ctrl-b` then `z` (toggle)
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| Not in tmux | Show restart instructions with `claude -c` |
+| Not a git repo | Ask user for correct directory |
+| tuicr not installed | Tell user to install tuicr |
+
+## When NOT to use
+
+- When user just wants `git diff` output (use git directly)
+- When reviewing remote/PR changes (use gh CLI or web)
+- When user explicitly asks for non-interactive review

--- a/.claude/skill/tuicr-wrapper.sh
+++ b/.claude/skill/tuicr-wrapper.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+set -e -u -o pipefail
+
+# Configuration - override via environment variables
+TUICR_PANE_POSITION="${TUICR_PANE_POSITION:-top}"    # top or bottom
+TUICR_PANE_SIZE="${TUICR_PANE_SIZE:-80}"              # percentage of screen
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+  echo -e "${GREEN}[tuicr]${NC} $*"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[tuicr]${NC} $*"
+}
+
+log_error() {
+  echo -e "${RED}[tuicr]${NC} $*"
+}
+
+usage() {
+  cat << EOF
+Usage: $(basename "$0") [directory]
+
+Launch tuicr in a tmux split pane to review git changes.
+
+Arguments:
+  directory    Git repository directory to review (default: current directory)
+
+Environment variables:
+  TUICR_PANE_POSITION   Position of tuicr pane: top or bottom (default: top)
+  TUICR_PANE_SIZE       Size of pane as percentage (default: 80)
+
+Examples:
+  $(basename "$0")                    # Review changes in current directory
+  $(basename "$0") ~/project          # Review changes in ~/project
+  TUICR_PANE_SIZE=70 $(basename "$0") # Use 70% of screen
+EOF
+}
+
+check_tmux() {
+  if [[ -z "${TMUX:-}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+check_tuicr() {
+  if ! command -v tuicr &> /dev/null; then
+    log_error "tuicr not found. Install it first."
+    return 1
+  fi
+  return 0
+}
+
+check_tuicr_stdout_support() {
+  # Check if tuicr supports --stdout flag
+  tuicr --help 2>&1 | grep -q -- '--stdout'
+}
+
+check_git_repo() {
+  local dir="$1"
+  if ! git -C "$dir" rev-parse --git-dir &> /dev/null; then
+    log_error "Not a git repository: $dir"
+    return 1
+  fi
+  return 0
+}
+
+check_tuicr_running() {
+  # Check if tuicr is already running in any tmux pane
+  if tmux list-panes -a -F '#{pane_current_command}' 2>/dev/null | grep -q '^tuicr$'; then
+    return 0  # tuicr is running
+  fi
+  return 1
+}
+
+launch_tuicr_pane() {
+  local target_dir="$1"
+
+  # Get window height and calculate lines (using -l instead of -p to avoid "size missing" error)
+  local window_height
+  window_height=$(tmux display-message -p '#{window_height}')
+  local pane_lines=$(( window_height * TUICR_PANE_SIZE / 100 ))
+
+  # Build the split-window command
+  local split_args=()
+
+  # Determine split direction based on position
+  if [[ "$TUICR_PANE_POSITION" == "top" ]]; then
+    split_args+=(-b)  # Create pane above
+  fi
+  # For bottom, no -b flag needed (default)
+
+  # Set pane size in lines (not percentage, to work without TTY)
+  split_args+=(-l "$pane_lines")
+
+  # Change to target directory
+  split_args+=(-c "$target_dir")
+
+  log_info "Launching tuicr in $TUICR_PANE_POSITION pane (${pane_lines} lines, ${TUICR_PANE_SIZE}%)"
+  log_info "Directory: $target_dir"
+
+  # Create unique channel for wait-for
+  local wait_channel="tuicr-$$"
+
+  # Check if --stdout is supported and set up output capture
+  local output_file=""
+  local tuicr_cmd="tuicr"
+  local use_stdout=false
+
+  if check_tuicr_stdout_support; then
+    output_file=$(mktemp /tmp/tuicr-output.XXXXXX)
+    tuicr_cmd="tuicr --stdout > '$output_file'"
+    use_stdout=true
+    log_info "Using --stdout mode (output will be captured)"
+  else
+    log_warn "tuicr --stdout not supported, output will be copied to clipboard"
+  fi
+
+  # Create the split pane with tuicr, signal when done
+  # Use -d to not switch, -P to print pane info so we can capture the ID
+  local new_pane_id
+  new_pane_id=$(tmux split-window -d -P -F '#{pane_id}' "${split_args[@]}" \
+    "cd '$target_dir' && $tuicr_cmd; tmux wait-for -S '$wait_channel'")
+
+  # Switch focus to the new tuicr pane
+  tmux select-pane -t "$new_pane_id"
+
+  log_info "tuicr is running in pane $new_pane_id"
+  log_info "Waiting for tuicr to exit..."
+
+  # Block until tuicr exits
+  tmux wait-for "$wait_channel"
+
+  log_info "tuicr finished"
+
+  # Output captured instructions if --stdout was used
+  if [[ "$use_stdout" == true ]] && [[ -f "$output_file" ]]; then
+    if [[ -s "$output_file" ]]; then
+      echo ""
+      echo "=== TUICR INSTRUCTIONS ==="
+      cat "$output_file"
+      echo "=== END TUICR INSTRUCTIONS ==="
+    else
+      log_info "No instructions exported from tuicr"
+      log_info "If you exported to clipboard, paste the instructions here"
+    fi
+    rm -f "$output_file"
+  else
+    log_info "If you exported instructions, they are in your clipboard - paste them here"
+  fi
+}
+
+main() {
+  # Handle help
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  # Check for tuicr
+  if ! check_tuicr; then
+    exit 1
+  fi
+
+  # Determine target directory
+  local target_dir="${1:-.}"
+  target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
+
+  # Verify it's a git repo
+  if ! check_git_repo "$target_dir"; then
+    exit 1
+  fi
+
+  # Check if we're in tmux
+  if ! check_tmux; then
+    log_error "Not running inside tmux!"
+    echo ""
+    echo "To use tuicr with Claude Code, you need to run Claude inside tmux."
+    echo ""
+    echo "1. Exit Claude now:"
+    echo "   Type /exit or press Ctrl+C twice"
+    echo ""
+    echo "2. Restart Claude inside tmux (will resume this session):"
+    echo "   tmux new-session 'claude -c'"
+    echo ""
+    echo "3. Then run /tuicr again"
+    exit 1
+  fi
+
+  # Check if tuicr is already running
+  if check_tuicr_running; then
+    log_warn "tuicr is already running in another pane"
+    log_info "Switch to it with Ctrl-b + arrow keys"
+    exit 0
+  fi
+
+  # Launch tuicr in a split pane
+  launch_tuicr_pane "$target_dir"
+}
+
+main "$@"

--- a/README.md
+++ b/README.md
@@ -195,3 +195,21 @@ Each comment is numbered and self-contained with its file path and line number o
 ## Session Persistence
 
 Sessions are automatically saved to `~/.local/share/tuicr/reviews/` (XDG compliant). When you reopen `tuicr` in the same repository, your previous review progress (comments, reviewed status) is restored.
+
+## Claude Code Integration
+
+tuicr includes a skill for [Claude Code](https://claude.ai/claude-code) that opens tuicr in a tmux split pane, letting you review changes interactively and feed comments back to Claude.
+
+**Prerequisites:** Claude Code running inside tmux, tuicr installed.
+
+**Installation** (choose one):
+
+```bash
+# Option 1: Copy to local skills
+cp -r /path/to/tuicr/.claude/skill ~/.claude/skills/tuicr
+
+# Option 2: Point Claude to this repo
+claude skill add /path/to/tuicr/.claude/skill
+```
+
+**Usage:** `/tuicr` or ask Claude to "review my changes with tuicr".


### PR DESCRIPTION
Adds a Claude Code skill that allows running tuicr from within Claude sessions via tmux integration. This complements PR #142 (--stdout flag) but works independently using clipboard mode.

## What this adds

- `.claude/skill/` - Claude Code skill that:
  - Detects if Claude is running in tmux
  - Opens tuicr in a split pane for interactive review
  - Waits for review completion
  - Captures output (via `--stdout` if available) or prompts user to paste from clipboard

- README section documenting how to install the skill

## How it works

The skill uses a tmux-based workaround since Claude Code can't run interactive TUI apps directly. When invoked:

1. Opens tuicr in a tmux split pane above the Claude pane
2. User reviews changes and exits tuicr
3. If `--stdout` is supported (PR #142), output is captured automatically
4. Otherwise, user pastes clipboard content back to Claude

## Installation

```bash
# Copy to local skills
cp -r /path/to/tuicr/.claude/skill ~/.claude/skills/tuicr

# Or point Claude to this repo
claude skill add /path/to/tuicr/.claude/skill
```

---

This is a great tool for AI-assisted development - the "let the agent loose, then review like a PR" workflow is exactly what's been missing.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)