### PR TITLE
feat: add inline commit selector for multi-commit reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ When `-r` / `--revisions` is provided, `tuicr` opens that revision range directl
 
 | Key | Action |
 |-----|--------|
-| `Tab` | Toggle focus between file list and diff |
+| `Tab` | Toggle focus between file list, diff, and commit selector |
 | `;h` | Focus file list (left panel) |
 | `;l` | Focus diff view (right panel) |
+| `;k` | Focus commit selector (top panel) |
+| `;j` | Focus diff view |
 | `;e` | Toggle file list visibility |
 | `Enter` | Select file (when file list is focused) |
 
@@ -182,6 +184,9 @@ When `-r` / `--revisions` is provided, `tuicr` opens that revision range directl
 | `:commits` | Select commits to review |
 | `:set wrap` | Enable line wrap in diff view |
 | `:set wrap!` | Toggle line wrap in diff view |
+| `:set commits` | Show inline commit selector |
+| `:set nocommits` | Hide inline commit selector |
+| `:set commits!` | Toggle inline commit selector |
 | `:clear` | Clear all comments |
 | `:version` | Show tuicr version |
 | `:update` | Check for updates |
@@ -191,7 +196,7 @@ When `-r` / `--revisions` is provided, `tuicr` opens that revision range directl
 | `?` | Toggle help |
 | `q` | Quick quit |
 
-#### Commit Selection
+#### Commit Selection (startup)
 
 | Key | Action |
 |-----|--------|
@@ -199,6 +204,17 @@ When `-r` / `--revisions` is provided, `tuicr` opens that revision range directl
 | `Space` | Toggle commit selection |
 | `Enter` | Confirm and load diff |
 | `q` / `Esc` | Quit |
+
+#### Inline Commit Selector (multi-commit reviews)
+
+When reviewing multiple commits, an inline commit selector panel appears at the top of the diff view. Focus it with `;k` or `Tab`.
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Navigate commits |
+| `Space` / `Enter` | Toggle commit selection (updates diff) |
+| `(` / `)` | Cycle through individual commits |
+| `Esc` | Return focus to diff |
 
 #### Confirm Dialogs
 

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -74,6 +74,10 @@ pub enum Action {
     CommitSelectDown,
     ToggleCommitSelect,
     ConfirmCommitSelect,
+    /// Cycle inline commit selector to next individual commit (`)`)
+    CycleCommitNext,
+    /// Cycle inline commit selector to previous individual commit (`(`)
+    CycleCommitPrev,
 
     ToggleExpand,
     ExpandAll,
@@ -117,6 +121,8 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('{'), _) => Action::PrevFile,
         (KeyCode::Char(']'), _) => Action::NextHunk,
         (KeyCode::Char('['), _) => Action::PrevHunk,
+        (KeyCode::Char(')'), _) => Action::CycleCommitNext,
+        (KeyCode::Char('('), _) => Action::CycleCommitPrev,
 
         // Panel focus
         (KeyCode::Tab, KeyModifiers::NONE) => Action::ToggleFocus,

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,8 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use app::{App, FocusedPanel, InputMode};
 use handler::{
     handle_command_action, handle_comment_action, handle_commit_select_action,
-    handle_confirm_action, handle_diff_action, handle_file_list_action, handle_help_action,
-    handle_search_action, handle_visual_action,
+    handle_commit_selector_action, handle_confirm_action, handle_diff_action,
+    handle_file_list_action, handle_help_action, handle_search_action, handle_visual_action,
 };
 use input::{Action, map_key_to_action};
 use theme::{parse_cli_args, resolve_theme};
@@ -204,7 +204,7 @@ fn main() -> anyhow::Result<()> {
                         // Otherwise fall through to normal handling
                     }
 
-                    // Handle pending ; command for ;e toggle file list, ;h/;l panel focus
+                    // Handle pending ; command for ;e toggle file list, ;h/;l/;k/;j panel focus
                     if pending_semicolon {
                         pending_semicolon = false;
                         match key.code {
@@ -217,6 +217,16 @@ fn main() -> anyhow::Result<()> {
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('l') => {
+                                app.focused_panel = app::FocusedPanel::Diff;
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('k') => {
+                                if app.has_inline_commit_selector() {
+                                    app.focused_panel = app::FocusedPanel::CommitSelector;
+                                }
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('j') => {
                                 app.focused_panel = app::FocusedPanel::Diff;
                                 continue;
                             }
@@ -256,6 +266,9 @@ fn main() -> anyhow::Result<()> {
                         InputMode::Normal => match app.focused_panel {
                             FocusedPanel::FileList => handle_file_list_action(&mut app, action),
                             FocusedPanel::Diff => handle_diff_action(&mut app, action),
+                            FocusedPanel::CommitSelector => {
+                                handle_commit_selector_action(&mut app, action)
+                            }
                         },
                     }
                 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -109,10 +109,51 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  ;k/;j     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Focus commit selector/diff"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  ;e        ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle file list visibility"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Commit Selector (multi-commit reviews)",
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  j/k       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Navigate commits"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Space/Enter",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Toggle commit selection (updates diff)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  (/)       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Cycle through individual commits"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Esc       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Return focus to diff"),
         ]),
         Line::from(""),
         Line::from(Span::styled(
@@ -346,6 +387,27 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Select commits or uncommitted changes"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :set commits",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Show inline commit selector"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :set nocommits",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Hide inline commit selector"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :set commits!",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Toggle inline commit selector"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -63,7 +63,16 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
             if commits.len() == 1 {
                 format!("[commit {}] ", &commits[0][..7.min(commits[0].len())])
             } else {
-                format!("[{} commits] ", commits.len())
+                match app.commit_selection_range {
+                    Some((start, end)) if end - start + 1 < app.review_commits.len() => {
+                        format!(
+                            "[{}/{} commits] ",
+                            end - start + 1,
+                            app.review_commits.len()
+                        )
+                    }
+                    _ => format!("[{} commits] ", commits.len()),
+                }
             }
         }
     };

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -103,4 +103,19 @@ impl VcsBackend for GitBackend {
     ) -> Result<Vec<DiffFile>> {
         get_commit_range_diff(&self.repo, commit_ids, highlighter)
     }
+
+    fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
+        let git_commits = repository::get_commits_info(&self.repo, ids)?;
+        Ok(git_commits
+            .into_iter()
+            .map(|c| CommitInfo {
+                id: c.id,
+                short_id: c.short_id,
+                branch_name: c.branch_name,
+                summary: c.summary,
+                author: c.author,
+                time: c.time,
+            })
+            .collect())
+    }
 }

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -89,6 +89,12 @@ pub trait VcsBackend: Send {
             "Commit range diff not supported for this VCS".into(),
         ))
     }
+
+    /// Get commit info for specific commit IDs (for inline commit selector).
+    /// Returns CommitInfo for each ID, in the same order as the input.
+    fn get_commits_info(&self, _ids: &[String]) -> Result<Vec<CommitInfo>> {
+        Ok(Vec::new())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
fixes #153 

When reviewing multiple commits, an inline commit selector panel appears at the top of the diff view showing all commits with checkboxes. Users can narrow the selection to see a subset of changes.

- ;k/;j to focus commit selector/diff panel
- Space/Enter to toggle individual commit selection
- ( / ) to cycle through individual commits
- :set commits/:set nocommits/:set commits! to show/hide/toggle panel
- Tab cycles focus through commit selector in the rotation
- Subrange diffs are cached for fast switching
- Status bar shows [N/M commits] when subset selected
- Works with both interactive selection and -r CLI flag
- Added get_commits_info() to VcsBackend trait (git/jj/hg)