### PR TITLE
feat(mouse): drag-to-select with cell-precise copy and visual range comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ mouse = true
 | Click on a file | Jump to that file (lazygit-style) |
 | Click on a directory | Expand or collapse it |
 | Click on a diff line | Position the cursor on that line |
+| Drag in diff | Highlight a range; press `y` to copy the selected source lines |
 
-When mouse capture is on, the terminal stops handling drag-to-select natively. To copy text, hold your terminal's bypass modifier while dragging (commonly **Shift** or **Option/Alt**, depending on the terminal). Check your terminal's docs if neither works.
+For full native terminal selection across the whole UI, hold your terminal's bypass modifier while dragging (commonly **Shift** or **Option/Alt**, depending on the terminal). Check your terminal's docs if neither works.
 
 ### Keybindings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,25 @@ pub const UNSTAGED_SELECTION_ID: &str = "__tuicr_unstaged__";
 pub const GAP_EXPAND_BATCH: usize = 20;
 
 /// Count how many annotation lines a gap produces (expanders + hidden count).
+/// `hi_char = None` means slice to the end.
+fn char_slice(s: &str, lo_char: usize, hi_char: Option<usize>) -> &str {
+    let mut indices = s.char_indices();
+    let lo_byte = indices
+        .by_ref()
+        .nth(lo_char)
+        .map(|(b, _)| b)
+        .unwrap_or(s.len());
+    let hi_byte = match hi_char {
+        None => s.len(),
+        Some(hi) if hi <= lo_char => return "",
+        Some(hi) => indices
+            .nth(hi - lo_char - 1)
+            .map(|(b, _)| b)
+            .unwrap_or(s.len()),
+    };
+    &s[lo_byte..hi_byte]
+}
+
 fn gap_annotation_line_count(is_top_of_file: bool, remaining: usize) -> usize {
     if remaining == 0 {
         0
@@ -66,6 +85,72 @@ pub enum ExpandDirection {
     Up,
     /// ↕ Expand all remaining lines in both directions (merged expander)
     Both,
+}
+
+/// Unified diff gutter: 1 (cursor indicator) + 5 (line_num + space) + 2 (prefix + space).
+pub const UNIFIED_GUTTER: u16 = 8;
+/// Side-by-side leading width before Old content: indicator(1) + lineno(4) + space(1) + prefix(1).
+pub const SBS_LEFT_GUTTER: u16 = 7;
+/// Side-by-side fixed overhead (both gutters + " │ " divider). The two content
+/// panes share what's left of the inner width equally.
+pub const SBS_OVERHEAD: u16 = 16;
+
+/// X-coords of one diff content pane. SBS has Old and New; Unified has one.
+#[derive(Debug, Clone, Copy)]
+pub struct PaneGeom {
+    pub content_x_start: u16,
+    pub content_x_end: u16,
+    pub content_width: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SelPoint {
+    pub annotation_idx: usize,
+    pub char_offset: usize,
+    pub side: LineSide,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VisualSelection {
+    pub anchor: SelPoint,
+    pub head: SelPoint,
+}
+
+impl VisualSelection {
+    pub fn collapsed(point: SelPoint) -> Self {
+        Self {
+            anchor: point,
+            head: point,
+        }
+    }
+
+    pub fn ordered(&self) -> (SelPoint, SelPoint) {
+        if (self.anchor.annotation_idx, self.anchor.char_offset)
+            <= (self.head.annotation_idx, self.head.char_offset)
+        {
+            (self.anchor, self.head)
+        } else {
+            (self.head, self.anchor)
+        }
+    }
+
+    /// Char range `[lo, hi)` of `total_chars` covered by this selection on the
+    /// annotation `ann_idx`. Returns `(0, total_chars)` for annotations
+    /// strictly between start and end.
+    pub fn char_range(&self, ann_idx: usize, total_chars: usize) -> (usize, usize) {
+        let (start, end) = self.ordered();
+        let lo = if ann_idx == start.annotation_idx {
+            start.char_offset.min(total_chars)
+        } else {
+            0
+        };
+        let hi = if ann_idx == end.annotation_idx {
+            end.char_offset.min(total_chars)
+        } else {
+            total_chars
+        };
+        (lo, hi)
+    }
 }
 
 /// Result of checking what the cursor is on in a gap region
@@ -139,6 +224,26 @@ pub enum FindSourceLineResult {
     Nearest(usize),
     /// No matching lines found in the current file at all.
     NotFound,
+}
+
+/// Best-guess side for an annotation: New for everything except a Side-by-Side
+/// line that only has an Old number (a deletion). Mouse cells outside content
+/// annotations get New as a harmless default; range-comment line resolution
+/// later filters non-diff annotations anyway.
+pub fn annotation_side_default(annotation: &AnnotatedLine) -> LineSide {
+    match annotation {
+        AnnotatedLine::SideBySideLine {
+            new_lineno: None,
+            old_lineno: Some(_),
+            ..
+        } => LineSide::Old,
+        AnnotatedLine::DiffLine {
+            new_lineno: None,
+            old_lineno: Some(_),
+            ..
+        } => LineSide::Old,
+        _ => LineSide::New,
+    }
 }
 
 pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
@@ -282,8 +387,10 @@ pub struct App {
     pub comment_line: Option<(u32, LineSide)>,
     pub editing_comment_id: Option<String>,
 
-    /// Visual selection anchor point (starting line, side)
-    pub visual_anchor: Option<(u32, LineSide)>,
+    pub visual_selection: Option<VisualSelection>,
+    /// True once the active mouse drag has actually moved off the press cell.
+    /// Lets Up distinguish click from drag-back-to-anchor.
+    pub mouse_drag_active: bool,
     /// Line range for range comments (used when creating comments from visual selection)
     pub comment_line_range: Option<(LineRange, LineSide)>,
 
@@ -802,7 +909,8 @@ impl App {
             comment_is_file_level: true,
             comment_line: None,
             editing_comment_id: None,
-            visual_anchor: None,
+            visual_selection: None,
+            mouse_drag_active: false,
             comment_line_range: None,
             commit_list,
             commit_list_cursor: 0,
@@ -2097,6 +2205,210 @@ impl App {
         }
     }
 
+    /// In SBS, picks Old or New per `side`, falling back to the other pane
+    /// if the requested one is empty. Unified diff rows ignore `side`.
+    pub fn content_for_side(&self, ann_idx: usize, side: LineSide) -> Option<&str> {
+        let ann = self.line_annotations.get(ann_idx)?;
+        match ann {
+            AnnotatedLine::DiffLine {
+                file_idx,
+                hunk_idx,
+                line_idx,
+                ..
+            } => {
+                let line = self
+                    .diff_files
+                    .get(*file_idx)?
+                    .hunks
+                    .get(*hunk_idx)?
+                    .lines
+                    .get(*line_idx)?;
+                Some(line.content.as_str())
+            }
+            AnnotatedLine::SideBySideLine {
+                file_idx,
+                hunk_idx,
+                del_line_idx,
+                add_line_idx,
+                ..
+            } => {
+                let hunk = self.diff_files.get(*file_idx)?.hunks.get(*hunk_idx)?;
+                let add = add_line_idx
+                    .and_then(|i| hunk.lines.get(i))
+                    .map(|l| l.content.as_str());
+                let del = del_line_idx
+                    .and_then(|i| hunk.lines.get(i))
+                    .map(|l| l.content.as_str());
+                match side {
+                    LineSide::New => add.or(del),
+                    LineSide::Old => del.or(add),
+                }
+            }
+            AnnotatedLine::ExpandedContext { gap_id, line_idx } => self
+                .get_expanded_line(gap_id, *line_idx)
+                .map(|l| l.content.as_str()),
+            _ => None,
+        }
+    }
+
+    /// For annotations rendered outside the content gutter (hunk headers,
+    /// file headers): returns a clean copy text. The selection's char range
+    /// is meaningless for these — they're emitted whole or not at all.
+    fn atomic_text_for_annotation(&self, ann_idx: usize) -> Option<String> {
+        match self.line_annotations.get(ann_idx)? {
+            AnnotatedLine::HunkHeader { file_idx, hunk_idx } => {
+                let hunk = self.diff_files.get(*file_idx)?.hunks.get(*hunk_idx)?;
+                Some(hunk.header.clone())
+            }
+            AnnotatedLine::FileHeader { file_idx } => {
+                let file = self.diff_files.get(*file_idx)?;
+                if file.is_commit_message {
+                    Some("Commit Message".to_string())
+                } else {
+                    Some(format!(
+                        "{} [{}]",
+                        file.display_path().display(),
+                        file.status.as_char()
+                    ))
+                }
+            }
+            _ => None,
+        }
+    }
+
+    pub fn copy_visual_selection(&mut self) -> Result<usize> {
+        let Some(sel) = self.visual_selection else {
+            return Ok(0);
+        };
+        let (start, end) = sel.ordered();
+        let side = sel.anchor.side;
+        let mut out = String::new();
+        let mut emitted = 0usize;
+        for idx in start.annotation_idx..=end.annotation_idx {
+            let snippet = if let Some(content) = self.content_for_side(idx, side) {
+                let total = content.chars().count();
+                let (lo, hi) = sel.char_range(idx, total);
+                char_slice(content, lo, Some(hi)).to_string()
+            } else if let Some(text) = self.atomic_text_for_annotation(idx) {
+                text
+            } else {
+                continue;
+            };
+            if emitted > 0 {
+                out.push('\n');
+            }
+            out.push_str(&snippet);
+            emitted += 1;
+        }
+        if out.is_empty() {
+            return Ok(0);
+        }
+        let count = out.chars().count();
+        crate::output::copy_text_to_clipboard(&out)
+            .map_err(|e| TuicrError::Clipboard(format!("{e}")))?;
+        Ok(count)
+    }
+
+    pub fn pane_geometry(&self, inner: ratatui::layout::Rect, side: LineSide) -> PaneGeom {
+        match self.diff_view_mode {
+            DiffViewMode::Unified => {
+                let content_width = (inner.width as usize).saturating_sub(UNIFIED_GUTTER as usize);
+                PaneGeom {
+                    content_x_start: inner.x + UNIFIED_GUTTER,
+                    content_x_end: inner.x + inner.width,
+                    content_width,
+                }
+            }
+            DiffViewMode::SideBySide => {
+                let half_w = (inner.width.saturating_sub(SBS_OVERHEAD) / 2) as usize;
+                match side {
+                    LineSide::Old => PaneGeom {
+                        content_x_start: inner.x + SBS_LEFT_GUTTER,
+                        content_x_end: inner.x + SBS_LEFT_GUTTER + half_w as u16,
+                        content_width: half_w,
+                    },
+                    LineSide::New => {
+                        let start = inner.x + SBS_OVERHEAD + half_w as u16;
+                        PaneGeom {
+                            content_x_start: start,
+                            content_x_end: start + half_w as u16,
+                            content_width: half_w,
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pub fn side_at_x(
+        &self,
+        inner: ratatui::layout::Rect,
+        x: u16,
+        ann_default: LineSide,
+    ) -> LineSide {
+        match self.diff_view_mode {
+            DiffViewMode::Unified => ann_default,
+            DiffViewMode::SideBySide => {
+                let half_w = inner.width.saturating_sub(SBS_OVERHEAD) / 2;
+                let divider = inner.x + SBS_LEFT_GUTTER + half_w;
+                if x < divider {
+                    LineSide::Old
+                } else {
+                    LineSide::New
+                }
+            }
+        }
+    }
+
+    pub fn cell_to_sel_point(&self, screen_col: u16, screen_row: u16) -> Option<SelPoint> {
+        let idx = self.diff_annotation_at_screen_row(screen_row)?;
+        let inner = self.diff_inner_area?;
+        let ann = self.line_annotations.get(idx)?;
+        let side = self.side_at_x(inner, screen_col, annotation_side_default(ann));
+
+        let zero_point = SelPoint {
+            annotation_idx: idx,
+            char_offset: 0,
+            side,
+        };
+        let Some(content) = self.content_for_side(idx, side) else {
+            return Some(zero_point);
+        };
+        let geom = self.pane_geometry(inner, side);
+        if geom.content_width == 0 {
+            return Some(zero_point);
+        }
+        let last_col = geom.content_x_end.saturating_sub(1);
+        let col = screen_col.clamp(geom.content_x_start, last_col);
+        let col_in_row = (col - geom.content_x_start) as usize;
+
+        let rel = (screen_row - inner.y) as usize;
+        let mut walker = rel;
+        while walker > 0 && self.diff_row_to_annotation.get(walker - 1).copied() == Some(idx) {
+            walker -= 1;
+        }
+        let which_row = rel - walker;
+        let total_chars = content.chars().count();
+        let char_offset = (which_row * geom.content_width + col_in_row).min(total_chars);
+        Some(SelPoint {
+            annotation_idx: idx,
+            char_offset,
+            side,
+        })
+    }
+
+    /// Mirrors `ensure_cursor_visible`'s notion of visibility (uses the
+    /// renderer's `visible_line_count` when present so wrapping is honored).
+    pub fn is_cursor_visible(&self) -> bool {
+        let visible = if self.diff_state.visible_line_count > 0 {
+            self.diff_state.visible_line_count
+        } else {
+            self.diff_state.viewport_height.max(1)
+        };
+        let cursor = self.diff_state.cursor_line;
+        cursor >= self.diff_state.scroll_offset && cursor < self.diff_state.scroll_offset + visible
+    }
+
     pub fn jump_to_file(&mut self, idx: usize) {
         use std::path::Path;
 
@@ -2789,58 +3101,113 @@ impl App {
         self.comment_line_range = None;
     }
 
-    /// Enter visual selection mode, anchoring at the current cursor position
-    pub fn enter_visual_mode(&mut self, line: u32, side: LineSide) {
+    pub fn enter_visual_mode_at_cursor(&mut self) {
+        let idx = self.diff_state.cursor_line;
+        let side = self
+            .get_line_at_cursor()
+            .map(|(_, s)| s)
+            .unwrap_or(LineSide::New);
+        let len = self.annotation_content_len(idx, side);
+        let anchor = SelPoint {
+            annotation_idx: idx,
+            char_offset: 0,
+            side,
+        };
+        let head = SelPoint {
+            annotation_idx: idx,
+            char_offset: len,
+            side,
+        };
         self.input_mode = InputMode::VisualSelect;
-        self.visual_anchor = Some((line, side));
+        self.visual_selection = Some(VisualSelection { anchor, head });
     }
 
-    /// Exit visual selection mode and return to normal mode
     pub fn exit_visual_mode(&mut self) {
         self.input_mode = InputMode::Normal;
-        self.visual_anchor = None;
+        self.visual_selection = None;
     }
 
-    /// Get the current visual selection range (if in visual mode)
-    /// Returns None if not in visual mode or if there's no valid selection
-    pub fn get_visual_selection(&self) -> Option<(LineRange, LineSide)> {
+    pub fn get_visual_selection(&self) -> Option<&VisualSelection> {
         if self.input_mode != InputMode::VisualSelect {
             return None;
         }
-
-        let (anchor_line, anchor_side) = self.visual_anchor?;
-        let (current_line, current_side) = self.get_line_at_cursor()?;
-
-        // Don't allow selection across sides (old vs new)
-        if anchor_side != current_side {
-            return None;
-        }
-
-        let range = LineRange::new(anchor_line, current_line);
-        Some((range, anchor_side))
+        self.visual_selection.as_ref()
     }
 
-    /// Check if a given line is within the current visual selection
-    pub fn is_line_in_visual_selection(&self, line: u32, side: LineSide) -> bool {
-        if let Some((range, sel_side)) = self.get_visual_selection() {
-            sel_side == side && range.contains(line)
+    pub fn annotation_content_len(&self, idx: usize, side: LineSide) -> usize {
+        self.content_for_side(idx, side)
+            .map(|s| s.chars().count())
+            .unwrap_or(0)
+    }
+
+    pub fn extend_visual_to_cursor(&mut self) {
+        let Some(sel) = self.visual_selection else {
+            return;
+        };
+        let anchor_idx = sel.anchor.annotation_idx;
+        let cursor_idx = self.diff_state.cursor_line;
+        let side = sel.anchor.side;
+        let anchor_len = self.annotation_content_len(anchor_idx, side);
+        let cursor_len = self.annotation_content_len(cursor_idx, side);
+        let (anchor_char, head_char) = if cursor_idx >= anchor_idx {
+            (0, cursor_len)
         } else {
-            false
+            (anchor_len, 0)
+        };
+        self.visual_selection = Some(VisualSelection {
+            anchor: SelPoint {
+                annotation_idx: anchor_idx,
+                char_offset: anchor_char,
+                side,
+            },
+            head: SelPoint {
+                annotation_idx: cursor_idx,
+                char_offset: head_char,
+                side,
+            },
+        });
+    }
+
+    pub fn visual_selection_line_range(&self) -> Option<(LineRange, LineSide)> {
+        let sel = self.get_visual_selection()?;
+        let (start, end) = sel.ordered();
+        let start_line = self.annotation_line_for_side(start.annotation_idx, start.side);
+        let end_line = self.annotation_line_for_side(end.annotation_idx, end.side);
+        let start_ln = start_line?;
+        let end_ln = end_line?;
+        Some((LineRange::new(start_ln, end_ln), start.side))
+    }
+
+    fn annotation_line_for_side(&self, idx: usize, side: LineSide) -> Option<u32> {
+        match self.line_annotations.get(idx)? {
+            AnnotatedLine::DiffLine {
+                old_lineno,
+                new_lineno,
+                ..
+            }
+            | AnnotatedLine::SideBySideLine {
+                old_lineno,
+                new_lineno,
+                ..
+            } => match side {
+                LineSide::New => *new_lineno,
+                LineSide::Old => *old_lineno,
+            },
+            _ => None,
         }
     }
 
-    /// Enter comment mode from visual selection
     pub fn enter_comment_from_visual(&mut self) {
-        if let Some((range, side)) = self.get_visual_selection() {
+        if let Some((range, side)) = self.visual_selection_line_range() {
             self.comment_line_range = Some((range, side));
-            self.comment_line = Some((range.end, side)); // Key by end line
+            self.comment_line = Some((range.end, side));
             self.input_mode = InputMode::Comment;
             self.comment_buffer.clear();
             self.comment_cursor = 0;
             self.comment_type = self.default_comment_type();
             self.comment_is_review_level = false;
             self.comment_is_file_level = false;
-            self.visual_anchor = None;
+            self.visual_selection = None;
         } else {
             self.set_warning("Invalid visual selection");
             self.exit_visual_mode();
@@ -5466,5 +5833,58 @@ mod expand_gap_tests {
             .filter(|a| matches!(a, AnnotatedLine::Expander { gap_id: g, direction: ExpandDirection::Both } if *g == gap_id))
             .count();
         assert_eq!(both_count, 1, "should merge to ↕ when <20 remaining");
+    }
+}
+
+#[cfg(test)]
+mod visual_selection_tests {
+    use super::*;
+
+    fn p(idx: usize, off: usize) -> SelPoint {
+        SelPoint {
+            annotation_idx: idx,
+            char_offset: off,
+            side: LineSide::New,
+        }
+    }
+
+    #[test]
+    fn collapsed_starts_at_point() {
+        let sel = VisualSelection::collapsed(p(5, 3));
+        assert_eq!(sel.anchor, p(5, 3));
+        assert_eq!(sel.head, p(5, 3));
+    }
+
+    #[test]
+    fn ordered_returns_anchor_head_when_already_in_order() {
+        let sel = VisualSelection {
+            anchor: p(1, 0),
+            head: p(4, 8),
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, p(1, 0));
+        assert_eq!(end, p(4, 8));
+    }
+
+    #[test]
+    fn ordered_swaps_when_head_before_anchor_by_idx() {
+        let sel = VisualSelection {
+            anchor: p(4, 0),
+            head: p(1, 0),
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, p(1, 0));
+        assert_eq!(end, p(4, 0));
+    }
+
+    #[test]
+    fn ordered_breaks_ties_on_idx_by_char_offset() {
+        let sel = VisualSelection {
+            anchor: p(7, 20),
+            head: p(7, 5),
+        };
+        let (start, end) = sel.ordered();
+        assert_eq!(start, p(7, 5));
+        assert_eq!(end, p(7, 20));
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,7 +1,10 @@
 use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Position;
 
-use crate::app::{self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit, InputMode};
+use crate::app::{
+    self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit, InputMode,
+    VisualSelection,
+};
 use crate::input::Action;
 use crate::model::ClearScope;
 use crate::output::{export_to_clipboard, generate_export_content};
@@ -12,9 +15,6 @@ use crate::text_edit::{
 
 const WHEEL_LINES: usize = 3;
 
-/// Routes a crossterm mouse event. Drags are intentionally unhandled so users
-/// can hold the terminal's bypass modifier (commonly Shift or Option/Alt) to
-/// fall back to native text selection for copy.
 pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
     let pos = Position::new(event.column, event.row);
     match event.kind {
@@ -30,13 +30,86 @@ pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
                 InputMode::Help => handle_help_action(app, action),
                 InputMode::Normal if over_file_list => handle_file_list_action(app, action),
                 InputMode::Normal if over_diff => handle_diff_action(app, action),
+                InputMode::VisualSelect if over_diff => handle_diff_action(app, action),
                 _ => {}
             }
+            clear_visual_if_cursor_offscreen(app);
         }
-        MouseEventKind::Down(MouseButton::Left) if app.input_mode == InputMode::Normal => {
-            handle_left_click(app, pos);
+        MouseEventKind::Down(MouseButton::Left)
+            if matches!(app.input_mode, InputMode::Normal | InputMode::VisualSelect) =>
+        {
+            // Reset back to Normal so an Up without drag falls through to handle_left_click.
+            if app.input_mode == InputMode::VisualSelect {
+                app.exit_visual_mode();
+            }
+            app.mouse_drag_active = false;
+            if app.diff_inner_area.is_some_and(|r| r.contains(pos))
+                && let Some(point) = app.cell_to_sel_point(pos.x, pos.y)
+            {
+                app.visual_selection = Some(VisualSelection::collapsed(point));
+                if let Some(idx) = app.diff_annotation_at_screen_row(pos.y) {
+                    app.move_cursor_to_annotation(idx);
+                }
+            } else {
+                app.visual_selection = None;
+                handle_left_click(app, pos);
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left)
+            if matches!(app.input_mode, InputMode::Normal | InputMode::VisualSelect) =>
+        {
+            let Some(sel) = app.visual_selection else {
+                return;
+            };
+            let Some(mut head) = app.cell_to_sel_point(pos.x, pos.y) else {
+                return;
+            };
+            // Pin head to the anchor's pane so cross-side drags don't escape.
+            head.side = sel.anchor.side;
+            if head == sel.head && app.mouse_drag_active {
+                return;
+            }
+            let moved = head != sel.head;
+            let promoted_now = moved && !app.mouse_drag_active;
+            app.visual_selection = Some(VisualSelection {
+                anchor: sel.anchor,
+                head,
+            });
+            if moved {
+                app.mouse_drag_active = true;
+            }
+            if promoted_now && app.input_mode == InputMode::Normal {
+                app.input_mode = InputMode::VisualSelect;
+            }
+            if app.input_mode == InputMode::VisualSelect
+                && head.annotation_idx != sel.head.annotation_idx
+            {
+                app.move_cursor_to_annotation(head.annotation_idx);
+            }
+        }
+        MouseEventKind::Up(MouseButton::Left)
+            if matches!(app.input_mode, InputMode::Normal | InputMode::VisualSelect) =>
+        {
+            if app.visual_selection.is_none() {
+                return;
+            }
+            if !app.mouse_drag_active {
+                app.visual_selection = None;
+                if app.input_mode == InputMode::VisualSelect {
+                    app.exit_visual_mode();
+                }
+                handle_left_click(app, pos);
+            }
+            app.mouse_drag_active = false;
         }
         _ => {}
+    }
+}
+
+/// Helix-style: scrolling the cursor off-viewport drops the selection.
+pub fn clear_visual_if_cursor_offscreen(app: &mut App) {
+    if app.input_mode == InputMode::VisualSelect && !app.is_cursor_visible() {
+        app.exit_visual_mode();
     }
 }
 
@@ -519,36 +592,39 @@ pub fn handle_visual_action(app: &mut App, action: Action) {
     match action {
         Action::CursorDown(n) => {
             app.cursor_down(n);
-            // Check if selection crosses sides
-            if let Some((_, anchor_side)) = app.visual_anchor
-                && let Some((_, current_side)) = app.get_line_at_cursor()
-                && anchor_side != current_side
-            {
-                app.set_warning("Cannot select across old/new sides");
-            }
+            app.extend_visual_to_cursor();
         }
         Action::CursorUp(n) => {
             app.cursor_up(n);
-            // Check if selection crosses sides
-            if let Some((_, anchor_side)) = app.visual_anchor
-                && let Some((_, current_side)) = app.get_line_at_cursor()
-                && anchor_side != current_side
-            {
-                app.set_warning("Cannot select across old/new sides");
-            }
+            app.extend_visual_to_cursor();
         }
         Action::AddRangeComment => {
-            if app.get_visual_selection().is_some() {
+            if app.visual_selection_line_range().is_some() {
                 app.enter_comment_from_visual();
             } else {
-                app.set_warning("Invalid selection - cannot span old and new lines");
+                app.set_warning("Invalid selection - move cursor to a diff line");
                 app.exit_visual_mode();
             }
         }
+        Action::ExportToClipboard => {
+            match app.copy_visual_selection() {
+                Ok(0) => app.set_message("Nothing to copy"),
+                Ok(n) => app.set_message(format!("Copied {n} chars")),
+                Err(e) => app.set_warning(format!("{e}")),
+            }
+            app.exit_visual_mode();
+        }
         Action::ExitMode => app.exit_visual_mode(),
         Action::Quit => app.should_quit = true,
+        Action::ScrollViewDown(n) | Action::MouseScrollDown(n) => app.scroll_view_down(n),
+        Action::ScrollViewUp(n) | Action::MouseScrollUp(n) => app.scroll_view_up(n),
+        Action::HalfPageDown => app.scroll_down(app.diff_state.viewport_height / 2),
+        Action::HalfPageUp => app.scroll_up(app.diff_state.viewport_height / 2),
+        Action::PageDown => app.scroll_down(app.diff_state.viewport_height),
+        Action::PageUp => app.scroll_up(app.diff_state.viewport_height),
         _ => {}
     }
+    clear_visual_if_cursor_offscreen(app);
 }
 
 /// Handle actions when file list panel is focused
@@ -711,8 +787,8 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             app.search_prev_in_diff();
         }
         Action::EnterVisualMode => {
-            if let Some((line, side)) = app.get_line_at_cursor() {
-                app.enter_visual_mode(line, side);
+            if app.get_line_at_cursor().is_some() {
+                app.enter_visual_mode_at_cursor();
             } else {
                 app.set_message("Move cursor to a diff line to start visual selection");
             }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -306,13 +306,11 @@ fn map_visual_mode(key: KeyEvent) -> Action {
         // Extend selection
         (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::CursorDown(1),
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::CursorUp(1),
-        // Create range comment
         (KeyCode::Char('c'), KeyModifiers::NONE) => Action::AddRangeComment,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::AddRangeComment,
-        // Cancel selection
+        (KeyCode::Char('y'), KeyModifiers::NONE) => Action::ExportToClipboard,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Char('v') | KeyCode::Char('V'), _) => Action::ExitMode,
-        // Quick quit
         (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
         _ => Action::None,
     }

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -38,20 +38,27 @@ pub fn export_to_clipboard(
     show_legend: bool,
 ) -> Result<String> {
     let content = generate_export_content(session, diff_source, comment_types, show_legend)?;
+    let via_terminal = copy_text_to_clipboard(&content)?;
+    Ok(if via_terminal {
+        "Review copied to clipboard (via terminal)".to_string()
+    } else {
+        "Review copied to clipboard".to_string()
+    })
+}
 
-    // Prefer OSC 52 in tmux/SSH where arboard may silently fail
+/// Copy arbitrary text to the system clipboard. Returns `Ok(true)` if the
+/// terminal-based fallback (tmux/OSC 52) was used, `Ok(false)` if the
+/// platform clipboard handled it.
+pub fn copy_text_to_clipboard(text: &str) -> Result<bool> {
     if should_prefer_osc52() {
-        copy_osc52(&content)?;
-        return Ok("Review copied to clipboard (via terminal)".to_string());
+        copy_osc52(text)?;
+        return Ok(true);
     }
-
-    // Try arboard (system clipboard) first, fall back to OSC 52 for SSH/remote sessions
-    match Clipboard::new().and_then(|mut cb| cb.set_text(&content)) {
-        Ok(_) => Ok("Review copied to clipboard".to_string()),
+    match Clipboard::new().and_then(|mut cb| cb.set_text(text)) {
+        Ok(_) => Ok(false),
         Err(_) => {
-            // Fall back to OSC 52 escape sequence (works over SSH)
-            copy_osc52(&content)?;
-            Ok("Review copied to clipboard (via terminal)".to_string())
+            copy_osc52(text)?;
+            Ok(true)
         }
     }
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,3 @@
 pub mod markdown;
 
-pub use markdown::{export_to_clipboard, generate_export_content};
+pub use markdown::{copy_text_to_clipboard, export_to_clipboard, generate_export_content};

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -9,7 +9,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::{
     AnnotatedLine, App, DiffViewMode, ExpandDirection, FileTreeItem, FocusedPanel,
-    GAP_EXPAND_BATCH, GapId, InputMode,
+    GAP_EXPAND_BATCH, GapId, InputMode, VisualSelection,
 };
 use crate::model::{LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
@@ -1006,27 +1006,7 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
                         LineOrigin::Context => (" ", styles::diff_context_style(&app.theme)),
                     };
 
-                    // Check if this line is in visual selection
-                    let is_in_visual_selection = {
-                        let line_num = match diff_line.origin {
-                            LineOrigin::Addition | LineOrigin::Context => diff_line.new_lineno,
-                            LineOrigin::Deletion => diff_line.old_lineno,
-                        };
-                        let side = match diff_line.origin {
-                            LineOrigin::Addition | LineOrigin::Context => LineSide::New,
-                            LineOrigin::Deletion => LineSide::Old,
-                        };
-                        line_num
-                            .map(|ln| app.is_line_in_visual_selection(ln, side))
-                            .unwrap_or(false)
-                    };
-
-                    // Apply visual selection highlighting if applicable
-                    let style = if is_in_visual_selection {
-                        base_style.patch(styles::visual_selection_style(&app.theme))
-                    } else {
-                        base_style
-                    };
+                    let style = base_style;
 
                     let line_num_str = match diff_line.origin {
                         LineOrigin::Addition => diff_line
@@ -1046,13 +1026,7 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
 
                     let indicator = cursor_indicator(line_idx, current_line_idx);
 
-                    // Build line spans - use syntax highlighting if available
-                    let line_num_style = if is_in_visual_selection {
-                        styles::dim_style(&app.theme)
-                            .patch(styles::visual_selection_style(&app.theme))
-                    } else {
-                        styles::dim_style(&app.theme)
-                    };
+                    let line_num_style = styles::dim_style(&app.theme);
 
                     let mut line_spans = vec![
                         Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
@@ -1060,19 +1034,11 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
                         Span::styled(format!("{prefix} "), style),
                     ];
 
-                    // Add content spans
                     if let Some(ref highlighted) = diff_line.highlighted_spans {
-                        // Use syntax-highlighted spans
                         for (span_style, span_text) in highlighted {
-                            let final_style = if is_in_visual_selection {
-                                span_style.patch(styles::visual_selection_style(&app.theme))
-                            } else {
-                                *span_style
-                            };
-                            line_spans.push(Span::styled(span_text.clone(), final_style));
+                            line_spans.push(Span::styled(span_text.clone(), *span_style));
                         }
                     } else {
-                        // Fall back to default diff styling
                         line_spans.push(Span::styled(diff_line.content.clone(), style));
                     }
 
@@ -1454,6 +1420,10 @@ fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     frame.render_widget(diff, inner);
 
+    if let Some(sel) = app.visual_selection {
+        paint_visual_selection_overlay(frame, inner, app, sel, &app.theme);
+    }
+
     // Calculate screen position for comment cursor if in Comment mode
     if let Some(cursor_logical_line) = comment_cursor_logical_line {
         let scroll_offset = app.diff_state.scroll_offset;
@@ -1561,6 +1531,126 @@ fn populate_row_to_annotation(
             out.push(scroll_offset + i);
         }
         viewport_height
+    }
+}
+
+struct OverlayPaint {
+    sel: VisualSelection,
+    geom: crate::app::PaneGeom,
+    inner_left: u16,
+    inner_right: u16,
+    style: Style,
+}
+
+fn paint_visual_selection_overlay(
+    frame: &mut Frame,
+    inner: Rect,
+    app: &App,
+    sel: VisualSelection,
+    theme: &Theme,
+) {
+    let (start, end) = sel.ordered();
+    let paint = OverlayPaint {
+        sel,
+        geom: app.pane_geometry(inner, sel.anchor.side),
+        inner_left: inner.x,
+        inner_right: inner.x + inner.width.saturating_sub(1),
+        style: styles::visual_selection_style(theme),
+    };
+
+    let mut current: Option<(usize, u16, u16)> = None;
+    for rel in 0..app.diff_row_to_annotation.len() {
+        let ann_idx = app.diff_row_to_annotation[rel];
+        if ann_idx < start.annotation_idx {
+            continue;
+        }
+        if ann_idx > end.annotation_idx {
+            break;
+        }
+        let row = inner.y + rel as u16;
+        match current {
+            Some((cur, first, _)) if cur == ann_idx => {
+                current = Some((cur, first, row));
+            }
+            _ => {
+                if let Some(group) = current.take() {
+                    paint_annotation_group(frame, app, group, &paint);
+                }
+                current = Some((ann_idx, row, row));
+            }
+        }
+    }
+    if let Some(group) = current.take() {
+        paint_annotation_group(frame, app, group, &paint);
+    }
+}
+
+fn paint_annotation_group(
+    frame: &mut Frame,
+    app: &App,
+    group: (usize, u16, u16),
+    paint: &OverlayPaint,
+) {
+    let (ann_idx, first_row, last_row) = group;
+    if paint.geom.content_width == 0 {
+        return;
+    }
+
+    let side = paint.sel.anchor.side;
+    let group_height = (last_row - first_row) as usize + 1;
+    let pane_last_col = paint
+        .geom
+        .content_x_end
+        .saturating_sub(1)
+        .min(paint.inner_right);
+
+    let Some(content) = app.content_for_side(ann_idx, side) else {
+        // Headers and other non-content rows aren't bound by the pane
+        // gutter; tint the full inner width.
+        for which_row in 0..group_height {
+            let rect = Rect {
+                x: paint.inner_left,
+                y: first_row + which_row as u16,
+                width: paint.inner_right - paint.inner_left + 1,
+                height: 1,
+            };
+            frame.buffer_mut().set_style(rect, paint.style);
+        }
+        return;
+    };
+
+    let total_chars = content.chars().count();
+    let (lo, hi) = paint.sel.char_range(ann_idx, total_chars);
+    if hi <= lo {
+        return;
+    }
+
+    for which_row in 0..group_height {
+        let row_char_start = which_row * paint.geom.content_width;
+        let row_char_end = row_char_start + paint.geom.content_width;
+        let isect_lo = lo.max(row_char_start);
+        let isect_hi = hi.min(row_char_end);
+        if isect_hi <= isect_lo {
+            continue;
+        }
+        let col_lo_off = (isect_lo - row_char_start) as u16;
+        let col_hi_off = (isect_hi - row_char_start) as u16;
+        let col_lo = (paint.geom.content_x_start + col_lo_off).min(pane_last_col);
+        let col_hi_excl = paint.geom.content_x_start + col_hi_off;
+        if col_hi_excl == 0 {
+            continue;
+        }
+        let col_hi = col_hi_excl.saturating_sub(1).min(pane_last_col);
+        if col_lo > col_hi {
+            continue;
+        }
+        let rect = Rect {
+            x: col_lo,
+            y: first_row + which_row as u16,
+            width: col_hi - col_lo + 1,
+            height: 1,
+        };
+        frame.buffer_mut().set_style(rect, paint.style);
     }
 }
 
@@ -1770,10 +1860,8 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     // Reset comment input annotation offset (will be set if a comment input box is rendered)
     app.comment_input_annotation_offset = None;
 
-    // Calculate column widths (split the area in half)
     // Layout: indicator(1) + linenum(4) + space(1) + prefix(1) + content + " │ "(3) + linenum(4) + space(1) + prefix(1) + content
-    // Total overhead: 1 + 5 + 1 + 3 + 5 + 1 = 16
-    let available_width = inner.width.saturating_sub(16) as usize;
+    let available_width = inner.width.saturating_sub(crate::app::SBS_OVERHEAD) as usize;
     let content_width = available_width / 2;
 
     // Determine if we're in line comment mode (not file-level)
@@ -2267,7 +2355,6 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     frame.render_widget(diff, inner);
 
-    // Paint cursor/selection line highlights for side-by-side view
     if app.cursor_line_highlight {
         let viewport_height = inner.height as usize;
         for offset in 0..viewport_height {
@@ -2283,6 +2370,11 @@ fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
                     .set_style(row_rect, Style::default().bg(app.theme.cursor_line_bg));
             }
         }
+    }
+
+    // Painted last so the cell overlay wins over cursor-line bg on overlap.
+    if let Some(sel) = app.visual_selection {
+        paint_visual_selection_overlay(frame, inner, app, sel, &app.theme);
     }
 
     // Calculate screen position for comment cursor if in Comment mode
@@ -2908,8 +3000,9 @@ fn is_line_highlighted(app: &App, viewport_idx: usize) -> bool {
         return true;
     }
 
-    // Visual selection or comment-mode range (preserved from visual selection)
-    let Some((range, sel_side)) = app.get_visual_selection().or(app.comment_line_range) else {
+    // Carryover from V → c: keep the comment-input box lit. The visual
+    // selection itself paints via the cell-precise overlay.
+    let Some((range, sel_side)) = app.comment_line_range else {
         return false;
     };
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -264,7 +264,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  y         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Yank (copy) review to clipboard"),
+            Span::raw("Yank: mouse selection if any, else review to clipboard"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -194,7 +194,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             InputMode::Confirm => " CONFIRM ".to_string(),
             InputMode::CommitSelect => " SELECT ".to_string(),
             InputMode::VisualSelect => {
-                if let Some((range, _)) = app.get_visual_selection() {
+                if let Some((range, _)) = app.visual_selection_line_range() {
                     if range.is_single() {
                         format!(" VISUAL L{} ", range.start)
                     } else {
@@ -220,7 +220,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             InputMode::CommitSelect => {
                 " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit "
             }
-            InputMode::VisualSelect => " j/k:extend  c/Enter:comment  Esc/V:cancel ",
+            InputMode::VisualSelect => " j/k:extend  c/Enter:comment  y:yank  Esc/V:cancel ",
         };
         let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 


### PR DESCRIPTION
Drag with the left mouse button in the diff to highlight a cell-precise range. Press `y` to copy the selected source content (no line numbers, no `+`/`-` markers); press `c` (or Enter) to open a range comment for the line span.

Keyboard `V` and mouse drag share one pipeline: same data model, same renderer, same actions. The selection is anchored to content (annotation index + char offset) so it survives scroll. When the cursor scrolls off-viewport the selection clears (helix-style). In side-by-side, drag is pinned to the pane the press started in.

Hunk headers (`@@ -38,20 +38,27 @@ ...`) and file headers (`src/foo.rs [M]`) participate as atomic rows: they paint a full-row highlight when in the selection and contribute their full text (decoration stripped for file headers) to the copy, giving the pasted block useful location context.

Behind the existing `mouse = true` opt-in flag from #261.

## Try it

- Drag across a few diff lines, press `y` to copy.
- Drag across a hunk header into a code block, press `y` - the `@@` line is included verbatim.
- `V` keyboard mode still works exactly as before for line-based range comments.
- Drag in side-by-side: the selection sticks to whichever pane (Old or New) you pressed in.

## Notes

- All 359 tests pass; clippy clean.
- No new dependencies.
- Native terminal text selection (Option/Shift drag bypass) is unaffected.
