### PR TITLE
fix(syntax): append newline to lines passed to syntect parser

### DIFF
--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -78,7 +78,7 @@ impl SyntaxHighlighter {
         Some(Self::collect_line_highlights(lines, |line| {
             // Highlight failures are scoped to the single line; other lines still keep highlighting.
             highlighter
-                .highlight_line(line, &self.syntax_set)
+                .highlight_line(&format!("{}\n", line), &self.syntax_set)
                 .ok()
                 .map(|ranges| {
                     ranges


### PR DESCRIPTION
closes #200

Duplicating the table from #200 for visibility here on the fix. See #200 for full context.

| Before | After |
| - | - |
| <img width="1120" height="953" alt="Image" src="https://github.com/user-attachments/assets/dc6ef3b9-0457-4c71-a6d9-5460f01d28df" /> | <img width="1097" height="943" alt="Image" src="https://github.com/user-attachments/assets/8726c08b-f979-48c4-bf4a-b9729115030d" /> |