### PR TITLE
feat: display diff stats (+insertions -deletions) in diff panel title

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1541,6 +1541,23 @@ impl App {
         self.session.reviewed_count()
     }
 
+    /// Returns `(total_files, total_additions, total_deletions)` across all diff files.
+    pub fn diff_stat(&self) -> (usize, usize, usize) {
+        let mut additions = 0;
+        let mut deletions = 0;
+        for file in &self.diff_files {
+            let (a, d) = file.stat();
+            additions += a;
+            deletions += d;
+        }
+        (self.diff_files.len(), additions, deletions)
+    }
+
+    /// Returns true when the cursor is in the review comments area above all files.
+    pub fn is_cursor_in_overview(&self) -> bool {
+        self.diff_state.cursor_line < self.review_comments_render_height()
+    }
+
     pub fn set_message(&mut self, msg: impl Into<String>) {
         self.message = Some(Message {
             content: msg.into(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -428,6 +428,31 @@ impl App {
         path_filter: Option<&str>,
         file_path: Option<&str>,
     ) -> Result<Self> {
+        let mut app = Self::new_inner(
+            theme,
+            comment_type_configs,
+            output_to_stdout,
+            revisions,
+            working_tree,
+            path_filter,
+            file_path,
+        )?;
+        // Start at the overview position (review comments header)
+        // so the diff title shows total stats on launch.
+        app.diff_state.cursor_line = 0;
+        app.diff_state.scroll_offset = 0;
+        Ok(app)
+    }
+
+    fn new_inner(
+        theme: Theme,
+        comment_type_configs: Option<Vec<CommentTypeConfig>>,
+        output_to_stdout: bool,
+        revisions: Option<&str>,
+        working_tree: bool,
+        path_filter: Option<&str>,
+        file_path: Option<&str>,
+    ) -> Result<Self> {
         // --file mode: open a single file for annotation without VCS
         if let Some(file_path) = file_path {
             let vcs = Box::new(FileBackend::new(file_path)?);

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -76,4 +76,20 @@ impl DiffFile {
             .or(self.old_path.as_ref())
             .expect("DiffFile must have at least one path")
     }
+
+    /// Returns `(additions, deletions)` for this file.
+    pub fn stat(&self) -> (usize, usize) {
+        let mut additions = 0;
+        let mut deletions = 0;
+        for hunk in &self.hunks {
+            for line in &hunk.lines {
+                match line.origin {
+                    LineOrigin::Addition => additions += 1,
+                    LineOrigin::Deletion => deletions += 1,
+                    LineOrigin::Context => {}
+                }
+            }
+        }
+        (additions, deletions)
+    }
 }

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -564,16 +564,43 @@ fn render_diff_view(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 }
 
+/// Build a right-aligned title showing diff stats for the current scope.
+/// In overview: total stats across all files. In a file: that file's stats.
+fn diff_stat_title(app: &App) -> Line<'static> {
+    let (additions, deletions) = if app.is_cursor_in_overview() || app.current_file_path().is_none()
+    {
+        let (_, a, d) = app.diff_stat();
+        (a, d)
+    } else {
+        app.diff_files[app.diff_state.current_file_idx].stat()
+    };
+
+    let theme = &app.theme;
+    Line::from(vec![
+        Span::styled(
+            format!(" +{additions}"),
+            Style::default().fg(theme.diff_add),
+        ),
+        Span::raw(" "),
+        Span::styled(
+            format!("-{deletions} "),
+            Style::default().fg(theme.diff_del),
+        ),
+    ])
+}
+
 fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
-    let title = match app.current_file_path() {
-        Some(path) => format!(" Diff (Unified) \u{2014} {} ", path.display()),
-        None => " Diff (Unified) ".to_string(),
+    let title = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
+        " Diff (Unified) \u{2014} Overview ".to_string()
+    } else {
+        format!(" Diff (Unified) \u{2014} {} ", app.current_file_path().unwrap().display())
     };
 
     let block = Block::default()
         .title(title)
+        .title_top(diff_stat_title(app).right_aligned())
         .borders(Borders::ALL)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
@@ -1655,13 +1682,15 @@ fn scroll_comment_input_into_view(
 fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
-    let title = match app.current_file_path() {
-        Some(path) => format!(" Diff (Side-by-Side) \u{2014} {} ", path.display()),
-        None => " Diff (Side-by-Side) ".to_string(),
+    let title = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
+        " Diff (Side-by-Side) \u{2014} Overview ".to_string()
+    } else {
+        format!(" Diff (Side-by-Side) \u{2014} {} ", app.current_file_path().unwrap().display())
     };
 
     let block = Block::default()
         .title(title)
+        .title_top(diff_stat_title(app).right_aligned())
         .borders(Borders::ALL)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -595,7 +595,10 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let title = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
         " Diff (Unified) \u{2014} Overview ".to_string()
     } else {
-        format!(" Diff (Unified) \u{2014} {} ", app.current_file_path().unwrap().display())
+        format!(
+            " Diff (Unified) \u{2014} {} ",
+            app.current_file_path().unwrap().display()
+        )
     };
 
     let block = Block::default()
@@ -1685,7 +1688,10 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let title = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
         " Diff (Side-by-Side) \u{2014} Overview ".to_string()
     } else {
-        format!(" Diff (Side-by-Side) \u{2014} {} ", app.current_file_path().unwrap().display())
+        format!(
+            " Diff (Side-by-Side) \u{2014} {} ",
+            app.current_file_path().unwrap().display()
+        )
     };
 
     let block = Block::default()


### PR DESCRIPTION
## Summary
- Adds `+insertions -deletions` stats to the diff panel border, right-aligned in green/red
- Stats are context-sensitive: shows totals when on the review comments header, per-file stats when scrolled into a file
- Works in both unified and side-by-side diff modes

## Startup cursor position change

This PR also changes where the cursor starts on launch. Previously, `sort_files_by_directory(true)` called `jump_to_file(0)`, landing the cursor on the first file header. Now `App::new()` resets the cursor to line 0 (the review comments header) after all setup, so the diff title shows "Overview" with total stats on startup. Pressing `j` moves into the first file as before.

This only affects initial launch — mid-session reloads (switching commits, changing diff sources) still call `sort_files_by_directory(true)` → `jump_to_file(0)` and land on the first file.

## Test plan
- [ ] Launch with `-r origin/main..HEAD`, verify "Overview" title with total stats on startup
- [ ] Press `j` to scroll into a file, verify title switches to file path with per-file stats
- [ ] Press `k` to scroll back up, verify title returns to "Overview"
- [ ] Toggle side-by-side mode (`s`), verify stats appear there too
- [ ] Multi-commit review: change commit selection with `Space`+`Enter`, verify cursor lands on first file (not overview)

Closes #244

🤖 *Generated by Claude Code*