### PR TITLE
feat: add Nord theme

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -499,71 +499,84 @@ impl Theme {
         gruvbox_theme(flavor)
     }
 
-    pub fn nord() -> Self {
-        Self {
-            highlighter: OnceLock::new(),
-
-            // Base colors
-            panel_bg: Color::Rgb(46, 52, 64),      // nord0
-            bg_highlight: Color::Rgb(59, 66, 82),  // nord1
-            fg_primary: Color::Rgb(216, 222, 233), // nord4
-            fg_secondary: Color::Rgb(229, 233, 240), // nord5
-            fg_dim: Color::Rgb(76, 86, 106),       // nord3
-
-            // Diff colors
-            diff_add: Color::Rgb(163, 190, 140),   // nord14
-            diff_add_bg: Color::Rgb(54, 67, 51),   // nord14 blended ~15% toward nord0
-            diff_del: Color::Rgb(191, 97, 106),    // nord11
-            diff_del_bg: Color::Rgb(69, 52, 53),   // nord11 blended ~15% toward nord0
-            diff_context: Color::Rgb(216, 222, 233), // nord4
-            diff_hunk_header: Color::Rgb(136, 192, 208), // nord8
-            expanded_context_fg: Color::Rgb(76, 86, 106), // nord3
-
-            // Syntax highlighting diff backgrounds
-            syntax_add_bg: Color::Rgb(50, 62, 48), // nord14 blended ~10% toward nord0
-            syntax_del_bg: Color::Rgb(65, 48, 50), // nord11 blended ~10% toward nord0
-
-            // Syntect theme for syntax highlighting
+    pub fn nord_dark() -> Self {
+        nord_theme(NordFlavor {
+            dark: true,
+            bg0: rgb(46, 52, 64),       // nord0
+            bg1: rgb(59, 66, 82),       // nord1
+            bg2: rgb(67, 76, 94),       // nord2
+            bg3: rgb(76, 86, 106),      // nord3
+            fg0: rgb(216, 222, 233),    // nord4
+            fg1: rgb(229, 233, 240),    // nord5
+            frost0: rgb(143, 188, 187), // nord7
+            frost1: rgb(136, 192, 208), // nord8
+            frost2: rgb(129, 161, 193), // nord9
+            red: rgb(191, 97, 106),     // nord11
+            orange: rgb(208, 135, 112), // nord12
+            yellow: rgb(235, 203, 139), // nord13
+            green: rgb(163, 190, 140),  // nord14
             syntect_theme: EmbeddedThemeName::Nord,
+        })
+    }
 
-            // File status colors
-            file_added: Color::Rgb(163, 190, 140),   // nord14
-            file_modified: Color::Rgb(235, 203, 139), // nord13
-            file_deleted: Color::Rgb(191, 97, 106),  // nord11
-            file_renamed: Color::Rgb(129, 161, 193), // nord9
+    pub fn nord_light() -> Self {
+        nord_theme(NordFlavor {
+            dark: false,
+            bg0: rgb(236, 239, 244),    // nord6
+            bg1: rgb(229, 233, 240),    // nord5
+            bg2: rgb(216, 222, 233),    // nord4
+            bg3: rgb(76, 86, 106),      // nord3
+            fg0: rgb(46, 52, 64),       // nord0
+            fg1: rgb(59, 66, 82),       // nord1
+            frost0: rgb(143, 188, 187), // nord7
+            frost1: rgb(136, 192, 208), // nord8
+            frost2: rgb(129, 161, 193), // nord9
+            red: rgb(191, 97, 106),     // nord11
+            orange: rgb(208, 135, 112), // nord12
+            yellow: rgb(235, 203, 139), // nord13
+            green: rgb(163, 190, 140),  // nord14
+            syntect_theme: EmbeddedThemeName::Base16OceanLight,
+        })
+    }
 
-            // Review status colors
-            reviewed: Color::Rgb(163, 190, 140),  // nord14
-            pending: Color::Rgb(235, 203, 139),   // nord13
+    pub fn nord_dark_high_contrast() -> Self {
+        nord_theme(NordFlavor {
+            dark: true,
+            bg0: rgb(46, 52, 64),       // nord0
+            bg1: rgb(59, 66, 82),       // nord1
+            bg2: rgb(67, 76, 94),       // nord2
+            bg3: rgb(76, 86, 106),      // nord3
+            fg0: rgb(236, 239, 244),    // nord6 (boosted from nord4 for contrast)
+            fg1: rgb(229, 233, 240),    // nord5
+            frost0: rgb(143, 188, 187), // nord7
+            frost1: rgb(136, 192, 208), // nord8
+            frost2: rgb(129, 161, 193), // nord9
+            red: rgb(191, 97, 106),     // nord11
+            orange: rgb(208, 135, 112), // nord12
+            yellow: rgb(235, 203, 139), // nord13
+            green: rgb(163, 190, 140),  // nord14
+            syntect_theme: EmbeddedThemeName::Nord,
+        })
+    }
 
-            // Comment type colors
-            comment_note: Color::Rgb(136, 192, 208), // nord8
-            comment_suggestion: Color::Rgb(143, 188, 187), // nord7
-            comment_issue: Color::Rgb(191, 97, 106),  // nord11
-            comment_praise: Color::Rgb(163, 190, 140), // nord14
-
-            // UI element colors
-            border_focused: Color::Rgb(136, 192, 208), // nord8
-            border_unfocused: Color::Rgb(59, 66, 82),  // nord1
-            status_bar_bg: Color::Rgb(67, 76, 94),     // nord2
-            cursor_color: Color::Rgb(129, 161, 193),   // nord9
-            branch_name: Color::Rgb(143, 188, 187),    // nord7
-            help_indicator: Color::Rgb(76, 86, 106),   // nord3
-
-            // Message/update badge colors
-            message_info_fg: Color::Black,
-            message_info_bg: Color::Rgb(136, 192, 208),  // nord8
-            message_warning_fg: Color::Black,
-            message_warning_bg: Color::Rgb(208, 135, 112), // nord12
-            message_error_fg: Color::White,
-            message_error_bg: Color::Rgb(191, 97, 106),  // nord11
-            update_badge_fg: Color::Black,
-            update_badge_bg: Color::Rgb(208, 135, 112),  // nord12
-
-            // Mode indicator colors
-            mode_fg: Color::Rgb(46, 52, 64),           // nord0
-            mode_bg: Color::Rgb(136, 192, 208),        // nord8
-        }
+    pub fn nord_light_high_contrast() -> Self {
+        nord_theme(NordFlavor {
+            dark: false,
+            bg0: rgb(236, 239, 244),    // nord6
+            bg1: rgb(229, 233, 240),    // nord5
+            bg2: rgb(216, 222, 233),    // nord4
+            bg3: rgb(67, 76, 94),       // nord2 (deeper than nord3 for contrast)
+            fg0: rgb(46, 52, 64),       // nord0
+            fg1: rgb(59, 66, 82),       // nord1
+            frost0: rgb(143, 188, 187), // nord7
+            frost1: rgb(136, 192, 208), // nord8
+            frost2: rgb(129, 161, 193), // nord9
+            red: rgb(191, 97, 106),     // nord11
+            orange: rgb(208, 135, 112), // nord12
+            yellow: rgb(235, 203, 139), // nord13
+            green: rgb(163, 190, 140),  // nord14
+            syntect_theme: EmbeddedThemeName::Base16OceanLight,
+        })
     }
 }
 
@@ -587,6 +600,25 @@ struct CatppuccinFlavor {
     lavender: Color,
     peach: Color,
     pink: Color,
+}
+
+#[derive(Clone, Copy)]
+struct NordFlavor {
+    dark: bool,
+    bg0: Color,
+    bg1: Color,
+    bg2: Color,
+    bg3: Color,
+    fg0: Color,
+    fg1: Color,
+    frost0: Color,
+    frost1: Color,
+    frost2: Color,
+    red: Color,
+    orange: Color,
+    yellow: Color,
+    green: Color,
+    syntect_theme: EmbeddedThemeName,
 }
 
 #[derive(Clone, Copy)]
@@ -780,6 +812,69 @@ fn gruvbox_theme(flavor: GruvboxFlavor) -> Theme {
     }
 }
 
+fn nord_theme(flavor: NordFlavor) -> Theme {
+    let accent_fg = if flavor.dark { flavor.bg0 } else { flavor.fg1 };
+    let diff_add_bg = blend(flavor.bg0, flavor.green, 15);
+    let diff_del_bg = blend(flavor.bg0, flavor.red, 15);
+    let syntax_add_bg = blend(flavor.bg0, flavor.green, 10);
+    let syntax_del_bg = blend(flavor.bg0, flavor.red, 10);
+
+    Theme {
+        highlighter: OnceLock::new(),
+
+        panel_bg: flavor.bg0,
+        bg_highlight: flavor.bg1,
+        fg_primary: flavor.fg0,
+        fg_secondary: flavor.fg1,
+        fg_dim: flavor.bg3,
+
+        diff_add: flavor.green,
+        diff_add_bg,
+        diff_del: flavor.red,
+        diff_del_bg,
+        diff_context: flavor.fg0,
+        diff_hunk_header: flavor.frost1,
+        expanded_context_fg: flavor.bg3,
+
+        syntax_add_bg,
+        syntax_del_bg,
+
+        syntect_theme: flavor.syntect_theme,
+
+        file_added: flavor.green,
+        file_modified: flavor.yellow,
+        file_deleted: flavor.red,
+        file_renamed: flavor.frost2,
+
+        reviewed: flavor.green,
+        pending: flavor.yellow,
+
+        comment_note: flavor.frost1,
+        comment_suggestion: flavor.frost0,
+        comment_issue: flavor.red,
+        comment_praise: flavor.green,
+
+        border_focused: flavor.frost1,
+        border_unfocused: flavor.bg1,
+        status_bar_bg: flavor.bg2,
+        cursor_color: flavor.frost2,
+        branch_name: flavor.frost0,
+        help_indicator: flavor.bg3,
+
+        message_info_fg: accent_fg,
+        message_info_bg: flavor.frost1,
+        message_warning_fg: accent_fg,
+        message_warning_bg: flavor.orange,
+        message_error_fg: accent_fg,
+        message_error_bg: flavor.red,
+        update_badge_fg: accent_fg,
+        update_badge_bg: flavor.orange,
+
+        mode_fg: accent_fg,
+        mode_bg: flavor.frost1,
+    }
+}
+
 /// Theme selection from CLI argument
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum ThemeArg {
@@ -794,10 +889,13 @@ pub enum ThemeArg {
     CatppuccinMocha,
     GruvboxDark,
     GruvboxLight,
-    Nord,
+    NordDark,
+    NordLight,
+    NordDarkHighContrast,
+    NordLightHighContrast,
 }
 
-const THEME_CHOICES: [(&str, ThemeArg); 11] = [
+const THEME_CHOICES: [(&str, ThemeArg); 14] = [
     ("dark", ThemeArg::Dark),
     ("light", ThemeArg::Light),
     ("ayu-light", ThemeArg::AyuLight),
@@ -808,7 +906,10 @@ const THEME_CHOICES: [(&str, ThemeArg); 11] = [
     ("catppuccin-mocha", ThemeArg::CatppuccinMocha),
     ("gruvbox-dark", ThemeArg::GruvboxDark),
     ("gruvbox-light", ThemeArg::GruvboxLight),
-    ("nord", ThemeArg::Nord),
+    ("nord-dark", ThemeArg::NordDark),
+    ("nord-light", ThemeArg::NordLight),
+    ("nord-dark-high-contrast", ThemeArg::NordDarkHighContrast),
+    ("nord-light-high-contrast", ThemeArg::NordLightHighContrast),
 ];
 
 /// CLI arguments parsed from command line
@@ -902,7 +1003,10 @@ pub fn resolve_theme(arg: ThemeArg) -> Theme {
         ThemeArg::CatppuccinMocha => Theme::catppuccin_mocha(),
         ThemeArg::GruvboxDark => Theme::gruvbox_dark(),
         ThemeArg::GruvboxLight => Theme::gruvbox_light(),
-        ThemeArg::Nord => Theme::nord(),
+        ThemeArg::NordDark => Theme::nord_dark(),
+        ThemeArg::NordLight => Theme::nord_light(),
+        ThemeArg::NordDarkHighContrast => Theme::nord_dark_high_contrast(),
+        ThemeArg::NordLightHighContrast => Theme::nord_light_high_contrast(),
     }
 }
 
@@ -1522,6 +1626,58 @@ mod tests {
     fn should_resolve_catppuccin_latte_syntect_theme() {
         let theme = resolve_theme(ThemeArg::CatppuccinLatte);
         assert_eq!(theme.syntect_theme, EmbeddedThemeName::CatppuccinLatte);
+    }
+
+    #[test]
+    fn should_resolve_nord_dark_to_nord_syntect_theme() {
+        let theme = resolve_theme(ThemeArg::NordDark);
+        assert_eq!(theme.syntect_theme, EmbeddedThemeName::Nord);
+    }
+
+    #[test]
+    fn should_resolve_nord_light_to_ocean_light_syntect_theme() {
+        let theme = resolve_theme(ThemeArg::NordLight);
+        assert_eq!(theme.syntect_theme, EmbeddedThemeName::Base16OceanLight);
+    }
+
+    #[test]
+    fn should_resolve_nord_dark_high_contrast_to_nord_syntect_theme() {
+        let theme = resolve_theme(ThemeArg::NordDarkHighContrast);
+        assert_eq!(theme.syntect_theme, EmbeddedThemeName::Nord);
+    }
+
+    #[test]
+    fn should_resolve_nord_light_high_contrast_to_ocean_light_syntect_theme() {
+        let theme = resolve_theme(ThemeArg::NordLightHighContrast);
+        assert_eq!(theme.syntect_theme, EmbeddedThemeName::Base16OceanLight);
+    }
+
+    #[test]
+    fn should_use_dark_bg_for_nord_dark_mode_foreground() {
+        let theme = Theme::nord_dark();
+        assert_eq!(theme.mode_fg, Color::Rgb(46, 52, 64)); // nord0
+    }
+
+    #[test]
+    fn should_use_fg1_for_nord_light_mode_foreground() {
+        let theme = Theme::nord_light();
+        assert_eq!(theme.mode_fg, Color::Rgb(59, 66, 82)); // nord1
+    }
+
+    #[test]
+    fn should_boost_fg_primary_for_nord_dark_high_contrast() {
+        let dark = resolve_theme(ThemeArg::NordDark);
+        let hc = resolve_theme(ThemeArg::NordDarkHighContrast);
+        assert_ne!(dark.fg_primary, hc.fg_primary);
+        assert_eq!(hc.fg_primary, Color::Rgb(236, 239, 244)); // nord6
+    }
+
+    #[test]
+    fn should_deepen_fg_dim_for_nord_light_high_contrast() {
+        let light = resolve_theme(ThemeArg::NordLight);
+        let hc = resolve_theme(ThemeArg::NordLightHighContrast);
+        assert_ne!(light.fg_dim, hc.fg_dim);
+        assert_eq!(hc.fg_dim, Color::Rgb(67, 76, 94)); // nord2
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds four Nord theme variants using the official [Nord colour palette](https://www.nordtheme.com/docs/colors-and-palettes).

- Introduces a shared `NordFlavor` struct + `nord_theme()` function (mirrors the `GruvboxFlavor` / `gruvbox_theme()` pattern)
- Adds four `ThemeArg` variants: `NordDark`, `NordLight`, `NordDarkHighContrast`, `NordLightHighContrast`
- Adds four CLI theme names: `nord-dark`, `nord-light`, `nord-dark-high-contrast`, `nord-light-high-contrast`
- Dark variants use `EmbeddedThemeName::Nord`; light variants use `EmbeddedThemeName::Base16OceanLight`
- Diff add/del backgrounds computed with `blend()` at 15% (add/del) and 10% (syntax highlighting)

## Colour mapping across variants

| Role | `nord-dark` | `nord-light` | `nord-dark-high-contrast` | `nord-light-high-contrast` |
|------|-------------|--------------|---------------------------|----------------------------|
| `panel_bg` | nord0 `#2E3440` | nord6 `#ECEFF4` | nord0 | nord6 |
| `bg_highlight`, `border_unfocused` | nord1 `#3B4252` | nord5 `#E5E9F0` | nord1 | nord5 |
| `status_bar_bg` | nord2 `#434C5E` | nord4 `#D8DEE9` | nord2 | nord4 |
| `fg_dim`, `help_indicator`, `expanded_context_fg` | nord3 `#4C566A` | nord3 `#4C566A` | nord3 | nord2 `#434C5E` |
| `fg_primary`, `diff_context` | nord4 `#D8DEE9` | nord0 `#2E3440` | nord6 `#ECEFF4` | nord0 |
| `fg_secondary` | nord5 `#E5E9F0` | nord1 `#3B4252` | nord5 | nord1 |
| `branch_name`, `comment_suggestion` | nord7 `#8FBCBB` | ← same | ← same | ← same |
| `border_focused`, `diff_hunk_header`, `mode_bg`, `message_info_bg` | nord8 `#88C0D0` | ← same | ← same | ← same |
| `cursor_color`, `file_renamed` | nord9 `#81A1C1` | ← same | ← same | ← same |
| `diff_del`, `comment_issue`, `file_deleted`, `message_error_bg` | nord11 `#BF616A` | ← same | ← same | ← same |
| `message_warning_bg`, `update_badge_bg` | nord12 `#D08770` | ← same | ← same | ← same |
| `file_modified`, `pending` | nord13 `#EBCB8B` | ← same | ← same | ← same |
| `diff_add`, `file_added`, `reviewed`, `comment_praise` | nord14 `#A3BE8C` | ← same | ← same | ← same |
| `mode_fg`, `accent_fg` | nord0 (bg0) | nord1 (fg1) | nord0 (bg0) | nord1 (fg1) |
| syntect theme | `Nord` | `Base16OceanLight` | `Nord` | `Base16OceanLight` |

High-contrast dark boosts `fg_primary` from nord4→nord6 for stronger text/background separation. High-contrast light deepens `fg_dim` from nord3→nord2 for better muted-element visibility.