### PR TITLE
feat(theme): default to transparent panel background

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | `--appearance <MODE>` | Appearance mode for default theme (`dark`, `light`, `system`) |
 | `--stdout` | Output to stdout instead of clipboard when exporting |
 | `--no-update-check` | Skip checking for updates on startup |
-| `--transparent` | Use the terminal's background color |
 
 By default, `tuicr` starts in commit selection mode.  
 If staged or unstaged changes exist, the first selectable entries are `Staged changes` and/or `Unstaged changes`.  
@@ -132,7 +131,7 @@ show_file_list = false
 diff_view = "side-by-side"
 wrap = true
 cursor_line = false
-transparent_background = true
+transparent_background = false
 
 comment_types = [
   { id = "note", label = "question", definition = "ask for clarification", color = "yellow" },
@@ -150,6 +149,8 @@ comment_types = [
 `wrap` enables line wrapping in the diff view (default: `false`). Toggle at runtime with `:set wrap!`.
 
 `cursor_line` highlights the current cursor line and visual selection in the diff view (default: `true`). Set to `false` to disable.
+
+`transparent_background` lets the terminal background show through panels (default: `true`). Set to `false` to paint the theme's `panel_bg` color instead.
 
 `comment_types` replaces the default list and defines Tab cycle order.
 Each entry requires `id` and can optionally set `label`, `definition`, and `color`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,12 +123,11 @@ fn main() -> anyhow::Result<()> {
     );
     startup_warnings.extend(theme_warnings);
 
-    let transparent = cli_args.transparent
-        || config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.transparent_background)
-            .unwrap_or(false);
+    let transparent = config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.transparent_background)
+        .unwrap_or(true);
     if transparent {
         theme.panel_bg = ratatui::style::Color::Reset;
     }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1208,8 +1208,6 @@ pub struct CliArgs {
     pub path_filter: Option<String>,
     /// Open a single file for annotation (no VCS required)
     pub file_path: Option<String>,
-    /// Don't paint panel backgrounds (let the terminal background show through)
-    pub transparent: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1569,7 +1567,6 @@ Options:
   --file <PATH>          Open a file for annotation (no VCS required)
   --stdout               Output to stdout instead of clipboard when exporting
   --no-update-check      Skip checking for updates on startup
-  --transparent          Use the terminal's background color
   -V, --version          Print version
   -h, --help             Print this help message
 
@@ -1613,11 +1610,6 @@ fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
         // Handle --no-update-check
         if args[i] == "--no-update-check" {
             cli_args.no_update_check = true;
-        }
-
-        // Handle --transparent
-        if args[i] == "--transparent" {
-            cli_args.transparent = true;
         }
 
         // Handle -w / --working-tree


### PR DESCRIPTION
Breaking change, opening for discussion.

## Why

Popular modern TUIs like lazygit and Claude Code show the terminal background through their panels. tuicr currently paints the theme's `panel_bg` instead. Flipping that, so terminal customizations (images, blur, colors) show through out of the box. Also looks nicer, especially for the default light/dark themes. The light theme's bg in particular is a bit ugly, imo :)

## What changes

- Default: transparent panel backgrounds.
- Opt out: `transparent_background = false` in config.
- `--transparent` flag removed (unreleased, only on main).

## Alternatives considered

- Bake into theme: themes are hardcoded in source, so no escape hatch for users who want a palette with transparent panels.
- Suffix on `--theme` (`catppuccin-mocha:transparent`): new parser grammar for one boolean.
- Conditional default (transparent only when no explicit theme): harder to reason about than a flat config key.

## Compatibility

- `transparent_background = true` in config: no change.
- No setting: panels go transparent on next launch.
- Want the painted bg: add `transparent_background = false`.