### PR TITLE
Update README.md with mise install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ brew install agavra/tap/tuicr
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/agavra/tuicr/releases).
 
+### Mise (macOS/Linux/Windows)
+
+```
+mise use github:agavra/tuicr
+```
+
 ### From crates.io
 
 ```bash


### PR DESCRIPTION
Installing github releases directly with [mise](https://mise.jdx.dev/).