### PR TITLE
enable view scrolling via ctrl-{e,y}

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1622,6 +1622,29 @@ impl App {
         self.update_current_file_from_cursor();
     }
 
+    pub fn scroll_view_down(&mut self, lines: usize) {
+        let max_scroll = self.max_scroll_offset();
+        self.diff_state.scroll_offset = (self.diff_state.scroll_offset + lines).min(max_scroll);
+        if self.diff_state.cursor_line < self.diff_state.scroll_offset {
+            self.diff_state.cursor_line = self.diff_state.scroll_offset;
+            self.update_current_file_from_cursor();
+        }
+    }
+
+    pub fn scroll_view_up(&mut self, lines: usize) {
+        self.diff_state.scroll_offset = self.diff_state.scroll_offset.saturating_sub(lines);
+        let visible_lines = if self.diff_state.visible_line_count > 0 {
+            self.diff_state.visible_line_count
+        } else {
+            self.diff_state.viewport_height.max(1)
+        };
+        let bottom = self.diff_state.scroll_offset + visible_lines.saturating_sub(1);
+        if self.diff_state.cursor_line > bottom {
+            self.diff_state.cursor_line = bottom;
+            self.update_current_file_from_cursor();
+        }
+    }
+
     pub fn scroll_left(&mut self, cols: usize) {
         if self.diff_state.wrap_lines {
             return;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -521,6 +521,8 @@ pub fn handle_diff_action(app: &mut App, action: Action) {
     match action {
         Action::CursorDown(n) => app.cursor_down(n),
         Action::CursorUp(n) => app.cursor_up(n),
+        Action::ScrollViewDown(n) => app.scroll_view_down(n),
+        Action::ScrollViewUp(n) => app.scroll_view_up(n),
         Action::ScrollLeft(n) => app.scroll_left(n),
         Action::ScrollRight(n) => app.scroll_right(n),
         Action::SelectFile => {

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -23,6 +23,8 @@ pub enum Action {
     PendingSemicolonCommand,
     ScrollLeft(usize),
     ScrollRight(usize),
+    ScrollViewDown(usize),
+    ScrollViewUp(usize),
 
     // Panel focus
     ToggleFocus,
@@ -110,6 +112,8 @@ fn map_normal_mode(key: KeyEvent) -> Action {
         // Cursor movement (vim-like: cursor moves, scroll follows when needed)
         (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::CursorDown(1),
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::CursorUp(1),
+        (KeyCode::Char('e'), KeyModifiers::CONTROL) => Action::ScrollViewDown(1),
+        (KeyCode::Char('y'), KeyModifiers::CONTROL) => Action::ScrollViewUp(1),
         (KeyCode::Char('d'), KeyModifiers::CONTROL) => Action::HalfPageDown,
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::HalfPageUp,
         (KeyCode::Char('f'), KeyModifiers::CONTROL) => Action::PageDown,

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -40,6 +40,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  Ctrl-e/y  ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Scroll view down/up"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  Ctrl-d/u  ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
In service of #14, enables scrolling the view a single line at a time regardless of present cursor location.