### PR TITLE
Feat: Add PR mode to review branch-level diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | Flag | Description |
 |------|-------------|
 | `-r` / `--revisions <REVSET>` | Commit range/Revision set to review. Exact syntax depends on VCS backend (Git, JJ, Hg) |
+| `--pr` | Review branch changes as a PR diff (`merge-base(base, HEAD)..HEAD`) |
+| `--base <REF>` | Base ref for PR mode (implies `--pr`), for example `origin/main` |
 | `--theme <THEME>` | Color theme override (`dark`, `light`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`) |
 | `--stdout` | Output to stdout instead of clipboard when exporting |
 | `--no-update-check` | Skip checking for updates on startup |
@@ -98,6 +100,8 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 By default, `tuicr` starts in commit selection mode.  
 If uncommitted changes exist, the first selectable entry is `Uncommitted changes`.  
 When `-r` / `--revisions` is provided, `tuicr` opens that revision range directly.
+
+In PR mode, `tuicr` opens a single combined diff from merge-base to `HEAD`, so merge commits are not shown as standalone review units.
 
 ### Configuration
 
@@ -202,6 +206,7 @@ Notes:
 | `:clip` (`:export`) | Copy review to clipboard |
 | `:diff` | Toggle diff view (unified / side-by-side) |
 | `:commits` | Select commits to review |
+| `:pr [base-ref]` | Load PR diff mode (optional base ref override) |
 | `:set wrap` | Enable line wrap in diff view |
 | `:set wrap!` | Toggle line wrap in diff view |
 | `:set commits` | Show inline commit selector |

--- a/src/app.rs
+++ b/src/app.rs
@@ -666,7 +666,8 @@ impl App {
             }
             DiffSource::WorkingTreeAndCommits(commit_ids) => {
                 let ids = commit_ids.clone();
-                self.vcs.get_working_tree_with_commits_diff(&ids, highlighter)?
+                self.vcs
+                    .get_working_tree_with_commits_diff(&ids, highlighter)?
             }
             DiffSource::PullRequest { base_ref, .. } => {
                 let pr_diff = self

--- a/src/app.rs
+++ b/src/app.rs
@@ -670,9 +670,10 @@ impl App {
                     .get_working_tree_with_commits_diff(&ids, highlighter)?
             }
             DiffSource::PullRequest { base_ref, .. } => {
+                let base = base_ref.clone();
                 let pr_diff = self
                     .vcs
-                    .get_pull_request_diff(Some(base_ref.as_str()), highlighter)?;
+                    .get_pull_request_diff(Some(base.as_str()), highlighter)?;
                 self.diff_source = DiffSource::PullRequest {
                     base_ref: pr_diff.info.base_ref,
                     merge_base_commit: pr_diff.info.merge_base_commit,

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,6 +94,8 @@ fn main() -> anyhow::Result<()> {
         theme,
         cli_args.output_to_stdout,
         cli_args.revisions.as_deref(),
+        cli_args.pr_mode,
+        cli_args.pr_base_ref.as_deref(),
     ) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
@@ -104,9 +106,16 @@ fn main() -> anyhow::Result<()> {
         }
         Err(e) => {
             eprintln!("Error: {e}");
-            eprintln!(
-                "\nMake sure you're in a git, jujutsu, or mercurial repository with commits or uncommitted changes."
-            );
+            if cli_args.pr_mode {
+                eprintln!(
+                    "\nPR mode requires a git repository with commits ahead of the selected base ref."
+                );
+                eprintln!("Try: tuicr --pr --base origin/main");
+            } else {
+                eprintln!(
+                    "\nMake sure you're in a git, jujutsu, or mercurial repository with commits or uncommitted changes."
+                );
+            }
             std::process::exit(1);
         }
     };

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 use std::io::Write as IoWrite;
 
 use arboard::Clipboard;
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
 use crate::app::DiffSource;
 use crate::error::{Result, TuicrError};

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 use std::io::Write as IoWrite;
 
 use arboard::Clipboard;
-use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 
 use crate::app::DiffSource;
 use crate::error::{Result, TuicrError};
@@ -145,6 +145,26 @@ fn generate_markdown(session: &ReviewSession, diff_source: &DiffSource) -> Strin
                 md,
                 "Reviewing working tree + commits: {}",
                 short_ids.join(", ")
+            );
+            let _ = writeln!(md);
+        }
+        DiffSource::PullRequest {
+            base_ref,
+            merge_base_commit,
+            head_commit,
+            commit_count,
+        } => {
+            let _ = writeln!(
+                md,
+                "Reviewing PR diff: {}...{} ({} commits)",
+                base_ref,
+                &head_commit[..7.min(head_commit.len())],
+                commit_count
+            );
+            let _ = writeln!(
+                md,
+                "Merge base: {}",
+                &merge_base_commit[..7.min(merge_base_commit.len())]
             );
             let _ = writeln!(md);
         }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -599,62 +599,87 @@ pub fn parse_cli_args() -> CliArgs {
 fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
     let mut cli_args = CliArgs::default();
 
-    for i in 0..args.len() {
-        // Handle --help / -h
-        if args[i] == "--help" || args[i] == "-h" {
-            print_help();
-        }
+    let mut i = if args.is_empty() { 0 } else { 1 };
+    while i < args.len() {
+        let arg = &args[i];
 
-        // Handle --stdout
-        if args[i] == "--stdout" {
-            cli_args.output_to_stdout = true;
-        }
-
-        // Handle --no-update-check
-        if args[i] == "--no-update-check" {
-            cli_args.no_update_check = true;
-        }
-
-        if args[i] == "--pr" {
-            cli_args.pr_mode = true;
-        }
-
-        if args[i] == "--base" {
-            let value = args
-                .get(i + 1)
-                .ok_or_else(|| "--base requires a value".to_string())?;
-            if value.starts_with('-') {
-                return Err("--base requires a value".to_string());
+        match arg.as_str() {
+            "--help" | "-h" => print_help(),
+            "--stdout" => {
+                cli_args.output_to_stdout = true;
+                i += 1;
+                continue;
             }
-            cli_args.pr_mode = true;
-            cli_args.pr_base_ref = Some(value.clone());
+            "--no-update-check" => {
+                cli_args.no_update_check = true;
+                i += 1;
+                continue;
+            }
+            "--pr" => {
+                cli_args.pr_mode = true;
+                i += 1;
+                continue;
+            }
+            "--base" => {
+                let value = args
+                    .get(i + 1)
+                    .ok_or_else(|| "--base requires a value".to_string())?;
+                if value.starts_with('-') {
+                    return Err("--base requires a value".to_string());
+                }
+                cli_args.pr_mode = true;
+                cli_args.pr_base_ref = Some(value.clone());
+                i += 2;
+                continue;
+            }
+            "--theme" => {
+                let valid_values = ThemeArg::valid_values_display();
+                let value = args
+                    .get(i + 1)
+                    .ok_or_else(|| format!("--theme requires a value ({valid_values})"))?;
+
+                if value.starts_with('-') {
+                    return Err(format!("--theme requires a value ({valid_values})"));
+                }
+
+                cli_args.theme = ThemeArg::from_str(value)
+                    .ok_or_else(|| {
+                        format!("Unknown theme '{value}'. Valid options: {valid_values}")
+                    })
+                    .map(Some)?;
+                i += 2;
+                continue;
+            }
+            "-r" | "--revisions" => {
+                if let Some(value) = args.get(i + 1) {
+                    if value.starts_with('-') {
+                        eprintln!("Warning: {arg} requires a value");
+                        i += 1;
+                        continue;
+                    }
+                    cli_args.revisions = Some(value.clone());
+                    i += 2;
+                    continue;
+                }
+
+                eprintln!("Warning: {arg} requires a value");
+                i += 1;
+                continue;
+            }
+            _ => {}
         }
 
-        if let Some(value) = args[i].strip_prefix("--base=") {
+        if let Some(value) = arg.strip_prefix("--base=") {
             if value.is_empty() {
                 return Err("--base requires a value".to_string());
             }
             cli_args.pr_mode = true;
             cli_args.pr_base_ref = Some(value.to_string());
+            i += 1;
+            continue;
         }
 
-        // Handle --theme value
-        if args[i] == "--theme" {
-            let valid_values = ThemeArg::valid_values_display();
-            let value = args
-                .get(i + 1)
-                .ok_or_else(|| format!("--theme requires a value ({valid_values})"))?;
-
-            if value.starts_with('-') {
-                return Err(format!("--theme requires a value ({valid_values})"));
-            }
-
-            cli_args.theme = ThemeArg::from_str(value)
-                .ok_or_else(|| format!("Unknown theme '{value}'. Valid options: {valid_values}"))
-                .map(Some)?;
-        }
-        // Handle --theme=value
-        if let Some(value) = args[i].strip_prefix("--theme=") {
+        if let Some(value) = arg.strip_prefix("--theme=") {
             let valid_values = ThemeArg::valid_values_display();
             if value.is_empty() {
                 return Err(format!("--theme requires a value ({valid_values})"));
@@ -663,20 +688,23 @@ fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
             cli_args.theme = ThemeArg::from_str(value)
                 .ok_or_else(|| format!("Unknown theme '{value}'. Valid options: {valid_values}"))
                 .map(Some)?;
+            i += 1;
+            continue;
         }
 
-        // Handle -r / --revisions value
-        if args[i] == "-r" || args[i] == "--revisions" {
-            if let Some(value) = args.get(i + 1) {
-                cli_args.revisions = Some(value.clone());
-            } else {
-                eprintln!("Warning: {0} requires a value", args[i]);
-            }
-        }
-        // Handle --revisions=value
-        if let Some(value) = args[i].strip_prefix("--revisions=") {
+        if let Some(value) = arg.strip_prefix("--revisions=") {
             cli_args.revisions = Some(value.to_string());
+            i += 1;
+            continue;
         }
+
+        if arg.starts_with('-') {
+            return Err(format!("Unknown option '{arg}'. Use --help for usage."));
+        }
+
+        return Err(format!(
+            "Unexpected argument '{arg}'. Use --help for usage."
+        ));
     }
 
     if cli_args.pr_mode && cli_args.revisions.is_some() {
@@ -791,6 +819,21 @@ mod tests {
         let err = parse_for_test(&["tuicr", "--base", "origin/main", "-r", "HEAD~3..HEAD"])
             .expect_err("parse should fail");
         assert!(err.contains("--pr/--base cannot be combined with --revisions"));
+    }
+
+    #[test]
+    fn should_error_for_unknown_option() {
+        let err = parse_for_test(&["tuicr", "--fmt"]).expect_err("parse should fail");
+        assert!(err.contains("Unknown option '--fmt'"));
+    }
+
+    #[test]
+    fn should_not_treat_consumed_option_value_as_argument() {
+        let parsed = parse_for_test(&["tuicr", "--base", "origin/main", "--stdout"])
+            .expect("parse should succeed");
+        assert!(parsed.pr_mode);
+        assert_eq!(parsed.pr_base_ref.as_deref(), Some("origin/main"));
+        assert!(parsed.output_to_stdout);
     }
 
     #[test]

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
 };
 
 use crate::app::App;
@@ -412,10 +412,10 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
-                "  :pr [base]",
+                "  :pr [base]   ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Load PR diff from merge-base to HEAD"),
+            Span::raw("  Load PR diff from merge-base to HEAD"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -412,6 +412,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  :pr [base]",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Load PR diff from merge-base to HEAD"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  :clear    ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -1,9 +1,9 @@
 use ratatui::{
+    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
-    Frame,
 };
 
 use crate::app::App;

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Paragraph},
+    Frame,
 };
 
 use crate::app::{App, DiffSource, InputMode, Message, MessageType};
@@ -77,6 +77,15 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
         }
         DiffSource::WorkingTreeAndCommits(commits) => {
             format!("[worktree + {} commits] ", commits.len())
+        }
+        DiffSource::PullRequest {
+            base_ref,
+            merge_base_commit,
+            commit_count,
+            ..
+        } => {
+            let short_merge_base = &merge_base_commit[..7.min(merge_base_commit.len())];
+            format!("[pr {base_ref}..{short_merge_base} ({commit_count} commits)] ")
         }
     };
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,9 +1,9 @@
 use ratatui::{
+    Frame,
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Paragraph},
-    Frame,
 };
 
 use crate::app::{App, DiffSource, InputMode, Message, MessageType};

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Paragraph},
+    Frame,
 };
 
 use crate::app::{App, DiffSource, InputMode, Message, MessageType};
@@ -80,12 +80,12 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
         }
         DiffSource::PullRequest {
             base_ref,
-            merge_base_commit,
+            head_commit,
             commit_count,
             ..
         } => {
-            let short_merge_base = &merge_base_commit[..7.min(merge_base_commit.len())];
-            format!("[pr {base_ref}..{short_merge_base} ({commit_count} commits)] ")
+            let short_head = &head_commit[..7.min(head_commit.len())];
+            format!("[pr {base_ref}..{short_head} ({commit_count} commits)] ")
         }
     };
 

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,9 +1,10 @@
-use git2::{Delta, Diff, DiffOptions, Repository};
+use git2::{BranchType, Delta, Diff, DiffOptions, Oid, Repository};
 use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
+use crate::vcs::{PullRequestDiff, PullRequestInfo};
 
 pub fn get_working_tree_diff(
     repo: &Repository,
@@ -85,6 +86,103 @@ pub fn get_working_tree_with_commits_diff(
     let diff = repo.diff_tree_to_workdir_with_index(old_tree.as_ref(), Some(&mut opts))?;
 
     parse_diff(&diff, highlighter)
+}
+
+/// Get a PR-style diff from merge-base(base_ref, HEAD) to HEAD.
+pub fn get_pull_request_diff(
+    repo: &Repository,
+    base_ref: Option<&str>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<PullRequestDiff> {
+    let head_commit = repo.head()?.peel_to_commit()?;
+    let head_oid = head_commit.id();
+    let head_tree = head_commit.tree()?;
+
+    let (resolved_base_ref, base_oid) = resolve_base_reference(repo, base_ref)?;
+    let merge_base_oid = repo.merge_base(base_oid, head_oid).map_err(|_| {
+        TuicrError::VcsCommand(format!(
+            "Failed to find merge-base between {resolved_base_ref} and HEAD"
+        ))
+    })?;
+
+    if merge_base_oid == head_oid {
+        return Err(TuicrError::NoChanges);
+    }
+
+    let merge_base_commit = repo.find_commit(merge_base_oid)?;
+    let merge_base_tree = merge_base_commit.tree()?;
+    let diff = repo.diff_tree_to_tree(Some(&merge_base_tree), Some(&head_tree), None)?;
+    let files = parse_diff(&diff, highlighter)?;
+
+    let commit_count = count_commits_between(repo, merge_base_oid, head_oid)?;
+
+    Ok(PullRequestDiff {
+        files,
+        info: PullRequestInfo {
+            base_ref: resolved_base_ref,
+            merge_base_commit: merge_base_oid.to_string(),
+            head_commit: head_oid.to_string(),
+            commit_count,
+        },
+    })
+}
+
+fn count_commits_between(repo: &Repository, merge_base_oid: Oid, head_oid: Oid) -> Result<usize> {
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(head_oid)?;
+    revwalk.hide(merge_base_oid)?;
+
+    let mut count = 0;
+    for oid_result in revwalk {
+        oid_result?;
+        count += 1;
+    }
+
+    Ok(count)
+}
+
+fn resolve_base_reference(repo: &Repository, explicit_base: Option<&str>) -> Result<(String, Oid)> {
+    if let Some(base_ref) = explicit_base {
+        let oid = resolve_ref_to_oid(repo, base_ref).map_err(|_| {
+            TuicrError::VcsCommand(format!("Could not resolve base reference '{base_ref}'"))
+        })?;
+        return Ok((base_ref.to_string(), oid));
+    }
+
+    if let Ok(head) = repo.head()
+        && head.is_branch()
+        && let Some(branch_name) = head.shorthand()
+        && let Ok(branch) = repo.find_branch(branch_name, BranchType::Local)
+        && let Ok(upstream) = branch.upstream()
+        && let Some(upstream_ref_name) = upstream.get().name()
+        && let Ok(oid) = resolve_ref_to_oid(repo, upstream_ref_name)
+    {
+        return Ok((upstream_ref_name.to_string(), oid));
+    }
+
+    if let Ok(origin_head) = repo.find_reference("refs/remotes/origin/HEAD")
+        && let Some(target) = origin_head.symbolic_target()
+        && let Ok(oid) = resolve_ref_to_oid(repo, target)
+    {
+        return Ok((target.to_string(), oid));
+    }
+
+    for candidate in ["origin/main", "origin/master", "main", "master"] {
+        if let Ok(oid) = resolve_ref_to_oid(repo, candidate) {
+            return Ok((candidate.to_string(), oid));
+        }
+    }
+
+    Err(TuicrError::VcsCommand(
+        "Could not determine PR base reference. Set an upstream branch or pass --base <ref>."
+            .to_string(),
+    ))
+}
+
+fn resolve_ref_to_oid(repo: &Repository, reference: &str) -> Result<Oid> {
+    let object = repo.revparse_single(reference)?;
+    let commit = object.peel_to_commit()?;
+    Ok(commit.id())
 }
 
 fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -160,7 +160,10 @@ fn resolve_base_reference(repo: &Repository, explicit_base: Option<&str>) -> Res
         // Skip if the upstream is just the remote copy of the current branch
         // (e.g. origin/feat-x for branch feat-x), since it's not a useful PR base.
         let upstream_short = upstream.get().shorthand().unwrap_or(upstream_ref_name);
-        let is_same_branch = upstream_short.ends_with(branch_name);
+        let is_same_branch = upstream_short
+            .split_once('/')
+            .map(|(_, upstream_branch_name)| upstream_branch_name == branch_name)
+            .unwrap_or(false);
         if !is_same_branch {
             return Ok((upstream_ref_name.to_string(), oid));
         }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -9,11 +9,14 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 
-use super::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use super::traits::{CommitInfo, PullRequestDiff, VcsBackend, VcsInfo, VcsType};
 
 // Re-export commonly used functions
 pub use context::{calculate_gap, fetch_context_lines};
-pub use diff::{get_commit_range_diff, get_working_tree_diff, get_working_tree_with_commits_diff};
+pub use diff::{
+    get_commit_range_diff, get_pull_request_diff, get_working_tree_diff,
+    get_working_tree_with_commits_diff,
+};
 
 /// Git backend implementation using git2 library
 pub struct GitBackend {
@@ -125,5 +128,13 @@ impl VcsBackend for GitBackend {
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
         get_working_tree_with_commits_diff(&self.repo, commit_ids, highlighter)
+    }
+
+    fn get_pull_request_diff(
+        &self,
+        base_ref: Option<&str>,
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<PullRequestDiff> {
+        get_pull_request_diff(&self.repo, base_ref, highlighter)
     }
 }

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -20,7 +20,7 @@ mod traits;
 pub use git::GitBackend;
 pub use hg::HgBackend;
 pub use jj::JjBackend;
-pub use traits::{CommitInfo, VcsBackend, VcsInfo};
+pub use traits::{CommitInfo, PullRequestDiff, PullRequestInfo, VcsBackend, VcsInfo};
 
 use crate::error::{Result, TuicrError};
 

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -46,6 +46,26 @@ pub struct CommitInfo {
     pub time: DateTime<Utc>,
 }
 
+/// Metadata about a pull-request style diff.
+#[derive(Debug, Clone)]
+pub struct PullRequestInfo {
+    /// Base reference used for the PR comparison, for example `origin/main`.
+    pub base_ref: String,
+    /// Merge-base commit between base_ref and HEAD.
+    pub merge_base_commit: String,
+    /// Current HEAD commit.
+    pub head_commit: String,
+    /// Number of commits between merge-base and HEAD.
+    pub commit_count: usize,
+}
+
+/// Pull-request diff result including files and metadata.
+#[derive(Debug, Clone)]
+pub struct PullRequestDiff {
+    pub files: Vec<DiffFile>,
+    pub info: PullRequestInfo,
+}
+
 /// Trait for VCS backend implementations
 pub trait VcsBackend: Send {
     /// Get repository information
@@ -106,6 +126,17 @@ pub trait VcsBackend: Send {
     ) -> Result<Vec<DiffFile>> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Working tree + commits diff not supported for this VCS".into(),
+        ))
+    }
+
+    /// Get a PR-style diff from merge-base(base_ref, HEAD) to HEAD.
+    fn get_pull_request_diff(
+        &self,
+        _base_ref: Option<&str>,
+        _highlighter: &SyntaxHighlighter,
+    ) -> Result<PullRequestDiff> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "PR diff not supported for this VCS".into(),
         ))
     }
 }


### PR DESCRIPTION
## Why
`tuicr` already supports commit-by-commit review, but many day-to-day self-review is PR-shaped. This adds a branch-level review mode so you can review the same combined diff you would see in GitHub, with less noise from merge commits.

## How
- Added PR mode via CLI: `--pr` and `--base <ref>` (base implies PR mode)
- Added in-app command: `:pr [base-ref]`
- For Git, PR mode computes a tree diff from merge-base to HEAD:
  - `merge-base(base, HEAD)..HEAD` as one combined review surface
- Base ref resolution now prefers a real target branch and skips upstream when it is only the remote copy of the current branch (for example `origin/feat-x` for local `feat-x`), which avoids false `No changes to review` results
- Updated UI/export context for PR mode and made reload (`:e`) preserve the active diff source

## How to test locally
1. Fetch latest refs (recommended):
   - `git fetch origin`
2. Build and run tests:
   - `cargo test`
3. Verify PR mode with explicit base:
   - `cargo run -- --pr --base origin/main`
   - Expected: combined branch diff loads (not commit-by-commit mode)
4. Verify default PR mode (no base passed):
   - `cargo run -- --pr`
   - Expected: resolves to a sensible default base and loads diff (does not incorrectly compare against `origin/<current-branch>`)
5. Verify in-app command mode:
   - Start `tuicr`, enter command mode with `:` and run `pr origin/main`
   - Expected: switches to PR diff mode and shows PR context in header/export
6. Verify argument guard:
   - `cargo run -- --pr -r HEAD~1..HEAD`
   - Expected: argument error, `--pr/--base` cannot be combined with `--revisions`