### PR TITLE
feat(config): add show_file_list option to hide file browser on startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ Repository-managed agent integrations:
 
 ### Data Flow
 
-1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), ignore unknown config keys with startup warnings, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), filters diff files via repo-root `.tuicrignore`, then enters commit selection mode by default. If uncommitted changes exist, the first selection row is "Uncommitted changes". With `-r/--revisions`, it opens the requested commit range directly.
+1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), ignore unknown config keys with startup warnings, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), filters diff files via repo-root `.tuicrignore`, then enters commit selection mode by default. If uncommitted changes exist, the first selection row is "Uncommitted changes". With `-r/--revisions`, it opens the requested commit range directly. Config `show_file_list = false` hides the file list panel on startup (toggleable at runtime with `;e`).
 2. **Render**: `ui::render()` draws the TUI based on `App` state
 3. **Input**: `crossterm` events → `map_key_to_action` → match on Action in main loop
 4. **Persistence**: `:w` calls `save_session()`, writes JSON to `~/.local/share/tuicr/reviews/`

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ appearance = "system"
 theme_dark = "gruvbox-dark"
 theme_light = "gruvbox-light"
 
+show_file_list = false
+
 comment_types = [
   { id = "note", label = "question", definition = "ask for clarification", color = "yellow" },
   { id = "suggestion", definition = "possible improvements" },
@@ -135,6 +137,8 @@ comment_types = [
   { id = "nit", label = "nitpick", definition = "small optional tweaks", color = "#d19a66" }
 ]
 ```
+
+`show_file_list` controls whether the file list panel is visible on startup (default: `true`). Toggle at runtime with `;e`.
 
 `comment_types` replaces the default list and defines Tab cycle order.
 Each entry requires `id` and can optionally set `label`, `definition`, and `color`.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,7 @@ pub struct AppConfig {
     pub theme_light: Option<String>,
     pub appearance: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
+    pub show_file_list: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -140,12 +141,24 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         config.comment_types = parse_comment_types(comment_types, &mut warnings);
     }
 
+    if let Some(show_file_list) = table.get("show_file_list") {
+        if let Some(val) = show_file_list.as_bool() {
+            config.show_file_list = Some(val);
+        } else {
+            warnings.push(
+                "Warning: Config key 'show_file_list' must be a boolean; ignoring value"
+                    .to_string(),
+            );
+        }
+    }
+
     for key in table.keys() {
         if key != "theme"
             && key != "theme_dark"
             && key != "theme_light"
             && key != "appearance"
             && key != "comment_types"
+            && key != "show_file_list"
         {
             warnings.push(format!("Warning: Unknown config key '{key}', ignoring"));
         }
@@ -489,6 +502,38 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'theme_dark' must be a string; ignoring value"
+        );
+    }
+
+    #[test]
+    fn should_parse_show_file_list_false() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "show_file_list = false\n").expect("failed to write config");
+
+        let outcome = load_config_from_path(&path).expect("config should parse");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.show_file_list),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_show_file_list_with_invalid_type() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let path = dir.path().join("config.toml");
+        fs::write(&path, "show_file_list = \"no\"\n").expect("failed to write config");
+
+        let outcome = load_config_from_path(&path).expect("config should parse");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.show_file_list),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'show_file_list' must be a boolean; ignoring value"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,7 +153,15 @@ fn main() -> anyhow::Result<()> {
     let backend = CrosstermBackend::new(tty_output);
     let mut terminal = Terminal::new(backend)?;
 
-    // On narrow terminals, start with only the diff panel visible.
+    // Apply config-driven file list visibility, then narrow-terminal override.
+    if let Some(false) = config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.show_file_list)
+    {
+        app.show_file_list = false;
+        app.focused_panel = FocusedPanel::Diff;
+    }
     if let Ok((width, _)) = crossterm::terminal::size()
         && width < MIN_WIDTH_FOR_FILE_LIST
     {


### PR DESCRIPTION
Add a `show_file_list` boolean config key that controls whether the file list panel is visible when tuicr starts. When set to false, tuicr opens with only the diff panel, giving more horizontal space for code review.

The file list can still be toggled at runtime with `;e`. The narrow terminal auto-hide (< 100 columns) takes precedence regardless of this setting.

Config example (~/.config/tuicr/config.toml):

    show_file_list = false