### PR TITLE
feat(export): filter comment type legend to used types

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -323,6 +323,8 @@ pub struct App {
     pub saved_inline_selection: Option<(usize, usize)>,
     /// Path filter for scoping diff to a specific file or directory
     pub path_filter: Option<String>,
+    /// Whether to include the "Comment types:" legend line in export
+    pub export_legend: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -801,6 +803,7 @@ impl App {
             range_diff_files: None,
             saved_inline_selection: None,
             path_filter: path_filter.map(|s| s.to_string()),
+            export_legend: true,
         };
         // Auto-hide file list when path filter matches exactly one file
         if app.path_filter.is_some() && app.diff_files.len() == 1 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,7 @@ pub struct AppConfig {
     pub show_file_list: Option<bool>,
     pub diff_view: Option<String>,
     pub wrap: Option<bool>,
+    pub export_legend: Option<bool>,
 }
 
 /// Known top-level config keys. Used to warn about typos.
@@ -38,6 +39,7 @@ const KNOWN_KEYS: &[&str] = &[
     "show_file_list",
     "diff_view",
     "wrap",
+    "export_legend",
 ];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -176,6 +178,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             &mut warnings,
         ),
         wrap: read_bool(table, "wrap", &mut warnings),
+        export_legend: read_bool(table, "export_legend", &mut warnings),
     };
 
     for key in table.keys() {
@@ -579,6 +582,27 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'wrap' must be a boolean; ignoring value"
+        );
+    }
+
+    // export_legend
+
+    #[test]
+    fn should_parse_export_legend_false() {
+        let outcome = parse_config("export_legend = false\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.export_legend),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_default_export_legend_to_none() {
+        let outcome = parse_config("\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.export_legend),
+            None
         );
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -10,7 +10,12 @@ use crate::text_edit::{
 /// When output_to_stdout is true, stores the content and sets should_quit.
 fn handle_export(app: &mut App) {
     if app.output_to_stdout {
-        match generate_export_content(&app.session, &app.diff_source, &app.comment_types) {
+        match generate_export_content(
+            &app.session,
+            &app.diff_source,
+            &app.comment_types,
+            app.export_legend,
+        ) {
             Ok(content) => {
                 app.pending_stdout_output = Some(content);
                 app.should_quit = true;
@@ -18,7 +23,12 @@ fn handle_export(app: &mut App) {
             Err(e) => app.set_warning(format!("{e}")),
         }
     } else {
-        match export_to_clipboard(&app.session, &app.diff_source, &app.comment_types) {
+        match export_to_clipboard(
+            &app.session,
+            &app.diff_source,
+            &app.comment_types,
+            app.export_legend,
+        ) {
             Ok(msg) => app.set_message(msg),
             Err(e) => app.set_warning(format!("{e}")),
         }
@@ -348,12 +358,18 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
                         &app.session,
                         &app.diff_source,
                         &app.comment_types,
+                        app.export_legend,
                     ) {
                         Ok(content) => app.pending_stdout_output = Some(content),
                         Err(e) => app.set_warning(format!("{e}")),
                     }
                 } else {
-                    match export_to_clipboard(&app.session, &app.diff_source, &app.comment_types) {
+                    match export_to_clipboard(
+                        &app.session,
+                        &app.diff_source,
+                        &app.comment_types,
+                        app.export_legend,
+                    ) {
                         Ok(msg) => app.set_message(msg),
                         Err(e) => app.set_warning(format!("{e}")),
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,9 @@ fn main() -> anyhow::Result<()> {
         if cfg.wrap == Some(true) {
             app.set_diff_wrap(true);
         }
+        if cfg.export_legend == Some(false) {
+            app.export_legend = false;
+        }
     }
 
     // On narrow terminals, start with only the diff panel visible.

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::fmt::Write;
 use std::io::Write as IoWrite;
 
@@ -17,19 +18,26 @@ pub fn generate_export_content(
     session: &ReviewSession,
     diff_source: &DiffSource,
     comment_types: &[CommentTypeDefinition],
+    show_legend: bool,
 ) -> Result<String> {
     if !session.has_comments() {
         return Err(TuicrError::NoComments);
     }
-    Ok(generate_markdown(session, diff_source, comment_types))
+    Ok(generate_markdown(
+        session,
+        diff_source,
+        comment_types,
+        show_legend,
+    ))
 }
 
 pub fn export_to_clipboard(
     session: &ReviewSession,
     diff_source: &DiffSource,
     comment_types: &[CommentTypeDefinition],
+    show_legend: bool,
 ) -> Result<String> {
-    let content = generate_export_content(session, diff_source, comment_types)?;
+    let content = generate_export_content(session, diff_source, comment_types, show_legend)?;
 
     // Prefer OSC 52 in tmux/SSH where arboard may silently fail
     if should_prefer_osc52() {
@@ -133,6 +141,7 @@ fn generate_markdown(
     session: &ReviewSession,
     diff_source: &DiffSource,
     comment_types: &[CommentTypeDefinition],
+    show_legend: bool,
 ) -> String {
     let mut md = String::new();
 
@@ -182,27 +191,43 @@ fn generate_markdown(
         }
     }
 
-    let legend = if comment_types.is_empty() {
-        "NOTE, SUGGESTION, ISSUE, PRAISE".to_string()
-    } else {
-        comment_types
-            .iter()
-            .map(|comment_type| {
-                let definition = comment_type
-                    .definition
-                    .as_deref()
-                    .unwrap_or(comment_type.id.as_str());
-                format!(
-                    "{} ({})",
-                    comment_type.label.to_ascii_uppercase(),
-                    definition
-                )
-            })
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
-    let _ = writeln!(md, "Comment types: {legend}");
-    let _ = writeln!(md);
+    if show_legend {
+        let used_ids = collect_used_comment_type_ids(session);
+        let legend = if comment_types.is_empty() {
+            let all = ["NOTE", "SUGGESTION", "ISSUE", "PRAISE"];
+            let filtered: Vec<&str> = if used_ids.is_empty() {
+                all.to_vec()
+            } else {
+                all.iter()
+                    .copied()
+                    .filter(|t| used_ids.contains(&t.to_ascii_lowercase()))
+                    .collect()
+            };
+            filtered.join(", ")
+        } else {
+            let filtered: Vec<_> = comment_types
+                .iter()
+                .filter(|ct| used_ids.is_empty() || used_ids.contains(&ct.id))
+                .collect();
+            filtered
+                .iter()
+                .map(|comment_type| {
+                    let definition = comment_type
+                        .definition
+                        .as_deref()
+                        .unwrap_or(comment_type.id.as_str());
+                    format!(
+                        "{} ({})",
+                        comment_type.label.to_ascii_uppercase(),
+                        definition
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        let _ = writeln!(md, "Comment types: {legend}");
+        let _ = writeln!(md);
+    }
 
     // Session notes/summary
     if let Some(notes) = &session.session_notes {
@@ -296,6 +321,24 @@ fn generate_markdown(
     md
 }
 
+fn collect_used_comment_type_ids(session: &ReviewSession) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    for c in &session.review_comments {
+        ids.insert(c.comment_type.id().to_string());
+    }
+    for review in session.files.values() {
+        for c in &review.file_comments {
+            ids.insert(c.comment_type.id().to_string());
+        }
+        for comments in review.line_comments.values() {
+            for c in comments {
+                ids.insert(c.comment_type.id().to_string());
+            }
+        }
+    }
+    ids
+}
+
 fn export_comment_type_label(
     comment_type: &CommentType,
     comment_types: &[CommentTypeDefinition],
@@ -383,12 +426,15 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("I reviewed your code and have the following comments"));
-        assert!(markdown.contains("Comment types:"));
-        assert!(markdown.contains("SUGGESTION (improvements)"));
+        assert!(
+            markdown.contains("Comment types: SUGGESTION (improvements), ISSUE (problems to fix)")
+        );
+        assert!(!markdown.contains("NOTE"));
+        assert!(!markdown.contains("PRAISE"));
         assert!(markdown.contains("[SUGGESTION]"));
         assert!(markdown.contains("`src/main.rs`"));
         assert!(markdown.contains("Consider adding documentation"));
@@ -421,7 +467,7 @@ mod tests {
             color: None,
         }];
 
-        let markdown = generate_markdown(&session, &DiffSource::WorkingTree, &custom_types);
+        let markdown = generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true);
 
         assert!(markdown.contains("Comment types: QUESTION (ask for clarification)"));
         assert!(markdown.contains("**[QUESTION]**"));
@@ -434,7 +480,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         // Should have 2 numbered comments
@@ -451,7 +497,8 @@ mod tests {
             None,
         ));
 
-        let markdown = generate_markdown(&session, &DiffSource::WorkingTree, &comment_types());
+        let markdown =
+            generate_markdown(&session, &DiffSource::WorkingTree, &comment_types(), true);
 
         assert!(markdown
             .contains("`Review Comment (scope: working tree changes)` - Please split this into smaller commits"));
@@ -470,6 +517,7 @@ mod tests {
             &session,
             &DiffSource::CommitRange(vec!["abc1234567890".to_string()]),
             &comment_types(),
+            true,
         );
 
         assert!(markdown.contains(
@@ -489,7 +537,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = export_to_clipboard(&session, &diff_source, &comment_types());
+        let result = export_to_clipboard(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(result.is_err());
@@ -503,7 +551,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = generate_export_content(&session, &diff_source, &comment_types());
+        let result = generate_export_content(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(result.is_ok());
@@ -525,7 +573,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = generate_export_content(&session, &diff_source, &comment_types());
+        let result = generate_export_content(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(result.is_err());
@@ -542,7 +590,7 @@ mod tests {
         ]);
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("Reviewing commits: abc1234, def4567"));
@@ -555,7 +603,7 @@ mod tests {
         let diff_source = DiffSource::CommitRange(vec!["abc1234567890".to_string()]);
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("Reviewing commit: abc1234"));
@@ -616,7 +664,7 @@ mod tests {
         // given - simulate what would be copied during export
         let session = create_test_session();
         let diff_source = DiffSource::WorkingTree;
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
         let mut buffer: Vec<u8> = Vec::new();
 
         // when
@@ -658,7 +706,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("`src/main.rs:42`"));
@@ -691,7 +739,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("`src/main.rs:10-15`"));
@@ -724,7 +772,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("`src/main.rs:~20-~25`"));
@@ -756,7 +804,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("`src/main.rs:~30`"));
@@ -788,9 +836,85 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types());
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
 
         // then
         assert!(markdown.contains("`src/main.rs:50`"));
+    }
+
+    #[test]
+    fn should_omit_legend_when_show_legend_is_false() {
+        let session = create_test_session();
+        let diff_source = DiffSource::WorkingTree;
+
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), false);
+
+        assert!(!markdown.contains("Comment types:"));
+        assert!(markdown.contains("[SUGGESTION]"));
+        assert!(markdown.contains("[ISSUE]"));
+    }
+
+    #[test]
+    fn should_only_list_used_comment_types_in_legend() {
+        let mut session = ReviewSession::new(
+            PathBuf::from("/tmp/test-repo"),
+            "abc1234def".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::WorkingTree,
+        );
+        session.add_file(PathBuf::from("src/main.rs"), FileStatus::Modified);
+        if let Some(review) = session.get_file_mut(&PathBuf::from("src/main.rs")) {
+            review.add_file_comment(Comment::new(
+                "Great work!".to_string(),
+                CommentType::Praise,
+                None,
+            ));
+        }
+
+        let markdown =
+            generate_markdown(&session, &DiffSource::WorkingTree, &comment_types(), true);
+
+        assert!(markdown.contains("Comment types: PRAISE (positive feedback)"));
+        assert!(!markdown.contains("NOTE"));
+        assert!(!markdown.contains("SUGGESTION"));
+        assert!(!markdown.contains("ISSUE"));
+    }
+
+    #[test]
+    fn should_only_list_used_custom_types_in_legend() {
+        let mut session = ReviewSession::new(
+            PathBuf::from("/tmp/test-repo"),
+            "abc1234def".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::WorkingTree,
+        );
+        session.add_file(PathBuf::from("src/main.rs"), FileStatus::Modified);
+        if let Some(review) = session.get_file_mut(&PathBuf::from("src/main.rs")) {
+            review.add_file_comment(Comment::new(
+                "Needs clarification".to_string(),
+                CommentType::Note,
+                None,
+            ));
+        }
+
+        let custom_types = vec![
+            CommentTypeDefinition {
+                id: "note".to_string(),
+                label: "question".to_string(),
+                definition: Some("ask for clarification".to_string()),
+                color: None,
+            },
+            CommentTypeDefinition {
+                id: "issue".to_string(),
+                label: "issue".to_string(),
+                definition: Some("problems to fix".to_string()),
+                color: None,
+            },
+        ];
+
+        let markdown = generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true);
+
+        assert!(markdown.contains("Comment types: QUESTION (ask for clarification)"));
+        assert!(!markdown.contains("ISSUE"));
     }
 }


### PR DESCRIPTION
## Summary
- The `Comment types:` line in exported markdown now only lists comment types actually used in the current review, instead of always listing all four
- New `export_legend` config option (default: `true`) to suppress the legend line entirely via `export_legend = false` in `config.toml`

## Test plan
- [x] Existing tests updated to verify legend filtering
- [x] New test: legend omitted when `show_legend` is false
- [x] New test: legend only lists used types (default types)
- [x] New test: legend only lists used types (custom types)
- [x] New tests: `export_legend` config parsing
- [x] Full test suite passes (339 tests)
- [x] Manual testing: added comments with subset of types, verified `y` export only lists used types

🤖 *Generated by Claude Code*