### PR TITLE
feat(update): check crates.io for new releases and surface update status in UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "bytes"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+
+[[package]]
 name = "cassowary"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +244,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -731,6 +766,22 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "iana-time-zone"
@@ -1764,6 +1815,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,6 +1861,41 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2000,6 +2100,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2269,6 +2375,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "unicode-width 0.2.2",
+ "ureq",
  "uuid",
 ]
 
@@ -2331,6 +2438,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf-8",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2486,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -2528,6 +2679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2693,6 +2853,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2970,6 +3139,12 @@ dependencies = [
  "syn 2.0.114",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ anyhow = "1.0"
 
 # Utilities
 directories = "6.0"
+ureq = { version = "3", features = ["json"] }
 unicode-width = "0.2"
 uuid = { version = "1.0", features = ["v4"] }
 arboard = { version = "3.4", features = ["wayland-data-control"] }

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | `--theme dark` | Use dark color theme (default) |
 | `--theme light` | Use light color theme for light terminal backgrounds |
 | `--stdout` | Output to stdout instead of clipboard when exporting |
+| `--no-update-check` | Skip checking for updates on startup |
 
 ### Keybindings
 
@@ -177,6 +178,8 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | `:set wrap` | Enable line wrap in diff view |
 | `:set wrap!` | Toggle line wrap in diff view |
 | `:clear` | Clear all comments |
+| `:version` | Show tuicr version |
+| `:update` | Check for updates |
 | `:q` | Quit (warns if unsaved) |
 | `:q!` | Force quit |
 | `:x` / `:wq` | Save and quit (prompts to copy if comments exist) |

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use crate::model::{
 };
 use crate::persistence::load_latest_session_for_context;
 use crate::theme::Theme;
+use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
 use crate::vcs::{CommitInfo, VcsBackend, VcsInfo, detect_vcs};
 
@@ -182,6 +183,8 @@ pub struct App {
     /// Calculated screen position for comment input cursor (col, row) for IME positioning.
     /// Set during render when in Comment mode, None otherwise.
     pub comment_cursor_screen_pos: Option<(u16, u16)>,
+    /// Information about available updates (set by background check)
+    pub update_info: Option<UpdateInfo>,
 }
 
 #[derive(Default)]
@@ -332,6 +335,7 @@ impl App {
                     output_to_stdout,
                     pending_stdout_output: None,
                     comment_cursor_screen_pos: None,
+                    update_info: None,
                 };
                 app.sort_files_by_directory(true);
                 app.expand_all_dirs();
@@ -404,6 +408,7 @@ impl App {
                     output_to_stdout,
                     pending_stdout_output: None,
                     comment_cursor_screen_pos: None,
+                    update_info: None,
                 })
             }
             Err(e) => Err(e),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -182,6 +182,26 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                 "version" => {
                     app.set_message(format!("tuicr v{}", env!("CARGO_PKG_VERSION")));
                 }
+                "update" => match crate::update::check_for_updates() {
+                    crate::update::UpdateCheckResult::UpdateAvailable(info) => {
+                        app.set_message(format!(
+                            "Update available: v{} -> v{}",
+                            info.current_version, info.latest_version
+                        ));
+                    }
+                    crate::update::UpdateCheckResult::UpToDate(info) => {
+                        app.set_message(format!("tuicr v{} is up to date", info.current_version));
+                    }
+                    crate::update::UpdateCheckResult::AheadOfRelease(info) => {
+                        app.set_message(format!(
+                            "You're from the future! v{} > v{}",
+                            info.current_version, info.latest_version
+                        ));
+                    }
+                    crate::update::UpdateCheckResult::Failed(err) => {
+                        app.set_warning(format!("Update check failed: {err}"));
+                    }
+                },
                 "set wrap" => app.set_diff_wrap(true),
                 "set wrap!" => app.toggle_diff_wrap(),
                 "diff" => app.toggle_diff_view_mode(),

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -195,6 +195,8 @@ pub struct CliArgs {
     pub theme: ThemeArg,
     /// Output to stdout instead of clipboard when exporting
     pub output_to_stdout: bool,
+    /// Skip checking for updates on startup
+    pub no_update_check: bool,
 }
 
 impl ThemeArg {
@@ -240,10 +242,11 @@ fn print_help() -> ! {
 Usage: {name} [OPTIONS]
 
 Options:
-  --theme <THEME>  Color theme to use [default: dark]
-                   Valid values: dark, light
-  --stdout         Output to stdout instead of clipboard when exporting
-  -h, --help       Print this help message
+  --theme <THEME>    Color theme to use [default: dark]
+                     Valid values: dark, light
+  --stdout           Output to stdout instead of clipboard when exporting
+  --no-update-check  Skip checking for updates on startup
+  -h, --help         Print this help message
 
 Press ? in the application for keybinding help."
     );
@@ -268,6 +271,11 @@ pub fn parse_cli_args() -> CliArgs {
         // Handle --stdout
         if args[i] == "--stdout" {
             cli_args.output_to_stdout = true;
+        }
+
+        // Handle --no-update-check
+        if args[i] == "--no-update-check" {
+            cli_args.no_update_check = true;
         }
 
         // Handle --theme value

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -375,6 +375,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
             ),
             Span::raw("Show tuicr version"),
         ]),
+        Line::from(vec![
+            Span::styled(
+                "  :update   ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Check for updates"),
+        ]),
         Line::from(""),
         Line::from(vec![
             Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -82,7 +82,37 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
         },
     );
 
-    let line = Line::from(vec![title_span, vcs_span, source_span, progress_span]);
+    let update_span = if let Some(ref info) = app.update_info {
+        if info.update_available {
+            Span::styled(
+                format!("[v{} available] ", info.latest_version),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(theme.comment_suggestion)
+                    .add_modifier(Modifier::BOLD),
+            )
+        } else if info.is_ahead {
+            Span::styled(
+                format!("[unreleased v{}] ", info.current_version),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(theme.comment_suggestion)
+                    .add_modifier(Modifier::BOLD),
+            )
+        } else {
+            Span::raw("")
+        }
+    } else {
+        Span::raw("")
+    };
+
+    let line = Line::from(vec![
+        title_span,
+        vcs_span,
+        source_span,
+        progress_span,
+        update_span,
+    ]);
 
     let header = Paragraph::new(line)
         .style(styles::status_bar_style(theme))

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,119 @@
+//! Version update checking against crates.io
+
+use std::time::Duration;
+
+use ureq::Agent;
+
+#[derive(Debug, Clone)]
+pub struct UpdateInfo {
+    pub current_version: String,
+    pub latest_version: String,
+    pub update_available: bool,
+    pub is_ahead: bool,
+}
+
+pub enum UpdateCheckResult {
+    UpdateAvailable(UpdateInfo),
+    UpToDate(UpdateInfo),
+    AheadOfRelease(UpdateInfo),
+    Failed(String),
+}
+
+/// Check for updates from crates.io (3-second timeout)
+pub fn check_for_updates() -> UpdateCheckResult {
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    let config = Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(3)))
+        .build();
+    let agent: Agent = config.into();
+
+    let response = match agent.get("https://crates.io/api/v1/crates/tuicr").call() {
+        Ok(resp) => resp,
+        Err(e) => return UpdateCheckResult::Failed(format!("Network error: {e}")),
+    };
+
+    let body: serde_json::Value = match response.into_body().read_json() {
+        Ok(json) => json,
+        Err(e) => return UpdateCheckResult::Failed(format!("Failed to parse response: {e}")),
+    };
+
+    let latest_version = match body
+        .get("crate")
+        .and_then(|c| c.get("max_version"))
+        .and_then(|v| v.as_str())
+    {
+        Some(v) => v.to_string(),
+        None => return UpdateCheckResult::Failed("Could not find version info".to_string()),
+    };
+
+    let update_available = is_newer_version(current_version, &latest_version);
+    let is_ahead = is_newer_version(&latest_version, current_version);
+
+    let info = UpdateInfo {
+        current_version: current_version.to_string(),
+        latest_version: latest_version.clone(),
+        update_available,
+        is_ahead,
+    };
+
+    if info.update_available {
+        UpdateCheckResult::UpdateAvailable(info)
+    } else if info.is_ahead {
+        UpdateCheckResult::AheadOfRelease(info)
+    } else {
+        UpdateCheckResult::UpToDate(info)
+    }
+}
+
+/// Simple semver comparison (major.minor.patch)
+/// Returns true if latest is newer than current
+fn is_newer_version(current: &str, latest: &str) -> bool {
+    let parse_version = |s: &str| -> Option<(u32, u32, u32)> {
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() >= 3 {
+            Some((
+                parts[0].parse().ok()?,
+                parts[1].parse().ok()?,
+                parts[2].parse().ok()?,
+            ))
+        } else if parts.len() == 2 {
+            Some((parts[0].parse().ok()?, parts[1].parse().ok()?, 0))
+        } else {
+            None
+        }
+    };
+
+    let Some((cur_major, cur_minor, cur_patch)) = parse_version(current) else {
+        return false;
+    };
+    let Some((lat_major, lat_minor, lat_patch)) = parse_version(latest) else {
+        return false;
+    };
+
+    (lat_major, lat_minor, lat_patch) > (cur_major, cur_minor, cur_patch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_newer_version() {
+        assert!(is_newer_version("0.5.0", "0.6.0"));
+        assert!(is_newer_version("0.5.0", "1.0.0"));
+        assert!(is_newer_version("0.5.0", "0.5.1"));
+        assert!(!is_newer_version("0.5.0", "0.5.0"));
+        assert!(!is_newer_version("0.6.0", "0.5.0"));
+        assert!(!is_newer_version("1.0.0", "0.9.9"));
+    }
+
+    #[test]
+    fn test_ahead_of_release_detection() {
+        // When current > latest, we can detect "ahead of release"
+        // by checking is_newer_version(latest, current)
+        assert!(is_newer_version("0.4.1", "0.5.0")); // 0.5.0 is ahead of 0.4.1 release
+        assert!(is_newer_version("0.4.1", "0.4.2")); // 0.4.2 is ahead of 0.4.1 release
+        assert!(!is_newer_version("0.5.0", "0.4.1")); // 0.4.1 is not ahead of 0.5.0
+    }
+}


### PR DESCRIPTION
This pull request introduces an automatic update check feature to the application, allowing users to be notified when a new version is available on crates.io. The update check runs in the background at startup (unless disabled), and users can also manually trigger it with a new `:update` command. Update information is shown in the status bar, and a CLI flag is provided to skip the check. The implementation includes robust error handling and version comparison.

**Update Checking Feature:**

- Added a new module `update.rs` that checks for newer versions of the app on crates.io, compares semantic versions, and exposes results as a new `UpdateInfo` struct and `UpdateCheckResult` enum.
- Integrated background update checking at startup in `main.rs`, using a non-blocking thread and channel to avoid UI delays. Update results are stored in the `App` state and displayed in the status bar. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR64-R75) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR128-R140) [[3]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R186-R187) [[4]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R338) [[5]](diffhunk://#diff-0b979b6de560b29c1d97336878db56179224aa21d96fe099630c6628479ed020R411) [[6]](diffhunk://#diff-098388b670e5b240a7f1a05579b4ff25b73c06ff1b47c65f9d91e519423caebcL85-R109)

**User Interaction:**

- Added a new `:update` command to manually check for updates, with clear messaging for available updates, up-to-date status, or errors.
- Updated the help popup to document the new `:update` command.

**CLI Improvements:**

- Introduced a `--no-update-check` CLI flag to skip the automatic update check, with argument parsing and help text updated accordingly. [[1]](diffhunk://#diff-99562c1595a39ee25355572b524da6b10b9347849c7e4b8df93d5da28849d89eR198-R199) [[2]](diffhunk://#diff-99562c1595a39ee25355572b524da6b10b9347849c7e4b8df93d5da28849d89eR248) [[3]](diffhunk://#diff-99562c1595a39ee25355572b524da6b10b9347849c7e4b8df93d5da28849d89eR276-R280)

**Dependency and Version Updates:**

- Added the `ureq` crate (with JSON support) as a dependency for HTTP requests in the update checker.
- Bumped the application version from `0.5.0` to `0.5.1` in `Cargo.toml`.

closes #146 