### PR TITLE
Add config file support and Catppuccin themes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,6 +1893,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2241,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tree_magic_mini"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,6 +2309,7 @@ dependencies = [
  "syntect",
  "tempfile",
  "thiserror 2.0.18",
+ "toml",
  "two-face",
  "unicode-width",
  "ureq",
@@ -2890,6 +2941,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ git2 = { version = "0.20", default-features = false }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 
 # Date/time
 chrono = { version = "0.4", default-features = false, features = ["std", "clock", "serde"] }

--- a/README.md
+++ b/README.md
@@ -91,14 +91,34 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | Flag | Description |
 |------|-------------|
 | `-r` / `--revisions <REVSET>` | Commit range/Revision set to review. Exact syntax depends on VCS backend (Git, JJ, Hg) |
-| `--theme dark` | Use dark color theme (default) |
-| `--theme light` | Use light color theme for light terminal backgrounds |
+| `--theme <THEME>` | Color theme override (`dark`, `light`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`) |
 | `--stdout` | Output to stdout instead of clipboard when exporting |
 | `--no-update-check` | Skip checking for updates on startup |
 
 By default, `tuicr` starts in commit selection mode.  
 If uncommitted changes exist, the first selectable entry is `Uncommitted changes`.  
 When `-r` / `--revisions` is provided, `tuicr` opens that revision range directly.
+
+### Configuration
+
+Set a default theme in:
+- Linux/macOS: `$XDG_CONFIG_HOME/tuicr/config.toml` (default: `~/.config/tuicr/config.toml`)
+- Windows: `%APPDATA%\tuicr\config.toml`
+
+Example:
+
+```toml
+theme = "catppuccin-mocha"
+```
+
+Theme resolution precedence:
+1. `--theme <THEME>`
+2. Config file path above (OS-specific)
+3. built-in default (`dark`)
+
+Notes:
+- Invalid `--theme` values cause an immediate non-zero exit.
+- Unknown keys in `config.toml` are rejected.
 
 ### Keybindings
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,201 @@
+use std::fs;
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(default, deny_unknown_fields)]
+pub struct AppConfig {
+    pub theme: Option<String>,
+}
+
+pub fn config_path() -> Result<PathBuf> {
+    let xdg_config_home = std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from);
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    let appdata = std::env::var_os("APPDATA").map(PathBuf::from);
+
+    config_path_from_parts(xdg_config_home, home, appdata)
+}
+
+pub fn config_path_hint() -> &'static str {
+    #[cfg(windows)]
+    {
+        r"%APPDATA%\tuicr\config.toml"
+    }
+
+    #[cfg(not(windows))]
+    {
+        "$XDG_CONFIG_HOME/tuicr/config.toml (default: ~/.config/tuicr/config.toml)"
+    }
+}
+
+fn config_path_from_parts(
+    xdg_config_home: Option<PathBuf>,
+    home: Option<PathBuf>,
+    _appdata: Option<PathBuf>,
+) -> Result<PathBuf> {
+    #[cfg(windows)]
+    {
+        let base = _appdata
+            .filter(|p| !p.as_os_str().is_empty())
+            .ok_or_else(|| anyhow!("Could not determine APPDATA for config directory"))?;
+        return Ok(base.join("tuicr").join("config.toml"));
+    }
+
+    #[cfg(not(windows))]
+    {
+        if let Some(base) = xdg_config_home.filter(|p| !p.as_os_str().is_empty()) {
+            return Ok(base.join("tuicr").join("config.toml"));
+        }
+
+        let home = home
+            .filter(|p| !p.as_os_str().is_empty())
+            .ok_or_else(|| anyhow!("Could not determine HOME for config directory"))?;
+        Ok(home.join(".config").join("tuicr").join("config.toml"))
+    }
+}
+
+pub fn load_config() -> Result<Option<AppConfig>> {
+    let path = config_path()?;
+    load_config_from_path(&path)
+}
+
+fn load_config_from_path(path: &Path) -> Result<Option<AppConfig>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let config = toml::from_str::<AppConfig>(&contents)?;
+    Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn should_return_none_when_config_file_missing() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        let config = load_config_from_path(&path).expect("missing config should not fail");
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn should_load_theme_from_valid_toml() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "theme = \"light\"\n").expect("failed to write config");
+
+        let config = load_config_from_path(&path)
+            .expect("valid config should parse")
+            .expect("config should exist");
+        assert_eq!(config.theme.as_deref(), Some("light"));
+    }
+
+    #[test]
+    fn should_parse_empty_config_as_defaults() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "").expect("failed to write config");
+
+        let config = load_config_from_path(&path)
+            .expect("empty config should parse")
+            .expect("config should exist");
+        assert_eq!(config, AppConfig::default());
+    }
+
+    #[test]
+    fn should_error_on_invalid_toml() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "theme =\n").expect("failed to write config");
+
+        let result = load_config_from_path(&path);
+        assert!(result.is_err(), "invalid TOML should return error");
+    }
+
+    #[test]
+    fn should_error_on_unknown_keys() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "themes = \"light\"\n").expect("failed to write config");
+
+        let result = load_config_from_path(&path);
+        assert!(result.is_err(), "unknown keys should return error");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn should_use_xdg_config_home_when_set() {
+        let path = config_path_from_parts(
+            Some(PathBuf::from("/tmp/xdg-config")),
+            Some(PathBuf::from("/tmp/home")),
+            None,
+        )
+        .expect("config path should resolve");
+
+        assert_eq!(path, PathBuf::from("/tmp/xdg-config/tuicr/config.toml"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn should_fallback_to_home_dot_config_when_xdg_unset() {
+        let path = config_path_from_parts(None, Some(PathBuf::from("/home/tester")), None)
+            .expect("config path should resolve");
+
+        assert_eq!(
+            path,
+            PathBuf::from("/home/tester/.config/tuicr/config.toml")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn should_ignore_empty_xdg_config_home() {
+        let path = config_path_from_parts(
+            Some(PathBuf::from("")),
+            Some(PathBuf::from("/home/tester")),
+            None,
+        )
+        .expect("config path should resolve");
+
+        assert_eq!(
+            path,
+            PathBuf::from("/home/tester/.config/tuicr/config.toml")
+        );
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn should_append_tuicr_config_toml_suffix() {
+        let path = config_path_from_parts(
+            Some(PathBuf::from("/tmp/xdg-config")),
+            Some(PathBuf::from("/tmp/home")),
+            None,
+        )
+        .expect("config path should resolve");
+
+        assert!(path.ends_with(Path::new("tuicr").join("config.toml")));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn should_use_windows_appdata_base_dir() {
+        let path = config_path_from_parts(
+            Some(PathBuf::from(r"C:\xdg\ignored")),
+            Some(PathBuf::from(r"C:\Users\tester")),
+            Some(PathBuf::from(r"C:\Users\tester\AppData\Roaming")),
+        )
+        .expect("config path should resolve");
+
+        assert_eq!(
+            path,
+            PathBuf::from(r"C:\Users\tester\AppData\Roaming\tuicr\config.toml")
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod config;
 mod error;
 mod handler;
 mod input;
@@ -37,7 +38,7 @@ use handler::{
     handle_search_action, handle_visual_action,
 };
 use input::{Action, map_key_to_action};
-use theme::{parse_cli_args, resolve_theme};
+use theme::{parse_cli_args, resolve_theme_with_config};
 
 /// Timeout for the "press Ctrl+C again to exit" feature
 const CTRL_C_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -58,7 +59,19 @@ fn main() -> anyhow::Result<()> {
     // Parse CLI arguments and resolve theme
     // This also configures syntax highlighting colors before diff parsing
     let cli_args = parse_cli_args();
-    let theme = resolve_theme(cli_args.theme);
+    let mut startup_warnings = Vec::new();
+    let config = match config::load_config() {
+        Ok(config) => config,
+        Err(e) => {
+            startup_warnings.push(format!("Failed to load config: {e}"));
+            None
+        }
+    };
+    let (theme, theme_warnings) = resolve_theme_with_config(
+        cli_args.theme,
+        config.as_ref().and_then(|cfg| cfg.theme.as_deref()),
+    );
+    startup_warnings.extend(theme_warnings);
 
     // Start update check in background (non-blocking)
     let update_rx = if !cli_args.no_update_check {
@@ -80,6 +93,9 @@ fn main() -> anyhow::Result<()> {
     ) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
+            if let Some(message) = startup_warnings.first() {
+                app.set_warning(message.clone());
+            }
             app
         }
         Err(e) => {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -7,6 +7,7 @@ use std::sync::OnceLock;
 use ratatui::style::Color;
 use two_face::theme::EmbeddedThemeName;
 
+use crate::config::config_path_hint;
 use crate::syntax::SyntaxHighlighter;
 
 /// Complete color theme for the application
@@ -15,6 +16,7 @@ pub struct Theme {
     highlighter: OnceLock<SyntaxHighlighter>,
 
     // Base colors
+    pub panel_bg: Color,
     pub bg_highlight: Color,
     pub fg_primary: Color,
     pub fg_secondary: Color,
@@ -57,6 +59,17 @@ pub struct Theme {
     pub border_unfocused: Color,
     pub status_bar_bg: Color,
     pub cursor_color: Color,
+    pub help_indicator: Color,
+
+    // Message/update badge colors
+    pub message_info_fg: Color,
+    pub message_info_bg: Color,
+    pub message_warning_fg: Color,
+    pub message_warning_bg: Color,
+    pub message_error_fg: Color,
+    pub message_error_bg: Color,
+    pub update_badge_fg: Color,
+    pub update_badge_bg: Color,
 
     // Mode indicator colors
     pub mode_fg: Color,
@@ -76,6 +89,7 @@ impl Theme {
             highlighter: OnceLock::new(),
 
             // Base colors
+            panel_bg: Color::Rgb(24, 24, 28),
             bg_highlight: Color::Rgb(70, 70, 70),
             fg_primary: Color::White,
             fg_secondary: Color::Rgb(210, 210, 210),
@@ -118,6 +132,17 @@ impl Theme {
             border_unfocused: Color::Rgb(110, 110, 110),
             status_bar_bg: Color::Rgb(30, 30, 30),
             cursor_color: Color::Rgb(255, 210, 90),
+            help_indicator: Color::Rgb(110, 110, 110),
+
+            // Message/update badge colors
+            message_info_fg: Color::Black,
+            message_info_bg: Color::Cyan,
+            message_warning_fg: Color::Black,
+            message_warning_bg: Color::Rgb(255, 210, 90),
+            message_error_fg: Color::White,
+            message_error_bg: Color::Rgb(240, 90, 90),
+            update_badge_fg: Color::Black,
+            update_badge_bg: Color::Rgb(255, 210, 90),
 
             // Mode indicator colors
             mode_fg: Color::Black,
@@ -131,6 +156,7 @@ impl Theme {
             highlighter: OnceLock::new(),
 
             // Base colors - dark text on light background
+            panel_bg: Color::Rgb(245, 243, 232),
             bg_highlight: Color::Rgb(200, 200, 220),
             fg_primary: Color::Rgb(0, 0, 0),
             fg_secondary: Color::Rgb(30, 30, 30),
@@ -174,26 +200,262 @@ impl Theme {
             border_unfocused: Color::Rgb(100, 100, 100),
             status_bar_bg: Color::Rgb(210, 210, 220),
             cursor_color: Color::Rgb(140, 80, 0),
+            help_indicator: Color::Rgb(90, 90, 90),
+
+            // Message/update badge colors
+            message_info_fg: Color::Black,
+            message_info_bg: Color::Rgb(140, 220, 255),
+            message_warning_fg: Color::Black,
+            message_warning_bg: Color::Rgb(240, 210, 150),
+            message_error_fg: Color::White,
+            message_error_bg: Color::Rgb(180, 60, 60),
+            update_badge_fg: Color::Black,
+            update_badge_bg: Color::Rgb(240, 210, 150),
 
             // Mode indicator colors
             mode_fg: Color::White,
             mode_bg: Color::Rgb(0, 80, 160),
         }
     }
+
+    pub fn catppuccin_latte() -> Self {
+        let flavor = CatppuccinFlavor {
+            dark: false,
+            text: rgb(76, 79, 105),
+            subtext1: rgb(92, 95, 119),
+            overlay1: rgb(140, 143, 161),
+            overlay0: rgb(156, 160, 176),
+            surface2: rgb(172, 176, 190),
+            surface1: rgb(188, 192, 204),
+            base: rgb(239, 241, 245),
+            mantle: rgb(230, 233, 239),
+            crust: rgb(220, 224, 232),
+            red: rgb(210, 15, 57),
+            yellow: rgb(223, 142, 29),
+            green: rgb(64, 160, 43),
+            teal: rgb(23, 146, 153),
+            blue: rgb(30, 102, 245),
+            lavender: rgb(114, 135, 253),
+            peach: rgb(254, 100, 11),
+            pink: rgb(234, 118, 203),
+        };
+        catppuccin_theme(flavor, EmbeddedThemeName::CatppuccinLatte)
+    }
+
+    pub fn catppuccin_frappe() -> Self {
+        let flavor = CatppuccinFlavor {
+            dark: true,
+            text: rgb(198, 208, 245),
+            subtext1: rgb(181, 191, 226),
+            overlay1: rgb(131, 139, 167),
+            overlay0: rgb(115, 121, 148),
+            surface2: rgb(98, 104, 128),
+            surface1: rgb(81, 87, 109),
+            base: rgb(48, 52, 70),
+            mantle: rgb(41, 44, 60),
+            crust: rgb(35, 38, 52),
+            red: rgb(231, 130, 132),
+            yellow: rgb(229, 200, 144),
+            green: rgb(166, 209, 137),
+            teal: rgb(129, 200, 190),
+            blue: rgb(140, 170, 238),
+            lavender: rgb(186, 187, 241),
+            peach: rgb(239, 159, 118),
+            pink: rgb(244, 184, 228),
+        };
+        catppuccin_theme(flavor, EmbeddedThemeName::CatppuccinFrappe)
+    }
+
+    pub fn catppuccin_macchiato() -> Self {
+        let flavor = CatppuccinFlavor {
+            dark: true,
+            text: rgb(202, 211, 245),
+            subtext1: rgb(184, 192, 224),
+            overlay1: rgb(128, 135, 162),
+            overlay0: rgb(110, 115, 141),
+            surface2: rgb(91, 96, 120),
+            surface1: rgb(73, 77, 100),
+            base: rgb(36, 39, 58),
+            mantle: rgb(30, 32, 48),
+            crust: rgb(24, 25, 38),
+            red: rgb(237, 135, 150),
+            yellow: rgb(238, 212, 159),
+            green: rgb(166, 218, 149),
+            teal: rgb(139, 213, 202),
+            blue: rgb(138, 173, 244),
+            lavender: rgb(183, 189, 248),
+            peach: rgb(245, 169, 127),
+            pink: rgb(245, 189, 230),
+        };
+        catppuccin_theme(flavor, EmbeddedThemeName::CatppuccinMacchiato)
+    }
+
+    pub fn catppuccin_mocha() -> Self {
+        let flavor = CatppuccinFlavor {
+            dark: true,
+            text: rgb(205, 214, 244),
+            subtext1: rgb(186, 194, 222),
+            overlay1: rgb(127, 132, 156),
+            overlay0: rgb(108, 112, 134),
+            surface2: rgb(88, 91, 112),
+            surface1: rgb(69, 71, 90),
+            base: rgb(30, 30, 46),
+            mantle: rgb(24, 24, 37),
+            crust: rgb(17, 17, 27),
+            red: rgb(243, 139, 168),
+            yellow: rgb(249, 226, 175),
+            green: rgb(166, 227, 161),
+            teal: rgb(148, 226, 213),
+            blue: rgb(137, 180, 250),
+            lavender: rgb(180, 190, 254),
+            peach: rgb(250, 179, 135),
+            pink: rgb(245, 194, 231),
+        };
+        catppuccin_theme(flavor, EmbeddedThemeName::CatppuccinMocha)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct CatppuccinFlavor {
+    dark: bool,
+    text: Color,
+    subtext1: Color,
+    overlay1: Color,
+    overlay0: Color,
+    surface2: Color,
+    surface1: Color,
+    base: Color,
+    mantle: Color,
+    crust: Color,
+    red: Color,
+    yellow: Color,
+    green: Color,
+    teal: Color,
+    blue: Color,
+    lavender: Color,
+    peach: Color,
+    pink: Color,
+}
+
+fn rgb(r: u8, g: u8, b: u8) -> Color {
+    Color::Rgb(r, g, b)
+}
+
+fn blend(base: Color, accent: Color, accent_percent: u8) -> Color {
+    debug_assert!(accent_percent <= 100);
+    match (base, accent) {
+        (Color::Rgb(br, bg, bb), Color::Rgb(ar, ag, ab)) => {
+            let p = u16::from(accent_percent);
+            let inv = 100_u16.saturating_sub(p);
+            let mix =
+                |b: u8, a: u8| -> u8 { ((u16::from(b) * inv + u16::from(a) * p) / 100) as u8 };
+            rgb(mix(br, ar), mix(bg, ag), mix(bb, ab))
+        }
+        _ => accent,
+    }
+}
+
+fn catppuccin_theme(flavor: CatppuccinFlavor, syntect_theme: EmbeddedThemeName) -> Theme {
+    let accent_fg = if flavor.dark {
+        flavor.base
+    } else {
+        flavor.crust
+    };
+    let diff_add_bg = blend(flavor.base, flavor.green, 20);
+    let diff_del_bg = blend(flavor.base, flavor.red, 20);
+    let syntax_add_bg = blend(flavor.base, flavor.green, 16);
+    let syntax_del_bg = blend(flavor.base, flavor.red, 16);
+
+    Theme {
+        highlighter: OnceLock::new(),
+
+        // Base colors
+        panel_bg: flavor.base,
+        bg_highlight: flavor.surface1,
+        fg_primary: flavor.text,
+        fg_secondary: flavor.subtext1,
+        fg_dim: flavor.overlay0,
+
+        // Diff colors
+        diff_add: flavor.green,
+        diff_add_bg,
+        diff_del: flavor.red,
+        diff_del_bg,
+        diff_context: flavor.text,
+        diff_hunk_header: flavor.blue,
+        expanded_context_fg: flavor.overlay1,
+
+        // Syntax highlighting diff backgrounds
+        syntax_add_bg,
+        syntax_del_bg,
+
+        // Syntect theme for syntax highlighting
+        syntect_theme,
+
+        // File status colors
+        file_added: flavor.green,
+        file_modified: flavor.yellow,
+        file_deleted: flavor.red,
+        file_renamed: flavor.pink,
+
+        // Review status colors
+        reviewed: flavor.green,
+        pending: flavor.yellow,
+
+        // Comment type colors
+        comment_note: flavor.blue,
+        comment_suggestion: flavor.teal,
+        comment_issue: flavor.red,
+        comment_praise: flavor.green,
+
+        // UI element colors
+        border_focused: flavor.blue,
+        border_unfocused: flavor.surface2,
+        status_bar_bg: flavor.mantle,
+        cursor_color: flavor.peach,
+        help_indicator: flavor.overlay0,
+
+        // Message/update badge colors
+        message_info_fg: accent_fg,
+        message_info_bg: flavor.teal,
+        message_warning_fg: accent_fg,
+        message_warning_bg: flavor.yellow,
+        message_error_fg: accent_fg,
+        message_error_bg: flavor.red,
+        update_badge_fg: accent_fg,
+        update_badge_bg: flavor.peach,
+
+        // Mode indicator colors
+        mode_fg: accent_fg,
+        mode_bg: flavor.lavender,
+    }
 }
 
 /// Theme selection from CLI argument
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ThemeArg {
     #[default]
     Dark,
     Light,
+    CatppuccinLatte,
+    CatppuccinFrappe,
+    CatppuccinMacchiato,
+    CatppuccinMocha,
 }
+
+const THEME_CHOICES: [(&str, ThemeArg); 6] = [
+    ("dark", ThemeArg::Dark),
+    ("light", ThemeArg::Light),
+    ("catppuccin-latte", ThemeArg::CatppuccinLatte),
+    ("catppuccin-frappe", ThemeArg::CatppuccinFrappe),
+    ("catppuccin-macchiato", ThemeArg::CatppuccinMacchiato),
+    ("catppuccin-mocha", ThemeArg::CatppuccinMocha),
+];
 
 /// CLI arguments parsed from command line
 #[derive(Debug, Clone, Default)]
 pub struct CliArgs {
-    pub theme: ThemeArg,
+    pub theme: Option<ThemeArg>,
     /// Output to stdout instead of clipboard when exporting
     pub output_to_stdout: bool,
     /// Skip checking for updates on startup
@@ -203,12 +465,27 @@ pub struct CliArgs {
 }
 
 impl ThemeArg {
+    fn choices() -> &'static [(&'static str, ThemeArg)] {
+        &THEME_CHOICES
+    }
+
     pub fn from_str(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
-            "dark" => Some(Self::Dark),
-            "light" => Some(Self::Light),
-            _ => None,
-        }
+        let normalized = s.trim().to_ascii_lowercase();
+        Self::choices().iter().find_map(|(name, theme)| {
+            if *name == normalized {
+                Some(*theme)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn valid_values_display() -> String {
+        Self::choices()
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 }
 
@@ -217,7 +494,43 @@ pub fn resolve_theme(arg: ThemeArg) -> Theme {
     match arg {
         ThemeArg::Dark => Theme::dark(),
         ThemeArg::Light => Theme::light(),
+        ThemeArg::CatppuccinLatte => Theme::catppuccin_latte(),
+        ThemeArg::CatppuccinFrappe => Theme::catppuccin_frappe(),
+        ThemeArg::CatppuccinMacchiato => Theme::catppuccin_macchiato(),
+        ThemeArg::CatppuccinMocha => Theme::catppuccin_mocha(),
     }
+}
+
+pub fn resolve_theme_arg_with_config(
+    cli_theme: Option<ThemeArg>,
+    config_theme: Option<&str>,
+) -> (ThemeArg, Vec<String>) {
+    let mut warnings = Vec::new();
+
+    if let Some(theme) = cli_theme {
+        return (theme, warnings);
+    }
+
+    if let Some(config_theme) = config_theme {
+        if let Some(theme) = ThemeArg::from_str(config_theme) {
+            return (theme, warnings);
+        }
+
+        let valid_values = ThemeArg::valid_values_display();
+        warnings.push(format!(
+            "Warning: Unknown theme '{config_theme}' in config, using dark. Valid options: {valid_values}"
+        ));
+    }
+
+    (ThemeArg::Dark, warnings)
+}
+
+pub fn resolve_theme_with_config(
+    cli_theme: Option<ThemeArg>,
+    config_theme: Option<&str>,
+) -> (Theme, Vec<String>) {
+    let (theme_arg, warnings) = resolve_theme_arg_with_config(cli_theme, config_theme);
+    (resolve_theme(theme_arg), warnings)
 }
 
 impl Theme {
@@ -239,6 +552,8 @@ fn print_help() -> ! {
                 .map(|s| s.to_string_lossy().into_owned())
         })
         .unwrap_or_else(|| "tuicr".to_string());
+    let valid_values = ThemeArg::valid_values_display();
+    let config_path = config_path_hint();
     println!(
         "tuicr - Review AI-generated diffs like a GitHub pull request
 
@@ -247,7 +562,8 @@ Usage: {name} [OPTIONS]
 Options:
   -r, --revisions <REVSET>  Commit range/Revset to review (syntax depends on VCS backend)
   --theme <THEME>        Color theme to use [default: dark]
-                         Valid values: dark, light
+                         Valid values: {valid_values}
+                         Precedence: --theme > {config_path} > dark
   --stdout               Output to stdout instead of clipboard when exporting
   --no-update-check      Skip checking for updates on startup
   -h, --help             Print this help message
@@ -264,6 +580,13 @@ Press ? in the application for keybinding help."
 /// handling, we can revisit this decision.
 pub fn parse_cli_args() -> CliArgs {
     let args: Vec<String> = std::env::args().collect();
+    parse_cli_args_from(&args).unwrap_or_else(|err| {
+        eprintln!("Error: {err}");
+        std::process::exit(2);
+    })
+}
+
+fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
     let mut cli_args = CliArgs::default();
 
     for i in 0..args.len() {
@@ -284,25 +607,29 @@ pub fn parse_cli_args() -> CliArgs {
 
         // Handle --theme value
         if args[i] == "--theme" {
-            if let Some(value) = args.get(i + 1) {
-                cli_args.theme = ThemeArg::from_str(value).unwrap_or_else(|| {
-                    eprintln!(
-                        "Warning: Unknown theme '{value}', using dark. Valid options: dark, light"
-                    );
-                    ThemeArg::Dark
-                });
-            } else {
-                eprintln!("Warning: --theme requires a value (dark, light)");
+            let valid_values = ThemeArg::valid_values_display();
+            let value = args
+                .get(i + 1)
+                .ok_or_else(|| format!("--theme requires a value ({valid_values})"))?;
+
+            if value.starts_with('-') {
+                return Err(format!("--theme requires a value ({valid_values})"));
             }
+
+            cli_args.theme = ThemeArg::from_str(value)
+                .ok_or_else(|| format!("Unknown theme '{value}'. Valid options: {valid_values}"))
+                .map(Some)?;
         }
         // Handle --theme=value
         if let Some(value) = args[i].strip_prefix("--theme=") {
-            cli_args.theme = ThemeArg::from_str(value).unwrap_or_else(|| {
-                eprintln!(
-                    "Warning: Unknown theme '{value}', using dark. Valid options: dark, light"
-                );
-                ThemeArg::Dark
-            });
+            let valid_values = ThemeArg::valid_values_display();
+            if value.is_empty() {
+                return Err(format!("--theme requires a value ({valid_values})"));
+            }
+
+            cli_args.theme = ThemeArg::from_str(value)
+                .ok_or_else(|| format!("Unknown theme '{value}'. Valid options: {valid_values}"))
+                .map(Some)?;
         }
 
         // Handle -r / --revisions value
@@ -319,5 +646,160 @@ pub fn parse_cli_args() -> CliArgs {
         }
     }
 
-    cli_args
+    Ok(cli_args)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn parse_for_test(args: &[&str]) -> Result<CliArgs, String> {
+        let args = args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        parse_cli_args_from(&args)
+    }
+
+    #[test]
+    fn should_parse_theme_when_provided() {
+        let parsed = parse_for_test(&["tuicr", "--theme", "light"]).expect("parse should succeed");
+        assert_eq!(parsed.theme, Some(ThemeArg::Light));
+    }
+
+    #[test]
+    fn should_parse_catppuccin_themes() {
+        let parsed = parse_for_test(&["tuicr", "--theme", "catppuccin-mocha"])
+            .expect("parse should succeed");
+        assert_eq!(parsed.theme, Some(ThemeArg::CatppuccinMocha));
+
+        let parsed =
+            parse_for_test(&["tuicr", "--theme=catppuccin-latte"]).expect("parse should succeed");
+        assert_eq!(parsed.theme, Some(ThemeArg::CatppuccinLatte));
+    }
+
+    #[test]
+    fn should_leave_theme_none_when_not_provided() {
+        let parsed = parse_for_test(&["tuicr"]).expect("parse should succeed");
+        assert_eq!(parsed.theme, None);
+    }
+
+    #[test]
+    fn should_error_for_invalid_theme_in_separate_arg() {
+        let err = parse_for_test(&["tuicr", "--theme", "nope"]).expect_err("parse should fail");
+        assert!(err.contains("Unknown theme 'nope'"));
+    }
+
+    #[test]
+    fn should_error_for_invalid_theme_in_equals_arg() {
+        let err = parse_for_test(&["tuicr", "--theme=nope"]).expect_err("parse should fail");
+        assert!(err.contains("Unknown theme 'nope'"));
+    }
+
+    #[test]
+    fn should_error_when_theme_value_missing() {
+        let err = parse_for_test(&["tuicr", "--theme"]).expect_err("parse should fail");
+        assert!(err.contains("--theme requires a value"));
+    }
+
+    #[test]
+    fn should_roundtrip_all_canonical_theme_values() {
+        for (name, expected_theme) in ThemeArg::choices() {
+            assert_eq!(ThemeArg::from_str(name), Some(*expected_theme));
+        }
+    }
+
+    #[test]
+    fn should_have_unique_theme_names_and_variants() {
+        let names: HashSet<&str> = ThemeArg::choices().iter().map(|(name, _)| *name).collect();
+        let variants: HashSet<ThemeArg> = ThemeArg::choices().iter().map(|(_, t)| *t).collect();
+        assert_eq!(names.len(), ThemeArg::choices().len());
+        assert_eq!(variants.len(), ThemeArg::choices().len());
+    }
+
+    #[test]
+    fn should_use_cli_theme_over_config_theme() {
+        let (resolved, warnings) =
+            resolve_theme_arg_with_config(Some(ThemeArg::Light), Some("dark"));
+        assert_eq!(resolved, ThemeArg::Light);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn should_use_config_theme_when_cli_missing() {
+        let (resolved, warnings) = resolve_theme_arg_with_config(None, Some("light"));
+        assert_eq!(resolved, ThemeArg::Light);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn should_fallback_to_dark_and_warn_for_invalid_config_theme() {
+        let (resolved, warnings) = resolve_theme_arg_with_config(None, Some("unknown"));
+        assert_eq!(resolved, ThemeArg::Dark);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("Unknown theme 'unknown'"));
+    }
+
+    #[test]
+    fn should_fallback_to_dark_when_no_theme_is_set() {
+        let (resolved, warnings) = resolve_theme_arg_with_config(None, None);
+        assert_eq!(resolved, ThemeArg::Dark);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn should_use_catppuccin_theme_from_config_when_cli_missing() {
+        let (resolved, warnings) = resolve_theme_arg_with_config(None, Some("catppuccin-fRappe"));
+        assert_eq!(resolved, ThemeArg::CatppuccinFrappe);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn should_resolve_catppuccin_mocha_syntect_theme() {
+        let theme = resolve_theme(ThemeArg::CatppuccinMocha);
+        assert_eq!(theme.syntect_theme, EmbeddedThemeName::CatppuccinMocha);
+    }
+
+    #[test]
+    fn should_resolve_catppuccin_latte_syntect_theme() {
+        let theme = resolve_theme(ThemeArg::CatppuccinLatte);
+        assert_eq!(theme.syntect_theme, EmbeddedThemeName::CatppuccinLatte);
+    }
+
+    #[test]
+    fn should_use_dark_flavor_base_for_catppuccin_mode_foreground() {
+        let theme = Theme::catppuccin_mocha();
+        assert_eq!(theme.mode_fg, Color::Rgb(30, 30, 46));
+    }
+
+    #[test]
+    fn should_use_light_flavor_crust_for_catppuccin_mode_foreground() {
+        let theme = Theme::catppuccin_latte();
+        assert_eq!(theme.mode_fg, Color::Rgb(220, 224, 232));
+    }
+
+    #[test]
+    fn should_blend_to_base_at_zero_percent() {
+        let base = Color::Rgb(10, 20, 30);
+        let accent = Color::Rgb(200, 210, 220);
+        assert_eq!(blend(base, accent, 0), base);
+    }
+
+    #[test]
+    fn should_blend_to_accent_at_hundred_percent() {
+        let base = Color::Rgb(10, 20, 30);
+        let accent = Color::Rgb(200, 210, 220);
+        assert_eq!(blend(base, accent, 100), accent);
+    }
+
+    #[test]
+    fn should_blend_midpoint_with_integer_rounding() {
+        let base = Color::Rgb(0, 10, 20);
+        let accent = Color::Rgb(100, 110, 120);
+        assert_eq!(blend(base, accent, 50), Color::Rgb(50, 60, 70));
+    }
+
+    #[test]
+    fn should_return_accent_for_non_rgb_blend_inputs() {
+        let accent = Color::Rgb(100, 110, 120);
+        assert_eq!(blend(Color::Reset, accent, 50), accent);
+    }
 }

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -14,6 +14,11 @@ use crate::ui::{comment_panel, help_popup, status_bar, styles};
 use crate::vcs::git::calculate_gap;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
+    frame.render_widget(
+        Block::default().style(styles::panel_style(&app.theme)),
+        frame.area(),
+    );
+
     // Special handling for commit selection mode
     if app.input_mode == InputMode::CommitSelect {
         render_commit_select(frame, app);
@@ -81,13 +86,14 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
     // Header
     let header = Paragraph::new(" Select commits to review ")
         .style(styles::header_style(&app.theme))
-        .block(Block::default());
+        .block(Block::default().style(styles::panel_style(&app.theme)));
     frame.render_widget(header, chunks[0]);
 
     // Commit list
     let block = Block::default()
         .title(" Recent Commits ")
         .borders(Borders::ALL)
+        .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, true));
 
     let inner = block.inner(chunks[1]);
@@ -201,7 +207,7 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
         .take(inner.height as usize)
         .collect();
 
-    let list = Paragraph::new(visible_items);
+    let list = Paragraph::new(visible_items).style(styles::panel_style(&app.theme));
     frame.render_widget(list, inner);
 
     // Footer with mode, hints, and right-aligned message
@@ -276,6 +282,7 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .title(" Files ")
         .borders(Borders::ALL)
+        .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
 
     let inner = block.inner(area);
@@ -408,7 +415,9 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    let list = List::new(items).block(block);
+    let list = List::new(items)
+        .style(styles::panel_style(&app.theme))
+        .block(block);
 
     frame.render_stateful_widget(list, area, &mut app.file_list_state.list_state);
 }
@@ -426,6 +435,7 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .title(" Diff (Unified) ")
         .borders(Borders::ALL)
+        .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
 
     let inner = block.inner(area);
@@ -1040,7 +1050,7 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
             .collect()
     };
 
-    let mut diff = Paragraph::new(visible_lines);
+    let mut diff = Paragraph::new(visible_lines).style(styles::panel_style(&app.theme));
     if app.diff_state.wrap_lines {
         diff = diff.wrap(Wrap { trim: false });
     }
@@ -1133,6 +1143,7 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .title(" Diff (Side-by-Side) ")
         .borders(Borders::ALL)
+        .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
 
     let inner = block.inner(area);
@@ -1478,7 +1489,7 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
             .collect()
     };
 
-    let mut diff = Paragraph::new(visible_lines);
+    let mut diff = Paragraph::new(visible_lines).style(styles::panel_style(&app.theme));
     if app.diff_state.wrap_lines {
         diff = diff.wrap(Wrap { trim: false });
     }

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -203,6 +203,7 @@ pub fn render_confirm_dialog(frame: &mut Frame, app: &App, message: &str) {
     let block = Block::default()
         .title(" Confirm ")
         .borders(Borders::ALL)
+        .style(styles::popup_style(theme))
         .border_style(styles::border_style(theme, true));
 
     let inner = block.inner(area);
@@ -220,7 +221,9 @@ pub fn render_confirm_dialog(frame: &mut Frame, app: &App, message: &str) {
         ]),
     ];
 
-    let paragraph = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+    let paragraph = Paragraph::new(lines)
+        .style(styles::popup_style(theme))
+        .alignment(ratatui::layout::Alignment::Center);
     frame.render_widget(paragraph, inner);
 }
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
@@ -19,6 +19,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
     let block = Block::default()
         .title(" Help (j/k to scroll) - Press ? or Esc to close ")
         .borders(Borders::ALL)
+        .style(styles::popup_style(theme))
         .border_style(styles::border_style(theme, true));
 
     let inner = block.inner(area);
@@ -409,11 +410,11 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         .take(viewport_height)
         .collect();
 
-    let paragraph = Paragraph::new(visible_lines);
+    let paragraph = Paragraph::new(visible_lines).style(styles::popup_style(theme));
     frame.render_widget(paragraph, inner);
 
     // Render scroll indicators
-    let indicator_style = Style::default().fg(Color::DarkGray);
+    let indicator_style = styles::help_indicator_style(theme);
 
     if can_scroll_up {
         let up_indicator = Paragraph::new(Line::from(Span::styled("▲ more", indicator_style)));

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Paragraph},
 };
@@ -13,9 +13,9 @@ use crate::ui::styles;
 pub fn build_message_span(message: Option<&Message>, theme: &Theme) -> (Span<'static>, usize) {
     if let Some(msg) = message {
         let (fg, bg) = match msg.message_type {
-            MessageType::Info => (Color::Black, Color::Cyan),
-            MessageType::Warning => (Color::Black, theme.pending),
-            MessageType::Error => (Color::White, theme.comment_issue),
+            MessageType::Info => (theme.message_info_fg, theme.message_info_bg),
+            MessageType::Warning => (theme.message_warning_fg, theme.message_warning_bg),
+            MessageType::Error => (theme.message_error_fg, theme.message_error_bg),
         };
         let content = format!(" {} ", msg.content);
         let width = content.len();
@@ -90,8 +90,8 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
                 Span::styled(
                     text,
                     Style::default()
-                        .fg(Color::Black)
-                        .bg(theme.pending)
+                        .fg(theme.update_badge_fg)
+                        .bg(theme.update_badge_bg)
                         .add_modifier(Modifier::BOLD),
                 ),
                 width,
@@ -103,8 +103,8 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
                 Span::styled(
                     text,
                     Style::default()
-                        .fg(Color::Black)
-                        .bg(theme.pending)
+                        .fg(theme.update_badge_fg)
+                        .bg(theme.update_badge_bg)
                         .add_modifier(Modifier::BOLD),
                 ),
                 width,
@@ -217,4 +217,49 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         .block(Block::default());
 
     frame.render_widget(status, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_message(message_type: MessageType) -> Message {
+        Message {
+            content: "hello".to_string(),
+            message_type,
+        }
+    }
+
+    #[test]
+    fn should_style_info_message_using_theme_fields() {
+        let theme = Theme::dark();
+        let (span, width) = build_message_span(Some(&test_message(MessageType::Info)), &theme);
+        assert_eq!(span.style.fg, Some(theme.message_info_fg));
+        assert_eq!(span.style.bg, Some(theme.message_info_bg));
+        assert_eq!(width, " hello ".len());
+    }
+
+    #[test]
+    fn should_return_empty_span_when_message_is_none() {
+        let theme = Theme::dark();
+        let (span, width) = build_message_span(None, &theme);
+        assert_eq!(span.content.as_ref(), "");
+        assert_eq!(width, 0);
+    }
+
+    #[test]
+    fn should_style_warning_message_using_theme_fields() {
+        let theme = Theme::dark();
+        let (span, _) = build_message_span(Some(&test_message(MessageType::Warning)), &theme);
+        assert_eq!(span.style.fg, Some(theme.message_warning_fg));
+        assert_eq!(span.style.bg, Some(theme.message_warning_bg));
+    }
+
+    #[test]
+    fn should_style_error_message_using_theme_fields() {
+        let theme = Theme::dark();
+        let (span, _) = build_message_span(Some(&test_message(MessageType::Error)), &theme);
+        assert_eq!(span.style.fg, Some(theme.message_error_fg));
+        assert_eq!(span.style.bg, Some(theme.message_error_bg));
+    }
 }

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -4,6 +4,7 @@ use crate::theme::Theme;
 
 pub fn header_style(theme: &Theme) -> Style {
     Style::default()
+        .bg(theme.panel_bg)
         .fg(theme.fg_primary)
         .add_modifier(Modifier::BOLD)
 }
@@ -58,6 +59,14 @@ pub fn border_style(theme: &Theme, focused: bool) -> Style {
     } else {
         Style::default().fg(theme.border_unfocused)
     }
+}
+
+pub fn panel_style(theme: &Theme) -> Style {
+    Style::default().bg(theme.panel_bg).fg(theme.fg_primary)
+}
+
+pub fn popup_style(theme: &Theme) -> Style {
+    panel_style(theme)
 }
 
 pub fn status_bar_style(theme: &Theme) -> Style {
@@ -120,4 +129,8 @@ pub fn comment_border_style(theme: &Theme, comment_type: crate::model::CommentTy
 
 pub fn visual_selection_style(theme: &Theme) -> Style {
     Style::default().bg(theme.bg_highlight)
+}
+
+pub fn help_indicator_style(theme: &Theme) -> Style {
+    Style::default().fg(theme.help_indicator).bg(theme.panel_bg)
 }


### PR DESCRIPTION
Closes #131

Hey! Here's the PR we talked about in that issue. I went with TOML for the config since you mentioned you preferred that over JSON. The config file lives in the standard XDG path (`~/.config/tuicr/config.toml`) on Linux/macOS and `%APPDATA%\tuicr\config.toml` on Windows, like we discussed.

Right now the only config option is `theme`, but the structure is there for adding more stuff down the road. I had to redo this from scratch since my earlier approach didn't really fit with the current codebase, but I think it came out cleaner this time around.

Here's what's in here:

- New `src/config/mod.rs` module for finding and loading the TOML config
- Four Catppuccin themes: latte, frappe, macchiato, mocha
- `--theme` flag now accepts the new theme names alongside the existing dark/light ones
- Theme resolution: CLI flag beats config file, config file beats the default (dark)
- Added new color fields to the Theme struct so message badges, status indicators, help text, and panel backgrounds are all theme-aware now
- All panels and popups use the theme's panel background color instead of relying on terminal defaults, so everything looks consistent
- Tests for config loading and theme resolution
- Updated the README with config docs

Only new dependency is the `toml` crate.

Invalid theme names on the CLI cause an immediate exit with an error, and unknown keys in config.toml are rejected too, so nothing fails silently. I tested across iTerm2, Kitty, and Alacritty and it looks good on all of them.