### PR TITLE
fix(config): ignore unknown keys while preserving known settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ src/
 
 ### Data Flow
 
-1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), reject unknown config keys, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), then enters commit selection mode by default. If uncommitted changes exist, the first selection row is "Uncommitted changes". With `-r/--revisions`, it opens the requested commit range directly.
+1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), ignore unknown config keys with startup warnings, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), then enters commit selection mode by default. If uncommitted changes exist, the first selection row is "Uncommitted changes". With `-r/--revisions`, it opens the requested commit range directly.
 2. **Render**: `ui::render()` draws the TUI based on `App` state
 3. **Input**: `crossterm` events → `map_key_to_action` → match on Action in main loop
 4. **Persistence**: `:w` calls `save_session()`, writes JSON to `~/.local/share/tuicr/reviews/`

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Theme resolution precedence:
 
 Notes:
 - Invalid `--theme` values cause an immediate non-zero exit.
-- Unknown keys in `config.toml` are rejected.
+- Unknown keys in `config.toml` are ignored with a startup warning.
 
 ### Keybindings
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,12 +3,19 @@ use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use toml::Value;
 
-#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
-#[serde(default, deny_unknown_fields)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
 pub struct AppConfig {
     pub theme: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ConfigLoadOutcome {
+    pub config: Option<AppConfig>,
+    pub warnings: Vec<String>,
 }
 
 pub fn config_path() -> Result<PathBuf> {
@@ -57,19 +64,45 @@ fn config_path_from_parts(
     }
 }
 
-pub fn load_config() -> Result<Option<AppConfig>> {
+pub fn load_config() -> Result<ConfigLoadOutcome> {
     let path = config_path()?;
     load_config_from_path(&path)
 }
 
-fn load_config_from_path(path: &Path) -> Result<Option<AppConfig>> {
+fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
     let contents = match fs::read_to_string(path) {
         Ok(contents) => contents,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(ConfigLoadOutcome::default()),
         Err(err) => return Err(err.into()),
     };
-    let config = toml::from_str::<AppConfig>(&contents)?;
-    Ok(Some(config))
+
+    let value: Value = toml::from_str(&contents)?;
+    let table = value
+        .as_table()
+        .ok_or_else(|| anyhow!("Config root must be a TOML table"))?;
+
+    let mut config = AppConfig::default();
+    let mut warnings = Vec::new();
+
+    if let Some(theme) = table.get("theme") {
+        if let Some(theme_str) = theme.as_str() {
+            config.theme = Some(theme_str.to_string());
+        } else {
+            warnings
+                .push("Warning: Config key 'theme' must be a string; ignoring value".to_string());
+        }
+    }
+
+    for key in table.keys() {
+        if key != "theme" {
+            warnings.push(format!("Warning: Unknown config key '{key}', ignoring"));
+        }
+    }
+
+    Ok(ConfigLoadOutcome {
+        config: Some(config),
+        warnings,
+    })
 }
 
 #[cfg(test)]
@@ -81,8 +114,9 @@ mod tests {
     fn should_return_none_when_config_file_missing() {
         let dir = tempdir().expect("failed to create temp dir");
         let path = dir.path().join("config.toml");
-        let config = load_config_from_path(&path).expect("missing config should not fail");
-        assert!(config.is_none());
+        let outcome = load_config_from_path(&path).expect("missing config should not fail");
+        assert_eq!(outcome.config, None);
+        assert!(outcome.warnings.is_empty());
     }
 
     #[test]
@@ -91,10 +125,12 @@ mod tests {
         let path = dir.path().join("config.toml");
         fs::write(&path, "theme = \"light\"\n").expect("failed to write config");
 
-        let config = load_config_from_path(&path)
-            .expect("valid config should parse")
-            .expect("config should exist");
-        assert_eq!(config.theme.as_deref(), Some("light"));
+        let outcome = load_config_from_path(&path).expect("valid config should parse");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.theme.as_deref()),
+            Some("light")
+        );
+        assert!(outcome.warnings.is_empty());
     }
 
     #[test]
@@ -103,10 +139,9 @@ mod tests {
         let path = dir.path().join("config.toml");
         fs::write(&path, "").expect("failed to write config");
 
-        let config = load_config_from_path(&path)
-            .expect("empty config should parse")
-            .expect("config should exist");
-        assert_eq!(config, AppConfig::default());
+        let outcome = load_config_from_path(&path).expect("empty config should parse");
+        assert_eq!(outcome.config, Some(AppConfig::default()));
+        assert!(outcome.warnings.is_empty());
     }
 
     #[test]
@@ -120,13 +155,51 @@ mod tests {
     }
 
     #[test]
-    fn should_error_on_unknown_keys() {
+    fn should_warn_on_unknown_keys_and_keep_known_values() {
         let dir = tempdir().expect("failed to create temp dir");
         let path = dir.path().join("config.toml");
-        fs::write(&path, "themes = \"light\"\n").expect("failed to write config");
+        fs::write(&path, "theme = \"light\"\nthemes = \"typo\"\n").expect("failed to write config");
 
-        let result = load_config_from_path(&path);
-        assert!(result.is_err(), "unknown keys should return error");
+        let outcome = load_config_from_path(&path).expect("config should parse");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.theme.as_deref()),
+            Some("light")
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Unknown config key 'themes', ignoring"
+        );
+    }
+
+    #[test]
+    fn should_warn_on_unknown_keys_only_and_use_defaults() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "themes = \"typo\"\n").expect("failed to write config");
+
+        let outcome = load_config_from_path(&path).expect("config should parse");
+        assert_eq!(outcome.config, Some(AppConfig::default()));
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Unknown config key 'themes', ignoring"
+        );
+    }
+
+    #[test]
+    fn should_warn_and_ignore_theme_with_invalid_type() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "theme = 123\n").expect("failed to write config");
+
+        let outcome = load_config_from_path(&path).expect("config should parse");
+        assert_eq!(outcome.config, Some(AppConfig::default()));
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'theme' must be a string; ignoring value"
+        );
     }
 
     #[cfg(not(windows))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,16 +60,20 @@ fn main() -> anyhow::Result<()> {
     // This also configures syntax highlighting colors before diff parsing
     let cli_args = parse_cli_args();
     let mut startup_warnings = Vec::new();
-    let config = match config::load_config() {
-        Ok(config) => config,
+    let config_outcome = match config::load_config() {
+        Ok(outcome) => outcome,
         Err(e) => {
             startup_warnings.push(format!("Failed to load config: {e}"));
-            None
+            config::ConfigLoadOutcome::default()
         }
     };
+    startup_warnings.extend(config_outcome.warnings);
     let (theme, theme_warnings) = resolve_theme_with_config(
         cli_args.theme,
-        config.as_ref().and_then(|cfg| cfg.theme.as_deref()),
+        config_outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.theme.as_deref()),
     );
     startup_warnings.extend(theme_warnings);
 


### PR DESCRIPTION
Hey, I put together a follow up for the config parsing behavior from #162.

Right now an unknown key can cause us to throw out the whole config file, so I changed the loader to parse known keys and ignore unknown keys with a startup warning.

In this change I removed strict unknown field rejection, parse the config table manually, keep valid known keys like theme, and collect warnings for unknown keys or invalid types. I also wired those config warnings into the existing startup warning flow in main so users still get feedback.

I updated the docs in README and AGENTS to match the new behavior.

I also added tests for mixed known and unknown keys, unknown only configs, invalid theme type, and kept the existing malformed TOML behavior as an error. I ran cargo test and everything passes locally as well as doing some light manual QA. 