### PR TITLE
Add external editor for comment drafts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ src/
 │   └── mod.rs           # User config loading (XDG on Unix, %APPDATA% on Windows)
 ├── app.rs               # Application state (App struct, InputMode, etc.)
 ├── error.rs             # Error types (TuicrError enum)
+├── external_editor.rs   # Resolve $VISUAL/$EDITOR and launch the comment editor
 ├── tuicrignore.rs       # .tuicrignore loader + diff file filtering (gitignore-style patterns)
 ├── theme/
 │   └── mod.rs           # Theme palette definitions + CLI theme parsing/resolution
@@ -79,7 +80,7 @@ src/
 **InputMode** (`src/app.rs`):
 - `Normal` - default navigation mode
 - `Command` - after pressing `:`, vim-style commands
-- `Comment` - typing a comment (Ctrl-S saves, Ctrl-C cancels)
+- `Comment` - typing a comment (Ctrl-S saves, Ctrl-C cancels, Ctrl-G opens external editor)
 - `Search` - after pressing `/`, search pattern entry
 - `Help` - showing help popup
 - `Confirm` - Y/N confirmation dialog
@@ -99,6 +100,7 @@ src/
 1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), ignore unknown config keys with startup warnings, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), filters diff files via repo-root `.tuicrignore`, then enters commit selection mode by default. If uncommitted changes exist, the first selection row is "Uncommitted changes". With `-r/--revisions`, it opens the requested commit range directly.
 2. **Render**: `ui::render()` draws the TUI based on `App` state
 3. **Input**: `crossterm` events → `map_key_to_action` → match on Action in main loop
+   Comment mode can hand the draft off to `external_editor.rs`, which suspends the TUI, opens `$VISUAL`/`$EDITOR`, then returns the updated text to the comment buffer.
 4. **Persistence**: `:w` calls `save_session()`, writes JSON to `~/.local/share/tuicr/reviews/`
 5. **Reload diff**: `:e` re-runs VCS diff loading and reapplies `.tuicrignore` filtering to refresh displayed files
 6. **Export**: `:clip` (alias `:export`) calls `export_to_clipboard()`, generating markdown and copying it to the clipboard (or stdout with `--stdout` flag)
@@ -107,6 +109,7 @@ src/
 
 - **Infinite scroll**: All files rendered into one `Vec<Line>`, then sliced by `scroll_offset`
 - **Inline comments**: Comments are rendered in `app_layout.rs` after file headers and after relevant diff lines
+- **External editor**: `Ctrl-G` in comment mode suspends the TUI, opens the current draft in `$VISUAL` or `$EDITOR`, then restores the terminal with the edited text
 - **Session loading**: `App::new()` calls `find_session_for_repo()` to restore previous review
 - **Clipboard**: Uses `arboard` crate for cross-platform clipboard support
 - **Hunk navigation**: `next_hunk()`/`prev_hunk()` calculate positions by iterating through files
@@ -122,6 +125,7 @@ src/
 - `ignore`: Gitignore-style matcher for `.tuicrignore`
 - `chrono`: Timestamps
 - `thiserror` + `anyhow`: Error handling
+- `shlex` + `tempfile`: External editor command parsing and temp-file staging
 
 ### Keeping Docs Updated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2419,6 +2419,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "shlex",
  "syntect",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,5 +43,6 @@ ignore = "0.4"
 syntect = "5.2"
 two-face = { version = "0.5", default-features = false, features = ["syntect-default-fancy"] }
 
-[dev-dependencies]
+# External editor support
+shlex = "1.3.0"
 tempfile = "3.24.0"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ to clipboard in a format ready to paste back to the agent.
 - **Expandable context** - Press Enter on "... expand (N lines) ..." to reveal hidden context between hunks
 - **Comments** - Add review-level, file-level, or line-level comments with types
 - **Visual mode** - Select line ranges with `v` / `V` and comment on multiple lines at once
+- **External editor** - Press `Ctrl-g` in comment mode to edit with `$VISUAL` or `$EDITOR`
 - **Review tracking** - Mark files as reviewed, persist progress to disk
 - **`.tuicrignore` support** - Exclude matching files from review diffs
 - **Clipboard export** - Copy structured Markdown optimized for LLM consumption
@@ -225,6 +226,7 @@ dist/
 | `Tab` | Cycle comment type (Note → Suggestion → Issue → Praise) |
 | `Enter` / `Ctrl-Enter` / `Ctrl-s` | Save comment |
 | `Shift-Enter` / `Ctrl-j` | Insert newline |
+| `Ctrl-g` | Open the draft in `$VISUAL` or `$EDITOR` |
 | `←` / `→` | Move cursor |
 | `Ctrl-w` | Delete word |
 | `Ctrl-u` | Clear line |

--- a/src/app.rs
+++ b/src/app.rs
@@ -264,6 +264,11 @@ pub struct App {
     /// Accumulated digit count for {N}G jump-to-line
     pub pending_count: Option<usize>,
 
+    /// Set to true when the user presses Ctrl+G in comment mode to open an
+    /// external editor. The main event loop checks this flag to suspend the
+    /// TUI, run the editor, and resume.
+    pub pending_external_edit: bool,
+
     // Inline commit selector state (shown at top of diff view for multi-commit reviews)
     /// CommitInfo for commits in the current review (display order: newest first)
     pub review_commits: Vec<CommitInfo>,
@@ -530,6 +535,7 @@ impl App {
             comment_cursor_screen_pos: None,
             update_info: None,
             pending_count: None,
+            pending_external_edit: false,
             review_commits: Vec::new(),
             show_commit_selector: false,
             commit_diff_cache: HashMap::new(),

--- a/src/external_editor.rs
+++ b/src/external_editor.rs
@@ -1,0 +1,195 @@
+use std::env;
+use std::fs;
+#[cfg(unix)]
+use std::fs::File;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum EditorError {
+    #[error("neither $VISUAL nor $EDITOR is set")]
+    MissingEditor,
+    #[error("failed to parse editor command")]
+    ParseFailed,
+    #[error("editor command is empty")]
+    EmptyCommand,
+    #[error("editor exited with status {0}")]
+    EditorFailed(std::process::ExitStatus),
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+fn parse_editor_command(raw: &str) -> Result<Vec<String>, EditorError> {
+    let parts = shlex::split(raw).ok_or(EditorError::ParseFailed)?;
+    if parts.is_empty() {
+        return Err(EditorError::EmptyCommand);
+    }
+    Ok(parts)
+}
+
+fn resolve_editor_command_from_env(
+    visual: Option<String>,
+    editor: Option<String>,
+) -> Result<Vec<String>, EditorError> {
+    let raw = visual.or(editor).ok_or(EditorError::MissingEditor)?;
+    parse_editor_command(&raw)
+}
+
+/// Resolve the editor command from environment variables.
+/// Prefers `$VISUAL` over `$EDITOR`.
+pub fn resolve_editor_command() -> Result<Vec<String>, EditorError> {
+    resolve_editor_command_from_env(env::var("VISUAL").ok(), env::var("EDITOR").ok())
+}
+
+/// Write `seed` to a temp file, launch the editor, and return the updated content.
+///
+/// The caller is responsible for suspending and restoring the TUI around this call
+/// (leave alternate screen, disable raw mode, etc.).
+pub fn run_editor(
+    seed: &str,
+    editor_cmd: &[String],
+    attach_to_tty: bool,
+) -> Result<String, EditorError> {
+    if editor_cmd.is_empty() {
+        return Err(EditorError::EmptyCommand);
+    }
+
+    // Convert to TempPath immediately so no file handle stays open while the
+    // editor runs.
+    let temp_path = tempfile::Builder::new()
+        .suffix(".md")
+        .tempfile()?
+        .into_temp_path();
+    fs::write(&temp_path, seed)?;
+
+    let mut cmd = Command::new(&editor_cmd[0]);
+    if editor_cmd.len() > 1 {
+        cmd.args(&editor_cmd[1..]);
+    }
+    configure_editor_stdio(&mut cmd, attach_to_tty)?;
+    let status = cmd.arg(&temp_path).status()?;
+
+    if !status.success() {
+        return Err(EditorError::EditorFailed(status));
+    }
+
+    let contents = fs::read_to_string(&temp_path)?;
+    Ok(contents)
+}
+
+fn configure_editor_stdio(cmd: &mut Command, attach_to_tty: bool) -> std::io::Result<()> {
+    if !attach_to_tty {
+        cmd.stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        let tty = File::options().read(true).write(true).open("/dev/tty")?;
+        let tty_out = tty.try_clone()?;
+        let tty_err = tty.try_clone()?;
+        cmd.stdin(Stdio::from(tty))
+            .stdout(Stdio::from(tty_out))
+            .stderr(Stdio::from(tty_err));
+    }
+
+    #[cfg(not(unix))]
+    {
+        cmd.stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit());
+    }
+
+    Ok(())
+}
+
+/// Normalize editor output for in-app use.
+///
+/// Strips one trailing newline that many editors add automatically on save.
+pub fn normalize_edited_content(contents: &str) -> String {
+    contents.strip_suffix('\n').unwrap_or(contents).to_owned()
+}
+
+/// Returns the short editor name for display (e.g. "nvim", "code").
+pub fn editor_display_name(editor_cmd: &[String]) -> String {
+    editor_cmd
+        .first()
+        .map(|cmd| {
+            PathBuf::from(cmd)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(cmd.as_str())
+                .to_owned()
+        })
+        .unwrap_or_else(|| "editor".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_editor_prefers_visual() {
+        let cmd = resolve_editor_command_from_env(Some("vis".to_string()), Some("ed".to_string()))
+            .unwrap();
+        assert_eq!(cmd, vec!["vis".to_string()]);
+    }
+
+    #[test]
+    fn resolve_editor_falls_back_to_editor() {
+        let cmd = resolve_editor_command_from_env(None, Some("nano".to_string())).unwrap();
+        assert_eq!(cmd, vec!["nano".to_string()]);
+    }
+
+    #[test]
+    fn resolve_editor_errors_when_unset() {
+        assert!(matches!(
+            resolve_editor_command_from_env(None, None),
+            Err(EditorError::MissingEditor)
+        ));
+    }
+
+    #[test]
+    fn resolve_editor_parses_arguments() {
+        let cmd = parse_editor_command("code --wait").unwrap();
+        assert_eq!(cmd, vec!["code".to_string(), "--wait".to_string()]);
+    }
+
+    #[test]
+    fn editor_display_name_extracts_basename() {
+        let cmd = vec!["/usr/bin/nvim".to_string()];
+        assert_eq!(editor_display_name(&cmd), "nvim");
+    }
+
+    #[test]
+    fn editor_display_name_handles_bare_name() {
+        let cmd = vec!["nano".to_string()];
+        assert_eq!(editor_display_name(&cmd), "nano");
+    }
+
+    #[test]
+    fn normalize_edited_content_trims_one_newline() {
+        assert_eq!(normalize_edited_content("first\n\n"), "first\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn run_editor_returns_updated_content() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let script_path = dir.path().join("edit.sh");
+        fs::write(&script_path, "#!/bin/sh\nprintf \"edited\" > \"$1\"\n").unwrap();
+        let mut perms = fs::metadata(&script_path).unwrap().permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).unwrap();
+
+        let cmd = vec![script_path.to_string_lossy().to_string()];
+        let result = run_editor("seed", &cmd, false).unwrap();
+        assert_eq!(result, "edited");
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -324,6 +324,11 @@ pub fn handle_comment_action(app: &mut App, action: Action) {
             app.comment_buffer.clear();
             app.comment_cursor = 0;
         }
+        Action::OpenExternalEditor => {
+            // Signal the main loop to suspend the TUI and launch the external editor.
+            // The main loop owns the terminal and handles the suspend/resume cycle.
+            app.pending_external_edit = true;
+        }
         Action::Quit => app.should_quit = true,
         _ => {}
     }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -66,6 +66,9 @@ pub enum Action {
     // Comment type
     CycleCommentType,
 
+    // External editor
+    OpenExternalEditor,
+
     // Confirm dialog
     ConfirmYes,
     ConfirmNo,
@@ -192,6 +195,8 @@ fn map_comment_mode(key: KeyEvent) -> Action {
         // Cancel: Esc, Ctrl+C
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Char('c'), KeyModifiers::CONTROL) => Action::ExitMode,
+        // Open external editor: Ctrl+G
+        (KeyCode::Char('g'), KeyModifiers::CONTROL) => Action::OpenExternalEditor,
         // Submit: Enter without shift (Ctrl+Enter and Ctrl+S also work)
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
         (KeyCode::Enter, KeyModifiers::CONTROL) => Action::SubmitInput,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod config;
 mod error;
+mod external_editor;
 mod handler;
 mod input;
 mod model;
@@ -348,6 +349,72 @@ fn main() -> anyhow::Result<()> {
                     }
                 }
                 _ => {}
+            }
+        }
+
+        // ==============================================================================
+        // External Editor
+        // ==============================================================================
+        //
+        // When the user presses Ctrl+G in comment mode, the handler sets the
+        // pending_external_edit flag. We handle it here because the terminal
+        // must be suspended (leave alternate screen, disable raw mode) before
+        // spawning the editor process, and only main.rs owns the terminal.
+
+        if app.pending_external_edit {
+            app.pending_external_edit = false;
+
+            match external_editor::resolve_editor_command() {
+                Ok(editor_cmd) => {
+                    let editor_name = external_editor::editor_display_name(&editor_cmd);
+
+                    // Suspend TUI: pop keyboard enhancements, leave alternate
+                    // screen, and disable raw mode so the editor gets a normal
+                    // terminal.
+                    if keyboard_enhancement_supported {
+                        let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
+                    }
+                    disable_raw_mode()?;
+                    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+
+                    let result = external_editor::run_editor(
+                        &app.comment_buffer,
+                        &editor_cmd,
+                        app.output_to_stdout,
+                    );
+
+                    // Resume TUI: re-enter alternate screen, re-enable raw
+                    // mode, and restore keyboard enhancements.
+                    enable_raw_mode()?;
+                    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+                    if keyboard_enhancement_supported {
+                        let _ = execute!(
+                            terminal.backend_mut(),
+                            PushKeyboardEnhancementFlags(
+                                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                            )
+                        );
+                    }
+
+                    // Force a full redraw so the TUI renders cleanly after
+                    // the editor process has written to the terminal.
+                    terminal.clear()?;
+
+                    match result {
+                        Ok(new_content) => {
+                            app.comment_buffer =
+                                external_editor::normalize_edited_content(&new_content);
+                            app.comment_cursor = app.comment_buffer.len();
+                            app.set_message(format!("Edited with {editor_name}"));
+                        }
+                        Err(e) => {
+                            app.set_error(format!("Editor failed: {e}"));
+                        }
+                    }
+                }
+                Err(e) => {
+                    app.set_error(format!("{e} — set $VISUAL or $EDITOR"));
+                }
             }
         }
 

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -72,7 +72,10 @@ pub fn format_comment_input_lines(
         Span::styled(format!("[{}] ", comment_type.as_str()), type_style),
         Span::styled(line_info, styles::dim_style(theme)),
         Span::styled(
-            format!("(Tab:type Enter:save {}:newline Esc:cancel)", newline_hint),
+            format!(
+                "(Tab:type Enter:save {}:newline Ctrl-G:editor Esc:cancel)",
+                newline_hint
+            ),
             styles::dim_style(theme),
         ),
     ]));

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -348,6 +348,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
             ),
             Span::raw("Cancel"),
         ]),
+        Line::from(vec![
+            Span::styled(
+                "  Ctrl-G    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open in external editor ($VISUAL/$EDITOR)"),
+        ]),
         Line::from(""),
         Line::from(Span::styled(
             "Commands",


### PR DESCRIPTION
## Summary
- add Ctrl-G in comment mode to edit the draft in $VISUAL or $EDITOR
- suspend and restore the TUI around the editor, including the --stdout path
- update help text and docs for the new keybinding

## Notes
- I referred to Codex's external editor implementation for the overall flow: https://github.com/openai/codex/blob/029aab5563caed2f2bbea8a1815a42cbf22b79a2/codex-rs/tui/src/external_editor.rs#L4
- I left out Windows-specific tweaks because I do not have a Windows machine to test them.
- This PR is coauthored with codex gpt-5.4-xhigh.