### PR TITLE
Fix New-side line comments missing from unified diff annotations

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2302,6 +2302,17 @@ impl App {
                     LineSide::Old,
                 );
             }
+
+            // Line comments on new side (added/context lines)
+            if let Some(new_ln) = diff_line.new_lineno {
+                Self::push_comments(
+                    annotations,
+                    file_idx,
+                    Some(new_ln),
+                    line_comments,
+                    LineSide::New,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
build_unified_diff_annotations only called push_comments for LineSide::Old,
but get_line_at_cursor saves most comments as LineSide::New.

Result: comments were rendered (via app_layout.rs which reads the session directly) but the annotation array had no matching entries, so find_comment_at_cursor returned None — making them undeletable and misaligned from the cursor system.