### PR TITLE
Add -r/--revisions CLI arg to review a revset/commit range

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 
 | Flag | Description |
 |------|-------------|
+| `-r` / `--revisions <REVSET>` | Commit range/Revision set to review. Exact syntax depends on VCS backend (Git, JJ, Hg) |
 | `--theme dark` | Use dark color theme (default) |
 | `--theme light` | Use light color theme for light terminal backgrounds |
 | `--stdout` | Output to stdout instead of clipboard when exporting |

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,11 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Initialize app
-    let mut app = match App::new(theme, cli_args.output_to_stdout) {
+    let mut app = match App::new(
+        theme,
+        cli_args.output_to_stdout,
+        cli_args.revisions.as_deref(),
+    ) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
             app

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -198,6 +198,8 @@ pub struct CliArgs {
     pub output_to_stdout: bool,
     /// Skip checking for updates on startup
     pub no_update_check: bool,
+    /// Commit/revision range to review
+    pub revisions: Option<String>,
 }
 
 impl ThemeArg {
@@ -243,11 +245,12 @@ fn print_help() -> ! {
 Usage: {name} [OPTIONS]
 
 Options:
-  --theme <THEME>    Color theme to use [default: dark]
-                     Valid values: dark, light
-  --stdout           Output to stdout instead of clipboard when exporting
-  --no-update-check  Skip checking for updates on startup
-  -h, --help         Print this help message
+  -r, --revisions <REVSET>  Commit range/Revset to review (syntax depends on VCS backend)
+  --theme <THEME>        Color theme to use [default: dark]
+                         Valid values: dark, light
+  --stdout               Output to stdout instead of clipboard when exporting
+  --no-update-check      Skip checking for updates on startup
+  -h, --help             Print this help message
 
 Press ? in the application for keybinding help."
     );
@@ -300,6 +303,19 @@ pub fn parse_cli_args() -> CliArgs {
                 );
                 ThemeArg::Dark
             });
+        }
+
+        // Handle -r / --revisions value
+        if args[i] == "-r" || args[i] == "--revisions" {
+            if let Some(value) = args.get(i + 1) {
+                cli_args.revisions = Some(value.clone());
+            } else {
+                eprintln!("Warning: {0} requires a value", args[i]);
+            }
+        }
+        // Handle --revisions=value
+        if let Some(value) = args[i].strip_prefix("--revisions=") {
+            cli_args.revisions = Some(value.to_string());
         }
     }
 

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -91,6 +91,10 @@ impl VcsBackend for GitBackend {
             .collect())
     }
 
+    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
+        repository::resolve_revisions(&self.repo, revisions)
+    }
+
     fn get_commit_range_diff(
         &self,
         commit_ids: &[String],

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -67,6 +67,14 @@ pub trait VcsBackend: Send {
         Ok(Vec::new())
     }
 
+    /// Resolve a revisions expression to a list of commit IDs (oldest first).
+    /// Returns error if not supported (default).
+    fn resolve_revisions(&self, _revisions: &str) -> Result<Vec<String>> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "Revset resolution not supported for this VCS".into(),
+        ))
+    }
+
     /// Get diff for a commit range.
     /// Returns error if not supported (default).
     fn get_commit_range_diff(


### PR DESCRIPTION
You can run tuicr with the `--revset/-r` arg to go straight into reviewing a set of revisions. For instance:

```
tuicr --revset 'main..'
```

This automatically starts reviewing all commits which are *not* in `main`. Note that if the selected revset is disjoint, intermediary revisions will be included too so we still end up with a valid range without "holes".

This also factorizes App construction.