### PR TITLE
fix: skip large untracked files to prevent startup hang

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1071,7 +1071,9 @@ impl App {
             }
             AnnotatedLine::BinaryOrEmpty { file_idx } => {
                 let file = self.diff_files.get(*file_idx)?;
-                if file.is_binary {
+                if file.is_too_large {
+                    Some("(file too large to display)".to_string())
+                } else if file.is_binary {
                     Some("(binary file)".to_string())
                 } else {
                     Some("(no changes)".to_string())
@@ -3113,6 +3115,7 @@ mod tree_tests {
             status: FileStatus::Modified,
             hunks: vec![],
             is_binary: false,
+            is_too_large: false,
         }
     }
 

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -65,6 +65,7 @@ pub struct DiffFile {
     pub status: FileStatus,
     pub hunks: Vec<DiffHunk>,
     pub is_binary: bool,
+    pub is_too_large: bool,
 }
 
 impl DiffFile {

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -49,6 +49,7 @@ mod tests {
             status: FileStatus::Modified,
             hunks: Vec::new(),
             is_binary: false,
+            is_too_large: false,
         }
     }
 
@@ -120,6 +121,7 @@ mod tests {
             status: FileStatus::Deleted,
             hunks: Vec::new(),
             is_binary: false,
+            is_too_large: false,
         };
         let kept = make_diff_file("src/lib.rs");
 

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -680,7 +680,14 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
             }
         }
 
-        if file.is_binary {
+        if file.is_too_large {
+            let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled("(file too large to display)", styles::dim_style(&app.theme)),
+            ]));
+            line_idx += 1;
+        } else if file.is_binary {
             let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
@@ -1404,7 +1411,14 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
             }
         }
 
-        if file.is_binary {
+        if file.is_too_large {
+            let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled("(file too large to display)", styles::dim_style(&app.theme)),
+            ]));
+            line_idx += 1;
+        } else if file.is_binary {
             let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -45,6 +45,7 @@ pub fn parse_unified_diff(
                     status,
                     hunks: Vec::new(),
                     is_binary: true,
+                    is_too_large: false,
                 });
                 continue;
             }
@@ -73,6 +74,7 @@ pub fn parse_unified_diff(
                 status,
                 hunks,
                 is_binary: false,
+                is_too_large: false,
             });
         }
     }


### PR DESCRIPTION
## Summary
- Untracked files larger than 10 MB (e.g. log dumps, debug traces, core files) are now shown in the file list with a "(file too large to display)" notice instead of having their content parsed and syntax-highlighted
- This prevents tuicr from hanging on repos with large stray files like a 96 MB `gdb.txt`

## Test plan
- [x] Run `tuicr` with no args in a repo containing a large untracked file (>10 MB) — starts instantly and shows the file with a "(file too large to display)" notice
- [x] Run `tuicr` in a repo with only small files — no change in behavior
- [x] Verify binary files still show "(binary file)" as before
- [x] Check both unified and side-by-side views show the notice correctly