### PR TITLE
feat(input): support Alt+Backspace to delete previous word

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ dist/
 | `Enter` / `Ctrl-Enter` / `Ctrl-s` | Save comment |
 | `Shift-Enter` / `Ctrl-j` | Insert newline |
 | `←` / `→` | Move cursor |
-| `Ctrl-w` | Delete word |
+| `Ctrl-w` / `Alt-Backspace` / `Cmd-Backspace` | Delete word |
 | `Ctrl-u` | Clear line |
 | `Esc` / `Ctrl-c` | Cancel |
 

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -178,6 +178,7 @@ fn map_command_mode(key: KeyEvent) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
+        (KeyCode::Backspace, mods) if mods.contains(KeyModifiers::ALT) => Action::DeleteWord,
         (KeyCode::Backspace, KeyModifiers::NONE) => Action::DeleteChar,
         (KeyCode::Char('w'), KeyModifiers::CONTROL) => Action::DeleteWord,
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::ClearLine,
@@ -190,6 +191,7 @@ fn map_search_mode(key: KeyEvent) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
+        (KeyCode::Backspace, mods) if mods.contains(KeyModifiers::ALT) => Action::DeleteWord,
         (KeyCode::Backspace, KeyModifiers::NONE) => Action::DeleteChar,
         (KeyCode::Char('w'), KeyModifiers::CONTROL) => Action::DeleteWord,
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::ClearLine,
@@ -242,7 +244,9 @@ fn map_comment_mode(key: KeyEvent) -> Action {
         (KeyCode::Right, KeyModifiers::NONE) => Action::TextCursorRight,
         // Editing
         (KeyCode::Backspace, mods)
-            if mods.contains(KeyModifiers::SUPER) || mods.contains(KeyModifiers::META) =>
+            if mods.contains(KeyModifiers::ALT)
+                || mods.contains(KeyModifiers::SUPER)
+                || mods.contains(KeyModifiers::META) =>
         {
             Action::DeleteWord
         }
@@ -402,5 +406,13 @@ mod tests {
     fn should_map_backtab_to_reverse_comment_type_in_comment_mode() {
         let action = map_comment_mode(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
         assert_eq!(action, Action::CycleCommentTypeReverse);
+    }
+
+    #[test]
+    fn should_map_alt_backspace_to_delete_word_in_text_input_modes() {
+        let alt_backspace = KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT);
+        assert_eq!(map_comment_mode(alt_backspace), Action::DeleteWord);
+        assert_eq!(map_command_mode(alt_backspace), Action::DeleteWord);
+        assert_eq!(map_search_mode(alt_backspace), Action::DeleteWord);
     }
 }


### PR DESCRIPTION
*Written by Claude*

## What

Adds `Alt+Backspace` (Option+Delete on macOS) as a 'delete previous word' binding alongside the existing `Ctrl+W`. Applied to comment, command (`:`), and search (`/`) input modes for consistency.

## Why

`Alt+Backspace` is the readline standard on Linux and the system-wide "delete word" shortcut on macOS. It was the only common 'delete word' chord that didn't work in tuicr — `Ctrl+W` and `Cmd+Backspace` (the latter from #87) already did.

## Notes

- `Cmd+Backspace` continues to map to `DeleteWord` in comment mode (unchanged from #87). Most macOS terminals translate the chord to plain backspaces before the app sees it, so the visible behavior is 'clear line' for most users — but on terminals that forward the modifier (e.g. Kitty keyboard protocol), it does delete-word, matching prior behavior.
- Added a small unit test asserting `Alt+Backspace → DeleteWord` in all three text input modes.
- README's Comment Mode table updated with the new binding.

## Test

```
cargo test
cargo fmt --check
```

Dogfooded: used the new binding while drafting comments on the very diff that introduces it.