### PR TITLE
feat(mouse): click on expand/hidden markers to toggle them

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -63,6 +63,7 @@ fn handle_left_click(app: &mut App, pos: Position) {
     {
         app.focused_panel = FocusedPanel::Diff;
         app.move_cursor_to_annotation(idx);
+        handle_diff_action(app, Action::SelectFile);
     }
 }
 


### PR DESCRIPTION
Click on the diff's gap rows to expand or collapse them, matching the keyboard Enter behavior:

- `... ↑ expand (20 lines) ...` / `... ↓ expand (20 lines) ...` - click expands 20 lines in that direction.
- `... 1199 lines hidden ...` - click expands the full gap.
- An expanded context line - click collapses the gap back.

Implementation is one line: after the click moves the cursor to the annotation, dispatch `Action::SelectFile` (the same action keyboard Enter binds to). The action is internally gated on `app.get_gap_at_cursor()` returning a `GapCursorHit`, so it's a no-op on plain code lines.

Behind the existing `mouse = true` opt-in flag from #261.

## Try it

- Open a diff with collapsed context (default).
- Click `... ↑ expand (20 lines) ...` - 20 lines appear above.
- Click `... 1199 lines hidden ...` (or the `↕` row) - the full gap expands.
- Click any of the expanded context lines - the gap collapses back.
- Click on a normal diff line - cursor moves, nothing else (unchanged behavior).

## Notes

- All 355 tests pass; clippy clean.
- No new dependencies.
- Independent of #262.
