### PR TITLE
feat(mouse): on by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,10 +204,10 @@ dist/
 
 ### Mouse
 
-Mouse support is **opt-in**. Enable it in your config:
+Mouse support is **on by default**. To disable, set in your config:
 
 ```toml
-mouse = true
+mouse = false
 ```
 
 | Action | Effect |

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,7 @@ fn main() -> anyhow::Result<()> {
         .config
         .as_ref()
         .and_then(|cfg| cfg.mouse)
-        .unwrap_or(false);
+        .unwrap_or(true);
     if mouse_enabled {
         execute!(tty_output, EnableMouseCapture)?;
     }


### PR DESCRIPTION
## Why

Most modern TUIs ship mouse on by default. The default UX is better with it, especially wheel-scrolling.

Mouse was opt-in (#261) because capture broke native copy (#140). #262 replaced that with in-app drag-to-select that's actually nicer than native: it copies clean source across multiple lines and includes file headers.

Native terminal selection still works via the Shift / Option bypass already documented in the README.

## What changes

- Default: `mouse = true`.
- Opt out: `mouse = false` in config.
