### PR TITLE
feat: show commit message as reviewable entry for single-commit reviews

### DIFF
--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -66,6 +66,7 @@ pub struct DiffFile {
     pub hunks: Vec<DiffHunk>,
     pub is_binary: bool,
     pub is_too_large: bool,
+    pub is_commit_message: bool,
 }
 
 impl DiffFile {

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -50,6 +50,7 @@ mod tests {
             hunks: Vec::new(),
             is_binary: false,
             is_too_large: false,
+            is_commit_message: false,
         }
     }
 
@@ -122,6 +123,7 @@ mod tests {
             hunks: Vec::new(),
             is_binary: false,
             is_too_large: false,
+            is_commit_message: false,
         };
         let kept = make_diff_file("src/lib.rs");
 

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -489,12 +489,8 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                 FileTreeItem::File { file_idx, depth } => {
                     let file = &app.diff_files[*file_idx];
                     let path = file.display_path();
-                    let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
-                    let status = file.status.as_char();
                     let is_reviewed = app.session.is_file_reviewed(path);
                     let review_mark = if is_reviewed { "✓" } else { " " };
-
-                    let indent = "  ".repeat(*depth);
 
                     let style = if is_selected {
                         styles::selected_style(&app.theme).add_modifier(Modifier::UNDERLINED)
@@ -502,22 +498,39 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                         Style::default()
                     };
 
-                    let line = Line::from(vec![
-                        Span::styled(indent, Style::default()),
-                        Span::styled(
-                            format!("[{review_mark}]"),
-                            if is_reviewed {
-                                styles::reviewed_style(&app.theme)
-                            } else {
-                                styles::pending_style(&app.theme)
-                            },
-                        ),
-                        Span::styled(
-                            format!(" {status} "),
-                            styles::file_status_style(&app.theme, status),
-                        ),
-                        Span::styled(filename.to_string(), style),
-                    ]);
+                    let line = if file.is_commit_message {
+                        Line::from(vec![
+                            Span::styled(
+                                format!("[{review_mark}]"),
+                                if is_reviewed {
+                                    styles::reviewed_style(&app.theme)
+                                } else {
+                                    styles::pending_style(&app.theme)
+                                },
+                            ),
+                            Span::styled("   Commit Message".to_string(), style),
+                        ])
+                    } else {
+                        let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                        let status = file.status.as_char();
+                        let indent = "  ".repeat(*depth);
+                        Line::from(vec![
+                            Span::styled(indent, Style::default()),
+                            Span::styled(
+                                format!("[{review_mark}]"),
+                                if is_reviewed {
+                                    styles::reviewed_style(&app.theme)
+                                } else {
+                                    styles::pending_style(&app.theme)
+                                },
+                            ),
+                            Span::styled(
+                                format!(" {status} "),
+                                styles::file_status_style(&app.theme, status),
+                            ),
+                            Span::styled(filename.to_string(), style),
+                        ])
+                    };
 
                     ListItem::new(apply_horizontal_scroll(line, scroll_x))
                 }
@@ -576,12 +589,14 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
         // Add checkmark if reviewed (using same character as file list)
         let review_mark = if is_reviewed { "✓ " } else { "" };
 
+        let header_text = if file.is_commit_message {
+            format!("═══ {}Commit Message ", review_mark)
+        } else {
+            format!("═══ {}{} [{}] ", review_mark, path.display(), status)
+        };
         lines.push(Line::from(vec![
             Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-            Span::styled(
-                format!("═══ {}{} [{}] ", review_mark, path.display(), status),
-                styles::file_header_style(&app.theme),
-            ),
+            Span::styled(header_text, styles::file_header_style(&app.theme)),
             Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
         ]));
         line_idx += 1;
@@ -1310,12 +1325,14 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
 
         let review_mark = if is_reviewed { "✓ " } else { "" };
 
+        let header_text = if file.is_commit_message {
+            format!("═══ {}Commit Message ", review_mark)
+        } else {
+            format!("═══ {}{} [{}] ", review_mark, path.display(), status)
+        };
         lines.push(Line::from(vec![
             Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-            Span::styled(
-                format!("═══ {}{} [{}] ", review_mark, path.display(), status),
-                styles::file_header_style(&app.theme),
-            ),
+            Span::styled(header_text, styles::file_header_style(&app.theme)),
             Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
         ]));
         line_idx += 1;

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -46,6 +46,7 @@ pub fn parse_unified_diff(
                     hunks: Vec::new(),
                     is_binary: true,
                     is_too_large: false,
+                    is_commit_message: false,
                 });
                 continue;
             }
@@ -75,6 +76,7 @@ pub fn parse_unified_diff(
                 hunks,
                 is_binary: false,
                 is_too_large: false,
+                is_commit_message: false,
             });
         }
     }

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -126,6 +126,7 @@ fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFi
             hunks,
             is_binary,
             is_too_large,
+            is_commit_message: false,
         });
     }
 

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -86,6 +86,7 @@ impl VcsBackend for GitBackend {
                 short_id: c.short_id,
                 branch_name: c.branch_name,
                 summary: c.summary,
+                body: c.body,
                 author: c.author,
                 time: c.time,
             })
@@ -113,6 +114,7 @@ impl VcsBackend for GitBackend {
                 short_id: c.short_id,
                 branch_name: c.branch_name,
                 summary: c.summary,
+                body: c.body,
                 author: c.author,
                 time: c.time,
             })

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -73,6 +73,7 @@ mod tests {
             short_id: "abc".to_string(),
             branch_name: Some("main".to_string()),
             summary: "test".to_string(),
+            body: None,
             author: "author".to_string(),
             time: chrono::Utc::now(),
         };

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -42,6 +42,7 @@ pub struct CommitInfo {
     /// For Git this is populated for commits that are branch tips.
     pub branch_name: Option<String>,
     pub summary: String,
+    pub body: Option<String>,
     pub author: String,
     pub time: DateTime<Utc>,
 }
@@ -173,6 +174,7 @@ mod tests {
             short_id: "abc123d".to_string(),
             branch_name: Some("main".to_string()),
             summary: "Fix bug".to_string(),
+            body: None,
             author: "Test User".to_string(),
             time: Utc::now(),
         };


### PR DESCRIPTION
## Summary

- When reviewing a single commit (`tuicr -r <commit>`), the commit message now appears as the first entry in the file list and diff view
- In multi-commit reviews, selecting a single commit in the inline selector also shows its commit message
- The commit message entry supports comments, reviewed status, and folding — just like any code file
- Added `body` field to `CommitInfo` across all VCS backends (git, hg, jj) to capture the full commit message beyond the summary line

## Test plan

- [x] `tuicr -r <single-commit>` — commit message appears as first entry, can be commented on and marked reviewed
- [x] `tuicr -r <commit-range>` — selecting a single commit shows its commit message; selecting a range hides it
- [x] Commit message entry folds when marked reviewed
- [x] Regular file commenting logic unchanged
- [x] `cargo test` — all 214 tests pass