### PR TITLE
feat(mouse): wheel + clicks behind opt-in 'mouse = true' (closes #140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,23 @@ dist/
 !Cargo.lock
 ```
 
+### Mouse
+
+Mouse support is **opt-in**. Enable it in your config:
+
+```toml
+mouse = true
+```
+
+| Action | Effect |
+|--------|--------|
+| Wheel up/down | Scroll the panel under the cursor (file list, diff, or help popup) without moving the cursor line |
+| Click on a file | Jump to that file (lazygit-style) |
+| Click on a directory | Expand or collapse it |
+| Click on a diff line | Position the cursor on that line |
+
+When mouse capture is on, the terminal stops handling drag-to-select natively. To copy text, hold your terminal's bypass modifier while dragging (commonly **Shift** or **Option/Alt**, depending on the terminal). Check your terminal's docs if neither works.
+
 ### Keybindings
 
 #### Navigation

--- a/src/app.rs
+++ b/src/app.rs
@@ -141,6 +141,24 @@ pub enum FindSourceLineResult {
     NotFound,
 }
 
+pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
+    match annotation {
+        AnnotatedLine::FileHeader { file_idx }
+        | AnnotatedLine::FileComment { file_idx, .. }
+        | AnnotatedLine::HunkHeader { file_idx, .. }
+        | AnnotatedLine::DiffLine { file_idx, .. }
+        | AnnotatedLine::SideBySideLine { file_idx, .. }
+        | AnnotatedLine::LineComment { file_idx, .. }
+        | AnnotatedLine::BinaryOrEmpty { file_idx } => Some(*file_idx),
+        AnnotatedLine::ReviewCommentsHeader
+        | AnnotatedLine::ReviewComment { .. }
+        | AnnotatedLine::Expander { .. }
+        | AnnotatedLine::HiddenLines { .. }
+        | AnnotatedLine::ExpandedContext { .. }
+        | AnnotatedLine::Spacing => None,
+    }
+}
+
 /// Search `line_annotations` for the annotation whose `new_lineno` best matches
 /// `target_lineno` within the file identified by `current_file`.
 pub fn find_source_line(
@@ -292,6 +310,13 @@ pub struct App {
     pub cursor_line_highlight: bool,
     pub file_list_area: Option<ratatui::layout::Rect>,
     pub diff_area: Option<ratatui::layout::Rect>,
+    /// Inner content rect of the file list panel; populated during render.
+    pub file_list_inner_area: Option<ratatui::layout::Rect>,
+    /// Inner content rect of the diff panel; populated during render.
+    pub diff_inner_area: Option<ratatui::layout::Rect>,
+    /// Visual-row -> annotation-index map for the diff viewport. Wrapped
+    /// logical lines repeat their annotation index across multiple rows.
+    pub diff_row_to_annotation: Vec<usize>,
     pub expanded_dirs: HashSet<String>,
     /// Stores lines expanded downward from the upper boundary of each gap
     pub expanded_top: HashMap<GapId, Vec<DiffLine>>,
@@ -797,6 +822,9 @@ impl App {
             cursor_line_highlight: true,
             file_list_area: None,
             diff_area: None,
+            file_list_inner_area: None,
+            diff_inner_area: None,
+            diff_row_to_annotation: Vec::new(),
             expanded_dirs: HashSet::new(),
             expanded_top: HashMap::new(),
             expanded_bottom: HashMap::new(),
@@ -2000,6 +2028,73 @@ impl App {
     pub fn file_list_up(&mut self, n: usize) {
         let new_idx = self.file_list_state.selected().saturating_sub(n);
         self.file_list_state.select(new_idx);
+    }
+
+    /// Scroll the file-list viewport down by `lines` without moving the
+    /// selection unless it would fall off the top of the viewport.
+    pub fn file_list_viewport_scroll_down(&mut self, lines: usize) {
+        let total = self.build_visible_items().len();
+        let viewport = self.file_list_state.viewport_height.max(1);
+        let max_offset = total.saturating_sub(viewport);
+        let new_offset = (self.file_list_state.list_state.offset() + lines).min(max_offset);
+        *self.file_list_state.list_state.offset_mut() = new_offset;
+        if self.file_list_state.selected() < new_offset {
+            self.file_list_state.select(new_offset);
+        }
+    }
+
+    /// Scroll the file-list viewport up by `lines` without moving the
+    /// selection unless it would fall off the bottom of the viewport.
+    pub fn file_list_viewport_scroll_up(&mut self, lines: usize) {
+        let viewport = self.file_list_state.viewport_height.max(1);
+        let new_offset = self
+            .file_list_state
+            .list_state
+            .offset()
+            .saturating_sub(lines);
+        *self.file_list_state.list_state.offset_mut() = new_offset;
+        let max_visible = (new_offset + viewport).saturating_sub(1);
+        if self.file_list_state.selected() > max_visible {
+            self.file_list_state.select(max_visible);
+        }
+    }
+
+    pub fn diff_annotation_at_screen_row(&self, screen_row: u16) -> Option<usize> {
+        let inner = self.diff_inner_area?;
+        if screen_row < inner.y || screen_row >= inner.y + inner.height {
+            return None;
+        }
+        let rel = (screen_row - inner.y) as usize;
+        self.diff_row_to_annotation.get(rel).copied()
+    }
+
+    pub fn file_list_idx_at_screen_row(&self, screen_row: u16) -> Option<usize> {
+        let inner = self.file_list_inner_area?;
+        if screen_row < inner.y || screen_row >= inner.y + inner.height {
+            return None;
+        }
+        let rel = (screen_row - inner.y) as usize;
+        let idx = self.file_list_state.list_state.offset() + rel;
+        let total = self.build_visible_items().len();
+        (idx < total).then_some(idx)
+    }
+
+    /// Syncs `current_file_idx` so the file list selection follows when the
+    /// new cursor lands on an annotation belonging to a file.
+    pub fn move_cursor_to_annotation(&mut self, idx: usize) {
+        if idx >= self.line_annotations.len() {
+            return;
+        }
+        self.diff_state.cursor_line = idx;
+        if let Some(file_idx) = annotation_file_idx(&self.line_annotations[idx]) {
+            self.diff_state.current_file_idx = file_idx;
+        }
+        let viewport = self.diff_state.viewport_height.max(1);
+        if idx < self.diff_state.scroll_offset {
+            self.diff_state.scroll_offset = idx;
+        } else if idx >= self.diff_state.scroll_offset + viewport {
+            self.diff_state.scroll_offset = idx + 1 - viewport;
+        }
     }
 
     pub fn jump_to_file(&mut self, idx: usize) {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,7 @@ pub struct AppConfig {
     pub wrap: Option<bool>,
     pub export_legend: Option<bool>,
     pub cursor_line: Option<bool>,
+    pub mouse: Option<bool>,
 }
 
 /// Known top-level config keys. Used to warn about typos.
@@ -42,6 +43,7 @@ const KNOWN_KEYS: &[&str] = &[
     "wrap",
     "export_legend",
     "cursor_line",
+    "mouse",
 ];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -182,6 +184,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         wrap: read_bool(table, "wrap", &mut warnings),
         export_legend: read_bool(table, "export_legend", &mut warnings),
         cursor_line: read_bool(table, "cursor_line", &mut warnings),
+        mouse: read_bool(table, "mouse", &mut warnings),
     };
 
     for key in table.keys() {
@@ -585,6 +588,35 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'wrap' must be a boolean; ignoring value"
+        );
+    }
+
+    // mouse
+
+    #[test]
+    fn should_parse_mouse_true() {
+        let outcome = parse_config("mouse = true\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.mouse),
+            Some(true)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_default_mouse_to_none() {
+        let outcome = parse_config("\n");
+        assert_eq!(outcome.config.as_ref().and_then(|cfg| cfg.mouse), None);
+    }
+
+    #[test]
+    fn should_warn_and_ignore_mouse_with_invalid_type() {
+        let outcome = parse_config("mouse = \"on\"\n");
+        assert_eq!(outcome.config.as_ref().and_then(|cfg| cfg.mouse), None);
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'mouse' must be a boolean; ignoring value"
         );
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,7 @@
-use crate::app::{self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit};
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Position;
+
+use crate::app::{self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit, InputMode};
 use crate::input::Action;
 use crate::model::ClearScope;
 use crate::output::{export_to_clipboard, generate_export_content};
@@ -6,6 +9,62 @@ use crate::persistence::save_session;
 use crate::text_edit::{
     delete_char_before, delete_word_before, next_char_boundary, prev_char_boundary,
 };
+
+const WHEEL_LINES: usize = 3;
+
+/// Routes a crossterm mouse event. Drags are intentionally unhandled so users
+/// can hold the terminal's bypass modifier (commonly Shift or Option/Alt) to
+/// fall back to native text selection for copy.
+pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
+    let pos = Position::new(event.column, event.row);
+    match event.kind {
+        MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
+            let action = if matches!(event.kind, MouseEventKind::ScrollUp) {
+                Action::MouseScrollUp(WHEEL_LINES)
+            } else {
+                Action::MouseScrollDown(WHEEL_LINES)
+            };
+            let over_file_list = app.file_list_area.is_some_and(|r| r.contains(pos));
+            let over_diff = app.diff_area.is_some_and(|r| r.contains(pos));
+            match app.input_mode {
+                InputMode::Help => handle_help_action(app, action),
+                InputMode::Normal if over_file_list => handle_file_list_action(app, action),
+                InputMode::Normal if over_diff => handle_diff_action(app, action),
+                _ => {}
+            }
+        }
+        MouseEventKind::Down(MouseButton::Left) if app.input_mode == InputMode::Normal => {
+            handle_left_click(app, pos);
+        }
+        _ => {}
+    }
+}
+
+fn handle_left_click(app: &mut App, pos: Position) {
+    if app.file_list_inner_area.is_some_and(|r| r.contains(pos))
+        && let Some(idx) = app.file_list_idx_at_screen_row(pos.y)
+    {
+        app.focused_panel = FocusedPanel::FileList;
+        app.file_list_state.select(idx);
+        if let Some(item) = app.build_visible_items().get(idx).cloned() {
+            match item {
+                FileTreeItem::Directory { path, .. } => app.toggle_directory(&path),
+                FileTreeItem::File { file_idx, .. } => {
+                    app.jump_to_file(file_idx);
+                    app.focused_panel = FocusedPanel::Diff;
+                }
+            }
+        }
+        return;
+    }
+
+    if app.diff_inner_area.is_some_and(|r| r.contains(pos))
+        && let Some(idx) = app.diff_annotation_at_screen_row(pos.y)
+    {
+        app.focused_panel = FocusedPanel::Diff;
+        app.move_cursor_to_annotation(idx);
+    }
+}
 
 /// Export review: either to clipboard or set pending stdout output based on app.output_to_stdout.
 /// When output_to_stdout is true, stores the content and sets should_quit.
@@ -140,6 +199,8 @@ pub fn handle_help_action(app: &mut App, action: Action) {
         Action::PageUp => app.help_scroll_up(app.help_state.viewport_height),
         Action::GoToTop => app.help_scroll_to_top(),
         Action::GoToBottom => app.help_scroll_to_bottom(),
+        Action::MouseScrollDown(n) => app.help_scroll_down(n),
+        Action::MouseScrollUp(n) => app.help_scroll_up(n),
         Action::ToggleHelp => app.toggle_help(),
         Action::Quit => app.should_quit = true,
         _ => {}
@@ -497,6 +558,8 @@ pub fn handle_file_list_action(app: &mut App, action: Action) {
         Action::CursorUp(n) => app.file_list_up(n),
         Action::ScrollLeft(n) => app.file_list_state.scroll_left(n),
         Action::ScrollRight(n) => app.file_list_state.scroll_right(n),
+        Action::MouseScrollDown(n) => app.file_list_viewport_scroll_down(n),
+        Action::MouseScrollUp(n) => app.file_list_viewport_scroll_up(n),
         Action::SelectFile | Action::ToggleExpand => {
             if let Some(item) = app.get_selected_tree_item() {
                 match item {
@@ -528,6 +591,8 @@ pub fn handle_diff_action(app: &mut App, action: Action) {
         Action::ScrollViewUp(n) => app.scroll_view_up(n),
         Action::ScrollLeft(n) => app.scroll_left(n),
         Action::ScrollRight(n) => app.scroll_right(n),
+        Action::MouseScrollDown(n) => app.scroll_view_down(n),
+        Action::MouseScrollUp(n) => app.scroll_view_up(n),
         Action::SelectFile => {
             if let Some(hit) = app.get_gap_at_cursor() {
                 match hit {

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -25,6 +25,8 @@ pub enum Action {
     ScrollRight(usize),
     ScrollViewDown(usize),
     ScrollViewUp(usize),
+    MouseScrollUp(usize),
+    MouseScrollDown(usize),
 
     // Panel focus
     ToggleFocus,
@@ -414,5 +416,47 @@ mod tests {
         assert_eq!(map_comment_mode(alt_backspace), Action::DeleteWord);
         assert_eq!(map_command_mode(alt_backspace), Action::DeleteWord);
         assert_eq!(map_search_mode(alt_backspace), Action::DeleteWord);
+    }
+
+    #[test]
+    fn no_key_should_produce_mouse_scroll_actions() {
+        let codes = [
+            KeyCode::Up,
+            KeyCode::Down,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::PageDown,
+            KeyCode::PageUp,
+            KeyCode::Char('j'),
+            KeyCode::Char('k'),
+            KeyCode::Char('e'),
+            KeyCode::Char('y'),
+        ];
+        let mod_sets = [
+            KeyModifiers::NONE,
+            KeyModifiers::CONTROL,
+            KeyModifiers::ALT,
+            KeyModifiers::SHIFT,
+        ];
+        for code in codes {
+            for mods in mod_sets {
+                let ev = KeyEvent::new(code, mods);
+                for action in [
+                    map_normal_mode(ev),
+                    map_command_mode(ev),
+                    map_search_mode(ev),
+                    map_comment_mode(ev),
+                    map_help_mode(ev),
+                ] {
+                    assert!(
+                        !matches!(
+                            action,
+                            Action::MouseScrollUp(_) | Action::MouseScrollDown(_)
+                        ),
+                        "key {code:?} + {mods:?} produced a mouse-scroll action"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,8 @@ use std::time::{Duration, Instant};
 
 use crossterm::{
     event::{
-        self, Event, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-        PushKeyboardEnhancementFlags,
+        self, DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{
@@ -37,7 +37,8 @@ use app::{App, FocusedPanel, InputMode};
 use handler::{
     handle_command_action, handle_comment_action, handle_commit_select_action,
     handle_commit_selector_action, handle_confirm_action, handle_diff_action,
-    handle_file_list_action, handle_help_action, handle_search_action, handle_visual_action,
+    handle_file_list_action, handle_help_action, handle_mouse_event, handle_search_action,
+    handle_visual_action,
 };
 use input::{Action, map_key_to_action};
 use theme::{parse_cli_args, resolve_theme_with_config};
@@ -52,6 +53,7 @@ fn main() -> anyhow::Result<()> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
         let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
+        let _ = execute!(io::stdout(), DisableMouseCapture);
         let _ = disable_raw_mode();
         let _ = execute!(io::stdout(), LeaveAlternateScreen);
         original_hook(panic_info);
@@ -171,6 +173,14 @@ fn main() -> anyhow::Result<()> {
         Box::new(io::stdout())
     };
     execute!(tty_output, EnterAlternateScreen)?;
+    let mouse_enabled = config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.mouse)
+        .unwrap_or(false);
+    if mouse_enabled {
+        execute!(tty_output, EnableMouseCapture)?;
+    }
 
     // Enable keyboard enhancement for better modifier key detection (e.g., Alt+Enter)
     // This is supported by modern terminals like Kitty, iTerm2, WezTerm, etc.
@@ -433,6 +443,7 @@ fn main() -> anyhow::Result<()> {
                         },
                     }
                 }
+                Event::Mouse(mouse_event) => handle_mouse_event(&mut app, mouse_event),
                 _ => {}
             }
         }
@@ -444,6 +455,9 @@ fn main() -> anyhow::Result<()> {
 
     // Restore terminal
     let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
+    if mouse_enabled {
+        let _ = execute!(terminal.backend_mut(), DisableMouseCapture);
+    }
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
 

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -408,6 +408,7 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         .border_style(styles::border_style(&app.theme, focused));
 
     let inner = block.inner(area);
+    app.file_list_inner_area = Some(inner);
     let visible_items = app.build_visible_items();
 
     let max_content_width = visible_items
@@ -613,6 +614,7 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Update viewport height for scroll calculations
     app.diff_state.viewport_height = inner.height as usize;
+    app.diff_inner_area = Some(inner);
 
     // Reset comment input annotation offset (will be set if a comment input box is rendered)
     app.comment_input_annotation_offset = None;
@@ -1404,29 +1406,16 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     app.diff_state.viewport_width = inner.width as usize;
     app.diff_state.max_content_width = max_content_width;
 
-    // Calculate how many logical lines actually fit in the viewport when wrapped
-    let viewport_width = inner.width as usize;
-    let viewport_height = inner.height as usize;
-    app.diff_state.visible_line_count = if app.diff_state.wrap_lines && viewport_width > 0 {
-        let mut visual_rows_used = 0;
-        let mut logical_lines_visible = 0;
-        for &width in &line_widths {
-            // Each line takes at least 1 row, plus extra rows if it wraps
-            let rows_for_line = if width == 0 {
-                1
-            } else {
-                width.div_ceil(viewport_width)
-            };
-            if visual_rows_used + rows_for_line > viewport_height {
-                break;
-            }
-            visual_rows_used += rows_for_line;
-            logical_lines_visible += 1;
-        }
-        logical_lines_visible.max(1)
-    } else {
-        viewport_height
-    };
+    let scroll_offset = app.diff_state.scroll_offset;
+    let wrap = app.diff_state.wrap_lines;
+    app.diff_state.visible_line_count = populate_row_to_annotation(
+        &mut app.diff_row_to_annotation,
+        &line_widths,
+        inner.width as usize,
+        inner.height as usize,
+        wrap,
+        scroll_offset,
+    );
 
     let max_scroll_x = max_content_width.saturating_sub(inner.width as usize);
     if app.diff_state.scroll_x > max_scroll_x {
@@ -1535,6 +1524,46 @@ struct SideBySideContext<'a> {
 }
 
 /// Get cursor indicator (single character for inline content)
+/// Populates `out` with the visual-row -> annotation-index map for the diff
+/// viewport and returns how many logical lines fit. Reuses the buffer's
+/// capacity to avoid per-frame allocations.
+fn populate_row_to_annotation(
+    out: &mut Vec<usize>,
+    line_widths: &[usize],
+    viewport_width: usize,
+    viewport_height: usize,
+    wrap: bool,
+    scroll_offset: usize,
+) -> usize {
+    out.clear();
+    out.reserve(viewport_height);
+    if wrap && viewport_width > 0 {
+        let mut visual_rows_used = 0;
+        let mut logical_lines_visible = 0;
+        for (i, &width) in line_widths.iter().enumerate() {
+            let rows_for_line = if width == 0 {
+                1
+            } else {
+                width.div_ceil(viewport_width)
+            };
+            if visual_rows_used + rows_for_line > viewport_height {
+                break;
+            }
+            for _ in 0..rows_for_line {
+                out.push(scroll_offset + i);
+            }
+            visual_rows_used += rows_for_line;
+            logical_lines_visible += 1;
+        }
+        logical_lines_visible.max(1)
+    } else {
+        for i in 0..line_widths.len().min(viewport_height) {
+            out.push(scroll_offset + i);
+        }
+        viewport_height
+    }
+}
+
 fn cursor_indicator(line_idx: usize, current_line_idx: usize) -> &'static str {
     if line_idx == current_line_idx {
         "▶"
@@ -1736,6 +1765,7 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Update viewport height for scroll calculations
     app.diff_state.viewport_height = inner.height as usize;
+    app.diff_inner_area = Some(inner);
 
     // Reset comment input annotation offset (will be set if a comment input box is rendered)
     app.comment_input_annotation_offset = None;
@@ -2202,29 +2232,16 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     app.diff_state.viewport_width = inner.width as usize;
     app.diff_state.max_content_width = max_content_width;
 
-    // Calculate how many logical lines actually fit in the viewport when wrapped
-    let viewport_width = inner.width as usize;
-    let viewport_height = inner.height as usize;
-    app.diff_state.visible_line_count = if app.diff_state.wrap_lines && viewport_width > 0 {
-        let mut visual_rows_used = 0;
-        let mut logical_lines_visible = 0;
-        for &width in &line_widths {
-            // Each line takes at least 1 row, plus extra rows if it wraps
-            let rows_for_line = if width == 0 {
-                1
-            } else {
-                width.div_ceil(viewport_width)
-            };
-            if visual_rows_used + rows_for_line > viewport_height {
-                break;
-            }
-            visual_rows_used += rows_for_line;
-            logical_lines_visible += 1;
-        }
-        logical_lines_visible.max(1)
-    } else {
-        viewport_height
-    };
+    let scroll_offset = app.diff_state.scroll_offset;
+    let wrap = app.diff_state.wrap_lines;
+    app.diff_state.visible_line_count = populate_row_to_annotation(
+        &mut app.diff_row_to_annotation,
+        &line_widths,
+        inner.width as usize,
+        inner.height as usize,
+        wrap,
+        scroll_offset,
+    );
 
     let max_scroll_x = max_content_width.saturating_sub(inner.width as usize);
     if app.diff_state.scroll_x > max_scroll_x {


### PR DESCRIPTION
## What

Re-enables mouse support, gated behind an opt-in config flag so users who hit #140 can keep current behavior unchanged.

Add to your config to turn it on:

```toml
mouse = true
```

When enabled:
- **Wheel** scrolls the panel under the cursor (file list, diff, help popup) by 3 lines, without moving the cursor.
- **Click on a file** jumps to it (lazygit-style).
- **Click on a directory** expands or collapses it.
- **Click on a diff line** positions the cursor on that line.

Default is off. With the flag off, `EnableMouseCapture` is never called and the binary behaves identically to today's main.

## Why

History recap:
- #117 added wheel + click-to-focus.
- #140 reported clicks broke text-copy in the terminal.
- #152 reverted everything.

The root cause of #140 is `EnableMouseCapture` itself: once it is on, the terminal stops forwarding drag-to-select natively, regardless of which mouse events the app handles. There is no in-app workaround that gives you both. lazygit lives with the same trade-off and gates it behind `gui.mouseEvents`. This PR follows the same pattern.

When the flag is on and you want to copy text from the terminal, hold your terminal's bypass modifier while dragging (commonly **Shift** or **Option/Alt**, depending on the terminal).

## Scope

- Wheel scroll (file list, diff, help popup).
- Single left-click on file list (file = jump, directory = toggle) and on diff content (positions cursor).
- Config flag `mouse` (boolean, default `false`), parsed and validated like the other booleans.

Out of scope (future PRs):
- Drag-to-select with cell precision plus a copy command (`:y` family).
- Double/triple-click and middle-click paste.

## Test

`cargo test --release` -> 355 pass (3 new for the mouse config flag, 1 guard test that no key produces mouse-scroll actions).

Manual:
- Mouse off (default): wheel does nothing in the TUI, terminal native selection works. Confirms no regression vs current main.
- Mouse on: wheel scrolls without cursor jump, click on file jumps, click on directory toggles, click on diff line positions cursor. Hold the bypass modifier while dragging to copy.
- Quit and panic both restore the terminal cleanly.

Closes #140.
