### PR TITLE
feat: allow selecting both worktree and commits in the selector

### DIFF
--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -46,6 +46,7 @@ pub enum SessionDiffSource {
     #[default]
     WorkingTree,
     CommitRange,
+    WorkingTreeAndCommits,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -102,6 +102,15 @@ fn generate_markdown(session: &ReviewSession, diff_source: &DiffSource) -> Strin
             }
             let _ = writeln!(md);
         }
+        DiffSource::WorkingTreeAndCommits(commits) => {
+            let short_ids: Vec<&str> = commits.iter().map(|c| &c[..7.min(c.len())]).collect();
+            let _ = writeln!(
+                md,
+                "Reviewing working tree + commits: {}",
+                short_ids.join(", ")
+            );
+            let _ = writeln!(md);
+        }
     }
 
     let _ = writeln!(

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -34,7 +34,10 @@ fn parse_session_filename(filename: &str) -> Option<SessionFilenameParts> {
     let date_part = parts.get(date_idx)?;
     let time_part = parts.get(time_idx)?;
 
-    if !matches!(*diff_source, "worktree" | "commits") {
+    if !matches!(
+        *diff_source,
+        "worktree" | "commits" | "worktree_and_commits"
+    ) {
         return None;
     }
 
@@ -152,6 +155,7 @@ fn session_filename(session: &ReviewSession) -> String {
     let diff_source = match session.diff_source {
         SessionDiffSource::WorkingTree => "worktree",
         SessionDiffSource::CommitRange => "commits",
+        SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
     };
 
     let timestamp = session.created_at.format("%Y%m%d_%H%M%S");
@@ -193,6 +197,7 @@ pub fn load_latest_session_for_context(
     let current_diff_source = match diff_source {
         SessionDiffSource::WorkingTree => "worktree",
         SessionDiffSource::CommitRange => "commits",
+        SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
     };
 
     let reviews_dir = get_reviews_dir()?;
@@ -279,8 +284,10 @@ pub fn load_latest_session_for_context(
             continue;
         }
 
-        if diff_source == SessionDiffSource::CommitRange
-            && let Some(expected_range) = commit_range
+        if matches!(
+            diff_source,
+            SessionDiffSource::CommitRange | SessionDiffSource::WorkingTreeAndCommits
+        ) && let Some(expected_range) = commit_range
             && session.commit_range.as_deref() != Some(expected_range)
         {
             continue;

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -75,6 +75,9 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
                 }
             }
         }
+        DiffSource::WorkingTreeAndCommits(commits) => {
+            format!("[worktree + {} commits] ", commits.len())
+        }
     };
 
     let progress = format!("{}/{} reviewed ", app.reviewed_count(), app.file_count());

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -13,7 +13,7 @@ use super::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
 
 // Re-export commonly used functions
 pub use context::{calculate_gap, fetch_context_lines};
-pub use diff::{get_commit_range_diff, get_working_tree_diff};
+pub use diff::{get_commit_range_diff, get_working_tree_diff, get_working_tree_with_commits_diff};
 
 /// Git backend implementation using git2 library
 pub struct GitBackend {
@@ -117,5 +117,13 @@ impl VcsBackend for GitBackend {
                 time: c.time,
             })
             .collect())
+    }
+
+    fn get_working_tree_with_commits_diff(
+        &self,
+        commit_ids: &[String],
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        get_working_tree_with_commits_diff(&self.repo, commit_ids, highlighter)
     }
 }

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -95,6 +95,19 @@ pub trait VcsBackend: Send {
     fn get_commits_info(&self, _ids: &[String]) -> Result<Vec<CommitInfo>> {
         Ok(Vec::new())
     }
+
+    /// Get a combined diff from the parent of the oldest commit through to the working tree.
+    /// This shows both committed and uncommitted changes in a single diff.
+    /// Returns error if not supported (default).
+    fn get_working_tree_with_commits_diff(
+        &self,
+        _commit_ids: &[String],
+        _highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "Working tree + commits diff not supported for this VCS".into(),
+        ))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When both uncommitted changes and commits are selected, diff from the parent of the oldest selected commit through to the working tree, producing a single unified diff covering both committed and uncommitted changes. Implements the combined diff for all three backends (git, jj, hg).