### PR TITLE
feat: add {N}G shortcut to jump to source line in diff view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -83,6 +83,60 @@ pub enum AnnotatedLine {
     Spacing,
 }
 
+/// Result of searching for a source line number in annotations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FindSourceLineResult {
+    /// Exact match found at the given annotation index.
+    Exact(usize),
+    /// No exact match; nearest line found at the given annotation index.
+    Nearest(usize),
+    /// No matching lines found in the current file at all.
+    NotFound,
+}
+
+/// Search `line_annotations` for the annotation whose `new_lineno` best matches
+/// `target_lineno` within the file identified by `current_file`.
+pub fn find_source_line(
+    annotations: &[AnnotatedLine],
+    current_file: usize,
+    target_lineno: u32,
+) -> FindSourceLineResult {
+    let mut best: Option<(usize, u32)> = None; // (index, distance)
+
+    for (idx, annotation) in annotations.iter().enumerate() {
+        let (file_idx, new_lineno) = match annotation {
+            AnnotatedLine::DiffLine {
+                file_idx,
+                new_lineno,
+                ..
+            } => (*file_idx, *new_lineno),
+            AnnotatedLine::SideBySideLine {
+                file_idx,
+                new_lineno,
+                ..
+            } => (*file_idx, *new_lineno),
+            _ => continue,
+        };
+        if file_idx != current_file {
+            continue;
+        }
+        if let Some(ln) = new_lineno {
+            let dist = ln.abs_diff(target_lineno);
+            if dist == 0 {
+                return FindSourceLineResult::Exact(idx);
+            }
+            if best.is_none() || dist < best.unwrap().1 {
+                best = Some((idx, dist));
+            }
+        }
+    }
+
+    match best {
+        Some((idx, _)) => FindSourceLineResult::Nearest(idx),
+        None => FindSourceLineResult::NotFound,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
     Normal,
@@ -202,6 +256,8 @@ pub struct App {
     pub comment_cursor_screen_pos: Option<(u16, u16)>,
     /// Information about available updates (set by background check)
     pub update_info: Option<UpdateInfo>,
+    /// Accumulated digit count for {N}G jump-to-line
+    pub pending_count: Option<usize>,
 
     // Inline commit selector state (shown at top of diff view for multi-commit reviews)
     /// CommitInfo for commits in the current review (display order: newest first)
@@ -464,6 +520,7 @@ impl App {
             pending_stdout_output: None,
             comment_cursor_screen_pos: None,
             update_info: None,
+            pending_count: None,
             review_commits: Vec::new(),
             show_commit_selector: false,
             commit_diff_cache: HashMap::new(),
@@ -1192,6 +1249,28 @@ impl App {
             .cursor_line
             .saturating_sub(half_viewport)
             .min(max_scroll);
+    }
+
+    pub fn go_to_source_line(&mut self, target_lineno: u32) {
+        let current_file = self.diff_state.current_file_idx;
+        let result = find_source_line(&self.line_annotations, current_file, target_lineno);
+
+        match result {
+            FindSourceLineResult::Exact(idx) | FindSourceLineResult::Nearest(idx) => {
+                self.diff_state.cursor_line = idx;
+                self.ensure_cursor_visible();
+                self.center_cursor();
+                self.update_current_file_from_cursor();
+                if matches!(result, FindSourceLineResult::Nearest(_)) {
+                    self.set_message(format!(
+                        "Line {target_lineno} not in diff, jumped to nearest"
+                    ));
+                }
+            }
+            FindSourceLineResult::NotFound => {
+                self.set_warning(format!("Line {target_lineno} not found in current file"));
+            }
+        }
     }
 
     pub fn file_list_down(&mut self, n: usize) {
@@ -3518,5 +3597,203 @@ mod scroll_tests {
         assert!(diff_state_wrap.wrap_lines);
         assert_eq!(diff_state_no_wrap.viewport_height, 20);
         assert_eq!(diff_state_wrap.viewport_height, 20);
+    }
+}
+
+#[cfg(test)]
+mod find_source_line_tests {
+    use super::*;
+
+    // hunk_idx and line_idx are set to 0 because find_source_line doesn't use them;
+    // only file_idx and new_lineno matter for the search.
+    fn make_diff_line(file_idx: usize, new_lineno: Option<u32>) -> AnnotatedLine {
+        AnnotatedLine::DiffLine {
+            file_idx,
+            hunk_idx: 0,
+            line_idx: 0,
+            old_lineno: None,
+            new_lineno,
+        }
+    }
+
+    fn make_sbs_line(file_idx: usize, new_lineno: Option<u32>) -> AnnotatedLine {
+        AnnotatedLine::SideBySideLine {
+            file_idx,
+            hunk_idx: 0,
+            del_line_idx: None,
+            add_line_idx: None,
+            old_lineno: None,
+            new_lineno,
+        }
+    }
+
+    #[test]
+    fn should_find_exact_match() {
+        let annotations = vec![
+            AnnotatedLine::FileHeader { file_idx: 0 },
+            make_diff_line(0, Some(10)),
+            make_diff_line(0, Some(11)),
+            make_diff_line(0, Some(12)),
+        ];
+
+        let result = find_source_line(&annotations, 0, 11);
+        assert_eq!(result, FindSourceLineResult::Exact(2));
+    }
+
+    #[test]
+    fn should_find_nearest_when_no_exact_match() {
+        let annotations = vec![
+            make_diff_line(0, Some(10)),
+            make_diff_line(0, Some(15)),
+            make_diff_line(0, Some(20)),
+        ];
+
+        // Target 12 is closest to line 10 (dist=2) vs 15 (dist=3) vs 20 (dist=8)
+        let result = find_source_line(&annotations, 0, 12);
+        assert_eq!(result, FindSourceLineResult::Nearest(0));
+    }
+
+    #[test]
+    fn should_find_nearest_above_target() {
+        let annotations = vec![
+            make_diff_line(0, Some(10)),
+            make_diff_line(0, Some(15)),
+            make_diff_line(0, Some(20)),
+        ];
+
+        // Target 18 is closest to line 20 (dist=2) vs 15 (dist=3) vs 10 (dist=8)
+        let result = find_source_line(&annotations, 0, 18);
+        assert_eq!(result, FindSourceLineResult::Nearest(2));
+    }
+
+    #[test]
+    fn should_return_not_found_for_empty_annotations() {
+        let annotations: Vec<AnnotatedLine> = vec![];
+        let result = find_source_line(&annotations, 0, 42);
+        assert_eq!(result, FindSourceLineResult::NotFound);
+    }
+
+    #[test]
+    fn should_return_not_found_when_no_lines_in_current_file() {
+        let annotations = vec![make_diff_line(1, Some(10)), make_diff_line(1, Some(20))];
+
+        // File 0 has no lines
+        let result = find_source_line(&annotations, 0, 10);
+        assert_eq!(result, FindSourceLineResult::NotFound);
+    }
+
+    #[test]
+    fn should_skip_lines_from_other_files() {
+        let annotations = vec![
+            make_diff_line(0, Some(100)), // file 0, line 100
+            make_diff_line(1, Some(42)),  // file 1, exact match but wrong file
+            make_diff_line(0, Some(50)),  // file 0, line 50
+        ];
+
+        // Searching file 0 for line 42 — should find nearest (50, dist=8) not file 1's exact match
+        let result = find_source_line(&annotations, 0, 42);
+        assert_eq!(result, FindSourceLineResult::Nearest(2));
+    }
+
+    #[test]
+    fn should_skip_non_diff_line_annotations() {
+        let annotations = vec![
+            AnnotatedLine::FileHeader { file_idx: 0 },
+            AnnotatedLine::HunkHeader {
+                file_idx: 0,
+                hunk_idx: 0,
+            },
+            AnnotatedLine::Spacing,
+            make_diff_line(0, Some(42)),
+        ];
+
+        let result = find_source_line(&annotations, 0, 42);
+        assert_eq!(result, FindSourceLineResult::Exact(3));
+    }
+
+    #[test]
+    fn should_skip_diff_lines_with_no_new_lineno() {
+        // Deletion-only lines have new_lineno = None
+        let annotations = vec![make_diff_line(0, None), make_diff_line(0, Some(20))];
+
+        let result = find_source_line(&annotations, 0, 5);
+        assert_eq!(result, FindSourceLineResult::Nearest(1));
+    }
+
+    #[test]
+    fn should_work_with_side_by_side_lines() {
+        let annotations = vec![
+            make_sbs_line(0, Some(10)),
+            make_sbs_line(0, Some(20)),
+            make_sbs_line(0, Some(30)),
+        ];
+
+        let result = find_source_line(&annotations, 0, 20);
+        assert_eq!(result, FindSourceLineResult::Exact(1));
+    }
+
+    #[test]
+    fn should_handle_mixed_diff_and_sbs_lines() {
+        let annotations = vec![
+            make_diff_line(0, Some(10)),
+            make_sbs_line(0, Some(20)),
+            make_diff_line(0, Some(30)),
+        ];
+
+        let result = find_source_line(&annotations, 0, 25);
+        // Nearest is line 20 (dist=5) or line 30 (dist=5), first match wins
+        assert_eq!(result, FindSourceLineResult::Nearest(1));
+    }
+
+    #[test]
+    fn should_return_not_found_when_only_non_line_annotations() {
+        let annotations = vec![
+            AnnotatedLine::FileHeader { file_idx: 0 },
+            AnnotatedLine::Spacing,
+            AnnotatedLine::HunkHeader {
+                file_idx: 0,
+                hunk_idx: 0,
+            },
+        ];
+
+        let result = find_source_line(&annotations, 0, 42);
+        assert_eq!(result, FindSourceLineResult::NotFound);
+    }
+
+    #[test]
+    fn should_prefer_exact_match_over_earlier_nearest() {
+        let annotations = vec![
+            make_diff_line(0, Some(41)), // dist=1 from target 42
+            make_diff_line(0, Some(42)), // exact match
+            make_diff_line(0, Some(43)), // dist=1 from target 42
+        ];
+
+        let result = find_source_line(&annotations, 0, 42);
+        assert_eq!(result, FindSourceLineResult::Exact(1));
+    }
+
+    #[test]
+    fn should_find_nearest_for_target_zero() {
+        // target_lineno = 0 is out-of-range (lines are 1-indexed) but should
+        // still return the nearest line rather than panicking.
+        let annotations = vec![make_diff_line(0, Some(1)), make_diff_line(0, Some(5))];
+
+        let result = find_source_line(&annotations, 0, 0);
+        assert_eq!(result, FindSourceLineResult::Nearest(0));
+    }
+
+    #[test]
+    fn should_tie_break_nearest_by_iteration_order() {
+        // When two lines are equidistant, the first one encountered wins.
+        // Here lines are in descending order; line 30 (idx 0) and line 10 (idx 2)
+        // are both dist=10 from target 20, so idx 0 should win.
+        let annotations = vec![
+            make_diff_line(0, Some(30)),
+            make_diff_line(0, Some(50)),
+            make_diff_line(0, Some(10)),
+        ];
+
+        let result = find_source_line(&annotations, 0, 20);
+        assert_eq!(result, FindSourceLineResult::Nearest(0));
     }
 }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -13,6 +13,7 @@ pub enum Action {
     PageUp,
     GoToTop,
     GoToBottom,
+    Digit(u8),
     NextFile,
     PrevFile,
     NextHunk,
@@ -156,6 +157,8 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('o'), KeyModifiers::NONE) => Action::ExpandAll,
         (KeyCode::Char('O'), _) => Action::CollapseAll,
 
+        (KeyCode::Char(c @ '0'..='9'), KeyModifiers::NONE) => Action::Digit(c as u8 - b'0'),
+
         _ => Action::None,
     }
 }
@@ -294,5 +297,86 @@ fn map_visual_mode(key: KeyEvent) -> Action {
         // Quick quit
         (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
         _ => Action::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn key_shift(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::SHIFT)
+    }
+
+    #[test]
+    fn should_map_digit_keys_to_digit_action_in_normal_mode() {
+        for d in 0..=9u8 {
+            let c = (b'0' + d) as char;
+            let action = map_normal_mode(key(KeyCode::Char(c)));
+            assert_eq!(
+                action,
+                Action::Digit(d),
+                "digit key '{c}' should map to Digit({d})"
+            );
+        }
+    }
+
+    #[test]
+    fn should_map_uppercase_g_to_go_to_bottom_in_normal_mode() {
+        let action = map_normal_mode(key_shift('G'));
+        assert_eq!(action, Action::GoToBottom);
+    }
+
+    #[test]
+    fn should_map_lowercase_g_to_go_to_top_in_normal_mode() {
+        let action = map_normal_mode(key(KeyCode::Char('g')));
+        assert_eq!(action, Action::GoToTop);
+    }
+
+    #[test]
+    fn should_not_map_digits_in_command_mode() {
+        for d in 0..=9u8 {
+            let c = (b'0' + d) as char;
+            let action = map_command_mode(key(KeyCode::Char(c)));
+            assert_eq!(
+                action,
+                Action::InsertChar(c),
+                "digit '{c}' in command mode should be InsertChar"
+            );
+        }
+    }
+
+    #[test]
+    fn should_not_map_digits_in_search_mode() {
+        for d in 0..=9u8 {
+            let c = (b'0' + d) as char;
+            let action = map_search_mode(key(KeyCode::Char(c)));
+            assert_eq!(
+                action,
+                Action::InsertChar(c),
+                "digit '{c}' in search mode should be InsertChar"
+            );
+        }
+    }
+
+    #[test]
+    fn should_not_map_shifted_digits_to_digit_action() {
+        // Shift+digit produces characters like !, @, #, etc. on most layouts,
+        // but if a terminal sends the raw digit with SHIFT modifier it must not
+        // be treated as Action::Digit.
+        for d in 0..=9u8 {
+            let c = (b'0' + d) as char;
+            let action = map_normal_mode(key_shift(c));
+            assert_ne!(
+                action,
+                Action::Digit(d),
+                "Shift+'{c}' in normal mode must not produce Digit({d})"
+            );
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,17 +272,44 @@ fn main() -> anyhow::Result<()> {
                     match action {
                         Action::PendingZCommand => {
                             pending_z = true;
+                            app.pending_count = None;
                             continue;
                         }
                         Action::PendingDCommand => {
                             pending_d = true;
+                            app.pending_count = None;
                             continue;
                         }
                         Action::PendingSemicolonCommand => {
                             pending_semicolon = true;
+                            app.pending_count = None;
                             continue;
                         }
                         _ => {}
+                    }
+
+                    // Handle digit accumulation for {N}G jump-to-line (Normal mode only)
+                    if app.input_mode == InputMode::Normal {
+                        match action {
+                            Action::Digit(d) => {
+                                let n = app.pending_count.unwrap_or(0);
+                                app.pending_count = Some(
+                                    (n.saturating_mul(10).saturating_add(d as usize)).min(999_999),
+                                );
+                                continue;
+                            }
+                            Action::GoToBottom if app.pending_count.is_some() => {
+                                // Clamp to 1 since source lines are 1-indexed; 0G behaves like 1G
+                                let count = app.pending_count.unwrap().max(1);
+                                app.pending_count = None;
+                                // Safe cast: count is clamped to 999_999 which fits in u32
+                                app.go_to_source_line(count as u32);
+                                continue;
+                            }
+                            _ => {
+                                app.pending_count = None;
+                            }
+                        }
                     }
 
                     // Dispatch by input mode

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -61,6 +61,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  {N}G      ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Go to source line N in current file"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  {/}       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -170,7 +170,13 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         )]
     } else {
         let mode_str = match app.input_mode {
-            InputMode::Normal => " NORMAL ".to_string(),
+            InputMode::Normal => {
+                if let Some(count) = app.pending_count {
+                    format!(" NORMAL {count} ")
+                } else {
+                    " NORMAL ".to_string()
+                }
+            }
             InputMode::Command => " COMMAND ".to_string(),
             InputMode::Search => " SEARCH ".to_string(),
             InputMode::Comment => " COMMENT ".to_string(),


### PR DESCRIPTION

  - Add vim-style {N}G command to jump to a source code line number in the current file's diff. The target is the new-side line number shown in the gutter (i.e. the actual source line), not the display row in the TUI.
  - Since diffs only show changed hunks, the requested line may not be present. When no exact match exists, the cursor jumps to the nearest visible diff line and a status bar message explains the approximation. If the file has no diff lines at all, a warning is shown.
  - Digits accumulate in Normal mode and are displayed in the status bar (NORMAL 42) for visual feedback. Pressing G consumes the count; any other key discards it. Plain G without a count still goes to the last file, preserving existing behavior.

  Test plan

  - cargo test — all 237 tests pass (17 new)
  - Open a diff, press 4 2 G — cursor jumps to source line 42 (or nearest) in current file
  - Press G without digits — still goes to last file
  - Press digits then a non-G key (e.g. j) — digits are discarded, key handled normally
  - Status bar shows accumulated digits as they're typed
  - Press ? — help popup shows the new {N}G entry