### PR TITLE
fix(ui): shift focus to diff when file list is collapsed

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2122,6 +2122,9 @@ impl App {
 
     pub fn toggle_file_list(&mut self) {
         self.show_file_list = !self.show_file_list;
+        if !self.show_file_list && self.focused_panel == FocusedPanel::FileList {
+            self.focused_panel = FocusedPanel::Diff;
+        }
         let status = if self.show_file_list {
             "visible"
         } else {


### PR DESCRIPTION
Fixes issue: https://github.com/agavra/tuicr/issues/134


https://github.com/user-attachments/assets/c612870d-7732-4420-953c-5e6cbab5d05e

