### PR TITLE
feat: add command :clearc to clear comments without clearing reviewed…

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,8 @@ use ratatui::style::Color;
 use crate::config::CommentTypeConfig;
 use crate::error::{Result, TuicrError};
 use crate::model::{
-    Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineRange,
-    LineSide, ReviewSession, SessionDiffSource,
+    ClearScope, Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin,
+    LineRange, LineSide, ReviewSession, SessionDiffSource,
 };
 use crate::persistence::load_latest_session_for_context;
 use crate::syntax::SyntaxHighlighter;
@@ -2515,8 +2515,8 @@ impl App {
         false
     }
 
-    pub fn clear_all_comments(&mut self) {
-        let (cleared, unreviewed) = self.session.clear_comments();
+    pub fn clear_comments(&mut self, scope: ClearScope) {
+        let (cleared, unreviewed) = self.session.clear_comments(scope);
         if cleared == 0 && unreviewed == 0 {
             self.set_message("No comments to clear");
             return;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,6 @@
 use crate::app::{self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit};
 use crate::input::Action;
+use crate::model::ClearScope;
 use crate::output::{export_to_clipboard, generate_export_content};
 use crate::persistence::save_session;
 use crate::text_edit::{
@@ -202,7 +203,8 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                     Err(e) => app.set_error(format!("Reload failed: {e}")),
                 },
                 "clip" | "export" => handle_export(app),
-                "clear" => app.clear_all_comments(),
+                "clear" => app.clear_comments(ClearScope::CommentsAndReviewed),
+                "clearc" => app.clear_comments(ClearScope::CommentsOnly),
                 "version" => {
                     app.set_message(format!("tuicr v{}", env!("CARGO_PKG_VERSION")));
                 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,4 +4,4 @@ pub mod review;
 
 pub use comment::{Comment, CommentType, LineRange, LineSide};
 pub use diff_types::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
-pub use review::{ReviewSession, SessionDiffSource};
+pub use review::{ClearScope, ReviewSession, SessionDiffSource};

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -6,6 +6,12 @@ use std::path::PathBuf;
 use super::comment::Comment;
 use super::diff_types::FileStatus;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClearScope {
+    CommentsOnly,
+    CommentsAndReviewed,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileReview {
     pub path: PathBuf,
@@ -129,7 +135,7 @@ impl ReviewSession {
         !self.review_comments.is_empty() || self.files.values().any(|f| f.comment_count() > 0)
     }
 
-    pub fn clear_comments(&mut self) -> (usize, usize) {
+    pub fn clear_comments(&mut self, scope: ClearScope) -> (usize, usize) {
         let mut cleared = self.review_comments.len();
         let mut unreviewed = 0;
         self.review_comments.clear();
@@ -137,7 +143,7 @@ impl ReviewSession {
             cleared += file.comment_count();
             file.file_comments.clear();
             file.line_comments.clear();
-            if file.reviewed {
+            if scope == ClearScope::CommentsAndReviewed && file.reviewed {
                 file.reviewed = false;
                 unreviewed += 1;
             }
@@ -170,7 +176,7 @@ mod tests {
     #[test]
     fn should_return_zero_when_clearing_empty_session() {
         let mut session = test_session();
-        let (cleared, unreviewed) = session.clear_comments();
+        let (cleared, unreviewed) = session.clear_comments(ClearScope::CommentsAndReviewed);
         assert_eq!(cleared, 0);
         assert_eq!(unreviewed, 0);
     }
@@ -185,7 +191,7 @@ mod tests {
             .review_comments
             .push(Comment::new("issue".to_string(), CommentType::Issue, None));
 
-        let (cleared, unreviewed) = session.clear_comments();
+        let (cleared, unreviewed) = session.clear_comments(ClearScope::CommentsAndReviewed);
         assert_eq!(cleared, 2);
         assert_eq!(unreviewed, 0);
         assert!(session.review_comments.is_empty());
@@ -203,7 +209,7 @@ mod tests {
             Comment::new("line".to_string(), CommentType::Note, None),
         );
 
-        let (cleared, _) = session.clear_comments();
+        let (cleared, _) = session.clear_comments(ClearScope::CommentsAndReviewed);
         assert_eq!(cleared, 2);
 
         let file = session.files.get(&path).unwrap();
@@ -222,7 +228,7 @@ mod tests {
         session.get_file_mut(&path_a).unwrap().reviewed = true;
         session.get_file_mut(&path_b).unwrap().reviewed = true;
 
-        let (cleared, unreviewed) = session.clear_comments();
+        let (cleared, unreviewed) = session.clear_comments(ClearScope::CommentsAndReviewed);
         assert_eq!(cleared, 0);
         assert_eq!(unreviewed, 2);
         assert!(!session.is_file_reviewed(&path_a));
@@ -239,7 +245,7 @@ mod tests {
 
         session.get_file_mut(&reviewed).unwrap().reviewed = true;
 
-        let (_, unreviewed) = session.clear_comments();
+        let (_, unreviewed) = session.clear_comments(ClearScope::CommentsAndReviewed);
         assert_eq!(unreviewed, 1);
     }
 
@@ -256,10 +262,29 @@ mod tests {
             .review_comments
             .push(Comment::new("review".to_string(), CommentType::Note, None));
 
-        let (cleared, unreviewed) = session.clear_comments();
+        let (cleared, unreviewed) = session.clear_comments(ClearScope::CommentsAndReviewed);
         assert_eq!(cleared, 2);
         assert_eq!(unreviewed, 1);
         assert!(!session.is_file_reviewed(&path));
+    }
+
+    #[test]
+    fn should_preserve_reviewed_status_when_requested() {
+        let mut session = test_session();
+        let path = PathBuf::from("src/lib.rs");
+        session.add_file(path.clone(), FileStatus::Modified, SOME_HASH);
+        let file = session.get_file_mut(&path).unwrap();
+        file.reviewed = true;
+        file.add_file_comment(Comment::new("comment".to_string(), CommentType::Note, None));
+
+        session
+            .review_comments
+            .push(Comment::new("review".to_string(), CommentType::Note, None));
+
+        let (cleared, unreviewed) = session.clear_comments(ClearScope::CommentsOnly);
+        assert_eq!(cleared, 2);
+        assert_eq!(unreviewed, 0);
+        assert!(session.is_file_reviewed(&path));
     }
 
     #[test]

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -443,7 +443,14 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  :clear    ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Clear all comments"),
+            Span::raw("Clear all comments and reviewed marks"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :clearc   ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Clear comments only"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
… files marks

When using the tool, I mark files as reviewed, and then I want to clean stale comments, without unmarking reviews files. The :clearc comment removes all comments without unmarking reviewed files