### PR TITLE
fix: reset cursor to overview in sort_files_by_directory, not just new()

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -428,31 +428,6 @@ impl App {
         path_filter: Option<&str>,
         file_path: Option<&str>,
     ) -> Result<Self> {
-        let mut app = Self::new_inner(
-            theme,
-            comment_type_configs,
-            output_to_stdout,
-            revisions,
-            working_tree,
-            path_filter,
-            file_path,
-        )?;
-        // Start at the overview position (review comments header)
-        // so the diff title shows total stats on launch.
-        app.diff_state.cursor_line = 0;
-        app.diff_state.scroll_offset = 0;
-        Ok(app)
-    }
-
-    fn new_inner(
-        theme: Theme,
-        comment_type_configs: Option<Vec<CommentTypeConfig>>,
-        output_to_stdout: bool,
-        revisions: Option<&str>,
-        working_tree: bool,
-        path_filter: Option<&str>,
-        file_path: Option<&str>,
-    ) -> Result<Self> {
         // --file mode: open a single file for annotation without VCS
         if let Some(file_path) = file_path {
             let vcs = Box::new(FileBackend::new(file_path)?);
@@ -3575,7 +3550,11 @@ impl App {
             return;
         }
 
-        self.jump_to_file(0);
+        // Start at the overview position (review comments header)
+        // so the diff title shows total stats on launch.
+        self.diff_state.cursor_line = 0;
+        self.diff_state.scroll_offset = 0;
+        self.diff_state.current_file_idx = 0;
     }
 
     pub fn expand_all_dirs(&mut self) {


### PR DESCRIPTION
The previous implementation only reset cursor_line/scroll_offset in a new() wrapper, but every transition to diff view (confirm_commit_selection, load_staged_selection, etc.) calls sort_files_by_directory(true) which called jump_to_file(0) and clobbered the cursor back to the first file header. Moving the reset into sort_files_by_directory fixes all paths.