### PR TITLE
fix(syntax): full-file context for container-grammar diffs (vue, svelte, astro, mdx)

### DIFF
--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -5,10 +5,42 @@ use two_face::theme::EmbeddedThemeName;
 use crate::model::diff_types::LineOrigin;
 
 /// A single line of highlighted spans (style + text pairs).
-type HighlightedSpans = Vec<(Style, String)>;
+pub(crate) type HighlightedSpans = Vec<(Style, String)>;
 
 /// Per-line highlight results for a file: `Some` if the line was highlighted, `None` on failure.
-type HighlightedLines = Vec<Option<HighlightedSpans>>;
+pub(crate) type HighlightedLines = Vec<Option<HighlightedSpans>>;
+
+/// Whether `path` belongs to a "container" syntax that embeds other languages
+/// and so needs the full file (not just a hunk slice) in scope before its
+/// nested grammars activate.
+///
+/// Sublime-syntax grammars start in a `main` context entered at the top of the
+/// file. For Vue, syntect stays in `text.html.vue`'s outer scope until it
+/// sees `<template>`, `<script>`, or `<style>`. Same shape for Svelte / Astro
+/// / MDX (fenced code blocks) / PHP / ERB-family templates: anything inside a
+/// nested block in a hunk that doesn't include the opening tag will fall back
+/// to the theme's default foreground.
+///
+/// Container extensions kept narrow. `html` and `md` are intentionally
+/// omitted: the vast majority of changes in those files are outside any
+/// embedded-language block, so paying the full-file cost on every diff would
+/// be a net regression. Add only when an extension is overwhelmingly used as
+/// a container (i.e. most hunks live inside a nested grammar).
+pub(crate) fn needs_full_file_highlight(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|e| e.to_str()),
+        Some(
+            "vue"     // text.html.vue: HTML + JS/TS + CSS blocks
+            | "svelte" // source.svelte: HTML + JS/TS + CSS blocks
+            | "astro"  // source.astro: frontmatter + HTML + JS
+            | "mdx"    // text.html.markdown with JSX inside
+            | "php"    // text.html.php: outer HTML, switches at <?php
+            | "erb"    // text.html.erb: outer HTML, switches at <% %>
+            | "eex"    // text.html.elixir: same shape as erb
+            | "heex" // text.html.heex: Phoenix component templates
+        )
+    )
+}
 
 /// Helper to highlight lines of code from a diff
 pub struct SyntaxHighlighter {

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::SyntaxHighlighter;
+use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
 
 /// Diff format variants for different VCS tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -263,23 +263,22 @@ where
             continue;
         };
 
-        // Match git backend behavior: normalize tabs to 4 spaces so rendering is consistent
-        // across all VCS backends.
-        line_contents.push(content.replace('\t', "    "));
+        line_contents.push(super::tabify(content));
         line_origins.push(origin);
         line_numbers.push((old_ln, new_ln));
     }
 
     // Apply syntax highlighting by side-specific sequence to keep parser state valid.
+    // Container grammars skip per-hunk highlighting; the full-file post-pass
+    // (`enhance_with_full_file_highlight`) overwrites these spans anyway.
     let highlight_sequences =
         SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
-    let (old_highlighted_lines, new_highlighted_lines) = if let Some(path) = file_path {
-        (
+    let (old_highlighted_lines, new_highlighted_lines) = match file_path {
+        Some(path) if !needs_full_file_highlight(path) => (
             highlighter.highlight_file_lines(path, &highlight_sequences.old_lines),
             highlighter.highlight_file_lines(path, &highlight_sequences.new_lines),
-        )
-    } else {
-        (None, None)
+        ),
+        _ => (None, None),
     };
 
     // Build DiffLines

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -63,7 +63,7 @@ impl VcsBackend for FileBackend {
         }
 
         // Build line contents and origins for syntax highlighting
-        let line_contents: Vec<String> = lines.iter().map(|l| l.replace('\t', "    ")).collect();
+        let line_contents: Vec<String> = lines.iter().map(|l| super::tabify(l)).collect();
         let line_origins: Vec<LineOrigin> = vec![LineOrigin::Addition; line_contents.len()];
 
         // Apply syntax highlighting

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,9 +1,10 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::SyntaxHighlighter;
+use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
+use crate::vcs::{enhance_with_full_file_highlight, tabify};
 
 pub fn get_working_tree_diff(
     repo: &Repository,
@@ -17,8 +18,14 @@ pub fn get_working_tree_diff(
     opts.recurse_untracked_dirs(true);
 
     let diff = repo.diff_tree_to_workdir_with_index(Some(&head), Some(&mut opts))?;
-
-    parse_diff(&diff, highlighter)
+    let mut files = parse_diff(&diff, highlighter)?;
+    enhance_with_full_file_highlight(
+        &mut files,
+        highlighter,
+        |path| read_path_from_tree(repo, &head, path),
+        |path| read_path_from_workdir(repo, path),
+    );
+    Ok(files)
 }
 
 /// Get the staged diff (index vs HEAD)
@@ -30,7 +37,17 @@ pub fn get_staged_diff(
     let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
     let index = repo.index()?;
     let diff = repo.diff_tree_to_index(head.as_ref(), Some(&index), None)?;
-    parse_diff(&diff, highlighter)
+    let mut files = parse_diff(&diff, highlighter)?;
+    enhance_with_full_file_highlight(
+        &mut files,
+        highlighter,
+        |path| {
+            head.as_ref()
+                .and_then(|tree| read_path_from_tree(repo, tree, path))
+        },
+        |path| read_path_from_index(repo, &index, path),
+    );
+    Ok(files)
 }
 
 /// Get the unstaged diff (working tree vs index)
@@ -45,7 +62,14 @@ pub fn get_unstaged_diff(
     opts.recurse_untracked_dirs(true);
 
     let diff = repo.diff_index_to_workdir(Some(&index), Some(&mut opts))?;
-    parse_diff(&diff, highlighter)
+    let mut files = parse_diff(&diff, highlighter)?;
+    enhance_with_full_file_highlight(
+        &mut files,
+        highlighter,
+        |path| read_path_from_index(repo, &index, path),
+        |path| read_path_from_workdir(repo, path),
+    );
+    Ok(files)
 }
 
 /// Get the diff for a range of commits.
@@ -60,15 +84,12 @@ pub fn get_commit_range_diff(
         return Err(TuicrError::NoChanges);
     }
 
-    // Find the oldest commit (last in our list since commits are oldest to newest)
     let oldest_id = git2::Oid::from_str(&commit_ids[0])?;
     let oldest_commit = repo.find_commit(oldest_id)?;
 
-    // Find the newest commit (first in our list)
     let newest_id = git2::Oid::from_str(commit_ids.last().unwrap())?;
     let newest_commit = repo.find_commit(newest_id)?;
 
-    // Get the parent of the oldest commit, or use an empty tree if it's the initial commit
     let old_tree = if oldest_commit.parent_count() > 0 {
         Some(oldest_commit.parent(0)?.tree()?)
     } else {
@@ -78,8 +99,18 @@ pub fn get_commit_range_diff(
     let new_tree = newest_commit.tree()?;
 
     let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), None)?;
-
-    parse_diff(&diff, highlighter)
+    let mut files = parse_diff(&diff, highlighter)?;
+    enhance_with_full_file_highlight(
+        &mut files,
+        highlighter,
+        |path| {
+            old_tree
+                .as_ref()
+                .and_then(|tree| read_path_from_tree(repo, tree, path))
+        },
+        |path| read_path_from_tree(repo, &new_tree, path),
+    );
+    Ok(files)
 }
 
 /// Get a combined diff from the parent of the oldest commit through to the working tree.
@@ -93,11 +124,9 @@ pub fn get_working_tree_with_commits_diff(
         return Err(TuicrError::NoChanges);
     }
 
-    // Find the oldest commit (first in our list since commits are oldest to newest)
     let oldest_id = git2::Oid::from_str(&commit_ids[0])?;
     let oldest_commit = repo.find_commit(oldest_id)?;
 
-    // Get the parent of the oldest commit, or use an empty tree if it's the initial commit
     let old_tree = if oldest_commit.parent_count() > 0 {
         Some(oldest_commit.parent(0)?.tree()?)
     } else {
@@ -110,8 +139,34 @@ pub fn get_working_tree_with_commits_diff(
     opts.recurse_untracked_dirs(true);
 
     let diff = repo.diff_tree_to_workdir_with_index(old_tree.as_ref(), Some(&mut opts))?;
+    let mut files = parse_diff(&diff, highlighter)?;
+    enhance_with_full_file_highlight(
+        &mut files,
+        highlighter,
+        |path| {
+            old_tree
+                .as_ref()
+                .and_then(|tree| read_path_from_tree(repo, tree, path))
+        },
+        |path| read_path_from_workdir(repo, path),
+    );
+    Ok(files)
+}
 
-    parse_diff(&diff, highlighter)
+fn read_path_from_tree(repo: &Repository, tree: &git2::Tree, path: &Path) -> Option<String> {
+    let entry = tree.get_path(path).ok()?;
+    let blob = repo.find_blob(entry.id()).ok()?;
+    Some(String::from_utf8_lossy(blob.content()).into_owned())
+}
+
+fn read_path_from_workdir(repo: &Repository, path: &Path) -> Option<String> {
+    crate::vcs::read_workdir_file(repo.workdir()?, path)
+}
+
+fn read_path_from_index(repo: &Repository, index: &git2::Index, path: &Path) -> Option<String> {
+    let entry = index.get_path(path, 0)?;
+    let blob = repo.find_blob(entry.id).ok()?;
+    Some(String::from_utf8_lossy(blob.content()).into_owned())
 }
 
 fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
@@ -137,13 +192,11 @@ fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFi
         let is_too_large =
             delta.status() == Delta::Untracked && delta.new_file().size() > MAX_UNTRACKED_FILE_SIZE;
 
-        // Use new_path for highlighting (the current version of the file)
-        let file_path = new_path.as_ref().or(old_path.as_ref());
-
+        let syntax_path = new_path.as_ref().or(old_path.as_ref()).map(|p| p.as_path());
         let hunks = if is_binary || is_too_large {
             Vec::new()
         } else {
-            parse_hunks(diff, delta_idx, file_path, highlighter)?
+            parse_hunks(diff, delta_idx, highlighter, syntax_path)?
         };
 
         let content_hash = DiffFile::compute_content_hash(&hunks);
@@ -169,8 +222,8 @@ fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFi
 fn parse_hunks(
     diff: &Diff,
     delta_idx: usize,
-    file_path: Option<&PathBuf>,
     highlighter: &SyntaxHighlighter,
+    file_path: Option<&Path>,
 ) -> Result<Vec<DiffHunk>> {
     let mut hunks: Vec<DiffHunk> = Vec::new();
 
@@ -186,11 +239,9 @@ fn parse_hunks(
             let new_start = hunk.new_start();
             let new_count = hunk.new_lines();
 
-            let mut lines: Vec<DiffLine> = Vec::new();
-
-            // First, collect all line content for syntax highlighting
             let mut line_contents: Vec<String> = Vec::new();
             let mut line_origins: Vec<LineOrigin> = Vec::new();
+            let mut line_numbers: Vec<(Option<u32>, Option<u32>)> = Vec::new();
 
             for line_idx in 0..patch.num_lines_in_hunk(hunk_idx)? {
                 let line = patch.line_in_hunk(hunk_idx, line_idx)?;
@@ -202,42 +253,36 @@ fn parse_hunks(
                     _ => LineOrigin::Context,
                 };
 
-                let content = String::from_utf8_lossy(line.content())
-                    .trim_end_matches('\n')
-                    .trim_end_matches('\r')
-                    .replace('\t', "    ")
-                    .to_string();
+                let raw = String::from_utf8_lossy(line.content());
+                let content = tabify(raw.trim_end_matches(['\n', '\r']));
 
                 line_contents.push(content);
                 line_origins.push(origin);
+                line_numbers.push((line.old_lineno(), line.new_lineno()));
             }
 
-            // Apply syntax highlighting if we have a file path
-            let highlight_sequences =
+            let sequences =
                 SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
-            let (old_highlighted_lines, new_highlighted_lines) = if let Some(path) = file_path {
-                (
-                    highlighter.highlight_file_lines(path, &highlight_sequences.old_lines),
-                    highlighter.highlight_file_lines(path, &highlight_sequences.new_lines),
-                )
-            } else {
-                (None, None)
+            // Container grammars skip per-hunk highlighting; the full-file
+            // post-pass overwrites these spans anyway.
+            let (old_highlighted, new_highlighted) = match file_path {
+                Some(path) if !needs_full_file_highlight(path) => (
+                    highlighter.highlight_file_lines(path, &sequences.old_lines),
+                    highlighter.highlight_file_lines(path, &sequences.new_lines),
+                ),
+                _ => (None, None),
             };
 
-            // Now create DiffLines with syntax highlighting applied
-            for line_idx in 0..patch.num_lines_in_hunk(hunk_idx)? {
-                let line = patch.line_in_hunk(hunk_idx, line_idx)?;
-                let old_lineno = line.old_lineno();
-                let new_lineno = line.new_lineno();
-                let content = line_contents[line_idx].clone();
-                let origin = line_origins[line_idx];
+            let mut lines: Vec<DiffLine> = Vec::with_capacity(line_contents.len());
+            for (idx, content) in line_contents.into_iter().enumerate() {
+                let origin = line_origins[idx];
+                let (old_lineno, new_lineno) = line_numbers[idx];
 
-                // Get highlighted spans and apply diff background
                 let highlighted_spans = highlighter.highlighted_line_for_diff_with_background(
-                    old_highlighted_lines.as_deref(),
-                    new_highlighted_lines.as_deref(),
-                    highlight_sequences.old_line_indices[line_idx],
-                    highlight_sequences.new_line_indices[line_idx],
+                    old_highlighted.as_deref(),
+                    new_highlighted.as_deref(),
+                    sequences.old_line_indices[idx],
+                    sequences.new_line_indices[idx],
                     origin,
                 );
 
@@ -291,7 +336,6 @@ mod tests {
 
     #[test]
     fn should_return_no_changes_for_clean_repo() {
-        // given
         let repo = Repository::discover(".").unwrap();
         let head = repo.head().unwrap().peel_to_tree().unwrap();
         let diff = repo
@@ -299,10 +343,8 @@ mod tests {
             .unwrap();
         let highlighter = SyntaxHighlighter::default();
 
-        // when
         let result = parse_diff(&diff, &highlighter);
 
-        // then
         assert!(matches!(result, Err(TuicrError::NoChanges)));
     }
 
@@ -334,6 +376,42 @@ mod tests {
             "expected tab-expanded content in git diff lines"
         );
         assert!(lines.iter().all(|l| !l.content.contains('\t')));
+    }
+
+    #[test]
+    fn should_highlight_vue_script_hunk_using_full_file_context() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        let initial = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hi')\nconst other = 1\n</script>\n";
+        create_initial_commit(&repo, "App.vue", initial);
+
+        let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
+        fs::write(temp_dir.path().join("App.vue"), edited).expect("failed to update file");
+
+        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
+            .expect("failed to get diff");
+        assert_eq!(files.len(), 1);
+
+        let changed_lines: Vec<_> = files[0].hunks[0]
+            .lines
+            .iter()
+            .filter(|l| matches!(l.origin, LineOrigin::Addition | LineOrigin::Deletion))
+            .collect();
+        assert!(!changed_lines.is_empty(), "expected change lines in hunk");
+
+        for line in changed_lines {
+            let spans = line
+                .highlighted_spans
+                .as_ref()
+                .unwrap_or_else(|| panic!("vue line should be highlighted: {line:?}"));
+            let unique_fgs: std::collections::HashSet<_> =
+                spans.iter().filter_map(|(s, _)| s.fg).collect();
+            assert!(
+                unique_fgs.len() >= 2,
+                "vue hunk line {line:?} should have varied fg colors, got {unique_fgs:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -9,7 +9,7 @@ use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
-use crate::vcs::{FULL_FILE_CONTEXT, enhance_with_full_context_diff};
+use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
 
 /// Parse an hg description into (summary, optional body).
 fn parse_hg_description(desc: &str) -> (String, Option<String>) {
@@ -82,18 +82,21 @@ impl VcsBackend for HgBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        // Get unified diff output from hg with full file context so the parser
-        // sees every line; the post-pass reconstructs file content from hunks
-        // when a container grammar needs end-to-end highlighting.
-        let context = FULL_FILE_CONTEXT.to_string();
-        let diff_output = run_hg_command(&self.info.root_path, &["diff", "-U", &context])?;
+        let diff_output = run_hg_command(&self.info.root_path, &["diff"])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
         let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
-        enhance_with_full_context_diff(&mut files, highlighter);
+        apply_container_full_file_highlight(
+            &self.info.root_path,
+            ".",
+            None,
+            &mut files,
+            highlighter,
+            hg_cat_batch,
+        )?;
         Ok(files)
     }
 
@@ -273,10 +276,9 @@ impl VcsBackend for HgBackend {
             _ => "null".to_string(),
         };
 
-        let context = FULL_FILE_CONTEXT.to_string();
         let diff_output = run_hg_command(
             &self.info.root_path,
-            &["diff", "-U", &context, "-r", &from_rev, "-r", newest_short],
+            &["diff", "-r", &from_rev, "-r", newest_short],
         )?;
 
         if diff_output.trim().is_empty() {
@@ -284,7 +286,14 @@ impl VcsBackend for HgBackend {
         }
 
         let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
-        enhance_with_full_context_diff(&mut files, highlighter);
+        apply_container_full_file_highlight(
+            &self.info.root_path,
+            &from_rev,
+            Some(newest_short),
+            &mut files,
+            highlighter,
+            hg_cat_batch,
+        )?;
         Ok(files)
     }
 
@@ -383,21 +392,48 @@ impl VcsBackend for HgBackend {
             _ => "null".to_string(),
         };
 
-        // Diff from parent of oldest to working directory (omit --to)
-        let context = FULL_FILE_CONTEXT.to_string();
-        let diff_output = run_hg_command(
-            &self.info.root_path,
-            &["diff", "-U", &context, "-r", &from_rev],
-        )?;
+        let diff_output =
+            run_hg_command(&self.info.root_path, &["diff", "-r", &from_rev])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
         let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
-        enhance_with_full_context_diff(&mut files, highlighter);
+        apply_container_full_file_highlight(
+            &self.info.root_path,
+            &from_rev,
+            None,
+            &mut files,
+            highlighter,
+            hg_cat_batch,
+        )?;
         Ok(files)
     }
+}
+
+/// Fetch the full content of `paths` at `rev` in a single `hg cat` subprocess.
+///
+/// hg cat is dominated by Python startup (~280 ms) regardless of file count,
+/// so batching every container file into one call is significantly faster than
+/// fetching each one separately.
+fn hg_cat_batch(
+    root: &Path,
+    rev: &str,
+    paths: &[PathBuf],
+) -> Result<HashMap<PathBuf, String>> {
+    if paths.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let template = format!("\n{BATCH_BOUNDARY}\n{{path}}\n{{data}}");
+    let path_strs: Vec<String> = paths
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    let mut args: Vec<&str> = vec!["cat", "-r", rev, "--template", &template];
+    args.extend(path_strs.iter().map(String::as_str));
+    let output = run_hg_command(root, &args)?;
+    Ok(parse_batched_files(&output))
 }
 
 /// Run an hg command and return its stdout

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -9,6 +9,7 @@ use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::{FULL_FILE_CONTEXT, enhance_with_full_context_diff};
 
 /// Parse an hg description into (summary, optional body).
 fn parse_hg_description(desc: &str) -> (String, Option<String>) {
@@ -81,14 +82,19 @@ impl VcsBackend for HgBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        // Get unified diff output from hg
-        let diff_output = run_hg_command(&self.info.root_path, &["diff"])?;
+        // Get unified diff output from hg with full file context so the parser
+        // sees every line; the post-pass reconstructs file content from hunks
+        // when a container grammar needs end-to-end highlighting.
+        let context = FULL_FILE_CONTEXT.to_string();
+        let diff_output = run_hg_command(&self.info.root_path, &["diff", "-U", &context])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)
+        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
+        enhance_with_full_context_diff(&mut files, highlighter);
+        Ok(files)
     }
 
     fn fetch_context_lines(
@@ -267,16 +273,19 @@ impl VcsBackend for HgBackend {
             _ => "null".to_string(),
         };
 
+        let context = FULL_FILE_CONTEXT.to_string();
         let diff_output = run_hg_command(
             &self.info.root_path,
-            &["diff", "-r", &from_rev, "-r", newest_short],
+            &["diff", "-U", &context, "-r", &from_rev, "-r", newest_short],
         )?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)
+        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
+        enhance_with_full_context_diff(&mut files, highlighter);
+        Ok(files)
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
@@ -375,13 +384,19 @@ impl VcsBackend for HgBackend {
         };
 
         // Diff from parent of oldest to working directory (omit --to)
-        let diff_output = run_hg_command(&self.info.root_path, &["diff", "-r", &from_rev])?;
+        let context = FULL_FILE_CONTEXT.to_string();
+        let diff_output = run_hg_command(
+            &self.info.root_path,
+            &["diff", "-U", &context, "-r", &from_rev],
+        )?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)
+        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
+        enhance_with_full_context_diff(&mut files, highlighter);
+        Ok(files)
     }
 }
 
@@ -873,6 +888,76 @@ mod tests {
         // Verify we can get display_path without panic (the bug we fixed)
         // Don't assert exact path/status as hg implementations differ (Sapling vs standard hg)
         let _path = file.display_path();
+    }
+
+    /// Set up an hg repo with a committed Vue file ready to be edited.
+    fn setup_test_repo_with_vue() -> Option<tempfile::TempDir> {
+        if !hg_available() {
+            return None;
+        }
+
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let root = temp_dir.path();
+
+        Command::new("hg")
+            .args(["init"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to init hg repo");
+
+        let initial = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hi')\nconst other = 1\n</script>\n";
+        fs::write(root.join("App.vue"), initial).expect("Failed to write Vue file");
+
+        Command::new("hg")
+            .args(["add", "App.vue"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to add file");
+        Command::new("hg")
+            .args(["commit", "-m", "Add Vue file"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to commit");
+
+        let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
+        fs::write(root.join("App.vue"), edited).expect("Failed to modify Vue file");
+
+        Some(temp_dir)
+    }
+
+    #[test]
+    fn test_hg_highlights_vue_script_hunk_using_full_file_context() {
+        let Some(temp) = setup_test_repo_with_vue() else {
+            eprintln!("Skipping test: hg command not available");
+            return;
+        };
+
+        let backend =
+            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("Failed to get diff");
+        assert_eq!(files.len(), 1);
+
+        let changed_lines: Vec<_> = files[0].hunks[0]
+            .lines
+            .iter()
+            .filter(|l| matches!(l.origin, LineOrigin::Addition | LineOrigin::Deletion))
+            .collect();
+        assert!(!changed_lines.is_empty(), "expected change lines in hunk");
+
+        for line in changed_lines {
+            let spans = line
+                .highlighted_spans
+                .as_ref()
+                .unwrap_or_else(|| panic!("vue line should be highlighted: {line:?}"));
+            let unique_fgs: std::collections::HashSet<_> =
+                spans.iter().filter_map(|(s, _)| s.fg).collect();
+            assert!(
+                unique_fgs.len() >= 2,
+                "vue hunk line {line:?} should have varied fg colors, got {unique_fgs:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -392,8 +392,7 @@ impl VcsBackend for HgBackend {
             _ => "null".to_string(),
         };
 
-        let diff_output =
-            run_hg_command(&self.info.root_path, &["diff", "-r", &from_rev])?;
+        let diff_output = run_hg_command(&self.info.root_path, &["diff", "-r", &from_rev])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -417,11 +416,7 @@ impl VcsBackend for HgBackend {
 /// hg cat is dominated by Python startup (~280 ms) regardless of file count,
 /// so batching every container file into one call is significantly faster than
 /// fetching each one separately.
-fn hg_cat_batch(
-    root: &Path,
-    rev: &str,
-    paths: &[PathBuf],
-) -> Result<HashMap<PathBuf, String>> {
+fn hg_cat_batch(root: &Path, rev: &str, paths: &[PathBuf]) -> Result<HashMap<PathBuf, String>> {
     if paths.is_empty() {
         return Ok(HashMap::new());
     }

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -402,11 +402,7 @@ impl VcsBackend for JjBackend {
 /// Fetch the full content of `paths` at `rev` in a single `jj file show`
 /// subprocess. jj is much cheaper per-call than hg, but batching still avoids
 /// repeated process startup when there are many container files in a diff.
-fn jj_show_batch(
-    root: &Path,
-    rev: &str,
-    paths: &[PathBuf],
-) -> Result<HashMap<PathBuf, String>> {
+fn jj_show_batch(root: &Path, rev: &str, paths: &[PathBuf]) -> Result<HashMap<PathBuf, String>> {
     if paths.is_empty() {
         return Ok(HashMap::new());
     }

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -11,7 +11,7 @@ use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
-use crate::vcs::{FULL_FILE_CONTEXT, enhance_with_full_context_diff};
+use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
 
 /// Parse a jj description into (summary, optional body).
 fn parse_description(desc: &str) -> (String, Option<String>) {
@@ -119,14 +119,7 @@ impl VcsBackend for JjBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        // Get unified diff output from jj with full file context so the parser
-        // sees every line; the post-pass reconstructs file content from hunks
-        // when a container grammar needs end-to-end highlighting.
-        let context = FULL_FILE_CONTEXT.to_string();
-        let diff_output = run_jj_command(
-            &self.info.root_path,
-            &["diff", "--git", "--context", &context],
-        )?;
+        let diff_output = run_jj_command(&self.info.root_path, &["diff", "--git"])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -134,7 +127,14 @@ impl VcsBackend for JjBackend {
 
         let mut files =
             diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
-        enhance_with_full_context_diff(&mut files, highlighter);
+        apply_container_full_file_highlight(
+            &self.info.root_path,
+            "@-",
+            None,
+            &mut files,
+            highlighter,
+            jj_show_batch,
+        )?;
         Ok(files)
     }
 
@@ -289,19 +289,9 @@ impl VcsBackend for JjBackend {
         // Get the parent of the oldest commit to include its changes
         // In jj, we use {commit}- to get the parent(s)
         let from_rev = format!("{}-", oldest);
-        let context = FULL_FILE_CONTEXT.to_string();
         let diff_output = run_jj_command(
             &self.info.root_path,
-            &[
-                "diff",
-                "--from",
-                &from_rev,
-                "--to",
-                newest,
-                "--git",
-                "--context",
-                &context,
-            ],
+            &["diff", "--from", &from_rev, "--to", newest, "--git"],
         )?;
 
         if diff_output.trim().is_empty() {
@@ -310,7 +300,14 @@ impl VcsBackend for JjBackend {
 
         let mut files =
             diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
-        enhance_with_full_context_diff(&mut files, highlighter);
+        apply_container_full_file_highlight(
+            &self.info.root_path,
+            &from_rev,
+            Some(newest),
+            &mut files,
+            highlighter,
+            jj_show_batch,
+        )?;
         Ok(files)
     }
 
@@ -379,19 +376,9 @@ impl VcsBackend for JjBackend {
 
         // Diff from the parent of the oldest commit to the working copy (@)
         let from_rev = format!("{}-", oldest);
-        let context = FULL_FILE_CONTEXT.to_string();
         let diff_output = run_jj_command(
             &self.info.root_path,
-            &[
-                "diff",
-                "--from",
-                &from_rev,
-                "--to",
-                "@",
-                "--git",
-                "--context",
-                &context,
-            ],
+            &["diff", "--from", &from_rev, "--to", "@", "--git"],
         )?;
 
         if diff_output.trim().is_empty() {
@@ -400,9 +387,38 @@ impl VcsBackend for JjBackend {
 
         let mut files =
             diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
-        enhance_with_full_context_diff(&mut files, highlighter);
+        apply_container_full_file_highlight(
+            &self.info.root_path,
+            &from_rev,
+            None,
+            &mut files,
+            highlighter,
+            jj_show_batch,
+        )?;
         Ok(files)
     }
+}
+
+/// Fetch the full content of `paths` at `rev` in a single `jj file show`
+/// subprocess. jj is much cheaper per-call than hg, but batching still avoids
+/// repeated process startup when there are many container files in a diff.
+fn jj_show_batch(
+    root: &Path,
+    rev: &str,
+    paths: &[PathBuf],
+) -> Result<HashMap<PathBuf, String>> {
+    if paths.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let template = format!("\"\\n{BATCH_BOUNDARY}\\n\" ++ path ++ \"\\n\"");
+    let path_strs: Vec<String> = paths
+        .iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    let mut args: Vec<&str> = vec!["file", "show", "-r", rev, "-T", &template];
+    args.extend(path_strs.iter().map(String::as_str));
+    let output = run_jj_command(root, &args)?;
+    Ok(parse_batched_files(&output))
 }
 
 /// Run a jj command and return its stdout

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -11,6 +11,7 @@ use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::{FULL_FILE_CONTEXT, enhance_with_full_context_diff};
 
 /// Parse a jj description into (summary, optional body).
 fn parse_description(desc: &str) -> (String, Option<String>) {
@@ -118,14 +119,23 @@ impl VcsBackend for JjBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        // Get unified diff output from jj using --git format
-        let diff_output = run_jj_command(&self.info.root_path, &["diff", "--git"])?;
+        // Get unified diff output from jj with full file context so the parser
+        // sees every line; the post-pass reconstructs file content from hunks
+        // when a container grammar needs end-to-end highlighting.
+        let context = FULL_FILE_CONTEXT.to_string();
+        let diff_output = run_jj_command(
+            &self.info.root_path,
+            &["diff", "--git", "--context", &context],
+        )?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)
+        let mut files =
+            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
+        enhance_with_full_context_diff(&mut files, highlighter);
+        Ok(files)
     }
 
     fn fetch_context_lines(
@@ -278,15 +288,19 @@ impl VcsBackend for JjBackend {
 
         // Get the parent of the oldest commit to include its changes
         // In jj, we use {commit}- to get the parent(s)
+        let from_rev = format!("{}-", oldest);
+        let context = FULL_FILE_CONTEXT.to_string();
         let diff_output = run_jj_command(
             &self.info.root_path,
             &[
                 "diff",
                 "--from",
-                &format!("{}-", oldest),
+                &from_rev,
                 "--to",
                 newest,
                 "--git",
+                "--context",
+                &context,
             ],
         )?;
 
@@ -294,7 +308,10 @@ impl VcsBackend for JjBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)
+        let mut files =
+            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
+        enhance_with_full_context_diff(&mut files, highlighter);
+        Ok(files)
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
@@ -361,15 +378,19 @@ impl VcsBackend for JjBackend {
         let oldest = &commit_ids[0];
 
         // Diff from the parent of the oldest commit to the working copy (@)
+        let from_rev = format!("{}-", oldest);
+        let context = FULL_FILE_CONTEXT.to_string();
         let diff_output = run_jj_command(
             &self.info.root_path,
             &[
                 "diff",
                 "--from",
-                &format!("{}-", oldest),
+                &from_rev,
                 "--to",
                 "@",
                 "--git",
+                "--context",
+                &context,
             ],
         )?;
 
@@ -377,7 +398,10 @@ impl VcsBackend for JjBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)
+        let mut files =
+            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
+        enhance_with_full_context_diff(&mut files, highlighter);
+        Ok(files)
     }
 }
 
@@ -859,6 +883,74 @@ mod tests {
             .expect("Failed to create bookmark");
 
         Some(temp_dir)
+    }
+
+    /// Set up a jj repo with a committed Vue file ready to be edited.
+    fn setup_test_repo_with_vue() -> Option<tempfile::TempDir> {
+        if !jj_available() {
+            return None;
+        }
+
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let root = temp_dir.path();
+
+        let output = Command::new("jj")
+            .args(["git", "init"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to init jj repo");
+        if !output.status.success() {
+            return None;
+        }
+
+        let initial = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hi')\nconst other = 1\n</script>\n";
+        fs::write(root.join("App.vue"), initial).expect("Failed to write Vue file");
+
+        Command::new("jj")
+            .args(["commit", "-m", "Add Vue file"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to commit");
+
+        let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
+        fs::write(root.join("App.vue"), edited).expect("Failed to modify Vue file");
+
+        Some(temp_dir)
+    }
+
+    #[test]
+    fn test_jj_highlights_vue_script_hunk_using_full_file_context() {
+        let Some(temp) = setup_test_repo_with_vue() else {
+            eprintln!("Skipping test: jj command not available");
+            return;
+        };
+
+        let backend =
+            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("Failed to get diff");
+        assert_eq!(files.len(), 1);
+
+        let changed_lines: Vec<_> = files[0].hunks[0]
+            .lines
+            .iter()
+            .filter(|l| matches!(l.origin, LineOrigin::Addition | LineOrigin::Deletion))
+            .collect();
+        assert!(!changed_lines.is_empty(), "expected change lines in hunk");
+
+        for line in changed_lines {
+            let spans = line
+                .highlighted_spans
+                .as_ref()
+                .unwrap_or_else(|| panic!("vue line should be highlighted: {line:?}"));
+            let unique_fgs: std::collections::HashSet<_> =
+                spans.iter().filter_map(|(s, _)| s.fg).collect();
+            assert!(
+                unique_fgs.len() >= 2,
+                "vue hunk line {line:?} should have varied fg colors, got {unique_fgs:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -24,7 +24,189 @@ pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use traits::{CommitInfo, VcsBackend, VcsInfo};
 
+use std::path::Path;
+
 use crate::error::{Result, TuicrError};
+use crate::model::{DiffFile, LineOrigin};
+use crate::syntax::{
+    HighlightedLines, HighlightedSpans, SyntaxHighlighter, needs_full_file_highlight,
+};
+
+/// Context size used by hg / jj diff calls when we want the diff text to act
+/// as the file's full content. Generous enough to cover any reasonable source
+/// file end-to-end, so the unified-diff parser sees every line as a context,
+/// addition, or deletion entry.
+pub(crate) const FULL_FILE_CONTEXT: usize = 1_000_000;
+
+/// Expand tabs to spaces in diff line content so highlighted spans line up
+/// with the displayed text in side-by-side and unified rendering.
+pub(crate) fn tabify(s: &str) -> String {
+    s.replace('\t', "    ")
+}
+
+/// Read a file from the working tree, returning `None` on any IO error.
+pub(crate) fn read_workdir_file(root: &Path, rel: &Path) -> Option<String> {
+    std::fs::read_to_string(root.join(rel)).ok()
+}
+
+/// Files larger than this skip the full-file highlight pass and fall back to
+/// per-hunk highlighting. Keeps a runaway-cost ceiling on diffs that include
+/// huge generated artefacts (lockfiles, vendored bundles, fixtures).
+const MAX_HIGHLIGHT_FILE_BYTES: usize = 1024 * 1024;
+
+/// Re-highlight each diff line using full-file context, for files whose
+/// grammar needs it (Vue, Svelte, Astro, MDX). Other files keep their existing
+/// per-hunk highlighting unchanged.
+///
+/// `fetch_old`/`fetch_new` return the entire content of the file at the old
+/// and new sides respectively (or `None` if unavailable). When a side is
+/// available, every diff line on that side is replaced with the span at its
+/// 1-based lineno from the full-file highlight. Lines whose side could not be
+/// fetched keep whatever the parser already assigned.
+pub(crate) fn enhance_with_full_file_highlight<F, G>(
+    files: &mut [DiffFile],
+    highlighter: &SyntaxHighlighter,
+    mut fetch_old: F,
+    mut fetch_new: G,
+) where
+    F: FnMut(&Path) -> Option<String>,
+    G: FnMut(&Path) -> Option<String>,
+{
+    for file in files.iter_mut() {
+        if file.is_binary || file.is_too_large || file.hunks.is_empty() {
+            continue;
+        }
+        let Some(syntax_path) = file.new_path.as_deref().or(file.old_path.as_deref()) else {
+            continue;
+        };
+        if !needs_full_file_highlight(syntax_path) {
+            continue;
+        }
+
+        let old_highlight = file
+            .old_path
+            .as_deref()
+            .and_then(&mut fetch_old)
+            .and_then(|c| highlight_content(highlighter, syntax_path, &c));
+        let new_highlight = file
+            .new_path
+            .as_deref()
+            .and_then(&mut fetch_new)
+            .and_then(|c| highlight_content(highlighter, syntax_path, &c));
+
+        if old_highlight.is_none() && new_highlight.is_none() {
+            continue;
+        }
+
+        apply_full_file_spans(
+            file,
+            highlighter,
+            old_highlight.as_deref(),
+            new_highlight.as_deref(),
+        );
+    }
+}
+
+fn highlight_content(
+    highlighter: &SyntaxHighlighter,
+    path: &Path,
+    content: &str,
+) -> Option<HighlightedLines> {
+    if content.len() > MAX_HIGHLIGHT_FILE_BYTES || content.as_bytes().contains(&0u8) {
+        return None;
+    }
+    let lines: Vec<String> = content.lines().map(tabify).collect();
+    highlighter.highlight_file_lines(path, &lines)
+}
+
+/// Re-highlight container-grammar files in place by reconstructing the old and
+/// new file content directly from the diff's own hunks. Assumes the diff was
+/// generated with `FULL_FILE_CONTEXT` so that every line of the file appears
+/// as a context, addition, or deletion entry. Avoids any extra subprocess.
+pub(crate) fn enhance_with_full_context_diff(
+    files: &mut [DiffFile],
+    highlighter: &SyntaxHighlighter,
+) {
+    for file in files.iter_mut() {
+        if file.is_binary || file.is_too_large || file.hunks.is_empty() {
+            continue;
+        }
+        let Some(syntax_path) = file.new_path.as_deref().or(file.old_path.as_deref()) else {
+            continue;
+        };
+        if !needs_full_file_highlight(syntax_path) {
+            continue;
+        }
+
+        let old_content = reconstruct_side(file, false);
+        let new_content = reconstruct_side(file, true);
+        let old_highlight = old_content
+            .as_deref()
+            .and_then(|c| highlight_content(highlighter, syntax_path, c));
+        let new_highlight = new_content
+            .as_deref()
+            .and_then(|c| highlight_content(highlighter, syntax_path, c));
+
+        if old_highlight.is_none() && new_highlight.is_none() {
+            continue;
+        }
+
+        apply_full_file_spans(
+            file,
+            highlighter,
+            old_highlight.as_deref(),
+            new_highlight.as_deref(),
+        );
+    }
+}
+
+fn apply_full_file_spans(
+    file: &mut DiffFile,
+    highlighter: &SyntaxHighlighter,
+    old_highlight: Option<&[Option<HighlightedSpans>]>,
+    new_highlight: Option<&[Option<HighlightedSpans>]>,
+) {
+    for hunk in &mut file.hunks {
+        for line in &mut hunk.lines {
+            let old_idx = line.old_lineno.map(|n| n.saturating_sub(1) as usize);
+            let new_idx = line.new_lineno.map(|n| n.saturating_sub(1) as usize);
+            let spans = highlighter.highlighted_line_for_diff_with_background(
+                old_highlight,
+                new_highlight,
+                old_idx,
+                new_idx,
+                line.origin,
+            );
+            if spans.is_some() {
+                line.highlighted_spans = spans;
+            }
+        }
+    }
+}
+
+/// Concatenate the side-relevant lines from a DiffFile's hunks into a single
+/// string. Pass `new_side = true` for additions + context (the new file),
+/// `false` for deletions + context (the old file).
+fn reconstruct_side(file: &DiffFile, new_side: bool) -> Option<String> {
+    let mut lines: Vec<&str> = Vec::new();
+    for hunk in &file.hunks {
+        for line in &hunk.lines {
+            let include = matches!(
+                (line.origin, new_side),
+                (LineOrigin::Context, _)
+                    | (LineOrigin::Addition, true)
+                    | (LineOrigin::Deletion, false)
+            );
+            if include {
+                lines.push(&line.content);
+            }
+        }
+    }
+    if lines.is_empty() {
+        return None;
+    }
+    Some(lines.join("\n"))
+}
 
 /// Detect the VCS type and return the appropriate backend.
 ///

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -24,19 +24,39 @@ pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use traits::{CommitInfo, VcsBackend, VcsInfo};
 
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, LineOrigin};
+use crate::model::{DiffFile, LineSide};
 use crate::syntax::{
     HighlightedLines, HighlightedSpans, SyntaxHighlighter, needs_full_file_highlight,
 };
 
-/// Context size used by hg / jj diff calls when we want the diff text to act
-/// as the file's full content. Generous enough to cover any reasonable source
-/// file end-to-end, so the unified-diff parser sees every line as a context,
-/// addition, or deletion entry.
-pub(crate) const FULL_FILE_CONTEXT: usize = 1_000_000;
+/// Boundary marker emitted between files in batched `hg cat` / `jj file show`
+/// output. The long random suffix makes accidental collision with real source
+/// content effectively impossible.
+pub(crate) const BATCH_BOUNDARY: &str = "@@TUICR_BATCH_BOUNDARY_e97f2d44_8b1a@@";
+
+/// Collect the unique paths of files that need full-file syntax highlighting
+/// (Vue, Svelte, PHP and friends) on the given side, skipping binary, too-large,
+/// or empty entries. Used by hg / jj to know which files to batch-fetch.
+pub(crate) fn container_file_paths(files: &[DiffFile], side: LineSide) -> Vec<PathBuf> {
+    files
+        .iter()
+        .filter(|f| !f.is_binary && !f.is_too_large && !f.hunks.is_empty())
+        .filter_map(|f| {
+            let syntax_path = f.new_path.as_deref().or(f.old_path.as_deref())?;
+            if !needs_full_file_highlight(syntax_path) {
+                return None;
+            }
+            match side {
+                LineSide::Old => f.old_path.clone(),
+                LineSide::New => f.new_path.clone(),
+            }
+        })
+        .collect()
+}
 
 /// Expand tabs to spaces in diff line content so highlighted spans line up
 /// with the displayed text in side-by-side and unified rendering.
@@ -47,6 +67,68 @@ pub(crate) fn tabify(s: &str) -> String {
 /// Read a file from the working tree, returning `None` on any IO error.
 pub(crate) fn read_workdir_file(root: &Path, rel: &Path) -> Option<String> {
     std::fs::read_to_string(root.join(rel)).ok()
+}
+
+/// Parse the output of a batched `hg cat` / `jj file show` invocation whose
+/// template prefixed each file with `\n{BATCH_BOUNDARY}\n{path}\n` before
+/// emitting `{data}`. Returns a `path → data` map.
+pub(crate) fn parse_batched_files(output: &str) -> HashMap<PathBuf, String> {
+    let sep = format!("\n{BATCH_BOUNDARY}\n");
+    output
+        .split(&sep)
+        .filter(|s| !s.is_empty())
+        .filter_map(|block| {
+            let mut iter = block.splitn(2, '\n');
+            let path = iter.next()?;
+            let data = iter.next().unwrap_or("");
+            Some((PathBuf::from(path), data.to_string()))
+        })
+        .collect()
+}
+
+/// Re-highlight container-grammar files (Vue, Svelte, etc) using their full
+/// content at the requested revisions. `new_rev = None` reads the new side
+/// from the working tree on disk instead of calling `fetch_batch`. The
+/// `fetch_batch` closure is the backend-specific batched-fetch primitive
+/// (`hg cat -r REV ...` or `jj file show -r REV ...`).
+pub(crate) fn apply_container_full_file_highlight<F>(
+    root: &Path,
+    old_rev: &str,
+    new_rev: Option<&str>,
+    files: &mut [DiffFile],
+    highlighter: &SyntaxHighlighter,
+    fetch_batch: F,
+) -> Result<()>
+where
+    F: Fn(&Path, &str, &[PathBuf]) -> Result<HashMap<PathBuf, String>>,
+{
+    let old_paths = container_file_paths(files, LineSide::Old);
+    let new_paths = container_file_paths(files, LineSide::New);
+
+    if old_paths.is_empty() && new_paths.is_empty() {
+        return Ok(());
+    }
+
+    let old_map = fetch_batch(root, old_rev, &old_paths)?;
+    let new_map = match new_rev {
+        Some(rev) => fetch_batch(root, rev, &new_paths)?,
+        None => HashMap::new(),
+    };
+
+    let workdir = new_rev.is_none().then(|| root.to_path_buf());
+
+    enhance_with_full_file_highlight(
+        files,
+        highlighter,
+        |p| old_map.get(p).cloned(),
+        |p| match (new_map.get(p), workdir.as_deref()) {
+            (Some(content), _) => Some(content.clone()),
+            (None, Some(root)) => read_workdir_file(root, p),
+            (None, None) => None,
+        },
+    );
+
+    Ok(())
 }
 
 /// Files larger than this skip the full-file highlight pass and fall back to
@@ -119,47 +201,6 @@ fn highlight_content(
     highlighter.highlight_file_lines(path, &lines)
 }
 
-/// Re-highlight container-grammar files in place by reconstructing the old and
-/// new file content directly from the diff's own hunks. Assumes the diff was
-/// generated with `FULL_FILE_CONTEXT` so that every line of the file appears
-/// as a context, addition, or deletion entry. Avoids any extra subprocess.
-pub(crate) fn enhance_with_full_context_diff(
-    files: &mut [DiffFile],
-    highlighter: &SyntaxHighlighter,
-) {
-    for file in files.iter_mut() {
-        if file.is_binary || file.is_too_large || file.hunks.is_empty() {
-            continue;
-        }
-        let Some(syntax_path) = file.new_path.as_deref().or(file.old_path.as_deref()) else {
-            continue;
-        };
-        if !needs_full_file_highlight(syntax_path) {
-            continue;
-        }
-
-        let old_content = reconstruct_side(file, false);
-        let new_content = reconstruct_side(file, true);
-        let old_highlight = old_content
-            .as_deref()
-            .and_then(|c| highlight_content(highlighter, syntax_path, c));
-        let new_highlight = new_content
-            .as_deref()
-            .and_then(|c| highlight_content(highlighter, syntax_path, c));
-
-        if old_highlight.is_none() && new_highlight.is_none() {
-            continue;
-        }
-
-        apply_full_file_spans(
-            file,
-            highlighter,
-            old_highlight.as_deref(),
-            new_highlight.as_deref(),
-        );
-    }
-}
-
 fn apply_full_file_spans(
     file: &mut DiffFile,
     highlighter: &SyntaxHighlighter,
@@ -182,30 +223,6 @@ fn apply_full_file_spans(
             }
         }
     }
-}
-
-/// Concatenate the side-relevant lines from a DiffFile's hunks into a single
-/// string. Pass `new_side = true` for additions + context (the new file),
-/// `false` for deletions + context (the old file).
-fn reconstruct_side(file: &DiffFile, new_side: bool) -> Option<String> {
-    let mut lines: Vec<&str> = Vec::new();
-    for hunk in &file.hunks {
-        for line in &hunk.lines {
-            let include = matches!(
-                (line.origin, new_side),
-                (LineOrigin::Context, _)
-                    | (LineOrigin::Addition, true)
-                    | (LineOrigin::Deletion, false)
-            );
-            if include {
-                lines.push(&line.content);
-            }
-        }
-    }
-    if lines.is_empty() {
-        return None;
-    }
-    Some(lines.join("\n"))
 }
 
 /// Detect the VCS type and return the appropriate backend.


### PR DESCRIPTION
Vue diffs (and Svelte / Astro / MDX / PHP / ERB-family templates, same root cause) render unhighlighted today. syntect's container grammars (`text.html.vue`, `text.html.php`, etc.) only enter their nested JS / HTML / CSS / template scope after seeing the opening `<template>`, `<script>`, `<style>`, `<?php`, or `<% %>` tag. The current code highlights only the hunk slice, so a hunk that lives inside `<script>` (or after `<?php`) never sees the opener, stays in its outer scope, and every span comes back with the theme's default foreground.

## Fix

An extension gate (`vue`, `svelte`, `astro`, `mdx`, `php`, `erb`, `eex`, `heex`) decides whether to pay the cost. Other files keep per-hunk highlighting unchanged. For matched files each backend obtains the full old and new content, re-highlights end-to-end, then re-keys each diff line by its 1-based lineno.

The shape per backend is the same: a "batched fetch" closure that returns full file content for a given list of paths at a given revision. Only container-grammar files are ever passed to it, so non-container files in the diff pay nothing extra.

- **git**: `git2` blob lookup in-process (`Tree::get_path` + `find_blob`; index / workdir for the staged, unstaged, and working-tree cases). Zero overhead.
- **hg**: one `hg cat -r REV --template '\n{BATCH_BOUNDARY}\n{path}\n{data}' file1 file2 ...` per side. hg cat is Python-startup-bound (~280 ms regardless of file count), so batching all paths into one call is essentially free.
- **jj**: one `jj file show -r REV -T '"\n{BATCH_BOUNDARY}\n" ++ path ++ "\n"' file1 file2 ...` per side. Sub-20 ms total.

Shared in `vcs/mod.rs`: `enhance_with_full_file_highlight` (closure-based, used by all three backends), `apply_container_full_file_highlight` (collects container paths, runs the backend's batched fetch, calls the enhance pass), and `parse_batched_files` for the boundary-delimited output. The git path uses its own in-process blob helpers; hg/jj plug in their batched-fetch subprocess wrappers.

Files larger than 1 MiB or containing null bytes skip and stay monochrome.

A regression test was added for each backend: build a real repo with a `.vue` file, edit a line inside `<script setup>`, assert the changed lines have multiple distinct foreground colors.

## Why not just inflate diff context?

An earlier draft of this PR bumped hg/jj to `-U 1000000` / `--context 1000000` and reconstructed file content from the resulting hunks. That avoided extra subprocesses but inflated every file's hunk to the whole file, so per-hunk syntax highlighting on non-container files (TS, CSS, Rust, etc.) ran over full-file content via syntect. On a worst-case mixed diff (50 Vue + 150 TS modified) that cost hg 5.60 s and jj 3.62 s. The current batched-fetch approach drops them to 4.58 s and 1.85 s by keeping non-container files on the cheap small-hunk path.

## Cost model

For matched files we pay syntect on the full file, twice (old + new sides). syntect runs at roughly 27 us/line on Vue / 37 us/line on TS, so the total scales linearly with `(container lines in diff) * 2`.

- **Realistic PR** (1-5 Vue files, ~200 lines each): ~50 ms of extra highlighting. Imperceptible.
- **Pathological** (50 Vue files at ~620 lines each, all modified in one review): ~1.6 s of extra highlighting. The 62k-line figure is genuinely the work syntect has to do to produce correct spans across template/script/style boundaries; there is no shortcut inside syntect itself.

That worst case is what it looks like to review an entire component library's rewrite in a single pass. It's not what tuicr's hot path looks like. If it ever becomes a real problem, file-level rayon parallelism in `enhance_with_full_file_highlight` is a straightforward follow-up (independent per file, syntect's `SyntaxSet` and `Theme` are `Sync`).
