### PR TITLE
feat(mouse): wheel + click on commit list (full-screen and inline)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,11 @@ mouse = true
 
 | Action | Effect |
 |--------|--------|
-| Wheel up/down | Scroll the panel under the cursor (file list, diff, or help popup) without moving the cursor line |
+| Wheel up/down | Scroll the panel under the cursor (file list, diff, commit list, or help popup) without moving the cursor line |
 | Click on a file | Jump to that file (lazygit-style) |
 | Click on a directory | Expand or collapse it |
 | Click on a diff line | Position the cursor on that line |
+| Click on a commit | Toggle selection (or expand the row to load more) |
 | Drag in diff | Highlight a range; press `y` to copy the selected source lines |
 
 For full native terminal selection across the whole UI, hold your terminal's bypass modifier while dragging (commonly **Shift** or **Option/Alt**, depending on the terminal). Check your terminal's docs if neither works.

--- a/src/app.rs
+++ b/src/app.rs
@@ -421,6 +421,9 @@ pub struct App {
     pub file_list_inner_area: Option<ratatui::layout::Rect>,
     /// Inner content rect of the diff panel; populated during render.
     pub diff_inner_area: Option<ratatui::layout::Rect>,
+    /// Inner content rect of the commit list panel (full-screen picker or inline selector);
+    /// populated during render.
+    pub commit_list_inner_area: Option<ratatui::layout::Rect>,
     /// Visual-row -> annotation-index map for the diff viewport. Wrapped
     /// logical lines repeat their annotation index across multiple rows.
     pub diff_row_to_annotation: Vec<usize>,
@@ -932,6 +935,7 @@ impl App {
             diff_area: None,
             file_list_inner_area: None,
             diff_inner_area: None,
+            commit_list_inner_area: None,
             diff_row_to_annotation: Vec::new(),
             expanded_dirs: HashSet::new(),
             expanded_top: HashMap::new(),
@@ -2184,6 +2188,22 @@ impl App {
         let rel = (screen_row - inner.y) as usize;
         let idx = self.file_list_state.list_state.offset() + rel;
         let total = self.build_visible_items().len();
+        (idx < total).then_some(idx)
+    }
+
+    pub fn commit_list_idx_at_screen_row(&self, screen_row: u16) -> Option<usize> {
+        let inner = self.commit_list_inner_area?;
+        if screen_row < inner.y || screen_row >= inner.y + inner.height {
+            return None;
+        }
+        let rel = (screen_row - inner.y) as usize;
+        let idx = self.commit_list_scroll_offset + rel;
+        let total = match self.input_mode {
+            InputMode::CommitSelect => {
+                self.visible_commit_count + usize::from(self.can_show_more_commits())
+            }
+            _ => self.review_commits.len(),
+        };
         (idx < total).then_some(idx)
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -19,15 +19,20 @@ pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
     let pos = Position::new(event.column, event.row);
     match event.kind {
         MouseEventKind::ScrollUp | MouseEventKind::ScrollDown => {
-            let action = if matches!(event.kind, MouseEventKind::ScrollUp) {
+            let scroll_up = matches!(event.kind, MouseEventKind::ScrollUp);
+            let action = if scroll_up {
                 Action::MouseScrollUp(WHEEL_LINES)
             } else {
                 Action::MouseScrollDown(WHEEL_LINES)
             };
             let over_file_list = app.file_list_area.is_some_and(|r| r.contains(pos));
             let over_diff = app.diff_area.is_some_and(|r| r.contains(pos));
+            let over_commit_list = app.commit_list_inner_area.is_some_and(|r| r.contains(pos));
             match app.input_mode {
                 InputMode::Help => handle_help_action(app, action),
+                InputMode::CommitSelect | InputMode::Normal if over_commit_list => {
+                    wheel_commit_list(app, scroll_up);
+                }
                 InputMode::Normal if over_file_list => handle_file_list_action(app, action),
                 InputMode::Normal if over_diff => handle_diff_action(app, action),
                 InputMode::VisualSelect if over_diff => handle_diff_action(app, action),
@@ -53,6 +58,12 @@ pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
             } else {
                 app.visual_selection = None;
                 handle_left_click(app, pos);
+            }
+        }
+        MouseEventKind::Down(MouseButton::Left) if app.input_mode == InputMode::CommitSelect => {
+            if let Some(idx) = app.commit_list_idx_at_screen_row(pos.y) {
+                app.commit_list_cursor = idx;
+                handle_commit_select_action(app, Action::ToggleCommitSelect);
             }
         }
         MouseEventKind::Drag(MouseButton::Left)
@@ -113,6 +124,19 @@ pub fn clear_visual_if_cursor_offscreen(app: &mut App) {
     }
 }
 
+/// Wheel scroll inside a commit list (full-screen picker or inline selector).
+/// The list is short and selection-oriented, so each tick moves the cursor
+/// rather than the viewport, matching how arrow keys behave.
+fn wheel_commit_list(app: &mut App, scroll_up: bool) {
+    for _ in 0..WHEEL_LINES {
+        if scroll_up {
+            app.commit_select_up();
+        } else {
+            app.commit_select_down();
+        }
+    }
+}
+
 fn handle_left_click(app: &mut App, pos: Position) {
     if app.file_list_inner_area.is_some_and(|r| r.contains(pos))
         && let Some(idx) = app.file_list_idx_at_screen_row(pos.y)
@@ -128,6 +152,16 @@ fn handle_left_click(app: &mut App, pos: Position) {
                 }
             }
         }
+        return;
+    }
+
+    if app.has_inline_commit_selector()
+        && app.commit_list_inner_area.is_some_and(|r| r.contains(pos))
+        && let Some(idx) = app.commit_list_idx_at_screen_row(pos.y)
+    {
+        app.focused_panel = FocusedPanel::CommitSelector;
+        app.commit_list_cursor = idx;
+        handle_commit_selector_action(app, Action::SelectFile);
         return;
     }
 

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -104,6 +104,7 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
 
     // Update viewport height for scroll calculations
     app.commit_list_viewport_height = inner.height as usize;
+    app.commit_list_inner_area = Some(inner);
 
     // Get range info for visual indicators
     let range = app.commit_selection_range;
@@ -272,6 +273,7 @@ fn render_main_content(frame: &mut Frame, app: &mut App, area: Rect) {
         render_inline_commit_selector(frame, app, chunks[0]);
         chunks[1]
     } else {
+        app.commit_list_inner_area = None;
         area
     };
 
@@ -309,6 +311,7 @@ fn render_inline_commit_selector(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Update viewport height for scroll
     app.commit_list_viewport_height = inner.height as usize;
+    app.commit_list_inner_area = Some(inner);
 
     {
         let range = app.commit_selection_range;


### PR DESCRIPTION
Wheel + click on the two commit lists that mouse hadn't reached yet.

- Full-screen commit picker (`InputMode::CommitSelect`): wheel moves the cursor, click positions the cursor and toggles selection (or expands the row when on `... show more commits ...`).
- Inline commit selector at the top of the diff in multi-commit reviews: wheel and click route the same way; click also focuses the panel and dispatches the same action `Enter` does (toggle + reload).

Both lists are short and selection-oriented, so wheel ticks move the cursor rather than viewport-scrolling away from it - matches `j`/`k`.

```sh
cargo install --path .
tuicr  # try clicking commits in the picker
```

359 tests pass.
