### PR TITLE
feat: add ZZ (export+quit) and ZQ (quit) vim keybindings

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -25,6 +25,14 @@ fn handle_export(app: &mut App) {
     }
 }
 
+/// Export and quit (used by ZZ keybinding).
+/// When --stdout is set, stores export content and quits.
+/// Otherwise, exports to clipboard and quits.
+pub fn handle_export_and_quit(app: &mut App) {
+    handle_export(app);
+    app.should_quit = true;
+}
+
 fn comment_line_start(buffer: &str, cursor: usize) -> usize {
     let cursor = cursor.min(buffer.len());
     match buffer[..cursor].rfind('\n') {

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -19,6 +19,7 @@ pub enum Action {
     NextHunk,
     PrevHunk,
     PendingZCommand,
+    PendingShiftZCommand,
     PendingSemicolonCommand,
     ScrollLeft(usize),
     ScrollRight(usize),
@@ -117,6 +118,7 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('g'), KeyModifiers::NONE) => Action::GoToTop,
         (KeyCode::Char('G'), _) => Action::GoToBottom,
         (KeyCode::Char('z'), KeyModifiers::NONE) => Action::PendingZCommand,
+        (KeyCode::Char('Z'), _) => Action::PendingShiftZCommand,
         (KeyCode::Char(';'), _) => Action::PendingSemicolonCommand,
 
         // File navigation (use _ for modifiers since shift is implicit in the character)

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,6 +177,8 @@ fn main() -> anyhow::Result<()> {
 
     // Track pending z command for zz centering
     let mut pending_z = false;
+    // Track pending Z command for ZZ export+quit / ZQ quit
+    let mut pending_shift_z = false;
     // Track pending d command for dd delete
     let mut pending_d = false;
     // Track pending ; command for ;e toggle file list
@@ -255,6 +257,30 @@ fn main() -> anyhow::Result<()> {
                         // Otherwise fall through to normal handling
                     }
 
+                    // Handle pending Z command for ZZ (export+quit) / ZQ (quit)
+                    if pending_shift_z {
+                        pending_shift_z = false;
+                        match key.code {
+                            crossterm::event::KeyCode::Char('Z') => {
+                                // ZZ: save session, export, and quit (same as :wq)
+                                let _ = persistence::save_session(&app.session);
+                                app.dirty = false;
+                                if app.session.has_comments() {
+                                    handler::handle_export_and_quit(&mut app);
+                                } else {
+                                    app.should_quit = true;
+                                }
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('Q') => {
+                                // ZQ: quit without exporting (same as q)
+                                app.should_quit = true;
+                                continue;
+                            }
+                            _ => {} // Fall through to normal handling
+                        }
+                    }
+
                     // Handle pending d command for dd delete comment
                     if pending_d {
                         pending_d = false;
@@ -308,6 +334,11 @@ fn main() -> anyhow::Result<()> {
                     match action {
                         Action::PendingZCommand => {
                             pending_z = true;
+                            app.pending_count = None;
+                            continue;
+                        }
+                        Action::PendingShiftZCommand => {
+                            pending_shift_z = true;
                             app.pending_count = None;
                             continue;
                         }


### PR DESCRIPTION
## Summary

- `ZZ` — save session, export comments, and quit (equivalent to `:wq`)
- `ZQ` — quit without exporting (equivalent to `q`)

These are standard vim keybindings for quick exit that many users expect.

## Details

- Adds a `PendingShiftZCommand` action (two-key sequence, same pattern as `zz` centering and `dd` delete)
- `ZZ` saves the session, exports if there are comments, then quits
- `ZQ` quits immediately without saving or exporting
- New `handle_export_and_quit` function in `handler.rs` combines export + quit

## Test plan

- [x] `ZZ` with comments → exports to clipboard/stdout and quits
- [x] `ZZ` without comments → quits without export
- [x] `ZQ` → quits immediately, no export
- [x] `zz` centering still works (lowercase z is unaffected)
- [x] `:wq` and `q` still work as before