### PR TITLE
chore(help): shorten --transparent description

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | `--appearance <MODE>` | Appearance mode for default theme (`dark`, `light`, `system`) |
 | `--stdout` | Output to stdout instead of clipboard when exporting |
 | `--no-update-check` | Skip checking for updates on startup |
-| `--transparent` | Don't paint the panel background (let the terminal background show through) |
+| `--transparent` | Use the terminal's background color |
 
 By default, `tuicr` starts in commit selection mode.  
 If staged or unstaged changes exist, the first selectable entries are `Staged changes` and/or `Unstaged changes`.  

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1569,7 +1569,7 @@ Options:
   --file <PATH>          Open a file for annotation (no VCS required)
   --stdout               Output to stdout instead of clipboard when exporting
   --no-update-check      Skip checking for updates on startup
-  --transparent          Don't paint the panel background (let the terminal background show through)
+  --transparent          Use the terminal's background color
   -V, --version          Print version
   -h, --help             Print this help message
 


### PR DESCRIPTION
Two-line follow-up to #264. The previous wording 'Don't paint the panel background (let the terminal background show through)' was awkward and long for a CLI flag description. Shortens both the `--help` output and the README options table to:

```
--transparent          Use the terminal's background color
```