### PR TITLE
feat(ui): auto-clear status messages after a TTL

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use ratatui::style::Color;
@@ -358,7 +359,12 @@ pub enum MessageType {
 pub struct Message {
     pub content: String,
     pub message_type: MessageType,
+    /// When this message should be auto-cleared. `None` means sticky.
+    pub expires_at: Option<Instant>,
 }
+
+const MESSAGE_TTL_INFO: Duration = Duration::from_secs(3);
+const MESSAGE_TTL_WARNING: Duration = Duration::from_secs(5);
 
 pub struct App {
     pub theme: Theme,
@@ -1761,24 +1767,45 @@ impl App {
     }
 
     pub fn set_message(&mut self, msg: impl Into<String>) {
-        self.message = Some(Message {
-            content: msg.into(),
-            message_type: MessageType::Info,
-        });
+        self.set_message_inner(msg, MessageType::Info, Some(MESSAGE_TTL_INFO));
     }
 
     pub fn set_warning(&mut self, msg: impl Into<String>) {
-        self.message = Some(Message {
-            content: msg.into(),
-            message_type: MessageType::Warning,
-        });
+        self.set_message_inner(msg, MessageType::Warning, Some(MESSAGE_TTL_WARNING));
     }
 
     pub fn set_error(&mut self, msg: impl Into<String>) {
+        self.set_message_inner(msg, MessageType::Error, None);
+    }
+
+    /// Warning that stays until something else overwrites it. Used for state-tied
+    /// messages like the dirty-quit prompt where the visual must outlive any TTL.
+    pub fn set_sticky_warning(&mut self, msg: impl Into<String>) {
+        self.set_message_inner(msg, MessageType::Warning, None);
+    }
+
+    fn set_message_inner(
+        &mut self,
+        msg: impl Into<String>,
+        message_type: MessageType,
+        ttl: Option<Duration>,
+    ) {
         self.message = Some(Message {
             content: msg.into(),
-            message_type: MessageType::Error,
+            message_type,
+            expires_at: ttl.map(|d| Instant::now() + d),
         });
+    }
+
+    pub fn clear_expired_message(&mut self) {
+        let expired = self
+            .message
+            .as_ref()
+            .and_then(|m| m.expires_at)
+            .is_some_and(|t| Instant::now() >= t);
+        if expired {
+            self.message = None;
+        }
     }
 
     pub fn cursor_down(&mut self, lines: usize) {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -756,7 +756,7 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
     match action {
         Action::Quit => {
             if app.dirty && !app.quit_warned {
-                app.set_warning("Unsaved changes. Press q again to quit.");
+                app.set_sticky_warning("Unsaved changes. Press q again to quit.");
                 app.quit_warned = true;
             } else {
                 app.should_quit = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -244,11 +244,6 @@ fn main() -> anyhow::Result<()> {
 
     // Main loop
     loop {
-        // Render
-        terminal.draw(|frame| {
-            ui::render(frame, &mut app);
-        })?;
-
         // Check for update result (non-blocking)
         if let Some(ref rx) = update_rx
             && let Ok(
@@ -266,6 +261,13 @@ fn main() -> anyhow::Result<()> {
             pending_ctrl_c = None;
             app.message = None;
         }
+
+        app.clear_expired_message();
+
+        // Render
+        terminal.draw(|frame| {
+            ui::render(frame, &mut app);
+        })?;
 
         // Handle events
         if event::poll(Duration::from_millis(100))? {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -255,6 +255,7 @@ mod tests {
         Message {
             content: "hello".to_string(),
             message_type,
+            expires_at: None,
         }
     }
 


### PR DESCRIPTION
Status messages used to stay on screen until something else overwrote them. Now they auto-clear:

- Info: 3s
- Warning: 5s
- Error: sticky (failures should stay visible until acknowledged)

The dirty-quit prompt ("Unsaved changes. Press q again to quit.") is the one warning that needs to outlive the timer because it's tied to `quit_warned`. It uses a new `set_sticky_warning` helper that sets `expires_at = None`.

Main loop runs `app.clear_expired_message()` once per iteration, before the draw, so an expired message disappears within ~100ms (the poll interval).
