### PR TITLE
docs: add {N}G jump-to-line shortcut to README and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Repository-managed agent integrations:
 **App** (`src/app.rs`):
 - Central application state
 - Contains: `vcs` (Box<dyn VcsBackend>), `vcs_info`, `session`, `diff_files`, `input_mode`, scroll/cursor state
-- Methods: `scroll_down/up`, `next/prev_file`, `next/prev_hunk`, `toggle_reviewed`, `save_comment`
+- Methods: `scroll_down/up`, `next/prev_file`, `next/prev_hunk`, `go_to_source_line`, `toggle_reviewed`, `save_comment`
 
 **VcsBackend** (`src/vcs/traits.rs`):
 - Trait abstracting VCS operations

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ dist/
 | `Ctrl-d` / `Ctrl-u` | Half page down/up |
 | `Ctrl-f` / `Ctrl-b` | Full page down/up |
 | `g` / `G` | Go to first/last file |
+| `{N}G` | Go to source line N in current file |
 | `{` / `}` | Jump to previous/next file |
 | `[` / `]` | Jump to previous/next hunk |
 | `/` | Search within diff |


### PR DESCRIPTION
The {N}G keybinding (type a number then G to jump to that source line in the current file) was documented in the inline help popup but missing from README.md keybindings table and AGENTS.md.