### PR TITLE
Fix sparse checkout diff support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,9 @@ src/
 ├── vcs/                 # VCS abstraction layer
 │   ├── mod.rs           # detect_vcs(): auto-detect VCS (jj first, then git, then hg)
 │   ├── traits.rs        # VcsBackend trait, VcsInfo, VcsType, CommitInfo
-│   ├── diff_parser.rs   # Unified diff text parser (shared by hg/jj)
+│   ├── diff_parser.rs   # Unified diff text parser (shared by hg/jj and Git sparse-checkout diffs)
 │   │                    # DiffFormat enum: Hg (with timestamps), GitStyle (jj/git patches)
-│   ├── git/             # Git backend (uses native git2 library, not diff_parser)
+│   ├── git/             # Git backend (uses git2 normally; Git CLI + diff_parser for sparse checkouts)
 │   │   ├── mod.rs       # GitBackend: wraps git2 library
 │   │   ├── repository.rs # CommitInfo, get_recent_commits()
 │   │   ├── diff.rs      # get_working_tree_diff(), get_commit_range_diff()

--- a/src/app.rs
+++ b/src/app.rs
@@ -1525,19 +1525,47 @@ impl App {
     }
 
     fn profile_rebuild_view(&mut self, label: &str, preserve_wrap: bool) {
-        crate::profile::time(label, || {
-            let wrap = self.diff_state.wrap_lines;
-            self.diff_state = DiffState::default();
-            if preserve_wrap {
-                self.diff_state.wrap_lines = wrap;
-            }
-            self.file_list_state = FileListState::default();
-            self.expanded_top.clear();
-            self.expanded_bottom.clear();
-            self.sort_files_by_directory(true);
-            self.expand_all_dirs();
-            self.rebuild_annotations();
-        });
+        let started = Instant::now();
+        let wrap = self.diff_state.wrap_lines;
+        self.diff_state = DiffState::default();
+        if preserve_wrap {
+            self.diff_state.wrap_lines = wrap;
+        }
+        self.file_list_state = FileListState::default();
+        self.expanded_top.clear();
+        self.expanded_bottom.clear();
+        self.sort_files_by_directory(true);
+        self.expand_all_dirs();
+        self.rebuild_annotations();
+        crate::profile::log_with(label, started.elapsed(), self.profile_view_metadata());
+    }
+
+    fn profile_view_metadata(&self) -> String {
+        let visible_items = self.build_visible_items();
+        let directories = visible_items
+            .iter()
+            .filter(|item| matches!(item, FileTreeItem::Directory { .. }))
+            .count();
+        let files = visible_items.len().saturating_sub(directories);
+        let commit_messages = self
+            .diff_files
+            .iter()
+            .filter(|file| file.is_commit_message)
+            .count();
+
+        format!(
+            "diff_files={}, tree_items={}, tree_dirs={}, tree_files={}, commit_messages={}, expanded_dirs={}, selected_tree={}, current_file={}, show_file_list={}, focused={:?}",
+            self.diff_files.len(),
+            visible_items.len(),
+            directories,
+            files,
+            commit_messages,
+            self.expanded_dirs.len(),
+            self.file_list_state.selected(),
+            self.diff_state.current_file_idx,
+            self.show_file_list,
+            self.focused_panel,
+        )
     }
 
     fn load_staged_and_unstaged_selection(&mut self) -> Result<()> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::syntax::SyntaxHighlighter;
 use crate::theme::Theme;
 use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
-use crate::vcs::{CommitInfo, FileBackend, VcsBackend, VcsInfo, detect_vcs};
+use crate::vcs::{CommitInfo, FileBackend, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs};
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
 const COMMIT_PAGE_SIZE: usize = 10;
@@ -53,6 +53,34 @@ fn gap_annotation_line_count(is_top_of_file: bool, remaining: usize) -> usize {
     } else {
         // Between hunks: ↓ + HiddenLines + ↑ when >= batch, else single ↕
         if remaining >= GAP_EXPAND_BATCH { 3 } else { 1 }
+    }
+}
+
+fn profile_diff_result(result: &Result<Vec<DiffFile>>) -> String {
+    match result {
+        Ok(files) => format!("files={}", files.len()),
+        Err(e) => format!("error={e}"),
+    }
+}
+
+fn profile_commit_result(result: &Result<Vec<CommitInfo>>) -> String {
+    match result {
+        Ok(commits) => format!("commits={}", commits.len()),
+        Err(e) => format!("error={e}"),
+    }
+}
+
+fn profile_change_status_result(result: &Result<VcsChangeStatus>) -> String {
+    match result {
+        Ok(status) => format!("staged={}, unstaged={}", status.staged, status.unstaged),
+        Err(e) => format!("error={e}"),
+    }
+}
+
+fn profile_unit_result(result: &Result<()>) -> String {
+    match result {
+        Ok(()) => "result=ok".to_string(),
+        Err(e) => format!("error={e}"),
     }
 }
 
@@ -627,9 +655,11 @@ impl App {
             return Ok(app);
         }
 
-        let vcs = detect_vcs()?;
+        let vcs = crate::profile::time("startup: detect vcs", detect_vcs)?;
         let vcs_info = vcs.info().clone();
-        let highlighter = theme.syntax_highlighter();
+        let highlighter = crate::profile::time("startup: initialize syntax highlighter", || {
+            theme.syntax_highlighter()
+        });
         // Determine the diff source, files, and session based on input.
         // Four paths:
         //   1. -r + -w: combined commit range and uncommitted changes
@@ -637,7 +667,14 @@ impl App {
         //   3. -w only: working tree directly (skip commit selector)
         //   4. neither: commit selection UI
         if let Some(revisions) = revisions {
-            let commit_ids = vcs.resolve_revisions(revisions)?;
+            let commit_ids = crate::profile::time_with(
+                "startup: resolve revisions",
+                || vcs.resolve_revisions(revisions),
+                |result| match result {
+                    Ok(ids) => format!("commits={}", ids.len()),
+                    Err(e) => format!("error={e}"),
+                },
+            )?;
 
             if working_tree {
                 // Combined: commit range + staged/unstaged changes
@@ -652,31 +689,26 @@ impl App {
                     &vcs_info,
                     &commit_ids,
                 );
-                let review_commits: Vec<CommitInfo> = vcs
-                    .get_commits_info(&commit_ids)?
-                    .into_iter()
-                    .rev()
-                    .collect();
+                let review_commits: Vec<CommitInfo> = crate::profile::time_with(
+                    "startup: selected commit info",
+                    || vcs.get_commits_info(&commit_ids),
+                    profile_commit_result,
+                )?
+                .into_iter()
+                .rev()
+                .collect();
                 // Prepend staged/unstaged entries only when the backend supports them
-                let has_staged = Self::get_staged_diff_with_ignore(
+                let change_status = Self::get_change_status_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
                     highlighter,
                     path_filter,
-                )
-                .is_ok();
-                let has_unstaged = Self::get_unstaged_diff_with_ignore(
-                    vcs.as_ref(),
-                    &vcs_info.root_path,
-                    highlighter,
-                    path_filter,
-                )
-                .is_ok();
+                )?;
                 let mut all_commits = Vec::new();
-                if has_staged {
+                if change_status.staged {
                     all_commits.push(Self::staged_commit_entry());
                 }
-                if has_unstaged {
+                if change_status.unstaged {
                     all_commits.push(Self::unstaged_commit_entry());
                 }
                 all_commits.extend(review_commits);
@@ -710,9 +742,7 @@ impl App {
                 app.commit_diff_cache.clear();
                 app.review_commits = all_commits;
                 app.insert_commit_message_if_single();
-                app.sort_files_by_directory(true);
-                app.expand_all_dirs();
-                app.rebuild_annotations();
+                app.profile_rebuild_view("startup: rebuild commits plus working tree view", false);
 
                 return Ok(app);
             }
@@ -727,7 +757,11 @@ impl App {
             )?;
             let session = Self::load_or_create_commit_range_session(&vcs_info, &commit_ids);
             // Get commit info for the inline commit selector
-            let review_commits = vcs.get_commits_info(&commit_ids)?;
+            let review_commits = crate::profile::time_with(
+                "startup: selected commit info",
+                || vcs.get_commits_info(&commit_ids),
+                profile_commit_result,
+            )?;
             // Reverse to newest-first display order
             let review_commits: Vec<CommitInfo> = review_commits.into_iter().rev().collect();
 
@@ -759,9 +793,7 @@ impl App {
             }
             app.review_commits = review_commits;
             app.insert_commit_message_if_single();
-            app.sort_files_by_directory(true);
-            app.expand_all_dirs();
-            app.rebuild_annotations();
+            app.profile_rebuild_view("startup: rebuild commit range view", false);
 
             Ok(app)
         } else if working_tree {
@@ -791,46 +823,20 @@ impl App {
 
             Ok(app)
         } else {
-            let has_staged_changes = match Self::get_staged_diff_with_ignore(
+            let change_status = Self::get_change_status_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
                 highlighter,
                 path_filter,
-            ) {
-                Ok(_) => true,
-                Err(TuicrError::NoChanges) => false,
-                Err(TuicrError::UnsupportedOperation(_)) => false,
-                Err(e) => return Err(e),
-            };
+            )?;
+            let has_staged_changes = change_status.staged;
+            let has_unstaged_changes = change_status.unstaged;
 
-            let has_unstaged_changes = match Self::get_unstaged_diff_with_ignore(
-                vcs.as_ref(),
-                &vcs_info.root_path,
-                highlighter,
-                path_filter,
-            ) {
-                Ok(_) => true,
-                Err(TuicrError::NoChanges) => false,
-                Err(TuicrError::UnsupportedOperation(_)) => false,
-                Err(e) => return Err(e),
-            };
-
-            let working_tree_diff = if has_staged_changes || has_unstaged_changes {
-                match Self::get_working_tree_diff_with_ignore(
-                    vcs.as_ref(),
-                    &vcs_info.root_path,
-                    highlighter,
-                    path_filter,
-                ) {
-                    Ok(diff_files) => Some(diff_files),
-                    Err(TuicrError::NoChanges) => None,
-                    Err(e) => return Err(e),
-                }
-            } else {
-                None
-            };
-
-            let commits = vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT)?;
+            let commits = crate::profile::time_with(
+                "startup: recent commits",
+                || vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT),
+                profile_commit_result,
+            )?;
             if !has_staged_changes && !has_unstaged_changes && commits.is_empty() {
                 return Err(TuicrError::NoChanges);
             }
@@ -871,7 +877,7 @@ impl App {
                 theme,
                 comment_type_configs,
                 output_to_stdout,
-                working_tree_diff.unwrap_or_default(),
+                Vec::new(),
                 session,
                 diff_source,
                 InputMode::CommitSelect,
@@ -988,9 +994,7 @@ impl App {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
-        app.sort_files_by_directory(true);
-        app.expand_all_dirs();
-        app.rebuild_annotations();
+        app.profile_rebuild_view("startup: rebuild initial view", false);
         Ok(app)
     }
 
@@ -1382,7 +1386,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_working_tree_diff(highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff: load working tree",
+            || vcs.get_working_tree_diff(highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1398,7 +1406,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_staged_diff(highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff: load staged",
+            || vcs.get_staged_diff(highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1414,9 +1426,17 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = match vcs.get_unstaged_diff(highlighter) {
+        let diff_files = match crate::profile::time_with(
+            "diff: load unstaged",
+            || vcs.get_unstaged_diff(highlighter),
+            profile_diff_result,
+        ) {
             Ok(diff_files) => diff_files,
-            Err(TuicrError::UnsupportedOperation(_)) => vcs.get_working_tree_diff(highlighter)?,
+            Err(TuicrError::UnsupportedOperation(_)) => crate::profile::time_with(
+                "diff: load working tree fallback",
+                || vcs.get_working_tree_diff(highlighter),
+                profile_diff_result,
+            )?,
             Err(e) => return Err(e),
         };
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
@@ -1435,7 +1455,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_commit_range_diff(commit_ids, highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff: load commit range",
+            || vcs.get_commit_range_diff(commit_ids, highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1452,7 +1476,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_working_tree_with_commits_diff(commit_ids, highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff: load commits and working tree",
+            || vcs.get_working_tree_with_commits_diff(commit_ids, highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1460,6 +1488,56 @@ impl App {
             diff_files
         };
         Self::require_non_empty_diff_files(diff_files)
+    }
+
+    fn get_change_status_with_ignore(
+        vcs: &dyn VcsBackend,
+        repo_root: &Path,
+        highlighter: &SyntaxHighlighter,
+        path_filter: Option<&str>,
+    ) -> Result<VcsChangeStatus> {
+        if path_filter.is_none() {
+            match crate::profile::time_with(
+                "vcs: change status",
+                || vcs.get_change_status(),
+                profile_change_status_result,
+            ) {
+                Ok(status) => return Ok(status),
+                Err(TuicrError::UnsupportedOperation(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        let staged =
+            match Self::get_staged_diff_with_ignore(vcs, repo_root, highlighter, path_filter) {
+                Ok(_) => true,
+                Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => false,
+                Err(e) => return Err(e),
+            };
+        let unstaged =
+            match Self::get_unstaged_diff_with_ignore(vcs, repo_root, highlighter, path_filter) {
+                Ok(_) => true,
+                Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => false,
+                Err(e) => return Err(e),
+            };
+
+        Ok(VcsChangeStatus { staged, unstaged })
+    }
+
+    fn profile_rebuild_view(&mut self, label: &str, preserve_wrap: bool) {
+        crate::profile::time(label, || {
+            let wrap = self.diff_state.wrap_lines;
+            self.diff_state = DiffState::default();
+            if preserve_wrap {
+                self.diff_state.wrap_lines = wrap;
+            }
+            self.file_list_state = FileListState::default();
+            self.expanded_top.clear();
+            self.expanded_bottom.clear();
+            self.sort_files_by_directory(true);
+            self.expand_all_dirs();
+            self.rebuild_annotations();
+        });
     }
 
     fn load_staged_and_unstaged_selection(&mut self) -> Result<()> {
@@ -1488,12 +1566,8 @@ impl App {
         self.diff_files = diff_files;
         self.diff_source = DiffSource::StagedAndUnstaged;
         self.input_mode = InputMode::Normal;
-        self.diff_state = DiffState::default();
-        self.file_list_state = FileListState::default();
         self.clear_expanded_gaps();
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        self.profile_rebuild_view("selection: rebuild staged and unstaged view", false);
 
         Ok(())
     }
@@ -1523,12 +1597,8 @@ impl App {
         self.diff_files = diff_files;
         self.diff_source = DiffSource::Staged;
         self.input_mode = InputMode::Normal;
-        self.diff_state = DiffState::default();
-        self.file_list_state = FileListState::default();
         self.clear_expanded_gaps();
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        self.profile_rebuild_view("selection: rebuild staged view", false);
 
         Ok(())
     }
@@ -1558,12 +1628,8 @@ impl App {
         self.diff_files = diff_files;
         self.diff_source = DiffSource::Unstaged;
         self.input_mode = InputMode::Normal;
-        self.diff_state = DiffState::default();
-        self.file_list_state = FileListState::default();
         self.clear_expanded_gaps();
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        self.profile_rebuild_view("selection: rebuild unstaged view", false);
 
         Ok(())
     }
@@ -3499,31 +3565,20 @@ impl App {
         }
 
         let highlighter = self.theme.syntax_highlighter();
-        let has_staged_changes = match Self::get_staged_diff_with_ignore(
+        let change_status = Self::get_change_status_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
             highlighter,
             self.path_filter.as_deref(),
-        ) {
-            Ok(_) => true,
-            Err(TuicrError::NoChanges) => false,
-            Err(TuicrError::UnsupportedOperation(_)) => false,
-            Err(e) => return Err(e),
-        };
+        )?;
+        let has_staged_changes = change_status.staged;
+        let has_unstaged_changes = change_status.unstaged;
 
-        let has_unstaged_changes = match Self::get_unstaged_diff_with_ignore(
-            self.vcs.as_ref(),
-            &self.vcs_info.root_path,
-            highlighter,
-            self.path_filter.as_deref(),
-        ) {
-            Ok(_) => true,
-            Err(TuicrError::NoChanges) => false,
-            Err(TuicrError::UnsupportedOperation(_)) => false,
-            Err(e) => return Err(e),
-        };
-
-        let commits = self.vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT)?;
+        let commits = crate::profile::time_with(
+            "commit select: recent commits",
+            || self.vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT),
+            profile_commit_result,
+        )?;
         if commits.is_empty() && !has_staged_changes && !has_unstaged_changes {
             self.set_message("No commits or staged/unstaged changes found");
             return Ok(());
@@ -3826,6 +3881,18 @@ impl App {
     }
 
     pub fn confirm_commit_selection(&mut self) -> Result<()> {
+        let selection = self
+            .commit_selection_range
+            .map(|(start, end)| format!("range={start}..={end}, rows={}", end - start + 1))
+            .unwrap_or_else(|| "range=none, rows=0".to_string());
+        crate::profile::time_with(
+            "commit select: confirm selection",
+            || self.confirm_commit_selection_inner(),
+            |result| format!("{selection}, {}", profile_unit_result(result)),
+        )
+    }
+
+    fn confirm_commit_selection_inner(&mut self) -> Result<()> {
         let Some((start, end)) = self.commit_selection_range else {
             self.set_message("Select at least one commit");
             return Ok(());
@@ -3884,15 +3951,17 @@ impl App {
 
         // Update session with the newest commit as base
         let newest_commit_id = selected_ids.last().unwrap().clone();
-        let loaded_session = load_latest_session_for_context(
-            &self.vcs_info.root_path,
-            self.vcs_info.branch_name.as_deref(),
-            &newest_commit_id,
-            SessionDiffSource::CommitRange,
-            Some(selected_ids.as_slice()),
-        )
-        .ok()
-        .and_then(|found| found.map(|(_path, session)| session));
+        let loaded_session = crate::profile::time("commit select: load review session", || {
+            load_latest_session_for_context(
+                &self.vcs_info.root_path,
+                self.vcs_info.branch_name.as_deref(),
+                &newest_commit_id,
+                SessionDiffSource::CommitRange,
+                Some(selected_ids.as_slice()),
+            )
+            .ok()
+            .and_then(|found| found.map(|(_path, session)| session))
+        });
 
         let mut session = loaded_session.unwrap_or_else(|| {
             let mut session = ReviewSession::new(
@@ -3948,15 +4017,25 @@ impl App {
         self.commit_diff_cache.clear();
         self.saved_inline_selection = None;
 
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        self.profile_rebuild_view("commit select: rebuild selected commit view", false);
 
         Ok(())
     }
 
     /// Reload the diff for the currently selected inline commit subrange.
     pub fn reload_inline_selection(&mut self) -> Result<()> {
+        let selection = self
+            .commit_selection_range
+            .map(|(start, end)| format!("range={start}..={end}, rows={}", end - start + 1))
+            .unwrap_or_else(|| "range=none, rows=0".to_string());
+        crate::profile::time_with(
+            "commit select: reload inline selection",
+            || self.reload_inline_selection_inner(),
+            |result| format!("{selection}, {}", profile_unit_result(result)),
+        )
+    }
+
+    fn reload_inline_selection_inner(&mut self) -> Result<()> {
         let Some((start, end)) = self.commit_selection_range else {
             self.set_message("Select at least one commit");
             return Ok(());
@@ -3975,9 +4054,7 @@ impl App {
             self.expanded_top.clear();
             self.expanded_bottom.clear();
             self.insert_commit_message_if_single();
-            self.sort_files_by_directory(true);
-            self.expand_all_dirs();
-            self.rebuild_annotations();
+            self.profile_rebuild_view("commit select: rebuild cached full-range view", true);
             return Ok(());
         }
 
@@ -3991,9 +4068,7 @@ impl App {
             self.expanded_top.clear();
             self.expanded_bottom.clear();
             self.insert_commit_message_if_single();
-            self.sort_files_by_directory(true);
-            self.expand_all_dirs();
-            self.rebuild_annotations();
+            self.profile_rebuild_view("commit select: rebuild cached subrange view", true);
             return Ok(());
         }
 
@@ -4086,9 +4161,7 @@ impl App {
         self.expanded_top.clear();
         self.expanded_bottom.clear();
         self.insert_commit_message_if_single();
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        self.profile_rebuild_view("commit select: rebuild inline subrange view", true);
 
         Ok(())
     }
@@ -4146,9 +4219,10 @@ impl App {
         self.saved_inline_selection = None;
 
         self.insert_commit_message_if_single();
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        self.profile_rebuild_view(
+            "commit select: rebuild commits plus working tree view",
+            false,
+        );
         Ok(())
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -178,12 +178,14 @@ fn handle_left_click(app: &mut App, pos: Position) {
 /// When output_to_stdout is true, stores the content and sets should_quit.
 fn handle_export(app: &mut App) {
     if app.output_to_stdout {
-        match generate_export_content(
-            &app.session,
-            &app.diff_source,
-            &app.comment_types,
-            app.export_legend,
-        ) {
+        match crate::profile::time("export: generate stdout markdown", || {
+            generate_export_content(
+                &app.session,
+                &app.diff_source,
+                &app.comment_types,
+                app.export_legend,
+            )
+        }) {
             Ok(content) => {
                 app.pending_stdout_output = Some(content);
                 app.should_quit = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ fn main() -> anyhow::Result<()> {
     }) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
+            startup_warnings.extend(app.vcs.startup_warnings());
             if let Some(message) = startup_warnings.first() {
                 app.set_warning(message.clone());
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod input;
 mod model;
 mod output;
 mod persistence;
+mod profile;
 mod syntax;
 mod text_edit;
 mod theme;
@@ -61,7 +62,7 @@ fn main() -> anyhow::Result<()> {
 
     // Parse CLI arguments and resolve theme
     // This also configures syntax highlighting colors before diff parsing
-    let mut cli_args = parse_cli_args();
+    let mut cli_args = profile::time("startup: parse cli args", parse_cli_args);
 
     // Check keyboard enhancement support before enabling raw mode.
     // Skip when --stdout is used because the probe writes escape sequences to stdout,
@@ -93,34 +94,36 @@ fn main() -> anyhow::Result<()> {
         cli_args.working_tree = true;
     }
     let mut startup_warnings = Vec::new();
-    let config_outcome = match config::load_config() {
+    let config_outcome = profile::time("startup: load config", || match config::load_config() {
         Ok(outcome) => outcome,
         Err(e) => {
             startup_warnings.push(format!("Failed to load config: {e}"));
             config::ConfigLoadOutcome::default()
         }
-    };
+    });
     startup_warnings.extend(config_outcome.warnings);
-    let (mut theme, theme_warnings) = resolve_theme_with_config(
-        cli_args.theme,
-        cli_args.appearance,
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.theme.as_deref()),
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.theme_dark.as_deref()),
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.theme_light.as_deref()),
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.appearance.as_deref()),
-    );
+    let (mut theme, theme_warnings) = profile::time("startup: resolve theme", || {
+        resolve_theme_with_config(
+            cli_args.theme,
+            cli_args.appearance,
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.theme.as_deref()),
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.theme_dark.as_deref()),
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.theme_light.as_deref()),
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.appearance.as_deref()),
+        )
+    });
     startup_warnings.extend(theme_warnings);
 
     let transparent = config_outcome
@@ -145,18 +148,20 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Initialize app
-    let mut app = match App::new(
-        theme,
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.comment_types.clone()),
-        cli_args.output_to_stdout,
-        cli_args.revisions.as_deref(),
-        cli_args.working_tree,
-        cli_args.path_filter.as_deref(),
-        cli_args.file_path.as_deref(),
-    ) {
+    let mut app = match profile::time("startup: app init", || {
+        App::new(
+            theme,
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.comment_types.clone()),
+            cli_args.output_to_stdout,
+            cli_args.revisions.as_deref(),
+            cli_args.working_tree,
+            cli_args.path_filter.as_deref(),
+            cli_args.file_path.as_deref(),
+        )
+    }) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
             if let Some(message) = startup_warnings.first() {

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -37,8 +37,12 @@ pub fn export_to_clipboard(
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
 ) -> Result<String> {
-    let content = generate_export_content(session, diff_source, comment_types, show_legend)?;
-    let via_terminal = copy_text_to_clipboard(&content)?;
+    let content = crate::profile::time("export: generate markdown", || {
+        generate_export_content(session, diff_source, comment_types, show_legend)
+    })?;
+    let via_terminal = crate::profile::time("export: copy to clipboard", || {
+        copy_text_to_clipboard(&content)
+    })?;
     Ok(if via_terminal {
         "Review copied to clipboard (via terminal)".to_string()
     } else {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,52 @@
+use std::time::{Duration, Instant};
+
+pub fn enabled() -> bool {
+    std::env::var_os("TUICR_PROFILE").is_some()
+}
+
+pub fn time<T, F>(label: &str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+
+    let started = Instant::now();
+    let result = f();
+    log(label, started.elapsed());
+    result
+}
+
+pub fn time_with<T, F, M>(label: &str, f: F, metadata: M) -> T
+where
+    F: FnOnce() -> T,
+    M: FnOnce(&T) -> String,
+{
+    if !enabled() {
+        return f();
+    }
+
+    let started = Instant::now();
+    let result = f();
+    log_with(label, started.elapsed(), metadata(&result));
+    result
+}
+
+pub fn log(label: &str, duration: Duration) {
+    log_with(label, duration, String::new());
+}
+
+pub fn log_with(label: &str, duration: Duration, metadata: String) {
+    if enabled() {
+        let suffix = if metadata.is_empty() {
+            String::new()
+        } else {
+            format!(" ({metadata})")
+        };
+        eprintln!(
+            "[tuicr profile] {label}: {:.2}ms{suffix}",
+            duration.as_secs_f64() * 1000.0
+        );
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,7 +1,13 @@
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
+static PROFILE_LOG: OnceLock<Option<Mutex<File>>> = OnceLock::new();
+
 pub fn enabled() -> bool {
-    std::env::var_os("TUICR_PROFILE").is_some()
+    profile_path().is_some()
 }
 
 pub fn time<T, F>(label: &str, f: F) -> T
@@ -38,15 +44,57 @@ pub fn log(label: &str, duration: Duration) {
 }
 
 pub fn log_with(label: &str, duration: Duration, metadata: String) {
-    if enabled() {
-        let suffix = if metadata.is_empty() {
-            String::new()
-        } else {
-            format!(" ({metadata})")
-        };
-        eprintln!(
+    let Some(log) = profile_log() else {
+        return;
+    };
+
+    let suffix = if metadata.is_empty() {
+        String::new()
+    } else {
+        format!(" ({metadata})")
+    };
+    if let Ok(mut file) = log.lock() {
+        let _ = writeln!(
+            file,
             "[tuicr profile] {label}: {:.2}ms{suffix}",
             duration.as_secs_f64() * 1000.0
         );
     }
+}
+
+fn profile_log() -> Option<&'static Mutex<File>> {
+    PROFILE_LOG
+        .get_or_init(|| {
+            let path = profile_path()?;
+            if let Some(parent) = path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(path)
+                .ok()?;
+            Some(Mutex::new(file))
+        })
+        .as_ref()
+}
+
+fn profile_path() -> Option<PathBuf> {
+    let value = std::env::var_os("TUICR_PROFILE")?;
+    let value = value.to_string_lossy();
+    let normalized = value.trim().to_ascii_lowercase();
+
+    if normalized.is_empty() || matches!(normalized.as_str(), "0" | "false" | "off" | "no") {
+        return None;
+    }
+
+    if let Some(path) = std::env::var_os("TUICR_PROFILE_FILE") {
+        return Some(PathBuf::from(path));
+    }
+
+    if matches!(normalized.as_str(), "1" | "true" | "on" | "yes") {
+        return Some(std::env::temp_dir().join("tuicr-profile.log"));
+    }
+
+    Some(PathBuf::from(value.as_ref()))
 }

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -17,6 +17,7 @@ use crate::ui::{comment_panel, help_popup, status_bar, styles};
 use crate::vcs::git::calculate_gap;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
+    frame.render_widget(Clear, frame.area());
     frame.render_widget(
         Block::default().style(styles::panel_style(&app.theme)),
         frame.area(),

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::Style,
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -17,7 +17,6 @@ use crate::ui::{comment_panel, help_popup, status_bar, styles};
 use crate::vcs::git::calculate_gap;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
-    frame.render_widget(Clear, frame.area());
     frame.render_widget(
         Block::default().style(styles::panel_style(&app.theme)),
         frame.area(),

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -1,8 +1,10 @@
-//! Unified diff parser for text-based VCS backends (hg, jj).
+//! Unified diff parser for text-based VCS backends (hg, jj, sparse Git).
 //!
 //! Parses unified diff format output from CLI tools into DiffFile structures.
-//! Git uses the native git2 library instead and has its own parser.
+//! Standard Git uses the native git2 library; sparse Git feeds CLI diff output
+//! through this parser to avoid sparse-index limitations in libgit2.
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
@@ -25,7 +27,7 @@ pub fn parse_unified_diff(
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     parse_unified_diff_lines(
-        diff_text.lines().map(|line| Ok(line.to_string())),
+        diff_text.lines().map(|line| Ok(Cow::Borrowed(line))),
         format,
         highlighter,
     )
@@ -36,13 +38,13 @@ pub fn parse_unified_diff(
 /// This entry point is used by Git's sparse-checkout fallback so large diffs
 /// can be parsed directly from command stdout instead of first buffering the
 /// whole patch into one String.
-pub fn parse_unified_diff_lines<I>(
+pub fn parse_unified_diff_lines<'a, I>(
     diff_lines: I,
     format: DiffFormat,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>>
 where
-    I: Iterator<Item = Result<String>>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
 {
     let mut files: Vec<DiffFile> = Vec::new();
     let mut lines = diff_lines.peekable();
@@ -52,6 +54,8 @@ where
         DiffFormat::GitStyle => "diff --git ",
     };
 
+    // `diff_lines` may be streaming from a child process, so each read can
+    // fail. Use `next_line` instead of `lines.next()` to propagate I/O errors.
     while let Some(line) = next_line(&mut lines)? {
         if line.starts_with(header_prefix) {
             let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format)?;
@@ -126,16 +130,19 @@ where
     Ok(files)
 }
 
-fn next_line<I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<String>>
+fn next_line<'a, I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<Cow<'a, str>>>
 where
-    I: Iterator<Item = Result<String>>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
 {
     lines.next().transpose()
 }
 
-fn peek_line<I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<&str>>
+fn peek_line<'lines, 'a, I>(
+    lines: &'lines mut std::iter::Peekable<I>,
+) -> Result<Option<&'lines str>>
 where
-    I: Iterator<Item = Result<String>>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
+    'a: 'lines,
 {
     let has_error = matches!(lines.peek(), Some(Err(_)));
     if has_error && let Some(Err(err)) = lines.next() {
@@ -145,16 +152,16 @@ where
     Ok(lines.peek().map(|line| {
         line.as_ref()
             .expect("peeked line errors are consumed before borrowing")
-            .as_str()
+            .as_ref()
     }))
 }
 
-fn parse_file_header<I>(
+fn parse_file_header<'a, I>(
     lines: &mut std::iter::Peekable<I>,
     format: DiffFormat,
 ) -> Result<(Option<PathBuf>, Option<PathBuf>, FileStatus)>
 where
-    I: Iterator<Item = Result<String>>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
 {
     let mut old_path: Option<PathBuf> = None;
     let mut new_path: Option<PathBuf> = None;
@@ -237,13 +244,13 @@ where
     Ok((old_path, new_path, status))
 }
 
-fn parse_hunk<I>(
+fn parse_hunk<'a, I>(
     lines: &mut std::iter::Peekable<I>,
     file_path: Option<&PathBuf>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Option<DiffHunk>>
 where
-    I: Iterator<Item = Result<String>>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
 {
     let Some(header_line) = next_line(lines)? else {
         return Ok(None);
@@ -1110,7 +1117,7 @@ new mode 100755
             "+new",
         ]
         .into_iter()
-        .map(|line| Ok(line.to_string()));
+        .map(|line| Ok(Cow::Owned(line.to_string())));
 
         let files =
             parse_unified_diff_lines(lines, DiffFormat::GitStyle, &SyntaxHighlighter::default())

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -24,24 +24,44 @@ pub fn parse_unified_diff(
     format: DiffFormat,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
+    parse_unified_diff_lines(
+        diff_text.lines().map(|line| Ok(line.to_string())),
+        format,
+        highlighter,
+    )
+}
+
+/// Parse unified diff lines into DiffFile structures.
+///
+/// This entry point is used by Git's sparse-checkout fallback so large diffs
+/// can be parsed directly from command stdout instead of first buffering the
+/// whole patch into one String.
+pub fn parse_unified_diff_lines<I>(
+    diff_lines: I,
+    format: DiffFormat,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>>
+where
+    I: Iterator<Item = Result<String>>,
+{
     let mut files: Vec<DiffFile> = Vec::new();
-    let mut lines = diff_text.lines().peekable();
+    let mut lines = diff_lines.peekable();
 
     let header_prefix = match format {
         DiffFormat::Hg => "diff ",
         DiffFormat::GitStyle => "diff --git ",
     };
 
-    while let Some(line) = lines.next() {
+    while let Some(line) = next_line(&mut lines)? {
         if line.starts_with(header_prefix) {
-            let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format);
+            let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format)?;
 
             // For git-style diffs (jj, git patches), if parse_file_header didn't find
             // ---/+++ or rename/copy lines (e.g. empty new files, mode-only changes),
             // fall back to parsing paths from the "diff --git a/X b/X" header.
             if old_path.is_none()
                 && new_path.is_none()
-                && let Some((a, b)) = parse_diff_git_header(line)
+                && let Some((a, b)) = parse_diff_git_header(&line)
             {
                 match status {
                     FileStatus::Deleted => old_path = Some(a),
@@ -54,8 +74,8 @@ pub fn parse_unified_diff(
             }
 
             // Check if binary - hg uses "Binary file", jj/git use just "Binary"
-            if lines.peek().is_some_and(|l| l.contains("Binary")) {
-                lines.next(); // consume binary message
+            if peek_line(&mut lines)?.is_some_and(|l| l.contains("Binary")) {
+                next_line(&mut lines)?; // consume binary message
                 files.push(DiffFile {
                     old_path,
                     new_path,
@@ -73,17 +93,15 @@ pub fn parse_unified_diff(
             let mut hunks = Vec::new();
 
             // Parse hunks until next file or end
-            while lines.peek().is_some() {
-                if let Some(peek_line) = lines.peek() {
-                    if peek_line.starts_with("diff ") {
-                        break;
-                    } else if peek_line.starts_with("@@") {
-                        if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter) {
-                            hunks.push(hunk);
-                        }
-                    } else {
-                        lines.next(); // skip non-hunk, non-diff lines
+            while let Some(line) = peek_line(&mut lines)? {
+                if line.starts_with("diff ") {
+                    break;
+                } else if line.starts_with("@@") {
+                    if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter)? {
+                        hunks.push(hunk);
                     }
+                } else {
+                    next_line(&mut lines)?; // skip non-hunk, non-diff lines
                 }
             }
 
@@ -108,19 +126,42 @@ pub fn parse_unified_diff(
     Ok(files)
 }
 
-fn parse_file_header<'a, I>(
+fn next_line<I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<String>>
+where
+    I: Iterator<Item = Result<String>>,
+{
+    lines.next().transpose()
+}
+
+fn peek_line<I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<&str>>
+where
+    I: Iterator<Item = Result<String>>,
+{
+    let has_error = matches!(lines.peek(), Some(Err(_)));
+    if has_error && let Some(Err(err)) = lines.next() {
+        return Err(err);
+    }
+
+    Ok(lines.peek().map(|line| {
+        line.as_ref()
+            .expect("peeked line errors are consumed before borrowing")
+            .as_str()
+    }))
+}
+
+fn parse_file_header<I>(
     lines: &mut std::iter::Peekable<I>,
     format: DiffFormat,
-) -> (Option<PathBuf>, Option<PathBuf>, FileStatus)
+) -> Result<(Option<PathBuf>, Option<PathBuf>, FileStatus)>
 where
-    I: Iterator<Item = &'a str>,
+    I: Iterator<Item = Result<String>>,
 {
     let mut old_path: Option<PathBuf> = None;
     let mut new_path: Option<PathBuf> = None;
     let mut status = FileStatus::Modified;
 
     // Parse --- and +++ lines and metadata
-    while let Some(line) = lines.peek() {
+    while let Some(line) = peek_line(lines)?.map(str::to_string) {
         if line.starts_with("---") {
             let path_str = line.trim_start_matches("--- ").trim_start_matches("a/");
             if path_str != "/dev/null" {
@@ -132,7 +173,7 @@ where
                 };
                 old_path = Some(PathBuf::from(path));
             }
-            lines.next();
+            next_line(lines)?;
         } else if line.starts_with("+++") {
             let path_str = line.trim_start_matches("+++ ").trim_start_matches("b/");
             if path_str != "/dev/null" {
@@ -143,34 +184,34 @@ where
                 };
                 new_path = Some(PathBuf::from(path));
             }
-            lines.next();
+            next_line(lines)?;
             break; // Done with file header
         } else if line.starts_with("new file") {
             status = FileStatus::Added;
-            lines.next();
+            next_line(lines)?;
         } else if line.starts_with("deleted file") {
             status = FileStatus::Deleted;
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("rename from ") {
             status = FileStatus::Renamed;
             old_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("rename to ") {
             new_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("copy from ") {
             status = FileStatus::Copied;
             old_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("copy to ") {
             new_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if line.starts_with("@@") || line.starts_with("diff ") {
             break;
         } else if line.starts_with("Binary file") {
             // Hg format: "Binary file <path> has changed"
             // Git format: "Binary files a/<old> and b/<new> differ"
-            if let Some((old, new)) = parse_binary_file_line(line) {
+            if let Some((old, new)) = parse_binary_file_line(&line) {
                 if old_path.is_none() {
                     old_path = old;
                 }
@@ -180,7 +221,7 @@ where
             }
             break;
         } else {
-            lines.next(); // Skip other metadata lines (rename to, copy to, index, etc.)
+            next_line(lines)?; // Skip other metadata lines (rename to, copy to, index, etc.)
         }
     }
 
@@ -193,21 +234,25 @@ where
         }
     }
 
-    (old_path, new_path, status)
+    Ok((old_path, new_path, status))
 }
 
-fn parse_hunk<'a, I>(
+fn parse_hunk<I>(
     lines: &mut std::iter::Peekable<I>,
     file_path: Option<&PathBuf>,
     highlighter: &SyntaxHighlighter,
-) -> Option<DiffHunk>
+) -> Result<Option<DiffHunk>>
 where
-    I: Iterator<Item = &'a str>,
+    I: Iterator<Item = Result<String>>,
 {
-    let header_line = lines.next()?;
+    let Some(header_line) = next_line(lines)? else {
+        return Ok(None);
+    };
 
     // Parse @@ -old_start,old_count +new_start,new_count @@
-    let (old_start, old_count, new_start, new_count) = parse_hunk_header(header_line)?;
+    let Some((old_start, old_count, new_start, new_count)) = parse_hunk_header(&header_line) else {
+        return Ok(None);
+    };
 
     let mut line_contents: Vec<String> = Vec::new();
     let mut line_origins: Vec<LineOrigin> = Vec::new();
@@ -217,12 +262,12 @@ where
     let mut new_lineno = new_start;
 
     // Collect lines until next hunk or file
-    while let Some(line) = lines.peek() {
+    while let Some(line) = peek_line(lines)?.map(str::to_string) {
         if line.starts_with("@@") || line.starts_with("diff ") {
             break;
         }
 
-        let line = lines.next().unwrap();
+        next_line(lines)?;
 
         if line.starts_with('\\') {
             // "\ No newline at end of file" - skip
@@ -304,14 +349,14 @@ where
         });
     }
 
-    Some(DiffHunk {
+    Ok(Some(DiffHunk {
         header: header_line.to_string(),
         lines: diff_lines,
         old_start,
         old_count,
         new_start,
         new_count,
-    })
+    }))
 }
 
 fn parse_hunk_header(line: &str) -> Option<(u32, u32, u32, u32)> {
@@ -1052,5 +1097,27 @@ new mode 100755
         assert_eq!(files[0].new_path, Some(PathBuf::from("script.sh")));
         assert!(files[0].hunks.is_empty());
         let _path = files[0].display_path();
+    }
+
+    #[test]
+    fn should_parse_unified_diff_from_streamed_lines() {
+        let lines = [
+            "diff --git a/file.txt b/file.txt",
+            "--- a/file.txt",
+            "+++ b/file.txt",
+            "@@ -1 +1 @@",
+            "-old",
+            "+new",
+        ]
+        .into_iter()
+        .map(|line| Ok(line.to_string()));
+
+        let files =
+            parse_unified_diff_lines(lines, DiffFormat::GitStyle, &SyntaxHighlighter::default())
+                .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].new_path, Some(PathBuf::from("file.txt")));
+        assert_eq!(files[0].hunks[0].lines.len(), 2);
     }
 }

--- a/src/vcs/git/context.rs
+++ b/src/vcs/git/context.rs
@@ -1,5 +1,6 @@
 use git2::Repository;
 use std::path::Path;
+use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffLine, FileStatus, LineOrigin};
@@ -53,12 +54,22 @@ pub fn fetch_context_lines(
 
 /// Fetch content from a git blob (for deleted files)
 fn fetch_blob_content(repo: &Repository, file_path: &Path) -> Result<String> {
-    let head = repo.head()?.peel_to_tree()?;
-    let entry = head.get_path(file_path)?;
-    let blob = repo.find_blob(entry.id())?;
-    let content = std::str::from_utf8(blob.content())
-        .map_err(|e| TuicrError::CorruptedSession(format!("Invalid UTF-8 in file: {e}")))?;
-    Ok(content.to_string())
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let spec = format!("HEAD:{}", file_path.to_string_lossy());
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(["show", &spec])
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| TuicrError::CorruptedSession(format!("Invalid UTF-8 in file: {e}")))
 }
 
 /// Calculate the number of hidden lines (gap) before a hunk.
@@ -85,6 +96,22 @@ pub fn calculate_gap(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    fn git(repo: &Repository, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(repo.workdir().expect("test repo should have workdir"))
+            .args(args)
+            .output()
+            .expect("failed to run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn should_calculate_gap_before_first_hunk() {
@@ -138,5 +165,34 @@ mod tests {
 
         // then
         assert_eq!(gap, 0); // saturating_sub prevents underflow
+    }
+
+    #[test]
+    fn fetch_deleted_context_lines_supports_sparse_index() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        git(&repo, &["config", "user.email", "test@example.com"]);
+        git(&repo, &["config", "user.name", "Test User"]);
+        fs::create_dir_all(temp_dir.path().join("keep")).expect("failed to create keep dir");
+        fs::create_dir_all(temp_dir.path().join("hidden")).expect("failed to create hidden dir");
+        fs::write(temp_dir.path().join("keep/file.txt"), "one\ntwo\nthree\n")
+            .expect("failed to write keep file");
+        fs::write(temp_dir.path().join("hidden/file.txt"), "hidden\n")
+            .expect("failed to write hidden file");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+        fs::remove_file(temp_dir.path().join("keep/file.txt")).expect("failed to delete file");
+
+        let lines =
+            fetch_context_lines(&repo, Path::new("keep/file.txt"), FileStatus::Deleted, 2, 3)
+                .expect("failed to fetch context lines");
+
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].content, "two");
+        assert_eq!(lines[1].content, "three");
     }
 }

--- a/src/vcs/git/context.rs
+++ b/src/vcs/git/context.rs
@@ -137,6 +137,8 @@ mod tests {
     fn sparse_index_capabilities() -> GitCapabilities {
         GitCapabilities {
             mode: GitRepoMode::SparseIndex,
+            untracked_cache: false,
+            fsmonitor: false,
         }
     }
 

--- a/src/vcs/git/context.rs
+++ b/src/vcs/git/context.rs
@@ -5,12 +5,15 @@ use std::process::Command;
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffLine, FileStatus, LineOrigin};
 
+use super::GitCapabilities;
+
 /// Fetch context lines from a file for gap expansion.
 ///
 /// For Added/Modified files: reads from working tree
 /// For Deleted files: reads from HEAD blob
 pub fn fetch_context_lines(
     repo: &Repository,
+    _capabilities: GitCapabilities,
     file_path: &Path,
     file_status: FileStatus,
     start_line: u32,
@@ -96,6 +99,7 @@ pub fn calculate_gap(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::git::GitRepoMode;
     use std::fs;
     use std::process::Command;
 
@@ -111,6 +115,12 @@ mod tests {
             args.join(" "),
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    fn sparse_index_capabilities() -> GitCapabilities {
+        GitCapabilities {
+            mode: GitRepoMode::SparseIndex,
+        }
     }
 
     #[test]
@@ -187,9 +197,15 @@ mod tests {
         git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
         fs::remove_file(temp_dir.path().join("keep/file.txt")).expect("failed to delete file");
 
-        let lines =
-            fetch_context_lines(&repo, Path::new("keep/file.txt"), FileStatus::Deleted, 2, 3)
-                .expect("failed to fetch context lines");
+        let lines = fetch_context_lines(
+            &repo,
+            sparse_index_capabilities(),
+            Path::new("keep/file.txt"),
+            FileStatus::Deleted,
+            2,
+            3,
+        )
+        .expect("failed to fetch context lines");
 
         assert_eq!(lines.len(), 2);
         assert_eq!(lines[0].content, "two");

--- a/src/vcs/git/context.rs
+++ b/src/vcs/git/context.rs
@@ -13,7 +13,7 @@ use super::GitCapabilities;
 /// For Deleted files: reads from HEAD blob
 pub fn fetch_context_lines(
     repo: &Repository,
-    _capabilities: GitCapabilities,
+    capabilities: GitCapabilities,
     file_path: &Path,
     file_status: FileStatus,
     start_line: u32,
@@ -26,7 +26,7 @@ pub fn fetch_context_lines(
     let content = match file_status {
         FileStatus::Deleted => {
             // Read from HEAD blob for deleted files
-            fetch_blob_content(repo, file_path)?
+            fetch_blob_content(repo, capabilities, file_path)?
         }
         _ => {
             // Read from working tree for all other statuses
@@ -56,7 +56,24 @@ pub fn fetch_context_lines(
 }
 
 /// Fetch content from a git blob (for deleted files)
-fn fetch_blob_content(repo: &Repository, file_path: &Path) -> Result<String> {
+fn fetch_blob_content(
+    repo: &Repository,
+    capabilities: GitCapabilities,
+    file_path: &Path,
+) -> Result<String> {
+    if capabilities.requires_git_cli() {
+        return fetch_blob_content_cli(repo, file_path);
+    }
+
+    let head = repo.head()?.peel_to_tree()?;
+    let entry = head.get_path(file_path)?;
+    let blob = repo.find_blob(entry.id())?;
+    let content = std::str::from_utf8(blob.content())
+        .map_err(|e| TuicrError::CorruptedSession(format!("Invalid UTF-8 in file: {e}")))?;
+    Ok(content.to_string())
+}
+
+fn fetch_blob_content_cli(repo: &Repository, file_path: &Path) -> Result<String> {
     let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
     let spec = format!("HEAD:{}", file_path.to_string_lossy());
     let output = Command::new("git")

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -25,6 +25,7 @@ pub fn get_working_tree_diff(
     if capabilities.requires_git_cli() {
         return get_cli_diff(
             repo,
+            capabilities,
             &["diff", "--no-ext-diff", "--binary", "HEAD", "--"],
             true,
             GitContentSource::Revision("HEAD"),
@@ -66,6 +67,7 @@ pub fn get_staged_diff(
         };
         return get_cli_diff(
             repo,
+            capabilities,
             &["diff", "--no-ext-diff", "--binary", "--cached", "--"],
             false,
             old_source,
@@ -99,6 +101,7 @@ pub fn get_unstaged_diff(
     if capabilities.requires_git_cli() {
         return get_cli_diff(
             repo,
+            capabilities,
             &["diff", "--no-ext-diff", "--binary", "--"],
             true,
             GitContentSource::Index,
@@ -142,6 +145,7 @@ pub fn get_commit_range_diff(
         let newest_rev = commit_ids.last().unwrap();
         return get_cli_diff(
             repo,
+            capabilities,
             &[
                 "diff",
                 "--no-ext-diff",
@@ -202,6 +206,7 @@ pub fn get_working_tree_with_commits_diff(
         let base_rev = parent_rev_or_empty(repo, &commit_ids[0]);
         return get_cli_diff(
             repo,
+            capabilities,
             &["diff", "--no-ext-diff", "--binary", &base_rev, "--"],
             true,
             GitContentSource::Revision(&base_rev),
@@ -277,6 +282,7 @@ fn parent_rev_or_empty(repo: &Repository, commit_id: &str) -> String {
 
 fn get_cli_diff(
     repo: &Repository,
+    capabilities: GitCapabilities,
     args: &[&str],
     include_untracked: bool,
     old_source: GitContentSource<'_>,
@@ -296,7 +302,7 @@ fn get_cli_diff(
     if include_untracked {
         crate::profile::time_with(
             "vcs: git cli untracked diff",
-            || append_untracked_cli_diffs(repo, &mut files, highlighter),
+            || append_untracked_cli_diffs(repo, capabilities, &mut files, highlighter),
             |result| match result {
                 Ok(count) => format!("files={count}"),
                 Err(e) => format!("error={e}"),
@@ -386,6 +392,7 @@ fn run_git_diff_command(
 
 fn append_untracked_cli_diffs(
     repo: &Repository,
+    capabilities: GitCapabilities,
     files: &mut Vec<DiffFile>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<usize> {
@@ -393,8 +400,16 @@ fn append_untracked_cli_diffs(
         return Ok(0);
     };
 
+    let pathspecs = crate::profile::time_with(
+        "vcs: git cli untracked pathspecs",
+        || sparse_checkout_untracked_pathspecs(repo, capabilities),
+        |result| match result {
+            Ok(pathspecs) => format!("pathspecs={}", pathspecs.len()),
+            Err(e) => format!("error={e}"),
+        },
+    )?;
     let previous_len = files.len();
-    for_each_untracked_path(repo, |path| {
+    for_each_untracked_path(repo, &pathspecs, |path| {
         let full_path = workdir.join(&path);
         let Some(file) = build_untracked_diff_file(&path, &full_path, highlighter) else {
             return Ok(());
@@ -403,6 +418,53 @@ fn append_untracked_cli_diffs(
         Ok(())
     })?;
     Ok(files.len().saturating_sub(previous_len))
+}
+
+fn sparse_checkout_untracked_pathspecs(
+    repo: &Repository,
+    capabilities: GitCapabilities,
+) -> Result<Vec<String>> {
+    if !capabilities.is_sparse_checkout() {
+        return Ok(Vec::new());
+    }
+
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(["sparse-checkout", "list"])
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let mut pathspecs = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let pattern = line.trim();
+        if pattern.is_empty() {
+            continue;
+        }
+
+        if !is_simple_sparse_path(pattern) {
+            return Ok(Vec::new());
+        }
+
+        let pathspec = pattern.trim_start_matches('/').trim_end_matches('/');
+        if !pathspec.is_empty() {
+            pathspecs.push(pathspec.to_string());
+        }
+    }
+
+    Ok(pathspecs)
+}
+
+fn is_simple_sparse_path(pattern: &str) -> bool {
+    !pattern.starts_with('!')
+        && !pattern.contains('*')
+        && !pattern.contains('?')
+        && !pattern.contains('[')
+        && !pattern.contains('\\')
 }
 
 fn build_untracked_diff_file(
@@ -485,14 +547,20 @@ fn diff_file_without_hunks(path: &Path, is_binary: bool, is_too_large: bool) -> 
     }
 }
 
-fn for_each_untracked_path<F>(repo: &Repository, mut visit: F) -> Result<()>
+fn for_each_untracked_path<F>(repo: &Repository, pathspecs: &[String], mut visit: F) -> Result<()>
 where
     F: FnMut(PathBuf) -> Result<()>,
 {
     let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let mut args = vec!["ls-files", "--others", "--exclude-standard", "-z"];
+    if !pathspecs.is_empty() {
+        args.push("--");
+        args.extend(pathspecs.iter().map(String::as_str));
+    }
+
     let mut child = Command::new("git")
         .current_dir(workdir)
-        .args(["ls-files", "--others", "--exclude-standard", "-z"])
+        .args(args)
         .stdout(Stdio::piped())
         .spawn()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
@@ -1129,6 +1197,9 @@ mod tests {
 
         fs::write(temp_dir.path().join("keep/new.txt"), "new sparse file\n")
             .expect("failed to write untracked file");
+        fs::create_dir_all(temp_dir.path().join("hidden")).expect("failed to create hidden dir");
+        fs::write(temp_dir.path().join("hidden/outside.txt"), "outside cone\n")
+            .expect("failed to write outside-cone untracked file");
 
         let files = get_working_tree_diff(
             &repo,

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,7 +1,8 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
@@ -294,13 +295,14 @@ fn append_untracked_cli_diffs(
         return Ok(());
     };
 
-    for path in untracked_paths(repo)? {
+    for_each_untracked_path(repo, |path| {
         let full_path = workdir.join(&path);
         let Some(file) = build_untracked_diff_file(&path, &full_path, highlighter) else {
-            continue;
+            return Ok(());
         };
         files.push(file);
-    }
+        Ok(())
+    })?;
     Ok(())
 }
 
@@ -384,17 +386,56 @@ fn diff_file_without_hunks(path: &Path, is_binary: bool, is_too_large: bool) -> 
     }
 }
 
-fn untracked_paths(repo: &Repository) -> Result<Vec<PathBuf>> {
-    let output = run_git_command(
-        repo,
-        &["ls-files", "--others", "--exclude-standard", "-z"],
-        false,
-    )?;
-    Ok(output
-        .split('\0')
-        .filter(|path| !path.is_empty())
-        .map(PathBuf::from)
-        .collect())
+fn for_each_untracked_path<F>(repo: &Repository, mut visit: F) -> Result<()>
+where
+    F: FnMut(PathBuf) -> Result<()>,
+{
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(["ls-files", "--others", "--exclude-standard", "-z"])
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git ls-files stdout unavailable".into()))?;
+    let mut buffer = [0; 8192];
+    let mut path = Vec::new();
+
+    loop {
+        let read = stdout.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+
+        for &byte in &buffer[..read] {
+            if byte == 0 {
+                if !path.is_empty() {
+                    visit(PathBuf::from(String::from_utf8_lossy(&path).into_owned()))?;
+                    path.clear();
+                }
+            } else {
+                path.push(byte);
+            }
+        }
+    }
+
+    if !path.is_empty() {
+        visit(PathBuf::from(String::from_utf8_lossy(&path).into_owned()))?;
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        return Err(TuicrError::VcsCommand(format!(
+            "git ls-files failed with status {}",
+            status
+        )));
+    }
+
+    Ok(())
 }
 
 fn read_path_from_git_source(
@@ -425,7 +466,7 @@ fn run_git_command(repo: &Repository, args: &[&str], allow_diff_exit: bool) -> R
         .output()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
 
-    if !output.status.success() && !(allow_diff_exit && output.status.code() == Some(1)) {
+    if !(output.status.success() || allow_diff_exit && output.status.code() == Some(1)) {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(TuicrError::VcsCommand(format!(
             "git {} failed: {}",

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,15 +1,32 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
+use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::{enhance_with_full_file_highlight, tabify};
+
+// Untracked files larger than this are shown in the file list but their
+// content is not parsed — they are likely logs, dumps, or build artefacts.
+const MAX_UNTRACKED_FILE_SIZE: u64 = 10 * 1_024 * 1_024;
 
 pub fn get_working_tree_diff(
     repo: &Repository,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
+    if is_sparse_checkout(repo) {
+        return get_cli_diff(
+            repo,
+            &["diff", "--no-ext-diff", "--binary", "HEAD", "--"],
+            true,
+            GitContentSource::Revision("HEAD"),
+            GitContentSource::Workdir,
+            highlighter,
+        );
+    }
+
     let head = repo.head()?.peel_to_tree()?;
 
     let mut opts = DiffOptions::new();
@@ -34,6 +51,22 @@ pub fn get_staged_diff(
     repo: &Repository,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
+    if is_sparse_checkout(repo) {
+        let old_source = if repo.head().is_ok() {
+            GitContentSource::Revision("HEAD")
+        } else {
+            GitContentSource::None
+        };
+        return get_cli_diff(
+            repo,
+            &["diff", "--no-ext-diff", "--binary", "--cached", "--"],
+            false,
+            old_source,
+            GitContentSource::Index,
+            highlighter,
+        );
+    }
+
     let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
     let index = repo.index()?;
     let diff = repo.diff_tree_to_index(head.as_ref(), Some(&index), None)?;
@@ -55,6 +88,17 @@ pub fn get_unstaged_diff(
     repo: &Repository,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
+    if is_sparse_checkout(repo) {
+        return get_cli_diff(
+            repo,
+            &["diff", "--no-ext-diff", "--binary", "--"],
+            true,
+            GitContentSource::Index,
+            GitContentSource::Workdir,
+            highlighter,
+        );
+    }
+
     let index = repo.index()?;
     let mut opts = DiffOptions::new();
     opts.include_untracked(true);
@@ -133,6 +177,22 @@ pub fn get_working_tree_with_commits_diff(
         None
     };
 
+    if is_sparse_checkout(repo) {
+        let base_rev = if oldest_commit.parent_count() > 0 {
+            oldest_commit.parent(0)?.id().to_string()
+        } else {
+            empty_tree_oid().to_string()
+        };
+        return get_cli_diff(
+            repo,
+            &["diff", "--no-ext-diff", "--binary", &base_rev, "--"],
+            true,
+            GitContentSource::Revision(&base_rev),
+            GitContentSource::Workdir,
+            highlighter,
+        );
+    }
+
     let mut opts = DiffOptions::new();
     opts.include_untracked(true);
     opts.show_untracked_content(true);
@@ -169,12 +229,169 @@ fn read_path_from_index(repo: &Repository, index: &git2::Index, path: &Path) -> 
     Some(String::from_utf8_lossy(blob.content()).into_owned())
 }
 
+#[derive(Clone, Copy)]
+enum GitContentSource<'a> {
+    None,
+    Workdir,
+    Index,
+    Revision(&'a str),
+}
+
+fn is_sparse_checkout(repo: &Repository) -> bool {
+    git_config_bool(repo, "core.sparseCheckout") || git_config_bool(repo, "index.sparse")
+}
+
+fn git_config_bool(repo: &Repository, key: &str) -> bool {
+    run_git_command(repo, &["config", "--bool", "--get", key], false)
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "true" | "1" | "yes" | "on"))
+}
+
+fn empty_tree_oid() -> git2::Oid {
+    git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
+        .expect("empty tree oid should be valid")
+}
+
+fn get_cli_diff(
+    repo: &Repository,
+    args: &[&str],
+    include_untracked: bool,
+    old_source: GitContentSource<'_>,
+    new_source: GitContentSource<'_>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>> {
+    let diff_output = run_git_command(repo, args, false)?;
+    let mut files = if diff_output.trim().is_empty() {
+        Vec::new()
+    } else {
+        diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?
+    };
+
+    if include_untracked {
+        append_untracked_cli_diffs(repo, &mut files, highlighter)?;
+    }
+
+    if files.is_empty() {
+        return Err(TuicrError::NoChanges);
+    }
+
+    enhance_with_full_file_highlight(
+        &mut files,
+        highlighter,
+        |path| read_path_from_git_source(repo, old_source, path),
+        |path| read_path_from_git_source(repo, new_source, path),
+    );
+    Ok(files)
+}
+
+fn append_untracked_cli_diffs(
+    repo: &Repository,
+    files: &mut Vec<DiffFile>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<()> {
+    for path in untracked_paths(repo)? {
+        let Some(workdir) = repo.workdir() else {
+            continue;
+        };
+        let full_path = workdir.join(&path);
+        if full_path
+            .metadata()
+            .is_ok_and(|metadata| metadata.len() > MAX_UNTRACKED_FILE_SIZE)
+        {
+            files.push(DiffFile {
+                old_path: None,
+                new_path: Some(path),
+                status: FileStatus::Added,
+                hunks: Vec::new(),
+                is_binary: false,
+                is_too_large: true,
+                is_commit_message: false,
+                content_hash: 0,
+            });
+            continue;
+        }
+
+        let path_arg = path.to_string_lossy();
+        let diff_output = run_git_command(
+            repo,
+            &[
+                "diff",
+                "--no-ext-diff",
+                "--binary",
+                "--no-index",
+                "--",
+                "/dev/null",
+                &path_arg,
+            ],
+            true,
+        )?;
+        if diff_output.trim().is_empty() {
+            continue;
+        }
+        match diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter) {
+            Ok(mut parsed) => files.append(&mut parsed),
+            Err(TuicrError::NoChanges) => {}
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+fn untracked_paths(repo: &Repository) -> Result<Vec<PathBuf>> {
+    let output = run_git_command(
+        repo,
+        &["ls-files", "--others", "--exclude-standard", "-z"],
+        false,
+    )?;
+    Ok(output
+        .split('\0')
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .collect())
+}
+
+fn read_path_from_git_source(
+    repo: &Repository,
+    source: GitContentSource<'_>,
+    path: &Path,
+) -> Option<String> {
+    match source {
+        GitContentSource::None => None,
+        GitContentSource::Workdir => read_path_from_workdir(repo, path),
+        GitContentSource::Index => read_git_object(repo, &format!(":0:{}", path.to_string_lossy())),
+        GitContentSource::Revision(rev) => {
+            read_git_object(repo, &format!("{}:{}", rev, path.to_string_lossy()))
+        }
+    }
+}
+
+fn read_git_object(repo: &Repository, spec: &str) -> Option<String> {
+    let output = run_git_command(repo, &["show", spec], false).ok()?;
+    Some(output)
+}
+
+fn run_git_command(repo: &Repository, args: &[&str], allow_diff_exit: bool) -> Result<String> {
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    if !output.status.success() && !(allow_diff_exit && output.status.code() == Some(1)) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(TuicrError::VcsCommand(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            stderr
+        )));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
     let mut files: Vec<DiffFile> = Vec::new();
-
-    // Untracked files larger than this are shown in the file list but their
-    // content is not parsed — they are likely logs, dumps, or build artefacts.
-    const MAX_UNTRACKED_FILE_SIZE: u64 = 10 * 1_024 * 1_024;
 
     for (delta_idx, delta) in diff.deltas().enumerate() {
         let status = match delta.status() {
@@ -314,6 +531,7 @@ mod tests {
     use super::*;
     use std::fs;
     use std::path::Path;
+    use std::process::Command;
 
     fn create_initial_commit(repo: &Repository, file_name: &str, content: &str) {
         fs::write(repo.workdir().unwrap().join(file_name), content)
@@ -332,6 +550,41 @@ mod tests {
 
         repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
             .expect("failed to create commit");
+    }
+
+    fn create_initial_commit_with_files(repo: &Repository, files: &[(&str, &str)]) {
+        for (file_name, content) in files {
+            let path = repo.workdir().unwrap().join(file_name);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("failed to create parent directory");
+            }
+            fs::write(path, content).expect("failed to write initial file");
+        }
+
+        let mut index = repo.index().expect("failed to open index");
+        for (file_name, _) in files {
+            index
+                .add_path(Path::new(file_name))
+                .expect("failed to add file to index");
+        }
+        index.write().expect("failed to write index");
+
+        let tree_id = index.write_tree().expect("failed to write tree");
+        let tree = repo.find_tree(tree_id).expect("failed to find tree");
+        let sig = git2::Signature::now("Test User", "test@example.com")
+            .expect("failed to create signature");
+
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .expect("failed to create commit");
+    }
+
+    fn git(repo: &Repository, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(repo.workdir().unwrap())
+            .status()
+            .expect("failed to run git");
+        assert!(status.success(), "git {args:?} failed with {status}");
     }
 
     #[test]
@@ -444,5 +697,122 @@ mod tests {
             get_unstaged_diff(&repo, &highlighter),
             Err(TuicrError::NoChanges)
         ));
+    }
+
+    #[test]
+    fn should_ignore_paths_outside_sparse_checkout_cone() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep changed\n")
+            .expect("failed to update included file");
+
+        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
+            .expect("failed to get sparse checkout diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/file.txt"))
+        );
+        assert_eq!(files[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn should_return_no_changes_for_clean_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        assert!(matches!(
+            get_working_tree_diff(&repo, &SyntaxHighlighter::default()),
+            Err(TuicrError::NoChanges)
+        ));
+    }
+
+    #[test]
+    fn should_include_untracked_files_in_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        fs::write(temp_dir.path().join("keep/new.txt"), "new sparse file\n")
+            .expect("failed to write untracked file");
+
+        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
+            .expect("failed to get sparse checkout diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/new.txt"))
+        );
+        assert_eq!(files[0].status, FileStatus::Added);
+    }
+
+    #[test]
+    fn should_read_staged_diff_in_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep staged\n")
+            .expect("failed to update included file");
+        git(&repo, &["add", "keep/file.txt"]);
+
+        let files = get_staged_diff(&repo, &SyntaxHighlighter::default())
+            .expect("failed to get sparse checkout staged diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/file.txt"))
+        );
+        assert_eq!(files[0].status, FileStatus::Modified);
     }
 }

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,4 +1,5 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -289,52 +290,98 @@ fn append_untracked_cli_diffs(
     files: &mut Vec<DiffFile>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<()> {
+    let Some(workdir) = repo.workdir() else {
+        return Ok(());
+    };
+
     for path in untracked_paths(repo)? {
-        let Some(workdir) = repo.workdir() else {
+        let full_path = workdir.join(&path);
+        let Some(file) = build_untracked_diff_file(&path, &full_path, highlighter) else {
             continue;
         };
-        let full_path = workdir.join(&path);
-        if full_path
-            .metadata()
-            .is_ok_and(|metadata| metadata.len() > MAX_UNTRACKED_FILE_SIZE)
-        {
-            files.push(DiffFile {
-                old_path: None,
-                new_path: Some(path),
-                status: FileStatus::Added,
-                hunks: Vec::new(),
-                is_binary: false,
-                is_too_large: true,
-                is_commit_message: false,
-                content_hash: 0,
-            });
-            continue;
-        }
-
-        let path_arg = path.to_string_lossy();
-        let diff_output = run_git_command(
-            repo,
-            &[
-                "diff",
-                "--no-ext-diff",
-                "--binary",
-                "--no-index",
-                "--",
-                "/dev/null",
-                &path_arg,
-            ],
-            true,
-        )?;
-        if diff_output.trim().is_empty() {
-            continue;
-        }
-        match diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter) {
-            Ok(mut parsed) => files.append(&mut parsed),
-            Err(TuicrError::NoChanges) => {}
-            Err(err) => return Err(err),
-        }
+        files.push(file);
     }
     Ok(())
+}
+
+fn build_untracked_diff_file(
+    path: &Path,
+    full_path: &Path,
+    highlighter: &SyntaxHighlighter,
+) -> Option<DiffFile> {
+    let metadata = full_path.metadata().ok()?;
+    if metadata.len() > MAX_UNTRACKED_FILE_SIZE {
+        return Some(diff_file_without_hunks(path, false, true));
+    }
+
+    let bytes = fs::read(full_path).ok()?;
+    if bytes.contains(&0) {
+        return Some(diff_file_without_hunks(path, true, false));
+    }
+
+    let content = String::from_utf8_lossy(&bytes);
+    let lines: Vec<String> = content
+        .lines()
+        .map(|line| tabify(line.trim_end_matches('\r')))
+        .collect();
+
+    if lines.is_empty() {
+        return Some(diff_file_without_hunks(path, false, false));
+    }
+
+    let highlighted = highlighter.highlight_file_lines(path, &lines);
+    let diff_lines: Vec<DiffLine> = lines
+        .into_iter()
+        .enumerate()
+        .map(|(idx, content)| DiffLine {
+            origin: LineOrigin::Addition,
+            content,
+            old_lineno: None,
+            new_lineno: Some((idx + 1) as u32),
+            highlighted_spans: highlighter.highlighted_line_for_diff_with_background(
+                None,
+                highlighted.as_deref(),
+                None,
+                Some(idx),
+                LineOrigin::Addition,
+            ),
+        })
+        .collect();
+
+    let new_count = diff_lines.len() as u32;
+    let hunks = vec![DiffHunk {
+        header: format!("@@ -0,0 +1,{} @@", new_count),
+        lines: diff_lines,
+        old_start: 0,
+        old_count: 0,
+        new_start: 1,
+        new_count,
+    }];
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+
+    Some(DiffFile {
+        old_path: None,
+        new_path: Some(path.to_path_buf()),
+        status: FileStatus::Added,
+        hunks,
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash,
+    })
+}
+
+fn diff_file_without_hunks(path: &Path, is_binary: bool, is_too_large: bool) -> DiffFile {
+    DiffFile {
+        old_path: None,
+        new_path: Some(path.to_path_buf()),
+        status: FileStatus::Added,
+        hunks: Vec::new(),
+        is_binary,
+        is_too_large,
+        is_commit_message: false,
+        content_hash: 0,
+    }
 }
 
 fn untracked_paths(repo: &Repository) -> Result<Vec<PathBuf>> {
@@ -782,6 +829,79 @@ mod tests {
             Some(Path::new("keep/new.txt"))
         );
         assert_eq!(files[0].status, FileStatus::Added);
+        assert_eq!(files[0].hunks.len(), 1);
+        assert_eq!(files[0].hunks[0].lines.len(), 1);
+        assert_eq!(files[0].hunks[0].lines[0].content, "new sparse file");
+        assert_eq!(files[0].hunks[0].lines[0].new_lineno, Some(1));
+    }
+
+    #[test]
+    fn should_mark_binary_untracked_files_in_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        fs::write(temp_dir.path().join("keep/image.bin"), [0_u8, 1, 2, 3])
+            .expect("failed to write binary untracked file");
+
+        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
+            .expect("failed to get sparse checkout diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/image.bin"))
+        );
+        assert_eq!(files[0].status, FileStatus::Added);
+        assert!(files[0].is_binary);
+        assert!(files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn should_cap_large_untracked_files_in_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        fs::write(
+            temp_dir.path().join("keep/dump.txt"),
+            vec![b'a'; (MAX_UNTRACKED_FILE_SIZE + 1) as usize],
+        )
+        .expect("failed to write large untracked file");
+
+        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
+            .expect("failed to get sparse checkout diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/dump.txt"))
+        );
+        assert_eq!(files[0].status, FileStatus::Added);
+        assert!(files[0].is_too_large);
+        assert!(files[0].hunks.is_empty());
     }
 
     #[test]

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -283,30 +283,54 @@ fn get_cli_diff(
     new_source: GitContentSource<'_>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    let mut files = match run_git_diff_command(repo, args, highlighter) {
+    let mut files = match crate::profile::time_with(
+        "vcs: git cli diff command",
+        || run_git_diff_command(repo, args, highlighter),
+        profile_diff_result,
+    ) {
         Ok(files) => files,
         Err(TuicrError::NoChanges) => Vec::new(),
         Err(err) => return Err(err),
     };
 
     if include_untracked {
-        append_untracked_cli_diffs(repo, &mut files, highlighter)?;
+        crate::profile::time_with(
+            "vcs: git cli untracked diff",
+            || append_untracked_cli_diffs(repo, &mut files, highlighter),
+            |result| match result {
+                Ok(count) => format!("files={count}"),
+                Err(e) => format!("error={e}"),
+            },
+        )?;
     }
 
     if files.is_empty() {
         return Err(TuicrError::NoChanges);
     }
 
-    let old_cache = git_source_content_cache(repo, old_source, &files, LineSide::Old);
-    let new_cache = git_source_content_cache(repo, new_source, &files, LineSide::New);
+    let old_cache = crate::profile::time("vcs: git cli old content cache", || {
+        git_source_content_cache(repo, old_source, &files, LineSide::Old)
+    });
+    let new_cache = crate::profile::time("vcs: git cli new content cache", || {
+        git_source_content_cache(repo, new_source, &files, LineSide::New)
+    });
 
-    enhance_with_full_file_highlight(
-        &mut files,
-        highlighter,
-        |path| read_path_from_git_source_cached(repo, old_source, old_cache.as_ref(), path),
-        |path| read_path_from_git_source_cached(repo, new_source, new_cache.as_ref(), path),
-    );
+    crate::profile::time("vcs: git cli full-file highlight", || {
+        enhance_with_full_file_highlight(
+            &mut files,
+            highlighter,
+            |path| read_path_from_git_source_cached(repo, old_source, old_cache.as_ref(), path),
+            |path| read_path_from_git_source_cached(repo, new_source, new_cache.as_ref(), path),
+        );
+    });
     Ok(files)
+}
+
+fn profile_diff_result(result: &Result<Vec<DiffFile>>) -> String {
+    match result {
+        Ok(files) => format!("files={}", files.len()),
+        Err(e) => format!("error={e}"),
+    }
 }
 
 fn run_git_diff_command(
@@ -364,11 +388,12 @@ fn append_untracked_cli_diffs(
     repo: &Repository,
     files: &mut Vec<DiffFile>,
     highlighter: &SyntaxHighlighter,
-) -> Result<()> {
+) -> Result<usize> {
     let Some(workdir) = repo.workdir() else {
-        return Ok(());
+        return Ok(0);
     };
 
+    let previous_len = files.len();
     for_each_untracked_path(repo, |path| {
         let full_path = workdir.join(&path);
         let Some(file) = build_untracked_diff_file(&path, &full_path, highlighter) else {
@@ -377,7 +402,7 @@ fn append_untracked_cli_diffs(
         files.push(file);
         Ok(())
     })?;
-    Ok(())
+    Ok(files.len().saturating_sub(previous_len))
 }
 
 fn build_untracked_diff_file(

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -404,8 +404,16 @@ fn append_untracked_cli_diffs(
         "vcs: git cli untracked pathspecs",
         || sparse_checkout_untracked_pathspecs(repo, capabilities),
         |result| match result {
-            Ok(pathspecs) => format!("pathspecs={}", pathspecs.len()),
-            Err(e) => format!("error={e}"),
+            Ok(pathspecs) => format!(
+                "pathspecs={}, untracked_cache={}, fsmonitor={}",
+                pathspecs.len(),
+                capabilities.untracked_cache,
+                capabilities.fsmonitor
+            ),
+            Err(e) => format!(
+                "error={e}, untracked_cache={}, fsmonitor={}",
+                capabilities.untracked_cache, capabilities.fsmonitor
+            ),
         },
     )?;
     let previous_len = files.len();
@@ -985,12 +993,16 @@ mod tests {
     fn standard_capabilities() -> GitCapabilities {
         GitCapabilities {
             mode: GitRepoMode::Standard,
+            untracked_cache: false,
+            fsmonitor: false,
         }
     }
 
     fn sparse_index_capabilities() -> GitCapabilities {
         GitCapabilities {
             mode: GitRepoMode::SparseIndex,
+            untracked_cache: false,
+            fsmonitor: false,
         }
     }
 

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -10,15 +10,18 @@ use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::{enhance_with_full_file_highlight, tabify};
 
+use super::GitCapabilities;
+
 // Untracked files larger than this are shown in the file list but their
 // content is not parsed — they are likely logs, dumps, or build artefacts.
 const MAX_UNTRACKED_FILE_SIZE: u64 = 10 * 1_024 * 1_024;
 
 pub fn get_working_tree_diff(
     repo: &Repository,
+    capabilities: GitCapabilities,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    if is_sparse_checkout(repo) {
+    if capabilities.requires_git_cli() {
         return get_cli_diff(
             repo,
             &["diff", "--no-ext-diff", "--binary", "HEAD", "--"],
@@ -51,9 +54,10 @@ pub fn get_working_tree_diff(
 /// On repos with no commits (unborn HEAD), diffs against an empty tree.
 pub fn get_staged_diff(
     repo: &Repository,
+    capabilities: GitCapabilities,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    if is_sparse_checkout(repo) {
+    if capabilities.requires_git_cli() {
         let old_source = if repo.head().is_ok() {
             GitContentSource::Revision("HEAD")
         } else {
@@ -88,9 +92,10 @@ pub fn get_staged_diff(
 /// Get the unstaged diff (working tree vs index)
 pub fn get_unstaged_diff(
     repo: &Repository,
+    capabilities: GitCapabilities,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    if is_sparse_checkout(repo) {
+    if capabilities.requires_git_cli() {
         return get_cli_diff(
             repo,
             &["diff", "--no-ext-diff", "--binary", "--"],
@@ -123,6 +128,7 @@ pub fn get_unstaged_diff(
 /// The diff compares the oldest commit's parent to the newest commit.
 pub fn get_commit_range_diff(
     repo: &Repository,
+    capabilities: GitCapabilities,
     commit_ids: &[String],
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
@@ -130,7 +136,7 @@ pub fn get_commit_range_diff(
         return Err(TuicrError::NoChanges);
     }
 
-    if is_sparse_checkout(repo) {
+    if capabilities.requires_git_cli() {
         let base_rev = parent_rev_or_empty(repo, &commit_ids[0]);
         let newest_rev = commit_ids.last().unwrap();
         return get_cli_diff(
@@ -183,6 +189,7 @@ pub fn get_commit_range_diff(
 /// This shows both committed and working tree changes in a single diff.
 pub fn get_working_tree_with_commits_diff(
     repo: &Repository,
+    capabilities: GitCapabilities,
     commit_ids: &[String],
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
@@ -190,7 +197,7 @@ pub fn get_working_tree_with_commits_diff(
         return Err(TuicrError::NoChanges);
     }
 
-    if is_sparse_checkout(repo) {
+    if capabilities.requires_git_cli() {
         let base_rev = parent_rev_or_empty(repo, &commit_ids[0]);
         return get_cli_diff(
             repo,
@@ -253,18 +260,6 @@ enum GitContentSource<'a> {
     Workdir,
     Index,
     Revision(&'a str),
-}
-
-fn is_sparse_checkout(repo: &Repository) -> bool {
-    git_config_bool(repo, "core.sparseCheckout")
-        || git_config_bool(repo, "index.sparse")
-        || run_git_command(repo, &["sparse-checkout", "list"], false).is_ok()
-}
-
-fn git_config_bool(repo: &Repository, key: &str) -> bool {
-    run_git_command(repo, &["config", "--bool", "--get", key], false)
-        .ok()
-        .is_some_and(|value| matches!(value.trim(), "true" | "1" | "yes" | "on"))
 }
 
 fn empty_tree_oid() -> git2::Oid {
@@ -692,6 +687,7 @@ fn parse_hunks(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::git::GitRepoMode;
     use std::fs;
     use std::path::Path;
     use std::process::Command;
@@ -770,6 +766,18 @@ mod tests {
         assert!(status.success(), "git {args:?} failed with {status}");
     }
 
+    fn standard_capabilities() -> GitCapabilities {
+        GitCapabilities {
+            mode: GitRepoMode::Standard,
+        }
+    }
+
+    fn sparse_index_capabilities() -> GitCapabilities {
+        GitCapabilities {
+            mode: GitRepoMode::SparseIndex,
+        }
+    }
+
     #[test]
     fn should_return_no_changes_for_clean_repo() {
         let repo = Repository::discover(".").unwrap();
@@ -801,8 +809,12 @@ mod tests {
         )
         .expect("failed to update file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get diff");
+        let files = get_working_tree_diff(
+            &repo,
+            standard_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get diff");
 
         assert_eq!(files.len(), 1);
         let lines = &files[0].hunks[0].lines;
@@ -825,8 +837,12 @@ mod tests {
         let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
         fs::write(temp_dir.path().join("App.vue"), edited).expect("failed to update file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get diff");
+        let files = get_working_tree_diff(
+            &repo,
+            standard_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get diff");
         assert_eq!(files.len(), 1);
 
         let changed_lines: Vec<_> = files[0].hunks[0]
@@ -861,10 +877,11 @@ mod tests {
 
         let highlighter = SyntaxHighlighter::default();
 
-        let unstaged = get_unstaged_diff(&repo, &highlighter).expect("unstaged diff failed");
+        let unstaged = get_unstaged_diff(&repo, standard_capabilities(), &highlighter)
+            .expect("unstaged diff failed");
         assert_eq!(unstaged.len(), 1);
         assert!(matches!(
-            get_staged_diff(&repo, &highlighter),
+            get_staged_diff(&repo, standard_capabilities(), &highlighter),
             Err(TuicrError::NoChanges)
         ));
 
@@ -874,10 +891,11 @@ mod tests {
             .expect("failed to add file to index");
         index.write().expect("failed to write index");
 
-        let staged = get_staged_diff(&repo, &highlighter).expect("staged diff failed");
+        let staged = get_staged_diff(&repo, standard_capabilities(), &highlighter)
+            .expect("staged diff failed");
         assert_eq!(staged.len(), 1);
         assert!(matches!(
-            get_unstaged_diff(&repo, &highlighter),
+            get_unstaged_diff(&repo, standard_capabilities(), &highlighter),
             Err(TuicrError::NoChanges)
         ));
     }
@@ -902,8 +920,12 @@ mod tests {
         fs::write(temp_dir.path().join("keep/file.txt"), "keep changed\n")
             .expect("failed to update included file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get sparse checkout diff");
+        let files = get_working_tree_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -931,7 +953,11 @@ mod tests {
         git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
 
         assert!(matches!(
-            get_working_tree_diff(&repo, &SyntaxHighlighter::default()),
+            get_working_tree_diff(
+                &repo,
+                sparse_index_capabilities(),
+                &SyntaxHighlighter::default()
+            ),
             Err(TuicrError::NoChanges)
         ));
     }
@@ -956,8 +982,12 @@ mod tests {
         fs::write(temp_dir.path().join("keep/new.txt"), "new sparse file\n")
             .expect("failed to write untracked file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get sparse checkout diff");
+        let files = get_working_tree_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -991,8 +1021,12 @@ mod tests {
         fs::write(temp_dir.path().join("keep/image.bin"), [0_u8, 1, 2, 3])
             .expect("failed to write binary untracked file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get sparse checkout diff");
+        let files = get_working_tree_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -1027,8 +1061,12 @@ mod tests {
         )
         .expect("failed to write large untracked file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get sparse checkout diff");
+        let files = get_working_tree_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -1061,8 +1099,12 @@ mod tests {
             .expect("failed to update included file");
         git(&repo, &["add", "keep/file.txt"]);
 
-        let files = get_staged_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get sparse checkout staged diff");
+        let files = get_staged_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout staged diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -1093,8 +1135,13 @@ mod tests {
         git(&repo, &["sparse-checkout", "set", "keep"]);
         git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
 
-        let files = get_commit_range_diff(&repo, &[second_id], &SyntaxHighlighter::default())
-            .expect("failed to get sparse checkout commit range diff");
+        let files = get_commit_range_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &[second_id],
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout commit range diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -1134,9 +1181,13 @@ mod tests {
         fs::write(temp_dir.path().join("keep/file.txt"), "keep worktree\n")
             .expect("failed to update included file");
 
-        let files =
-            get_working_tree_with_commits_diff(&repo, &[second_id], &SyntaxHighlighter::default())
-                .expect("failed to get sparse checkout working tree + commits diff");
+        let files = get_working_tree_with_commits_diff(
+            &repo,
+            sparse_index_capabilities(),
+            &[second_id],
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get sparse checkout working tree + commits diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,6 +1,6 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
 use std::fs;
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -262,11 +262,10 @@ fn get_cli_diff(
     new_source: GitContentSource<'_>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    let diff_output = run_git_command(repo, args, false)?;
-    let mut files = if diff_output.trim().is_empty() {
-        Vec::new()
-    } else {
-        diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?
+    let mut files = match run_git_diff_command(repo, args, highlighter) {
+        Ok(files) => files,
+        Err(TuicrError::NoChanges) => Vec::new(),
+        Err(err) => return Err(err),
     };
 
     if include_untracked {
@@ -284,6 +283,57 @@ fn get_cli_diff(
         |path| read_path_from_git_source(repo, new_source, path),
     );
     Ok(files)
+}
+
+fn run_git_diff_command(
+    repo: &Repository,
+    args: &[&str],
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>> {
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git diff stdout unavailable".into()))?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git diff stderr unavailable".into()))?;
+    let stderr_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = stderr.read_to_end(&mut bytes);
+        bytes
+    });
+
+    let diff_lines = BufReader::new(stdout)
+        .lines()
+        .map(|line| line.map_err(TuicrError::from));
+    let parse_result =
+        diff_parser::parse_unified_diff_lines(diff_lines, DiffFormat::GitStyle, highlighter);
+
+    let status = child.wait()?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| TuicrError::VcsCommand("git diff stderr reader panicked".into()))?;
+
+    if !status.success() {
+        let stderr = String::from_utf8_lossy(&stderr);
+        return Err(TuicrError::VcsCommand(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            stderr
+        )));
+    }
+
+    parse_result
 }
 
 fn append_untracked_cli_diffs(

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -130,6 +130,26 @@ pub fn get_commit_range_diff(
         return Err(TuicrError::NoChanges);
     }
 
+    if is_sparse_checkout(repo) {
+        let base_rev = parent_rev_or_empty(repo, &commit_ids[0]);
+        let newest_rev = commit_ids.last().unwrap();
+        return get_cli_diff(
+            repo,
+            &[
+                "diff",
+                "--no-ext-diff",
+                "--binary",
+                &base_rev,
+                newest_rev,
+                "--",
+            ],
+            false,
+            GitContentSource::Revision(&base_rev),
+            GitContentSource::Revision(newest_rev),
+            highlighter,
+        );
+    }
+
     let oldest_id = git2::Oid::from_str(&commit_ids[0])?;
     let oldest_commit = repo.find_commit(oldest_id)?;
 
@@ -170,21 +190,8 @@ pub fn get_working_tree_with_commits_diff(
         return Err(TuicrError::NoChanges);
     }
 
-    let oldest_id = git2::Oid::from_str(&commit_ids[0])?;
-    let oldest_commit = repo.find_commit(oldest_id)?;
-
-    let old_tree = if oldest_commit.parent_count() > 0 {
-        Some(oldest_commit.parent(0)?.tree()?)
-    } else {
-        None
-    };
-
     if is_sparse_checkout(repo) {
-        let base_rev = if oldest_commit.parent_count() > 0 {
-            oldest_commit.parent(0)?.id().to_string()
-        } else {
-            empty_tree_oid().to_string()
-        };
+        let base_rev = parent_rev_or_empty(repo, &commit_ids[0]);
         return get_cli_diff(
             repo,
             &["diff", "--no-ext-diff", "--binary", &base_rev, "--"],
@@ -194,6 +201,15 @@ pub fn get_working_tree_with_commits_diff(
             highlighter,
         );
     }
+
+    let oldest_id = git2::Oid::from_str(&commit_ids[0])?;
+    let oldest_commit = repo.find_commit(oldest_id)?;
+
+    let old_tree = if oldest_commit.parent_count() > 0 {
+        Some(oldest_commit.parent(0)?.tree()?)
+    } else {
+        None
+    };
 
     let mut opts = DiffOptions::new();
     opts.include_untracked(true);
@@ -240,7 +256,9 @@ enum GitContentSource<'a> {
 }
 
 fn is_sparse_checkout(repo: &Repository) -> bool {
-    git_config_bool(repo, "core.sparseCheckout") || git_config_bool(repo, "index.sparse")
+    git_config_bool(repo, "core.sparseCheckout")
+        || git_config_bool(repo, "index.sparse")
+        || run_git_command(repo, &["sparse-checkout", "list"], false).is_ok()
 }
 
 fn git_config_bool(repo: &Repository, key: &str) -> bool {
@@ -252,6 +270,13 @@ fn git_config_bool(repo: &Repository, key: &str) -> bool {
 fn empty_tree_oid() -> git2::Oid {
     git2::Oid::from_str("4b825dc642cb6eb9a060e54bf8d69288fbee4904")
         .expect("empty tree oid should be valid")
+}
+
+fn parent_rev_or_empty(repo: &Repository, commit_id: &str) -> String {
+    let parent_spec = format!("{commit_id}^");
+    run_git_command(repo, &["rev-parse", &parent_spec], false)
+        .map(|rev| rev.trim().to_string())
+        .unwrap_or_else(|_| empty_tree_oid().to_string())
 }
 
 fn get_cli_diff(
@@ -716,6 +741,26 @@ mod tests {
             .expect("failed to create commit");
     }
 
+    fn commit_paths(repo: &Repository, message: &str, paths: &[&str]) -> String {
+        let mut index = repo.index().expect("failed to open index");
+        for path in paths {
+            index
+                .add_path(Path::new(path))
+                .expect("failed to add file to index");
+        }
+        index.write().expect("failed to write index");
+
+        let tree_id = index.write_tree().expect("failed to write tree");
+        let tree = repo.find_tree(tree_id).expect("failed to find tree");
+        let sig = git2::Signature::now("Test User", "test@example.com")
+            .expect("failed to create signature");
+        let parent = repo.head().unwrap().peel_to_commit().unwrap();
+        let oid = repo
+            .commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+            .expect("failed to create commit");
+        oid.to_string()
+    }
+
     fn git(repo: &Repository, args: &[&str]) {
         let status = Command::new("git")
             .args(args)
@@ -1025,5 +1070,85 @@ mod tests {
             Some(Path::new("keep/file.txt"))
         );
         assert_eq!(files[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn should_read_commit_range_diff_in_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep commit\n")
+            .expect("failed to update included file");
+        let second_id = commit_paths(&repo, "second", &["keep/file.txt"]);
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        let files = get_commit_range_diff(&repo, &[second_id], &SyntaxHighlighter::default())
+            .expect("failed to get sparse checkout commit range diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/file.txt"))
+        );
+        assert!(
+            files[0]
+                .hunks
+                .iter()
+                .flat_map(|hunk| &hunk.lines)
+                .any(|line| line.content == "keep commit")
+        );
+    }
+
+    #[test]
+    fn should_read_working_tree_with_commits_diff_in_sparse_checkout() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit_with_files(
+            &repo,
+            &[
+                ("keep/file.txt", "keep base\n"),
+                ("hidden/file.txt", "hidden base\n"),
+            ],
+        );
+
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep commit\n")
+            .expect("failed to update included file");
+        let second_id = commit_paths(&repo, "second", &["keep/file.txt"]);
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep worktree\n")
+            .expect("failed to update included file");
+
+        let files =
+            get_working_tree_with_commits_diff(&repo, &[second_id], &SyntaxHighlighter::default())
+                .expect("failed to get sparse checkout working tree + commits diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/file.txt"))
+        );
+        assert!(
+            files[0]
+                .hunks
+                .iter()
+                .flat_map(|hunk| &hunk.lines)
+                .any(|line| line.content == "keep worktree")
+        );
     }
 }

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,14 +1,15 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
+use std::collections::HashMap;
 use std::fs;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide};
 use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::{enhance_with_full_file_highlight, tabify};
+use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
 
 use super::GitCapabilities;
 
@@ -296,11 +297,14 @@ fn get_cli_diff(
         return Err(TuicrError::NoChanges);
     }
 
+    let old_cache = git_source_content_cache(repo, old_source, &files, LineSide::Old);
+    let new_cache = git_source_content_cache(repo, new_source, &files, LineSide::New);
+
     enhance_with_full_file_highlight(
         &mut files,
         highlighter,
-        |path| read_path_from_git_source(repo, old_source, path),
-        |path| read_path_from_git_source(repo, new_source, path),
+        |path| read_path_from_git_source_cached(repo, old_source, old_cache.as_ref(), path),
+        |path| read_path_from_git_source_cached(repo, new_source, new_cache.as_ref(), path),
     );
     Ok(files)
 }
@@ -523,6 +527,124 @@ fn read_path_from_git_source(
     }
 }
 
+fn read_path_from_git_source_cached(
+    repo: &Repository,
+    source: GitContentSource<'_>,
+    cache: Option<&HashMap<PathBuf, String>>,
+    path: &Path,
+) -> Option<String> {
+    cache
+        .and_then(|contents| contents.get(path).cloned())
+        .or_else(|| read_path_from_git_source(repo, source, path))
+}
+
+fn git_source_content_cache(
+    repo: &Repository,
+    source: GitContentSource<'_>,
+    files: &[DiffFile],
+    side: LineSide,
+) -> Option<HashMap<PathBuf, String>> {
+    let paths = container_file_paths(files, side);
+    match source {
+        GitContentSource::Revision(rev) => {
+            let requests = paths
+                .into_iter()
+                .map(|path| {
+                    let spec = format!("{rev}:{}", path.to_string_lossy());
+                    (path, spec)
+                })
+                .collect();
+            read_git_objects(repo, requests).ok()
+        }
+        GitContentSource::Index => {
+            let requests = paths
+                .into_iter()
+                .map(|path| {
+                    let spec = format!(":0:{}", path.to_string_lossy());
+                    (path, spec)
+                })
+                .collect();
+            read_git_objects(repo, requests).ok()
+        }
+        GitContentSource::None | GitContentSource::Workdir => None,
+    }
+}
+
+fn read_git_objects(
+    repo: &Repository,
+    requests: Vec<(PathBuf, String)>,
+) -> Result<HashMap<PathBuf, String>> {
+    if requests.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(["cat-file", "--batch"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| TuicrError::VcsCommand("git cat-file stdin unavailable".into()))?;
+        for (_, spec) in &requests {
+            writeln!(stdin, "{spec}")?;
+        }
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git cat-file stdout unavailable".into()))?;
+    let mut reader = BufReader::new(stdout);
+    let mut contents = HashMap::new();
+
+    for (path, _) in requests {
+        let mut header = String::new();
+        if reader.read_line(&mut header)? == 0 {
+            break;
+        }
+
+        let header = header.trim_end();
+        if header.ends_with(" missing") {
+            continue;
+        }
+
+        let mut parts = header.split_whitespace();
+        let _oid = parts.next();
+        let kind = parts.next();
+        let size = parts
+            .next()
+            .and_then(|value| value.parse::<usize>().ok())
+            .ok_or_else(|| TuicrError::VcsCommand("invalid git cat-file header".into()))?;
+
+        let mut bytes = vec![0; size];
+        reader.read_exact(&mut bytes)?;
+        let mut trailing_newline = [0; 1];
+        reader.read_exact(&mut trailing_newline)?;
+
+        if kind == Some("blob") {
+            contents.insert(path, String::from_utf8_lossy(&bytes).into_owned());
+        }
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        return Err(TuicrError::VcsCommand(format!(
+            "git cat-file failed with status {}",
+            status
+        )));
+    }
+
+    Ok(contents)
+}
+
 fn read_git_object(repo: &Repository, spec: &str) -> Option<String> {
     let output = run_git_command(repo, &["show", spec], false).ok()?;
     Some(output)
@@ -691,6 +813,7 @@ mod tests {
     use std::fs;
     use std::path::Path;
     use std::process::Command;
+    use std::time::Instant;
 
     fn create_initial_commit(repo: &Repository, file_name: &str, content: &str) {
         fs::write(repo.workdir().unwrap().join(file_name), content)
@@ -1200,6 +1323,95 @@ mod tests {
                 .iter()
                 .flat_map(|hunk| &hunk.lines)
                 .any(|line| line.content == "keep worktree")
+        );
+    }
+
+    #[test]
+    fn should_batch_read_revision_and_index_blobs() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit(&repo, "file.txt", "old\n");
+        fs::write(temp_dir.path().join("file.txt"), "new\n").expect("failed to update file");
+        git(&repo, &["add", "file.txt"]);
+
+        let contents = read_git_objects(
+            &repo,
+            vec![
+                (PathBuf::from("old.txt"), "HEAD:file.txt".to_string()),
+                (PathBuf::from("index.txt"), ":0:file.txt".to_string()),
+            ],
+        )
+        .expect("failed to batch read git objects");
+
+        assert_eq!(contents.get(Path::new("old.txt")).unwrap(), "old\n");
+        assert_eq!(contents.get(Path::new("index.txt")).unwrap(), "new\n");
+    }
+
+    #[test]
+    #[ignore = "benchmark for sparse checkout real-path performance"]
+    fn bench_sparse_checkout_real_path_many_vue_files() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        git(&repo, &["config", "user.email", "test@example.com"]);
+        git(&repo, &["config", "user.name", "Test User"]);
+
+        for idx in 0..150 {
+            let path = temp_dir.path().join(format!("keep/app-{idx}.vue"));
+            fs::create_dir_all(path.parent().unwrap()).expect("failed to create keep dir");
+            fs::write(
+                path,
+                format!(
+                    "<template>\n  <div>{{{{ msg{idx} }}}}</div>\n</template>\n\n<script setup>\nconst msg{idx} = 'old'\n</script>\n"
+                ),
+            )
+            .expect("failed to write vue file");
+        }
+        for idx in 0..12_000 {
+            let path = temp_dir
+                .path()
+                .join(format!("hidden/dir{}/file-{idx}.txt", idx / 100));
+            fs::create_dir_all(path.parent().unwrap()).expect("failed to create hidden dir");
+            fs::write(path, format!("hidden {idx}\n")).expect("failed to write hidden file");
+        }
+
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "--quiet", "-m", "initial"]);
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        for idx in 0..150 {
+            fs::write(
+                temp_dir.path().join(format!("keep/app-{idx}.vue")),
+                format!(
+                    "<template>\n  <div>{{{{ msg{idx} }}}}</div>\n</template>\n\n<script setup>\nconst msg{idx} = 'new'\n</script>\n"
+                ),
+            )
+            .expect("failed to update vue file");
+        }
+
+        let highlighter = SyntaxHighlighter::default();
+        let capabilities = sparse_index_capabilities();
+        let warmup = get_working_tree_diff(&repo, capabilities, &highlighter)
+            .expect("failed to warm up sparse diff");
+        assert_eq!(warmup.len(), 150);
+
+        let iterations = 5;
+        let started = Instant::now();
+        let mut files_seen = 0;
+        for _ in 0..iterations {
+            let files = get_working_tree_diff(&repo, capabilities, &highlighter)
+                .expect("failed to get sparse diff");
+            files_seen += files.len();
+        }
+        let elapsed = started.elapsed();
+        println!(
+            "bench_sparse_checkout_real_path_many_vue_files iterations={iterations} files_per_iteration={} total_ms={:.2} mean_ms={:.2}",
+            files_seen / iterations,
+            elapsed.as_secs_f64() * 1000.0,
+            elapsed.as_secs_f64() * 1000.0 / iterations as f64,
         );
     }
 }

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -1,4 +1,5 @@
 use git2::{Delta, Diff, DiffOptions, Repository};
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::io::{BufRead, BufReader, Read, Write};
@@ -369,7 +370,7 @@ fn run_git_diff_command(
 
     let diff_lines = BufReader::new(stdout)
         .lines()
-        .map(|line| line.map_err(TuicrError::from));
+        .map(|line| line.map(Cow::Owned).map_err(TuicrError::from));
     let parse_result =
         diff_parser::parse_unified_diff_lines(diff_lines, DiffFormat::GitStyle, highlighter);
 
@@ -436,6 +437,9 @@ fn sparse_checkout_untracked_pathspecs(
         return Ok(Vec::new());
     }
 
+    // Simple cone sparse patterns can narrow `git ls-files --others` to the
+    // checked-out cones. Complex patterns fall back to Git's full scan so we do
+    // not accidentally hide valid untracked files.
     let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
     let output = Command::new("git")
         .current_dir(workdir)

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -82,16 +82,20 @@ impl GitBackend {
             .ok_or(TuicrError::NotARepository)?
             .to_path_buf();
 
-        let head_commit = run_git_command(&root_path, &["rev-parse", "--verify", "HEAD"])
+        let head_commit = repo
+            .head()
             .ok()
-            .map(|value| value.trim().to_string())
+            .and_then(|h| h.peel_to_commit().ok())
+            .map(|c| c.id().to_string())
             .unwrap_or_else(|| "HEAD".to_string());
 
-        let branch_name =
-            run_git_command(&root_path, &["symbolic-ref", "--quiet", "--short", "HEAD"])
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty());
+        let branch_name = repo.head().ok().and_then(|h| {
+            if h.is_branch() {
+                h.shorthand().map(|s| s.to_string())
+            } else {
+                None
+            }
+        });
         let capabilities = GitCapabilities::detect(&root_path);
 
         let info = VcsInfo {
@@ -312,6 +316,11 @@ impl VcsBackend for GitBackend {
     }
 
     fn get_change_status(&self) -> Result<VcsChangeStatus> {
+        if !self.capabilities.requires_git_cli() {
+            return Err(TuicrError::UnsupportedOperation(
+                "Git change status probe only used for sparse checkouts".into(),
+            ));
+        }
         get_change_status(&self.repo, self.capabilities)
     }
 

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -168,53 +168,38 @@ fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
 }
 
 fn get_change_status(repo: &Repository, _capabilities: GitCapabilities) -> Result<VcsChangeStatus> {
-    let mut status = crate::profile::time("vcs: git status tracked changes", || {
-        get_tracked_change_status(repo)
+    let staged = crate::profile::time("vcs: git staged diff probe", || {
+        has_diff_changes(repo, &["diff", "--quiet", "--cached", "--"])
     })?;
+    let tracked_unstaged = crate::profile::time("vcs: git unstaged diff probe", || {
+        has_diff_changes(repo, &["diff", "--quiet", "--"])
+    })?;
+    let unstaged = if tracked_unstaged {
+        true
+    } else {
+        crate::profile::time("vcs: git untracked scan", || has_untracked_changes(repo))?
+    };
 
-    if !status.unstaged {
-        status.unstaged =
-            crate::profile::time("vcs: git untracked scan", || has_untracked_changes(repo))?;
-    }
-
-    Ok(status)
+    Ok(VcsChangeStatus { staged, unstaged })
 }
 
-fn get_tracked_change_status(repo: &Repository) -> Result<VcsChangeStatus> {
+fn has_diff_changes(repo: &Repository, args: &[&str]) -> Result<bool> {
     let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
-    let mut child = Command::new("git")
+    let output = Command::new("git")
         .current_dir(workdir)
-        .args(["status", "--porcelain=v1", "-z", "--untracked-files=no"])
-        .stdout(Stdio::piped())
+        .args(args)
+        .stdout(Stdio::null())
         .stderr(Stdio::piped())
-        .spawn()
+        .output()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
 
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| TuicrError::VcsCommand("git status stdout unavailable".into()))?;
-
-    let mut status = VcsChangeStatus::default();
-    let stopped_early = parse_change_status_stream(BufReader::new(stdout), &mut status)?;
-
-    if stopped_early {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Ok(status);
-    }
-
-    let output = child
-        .wait_with_output()
-        .map_err(|e| TuicrError::VcsCommand(format!("git status failed: {e}")))?;
-
-    if !output.status.success() {
-        return Err(TuicrError::VcsCommand(
+    match output.status.code() {
+        Some(0) => Ok(false),
+        Some(1) => Ok(true),
+        _ => Err(TuicrError::VcsCommand(
             String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        ));
+        )),
     }
-
-    Ok(status)
 }
 
 fn has_untracked_changes(repo: &Repository) -> Result<bool> {
@@ -257,45 +242,6 @@ fn has_untracked_changes(repo: &Repository) -> Result<bool> {
     }
 
     Ok(false)
-}
-
-fn parse_change_status_stream<R: BufRead>(
-    mut reader: R,
-    status: &mut VcsChangeStatus,
-) -> Result<bool> {
-    let mut record = Vec::new();
-    loop {
-        record.clear();
-        let read = reader.read_until(0, &mut record)?;
-        if read == 0 {
-            return Ok(false);
-        }
-        if record.last() == Some(&0) {
-            record.pop();
-        }
-        parse_change_status_record(&record, status);
-        if status.staged && status.unstaged {
-            return Ok(true);
-        }
-    }
-}
-
-fn parse_change_status_record(record: &[u8], status: &mut VcsChangeStatus) {
-    if record.len() < 3 || record[2] != b' ' {
-        return;
-    }
-
-    match (record[0], record[1]) {
-        (b'?', b'?') => status.unstaged = true,
-        (x, y) => {
-            if x != b' ' {
-                status.staged = true;
-            }
-            if y != b' ' {
-                status.unstaged = true;
-            }
-        }
-    }
 }
 
 impl VcsBackend for GitBackend {
@@ -450,50 +396,6 @@ mod tests {
         let output = "core.sparsecheckout true\nindex.sparse true\n";
 
         assert_eq!(parse_sparse_config(output), (true, true));
-    }
-
-    #[test]
-    fn parses_change_status_records() {
-        let mut status = VcsChangeStatus::default();
-        parse_change_status_record(b" M src/main.rs", &mut status);
-        assert_eq!(
-            status,
-            VcsChangeStatus {
-                staged: false,
-                unstaged: true,
-            }
-        );
-
-        let mut status = VcsChangeStatus::default();
-        parse_change_status_record(b"M  src/main.rs", &mut status);
-        assert_eq!(
-            status,
-            VcsChangeStatus {
-                staged: true,
-                unstaged: false,
-            }
-        );
-
-        let mut status = VcsChangeStatus::default();
-        parse_change_status_record(b"?? new-file.rs", &mut status);
-        assert_eq!(
-            status,
-            VcsChangeStatus {
-                staged: false,
-                unstaged: true,
-            }
-        );
-
-        let mut status = VcsChangeStatus::default();
-        parse_change_status_record(b"R  new-name.rs", &mut status);
-        parse_change_status_record(b"old-name.rs", &mut status);
-        assert_eq!(
-            status,
-            VcsChangeStatus {
-                staged: true,
-                unstaged: false,
-            }
-        );
     }
 
     #[test]

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -38,16 +38,23 @@ pub enum GitRepoMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GitCapabilities {
     pub mode: GitRepoMode,
+    pub untracked_cache: bool,
+    pub fsmonitor: bool,
 }
 
 impl GitCapabilities {
     fn detect(root_path: &Path) -> Self {
-        let (sparse_checkout, sparse_index) = git_sparse_config(root_path);
+        let (sparse_checkout, sparse_index, untracked_cache, fsmonitor) = git_config(root_path);
 
-        Self::from_config(sparse_checkout, sparse_index)
+        Self::from_config(sparse_checkout, sparse_index, untracked_cache, fsmonitor)
     }
 
-    fn from_config(sparse_checkout: bool, sparse_index: bool) -> Self {
+    fn from_config(
+        sparse_checkout: bool,
+        sparse_index: bool,
+        untracked_cache: bool,
+        fsmonitor: bool,
+    ) -> Self {
         let mode = if sparse_index {
             GitRepoMode::SparseIndex
         } else if sparse_checkout {
@@ -56,7 +63,11 @@ impl GitCapabilities {
             GitRepoMode::Standard
         };
 
-        Self { mode }
+        Self {
+            mode,
+            untracked_cache,
+            fsmonitor,
+        }
     }
 
     pub fn is_sparse_checkout(self) -> bool {
@@ -68,6 +79,16 @@ impl GitCapabilities {
 
     pub fn requires_git_cli(self) -> bool {
         self.is_sparse_checkout()
+    }
+
+    pub fn startup_warnings(self) -> Vec<String> {
+        if self.is_sparse_checkout() && !self.untracked_cache {
+            vec![
+                "Sparse checkout without core.untrackedCache can make untracked scans slow; run `git update-index --test-untracked-cache` then `git config core.untrackedCache true` if it passes.".to_string(),
+            ]
+        } else {
+            Vec::new()
+        }
     }
 }
 
@@ -113,42 +134,54 @@ impl GitBackend {
     }
 }
 
-fn git_sparse_config(workdir: &Path) -> (bool, bool) {
+fn git_config(workdir: &Path) -> (bool, bool, bool, bool) {
     let output = run_git_command(
         workdir,
         &[
             "config",
-            "--bool",
             "--get-regexp",
-            r"^(core\.sparsecheckout|index\.sparse)$",
+            r"^(core\.sparsecheckout|index\.sparse|core\.untrackedcache|core\.fsmonitor)$",
         ],
     )
     .unwrap_or_default();
 
-    parse_sparse_config(&output)
+    parse_git_config(&output)
 }
 
-fn parse_sparse_config(output: &str) -> (bool, bool) {
+fn parse_git_config(output: &str) -> (bool, bool, bool, bool) {
     let mut sparse_checkout = false;
     let mut sparse_index = false;
+    let mut untracked_cache = false;
+    let mut fsmonitor = false;
 
     for line in output.lines() {
-        let mut parts = line.split_whitespace();
+        let mut parts = line.splitn(2, char::is_whitespace);
         let Some(key) = parts.next() else {
             continue;
         };
-        let enabled = parts
-            .next()
-            .is_some_and(|value| matches!(value, "true" | "1" | "yes" | "on"));
+        let raw_value = parts.next().unwrap_or_default();
 
         match key {
-            "core.sparsecheckout" => sparse_checkout = enabled,
-            "index.sparse" => sparse_index = enabled,
+            "core.sparsecheckout" => sparse_checkout = git_bool_config_enabled(raw_value),
+            "index.sparse" => sparse_index = git_bool_config_enabled(raw_value),
+            "core.untrackedcache" => untracked_cache = git_bool_config_enabled(raw_value),
+            "core.fsmonitor" => fsmonitor = git_fsmonitor_config_enabled(raw_value),
             _ => {}
         }
     }
 
-    (sparse_checkout, sparse_index)
+    (sparse_checkout, sparse_index, untracked_cache, fsmonitor)
+}
+
+fn git_bool_config_enabled(value: &str) -> bool {
+    let value = value.trim();
+    matches!(value, "true" | "1" | "yes" | "on")
+}
+
+fn git_fsmonitor_config_enabled(value: &str) -> bool {
+    let value = value.trim();
+    git_bool_config_enabled(value)
+        || (!value.is_empty() && !matches!(value, "false" | "0" | "no" | "off"))
 }
 
 fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
@@ -167,7 +200,7 @@ fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-fn get_change_status(repo: &Repository, _capabilities: GitCapabilities) -> Result<VcsChangeStatus> {
+fn get_change_status(repo: &Repository, capabilities: GitCapabilities) -> Result<VcsChangeStatus> {
     let staged = crate::profile::time("vcs: git staged diff probe", || {
         has_diff_changes(repo, &["diff", "--quiet", "--cached", "--"])
     })?;
@@ -177,7 +210,20 @@ fn get_change_status(repo: &Repository, _capabilities: GitCapabilities) -> Resul
     let unstaged = if tracked_unstaged {
         true
     } else {
-        crate::profile::time("vcs: git untracked scan", || has_untracked_changes(repo))?
+        crate::profile::time_with(
+            "vcs: git untracked scan",
+            || has_untracked_changes(repo),
+            |result| match result {
+                Ok(has_untracked) => format!(
+                    "result={has_untracked}, untracked_cache={}, fsmonitor={}",
+                    capabilities.untracked_cache, capabilities.fsmonitor
+                ),
+                Err(e) => format!(
+                    "error={e}, untracked_cache={}, fsmonitor={}",
+                    capabilities.untracked_cache, capabilities.fsmonitor
+                ),
+            },
+        )?
     };
 
     Ok(VcsChangeStatus { staged, unstaged })
@@ -247,6 +293,10 @@ fn has_untracked_changes(repo: &Repository) -> Result<bool> {
 impl VcsBackend for GitBackend {
     fn info(&self) -> &VcsInfo {
         &self.info
+    }
+
+    fn startup_warnings(&self) -> Vec<String> {
+        self.capabilities.startup_warnings()
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
@@ -378,24 +428,57 @@ mod tests {
     #[test]
     fn derives_git_repo_mode_from_sparse_config() {
         assert_eq!(
-            GitCapabilities::from_config(false, false).mode,
+            GitCapabilities::from_config(false, false, false, false).mode,
             GitRepoMode::Standard
         );
         assert_eq!(
-            GitCapabilities::from_config(true, false).mode,
+            GitCapabilities::from_config(true, false, false, false).mode,
             GitRepoMode::SparseCheckout
         );
         assert_eq!(
-            GitCapabilities::from_config(true, true).mode,
+            GitCapabilities::from_config(true, true, false, false).mode,
             GitRepoMode::SparseIndex
         );
     }
 
     #[test]
-    fn parses_sparse_config_from_single_git_config_read() {
-        let output = "core.sparsecheckout true\nindex.sparse true\n";
+    fn parses_git_config_from_single_git_config_read() {
+        let output = "core.sparsecheckout true\nindex.sparse true\ncore.untrackedcache true\ncore.fsmonitor true\n";
 
-        assert_eq!(parse_sparse_config(output), (true, true));
+        assert_eq!(parse_git_config(output), (true, true, true, true));
+    }
+
+    #[test]
+    fn treats_custom_fsmonitor_hook_as_enabled() {
+        let output = "core.fsmonitor .git/hooks/fsmonitor-watchman\n";
+
+        assert_eq!(parse_git_config(output), (false, false, false, true));
+    }
+
+    #[test]
+    fn warns_when_sparse_checkout_lacks_untracked_cache() {
+        let capabilities = GitCapabilities::from_config(true, false, false, true);
+
+        assert_eq!(
+            capabilities.startup_warnings(),
+            vec![
+                "Sparse checkout without core.untrackedCache can make untracked scans slow; run `git update-index --test-untracked-cache` then `git config core.untrackedCache true` if it passes.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_warn_for_standard_repos_or_sparse_repos_with_untracked_cache() {
+        assert!(
+            GitCapabilities::from_config(false, false, false, false)
+                .startup_warnings()
+                .is_empty()
+        );
+        assert!(
+            GitCapabilities::from_config(true, false, true, false)
+                .startup_warnings()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -422,6 +505,8 @@ mod tests {
             &repo,
             GitCapabilities {
                 mode: GitRepoMode::Standard,
+                untracked_cache: false,
+                fsmonitor: false,
             },
         )
         .expect("failed to get change status");
@@ -439,6 +524,8 @@ mod tests {
             &repo,
             GitCapabilities {
                 mode: GitRepoMode::Standard,
+                untracked_cache: false,
+                fsmonitor: false,
             },
         )
         .expect("failed to get change status");

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -24,6 +24,48 @@ pub use diff::{
 pub struct GitBackend {
     repo: Repository,
     info: VcsInfo,
+    capabilities: GitCapabilities,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitRepoMode {
+    Standard,
+    SparseCheckout,
+    SparseIndex,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GitCapabilities {
+    pub mode: GitRepoMode,
+}
+
+impl GitCapabilities {
+    fn detect(root_path: &Path) -> Self {
+        let sparse_index = git_config_bool(root_path, "index.sparse");
+        let sparse_checkout = git_config_bool(root_path, "core.sparseCheckout")
+            || run_git_command(root_path, &["sparse-checkout", "list"]).is_ok();
+
+        let mode = if sparse_index {
+            GitRepoMode::SparseIndex
+        } else if sparse_checkout {
+            GitRepoMode::SparseCheckout
+        } else {
+            GitRepoMode::Standard
+        };
+
+        Self { mode }
+    }
+
+    pub fn is_sparse_checkout(self) -> bool {
+        matches!(
+            self.mode,
+            GitRepoMode::SparseCheckout | GitRepoMode::SparseIndex
+        )
+    }
+
+    pub fn requires_git_cli(self) -> bool {
+        self.is_sparse_checkout()
+    }
 }
 
 impl GitBackend {
@@ -47,6 +89,7 @@ impl GitBackend {
                 .ok()
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty());
+        let capabilities = GitCapabilities::detect(&root_path);
 
         let info = VcsInfo {
             root_path,
@@ -55,8 +98,18 @@ impl GitBackend {
             vcs_type: VcsType::Git,
         };
 
-        Ok(Self { repo, info })
+        Ok(Self {
+            repo,
+            info,
+            capabilities,
+        })
     }
+}
+
+fn git_config_bool(workdir: &Path, key: &str) -> bool {
+    run_git_command(workdir, &["config", "--bool", "--get", key])
+        .ok()
+        .is_some_and(|value| matches!(value.trim(), "true" | "1" | "yes" | "on"))
 }
 
 fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
@@ -81,15 +134,15 @@ impl VcsBackend for GitBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        get_working_tree_diff(&self.repo, highlighter)
+        get_working_tree_diff(&self.repo, self.capabilities, highlighter)
     }
 
     fn get_staged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        get_staged_diff(&self.repo, highlighter)
+        get_staged_diff(&self.repo, self.capabilities, highlighter)
     }
 
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        get_unstaged_diff(&self.repo, highlighter)
+        get_unstaged_diff(&self.repo, self.capabilities, highlighter)
     }
 
     fn fetch_context_lines(
@@ -99,11 +152,19 @@ impl VcsBackend for GitBackend {
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
-        fetch_context_lines(&self.repo, file_path, file_status, start_line, end_line)
+        fetch_context_lines(
+            &self.repo,
+            self.capabilities,
+            file_path,
+            file_status,
+            start_line,
+            end_line,
+        )
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
-        let git_commits = repository::get_recent_commits(&self.repo, offset, limit)?;
+        let git_commits =
+            repository::get_recent_commits(&self.repo, self.capabilities, offset, limit)?;
         Ok(git_commits
             .into_iter()
             .map(|c| CommitInfo {
@@ -119,7 +180,7 @@ impl VcsBackend for GitBackend {
     }
 
     fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
-        repository::resolve_revisions(&self.repo, revisions)
+        repository::resolve_revisions(&self.repo, self.capabilities, revisions)
     }
 
     fn get_commit_range_diff(
@@ -127,11 +188,11 @@ impl VcsBackend for GitBackend {
         commit_ids: &[String],
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        get_commit_range_diff(&self.repo, commit_ids, highlighter)
+        get_commit_range_diff(&self.repo, self.capabilities, commit_ids, highlighter)
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
-        let git_commits = repository::get_commits_info(&self.repo, ids)?;
+        let git_commits = repository::get_commits_info(&self.repo, self.capabilities, ids)?;
         Ok(git_commits
             .into_iter()
             .map(|c| CommitInfo {
@@ -151,10 +212,72 @@ impl VcsBackend for GitBackend {
         commit_ids: &[String],
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        get_working_tree_with_commits_diff(&self.repo, commit_ids, highlighter)
+        get_working_tree_with_commits_diff(&self.repo, self.capabilities, commit_ids, highlighter)
     }
 
     fn stage_file(&self, path: &Path) -> Result<()> {
-        staging::stage_file(&self.repo, path)
+        staging::stage_file(&self.repo, self.capabilities, path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git(workdir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(workdir)
+            .args(args)
+            .output()
+            .expect("failed to run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn detects_standard_git_repo_mode() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        git(temp_dir.path(), &["init"]);
+
+        let capabilities = GitCapabilities::detect(temp_dir.path());
+
+        assert_eq!(capabilities.mode, GitRepoMode::Standard);
+        assert!(!capabilities.requires_git_cli());
+    }
+
+    #[test]
+    fn detects_sparse_index_repo_mode_once() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        git(temp_dir.path(), &["init"]);
+        git(
+            temp_dir.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        git(temp_dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::create_dir_all(temp_dir.path().join("keep")).expect("failed to create keep dir");
+        std::fs::create_dir_all(temp_dir.path().join("hidden"))
+            .expect("failed to create hidden dir");
+        std::fs::write(temp_dir.path().join("keep/file.txt"), "keep\n")
+            .expect("failed to write keep file");
+        std::fs::write(temp_dir.path().join("hidden/file.txt"), "hidden\n")
+            .expect("failed to write hidden file");
+        git(temp_dir.path(), &["add", "."]);
+        git(temp_dir.path(), &["commit", "-m", "initial"]);
+        git(temp_dir.path(), &["sparse-checkout", "init", "--cone"]);
+        git(temp_dir.path(), &["sparse-checkout", "set", "keep"]);
+        git(
+            temp_dir.path(),
+            &["sparse-checkout", "reapply", "--sparse-index"],
+        );
+
+        let capabilities = GitCapabilities::detect(temp_dir.path());
+
+        assert_eq!(capabilities.mode, GitRepoMode::SparseIndex);
+        assert!(capabilities.is_sparse_checkout());
+        assert!(capabilities.requires_git_cli());
     }
 }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -41,10 +41,12 @@ pub struct GitCapabilities {
 
 impl GitCapabilities {
     fn detect(root_path: &Path) -> Self {
-        let sparse_index = git_config_bool(root_path, "index.sparse");
-        let sparse_checkout = git_config_bool(root_path, "core.sparseCheckout")
-            || run_git_command(root_path, &["sparse-checkout", "list"]).is_ok();
+        let (sparse_checkout, sparse_index) = git_sparse_config(root_path);
 
+        Self::from_config(sparse_checkout, sparse_index)
+    }
+
+    fn from_config(sparse_checkout: bool, sparse_index: bool) -> Self {
         let mode = if sparse_index {
             GitRepoMode::SparseIndex
         } else if sparse_checkout {
@@ -106,10 +108,42 @@ impl GitBackend {
     }
 }
 
-fn git_config_bool(workdir: &Path, key: &str) -> bool {
-    run_git_command(workdir, &["config", "--bool", "--get", key])
-        .ok()
-        .is_some_and(|value| matches!(value.trim(), "true" | "1" | "yes" | "on"))
+fn git_sparse_config(workdir: &Path) -> (bool, bool) {
+    let output = run_git_command(
+        workdir,
+        &[
+            "config",
+            "--bool",
+            "--get-regexp",
+            r"^(core\.sparsecheckout|index\.sparse)$",
+        ],
+    )
+    .unwrap_or_default();
+
+    parse_sparse_config(&output)
+}
+
+fn parse_sparse_config(output: &str) -> (bool, bool) {
+    let mut sparse_checkout = false;
+    let mut sparse_index = false;
+
+    for line in output.lines() {
+        let mut parts = line.split_whitespace();
+        let Some(key) = parts.next() else {
+            continue;
+        };
+        let enabled = parts
+            .next()
+            .is_some_and(|value| matches!(value, "true" | "1" | "yes" | "on"));
+
+        match key {
+            "core.sparsecheckout" => sparse_checkout = enabled,
+            "index.sparse" => sparse_index = enabled,
+            _ => {}
+        }
+    }
+
+    (sparse_checkout, sparse_index)
 }
 
 fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
@@ -247,6 +281,29 @@ mod tests {
 
         assert_eq!(capabilities.mode, GitRepoMode::Standard);
         assert!(!capabilities.requires_git_cli());
+    }
+
+    #[test]
+    fn derives_git_repo_mode_from_sparse_config() {
+        assert_eq!(
+            GitCapabilities::from_config(false, false).mode,
+            GitRepoMode::Standard
+        );
+        assert_eq!(
+            GitCapabilities::from_config(true, false).mode,
+            GitRepoMode::SparseCheckout
+        );
+        assert_eq!(
+            GitCapabilities::from_config(true, true).mode,
+            GitRepoMode::SparseIndex
+        );
+    }
+
+    #[test]
+    fn parses_sparse_config_from_single_git_config_read() {
+        let output = "core.sparsecheckout true\nindex.sparse true\n";
+
+        assert_eq!(parse_sparse_config(output), (true, true));
     }
 
     #[test]

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -4,14 +4,15 @@ pub mod repository;
 pub mod staging;
 
 use git2::Repository;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 
-use super::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use super::traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo, VcsType};
 
 // Re-export commonly used functions
 pub use context::{calculate_gap, fetch_context_lines};
@@ -162,6 +163,137 @@ fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
+fn get_change_status(repo: &Repository, _capabilities: GitCapabilities) -> Result<VcsChangeStatus> {
+    let mut status = crate::profile::time("vcs: git status tracked changes", || {
+        get_tracked_change_status(repo)
+    })?;
+
+    if !status.unstaged {
+        status.unstaged =
+            crate::profile::time("vcs: git untracked scan", || has_untracked_changes(repo))?;
+    }
+
+    Ok(status)
+}
+
+fn get_tracked_change_status(repo: &Repository) -> Result<VcsChangeStatus> {
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(["status", "--porcelain=v1", "-z", "--untracked-files=no"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git status stdout unavailable".into()))?;
+
+    let mut status = VcsChangeStatus::default();
+    let stopped_early = parse_change_status_stream(BufReader::new(stdout), &mut status)?;
+
+    if stopped_early {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Ok(status);
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| TuicrError::VcsCommand(format!("git status failed: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(status)
+}
+
+fn has_untracked_changes(repo: &Repository) -> Result<bool> {
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args([
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--directory",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git ls-files stdout unavailable".into()))?;
+    let mut reader = BufReader::new(stdout);
+    let mut record = Vec::new();
+    let read = reader.read_until(0, &mut record)?;
+    if read > 0 {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Ok(true);
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| TuicrError::VcsCommand(format!("git ls-files failed: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(false)
+}
+
+fn parse_change_status_stream<R: BufRead>(
+    mut reader: R,
+    status: &mut VcsChangeStatus,
+) -> Result<bool> {
+    let mut record = Vec::new();
+    loop {
+        record.clear();
+        let read = reader.read_until(0, &mut record)?;
+        if read == 0 {
+            return Ok(false);
+        }
+        if record.last() == Some(&0) {
+            record.pop();
+        }
+        parse_change_status_record(&record, status);
+        if status.staged && status.unstaged {
+            return Ok(true);
+        }
+    }
+}
+
+fn parse_change_status_record(record: &[u8], status: &mut VcsChangeStatus) {
+    if record.len() < 3 || record[2] != b' ' {
+        return;
+    }
+
+    match (record[0], record[1]) {
+        (b'?', b'?') => status.unstaged = true,
+        (x, y) => {
+            if x != b' ' {
+                status.staged = true;
+            }
+            if y != b' ' {
+                status.unstaged = true;
+            }
+        }
+    }
+}
+
 impl VcsBackend for GitBackend {
     fn info(&self) -> &VcsInfo {
         &self.info
@@ -177,6 +309,10 @@ impl VcsBackend for GitBackend {
 
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         get_unstaged_diff(&self.repo, self.capabilities, highlighter)
+    }
+
+    fn get_change_status(&self) -> Result<VcsChangeStatus> {
+        get_change_status(&self.repo, self.capabilities)
     }
 
     fn fetch_context_lines(
@@ -304,6 +440,104 @@ mod tests {
         let output = "core.sparsecheckout true\nindex.sparse true\n";
 
         assert_eq!(parse_sparse_config(output), (true, true));
+    }
+
+    #[test]
+    fn parses_change_status_records() {
+        let mut status = VcsChangeStatus::default();
+        parse_change_status_record(b" M src/main.rs", &mut status);
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+
+        let mut status = VcsChangeStatus::default();
+        parse_change_status_record(b"M  src/main.rs", &mut status);
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: true,
+                unstaged: false,
+            }
+        );
+
+        let mut status = VcsChangeStatus::default();
+        parse_change_status_record(b"?? new-file.rs", &mut status);
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+
+        let mut status = VcsChangeStatus::default();
+        parse_change_status_record(b"R  new-name.rs", &mut status);
+        parse_change_status_record(b"old-name.rs", &mut status);
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: true,
+                unstaged: false,
+            }
+        );
+    }
+
+    #[test]
+    fn detects_change_status_without_loading_diff() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        git(temp_dir.path(), &["init"]);
+        git(
+            temp_dir.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        git(temp_dir.path(), &["config", "user.name", "Test User"]);
+        std::fs::write(temp_dir.path().join("file.txt"), "initial\n")
+            .expect("failed to write file");
+        git(temp_dir.path(), &["add", "."]);
+        git(temp_dir.path(), &["commit", "-m", "initial"]);
+
+        std::fs::write(temp_dir.path().join("file.txt"), "modified\n")
+            .expect("failed to modify file");
+        std::fs::write(temp_dir.path().join("new.txt"), "new\n")
+            .expect("failed to write untracked file");
+
+        let repo = Repository::discover(temp_dir.path()).expect("failed to discover repo");
+        let status = get_change_status(
+            &repo,
+            GitCapabilities {
+                mode: GitRepoMode::Standard,
+            },
+        )
+        .expect("failed to get change status");
+
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+
+        git(temp_dir.path(), &["add", "file.txt"]);
+        let status = get_change_status(
+            &repo,
+            GitCapabilities {
+                mode: GitRepoMode::Standard,
+            },
+        )
+        .expect("failed to get change status");
+
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: true,
+                unstaged: true,
+            }
+        );
     }
 
     #[test]

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -316,12 +316,13 @@ impl VcsBackend for GitBackend {
     }
 
     fn get_change_status(&self) -> Result<VcsChangeStatus> {
-        if !self.capabilities.requires_git_cli() {
-            return Err(TuicrError::UnsupportedOperation(
-                "Git change status probe only used for sparse checkouts".into(),
-            ));
+        if self.capabilities.requires_git_cli() {
+            return get_change_status(&self.repo, self.capabilities);
         }
-        get_change_status(&self.repo, self.capabilities)
+
+        Err(TuicrError::UnsupportedOperation(
+            "Git change status probe only used for sparse checkouts".into(),
+        ))
     }
 
     fn fetch_context_lines(

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -5,6 +5,7 @@ pub mod staging;
 
 use git2::Repository;
 use std::path::Path;
+use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
@@ -36,20 +37,16 @@ impl GitBackend {
             .ok_or(TuicrError::NotARepository)?
             .to_path_buf();
 
-        let head_commit = repo
-            .head()
+        let head_commit = run_git_command(&root_path, &["rev-parse", "--verify", "HEAD"])
             .ok()
-            .and_then(|h| h.peel_to_commit().ok())
-            .map(|c| c.id().to_string())
+            .map(|value| value.trim().to_string())
             .unwrap_or_else(|| "HEAD".to_string());
 
-        let branch_name = repo.head().ok().and_then(|h| {
-            if h.is_branch() {
-                h.shorthand().map(|s| s.to_string())
-            } else {
-                None
-            }
-        });
+        let branch_name =
+            run_git_command(&root_path, &["symbolic-ref", "--quiet", "--short", "HEAD"])
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty());
 
         let info = VcsInfo {
             root_path,
@@ -60,6 +57,22 @@ impl GitBackend {
 
         Ok(Self { repo, info })
     }
+}
+
+fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 impl VcsBackend for GitBackend {

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -38,7 +38,11 @@ pub enum GitRepoMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct GitCapabilities {
     pub mode: GitRepoMode,
+    /// Git's untracked cache avoids re-reading unchanged directories during
+    /// exact untracked-file scans. This matters most for sparse monorepos.
     pub untracked_cache: bool,
+    /// `core.fsmonitor` may be `true` or a custom hook path; both mean Git can
+    /// avoid broad tracked-file stat walks.
     pub fsmonitor: bool,
 }
 
@@ -135,6 +139,8 @@ impl GitBackend {
 }
 
 fn git_config(workdir: &Path) -> (bool, bool, bool, bool) {
+    // Keep this as a raw config read: core.fsmonitor can be a custom hook path,
+    // so `git config --bool` would reject valid enabled configurations.
     let output = run_git_command(
         workdir,
         &[
@@ -201,6 +207,9 @@ fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
 }
 
 fn get_change_status(repo: &Repository, capabilities: GitCapabilities) -> Result<VcsChangeStatus> {
+    // Tracked changes have a cheap exact probe. Untracked files require a
+    // working-tree scan, so only pay that cost when no tracked unstaged changes
+    // already prove the "unstaged" row should be shown.
     let staged = crate::profile::time("vcs: git staged diff probe", || {
         has_diff_changes(repo, &["diff", "--quiet", "--cached", "--"])
     })?;

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -146,7 +146,7 @@ fn git_config(workdir: &Path) -> (bool, bool, bool, bool) {
         &[
             "config",
             "--get-regexp",
-            r"^(core\.sparsecheckout|index\.sparse|core\.untrackedcache|core\.fsmonitor)$",
+            r"^(core\.sparsecheckout|index\.sparse|core\.untrackedcache|core\.fsmonitor|feature\.manyfiles)$",
         ],
     )
     .unwrap_or_default();
@@ -157,8 +157,9 @@ fn git_config(workdir: &Path) -> (bool, bool, bool, bool) {
 fn parse_git_config(output: &str) -> (bool, bool, bool, bool) {
     let mut sparse_checkout = false;
     let mut sparse_index = false;
-    let mut untracked_cache = false;
+    let mut untracked_cache = None;
     let mut fsmonitor = false;
+    let mut many_files = false;
 
     for line in output.lines() {
         let mut parts = line.splitn(2, char::is_whitespace);
@@ -170,11 +171,16 @@ fn parse_git_config(output: &str) -> (bool, bool, bool, bool) {
         match key {
             "core.sparsecheckout" => sparse_checkout = git_bool_config_enabled(raw_value),
             "index.sparse" => sparse_index = git_bool_config_enabled(raw_value),
-            "core.untrackedcache" => untracked_cache = git_bool_config_enabled(raw_value),
+            "core.untrackedcache" => untracked_cache = Some(git_bool_config_enabled(raw_value)),
             "core.fsmonitor" => fsmonitor = git_fsmonitor_config_enabled(raw_value),
+            "feature.manyfiles" => many_files = git_bool_config_enabled(raw_value),
             _ => {}
         }
     }
+
+    // `feature.manyFiles` makes core.untrackedCache default to true, but
+    // `git config --get core.untrackedCache` does not print that implied value.
+    let untracked_cache = untracked_cache.unwrap_or(many_files);
 
     (sparse_checkout, sparse_index, untracked_cache, fsmonitor)
 }
@@ -455,6 +461,20 @@ mod tests {
         let output = "core.sparsecheckout true\nindex.sparse true\ncore.untrackedcache true\ncore.fsmonitor true\n";
 
         assert_eq!(parse_git_config(output), (true, true, true, true));
+    }
+
+    #[test]
+    fn treats_feature_many_files_as_enabling_untracked_cache_by_default() {
+        let output = "feature.manyfiles true\n";
+
+        assert_eq!(parse_git_config(output), (false, false, true, false));
+    }
+
+    #[test]
+    fn explicit_untracked_cache_config_overrides_feature_many_files_default() {
+        let output = "feature.manyfiles true\ncore.untrackedcache keep\n";
+
+        assert_eq!(parse_git_config(output), (false, false, false, false));
     }
 
     #[test]

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, TimeZone, Utc};
-use git2::Repository;
+use git2::{BranchType, Oid, Repository};
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::process::Command;
@@ -59,7 +59,34 @@ where
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
-fn get_branch_tip_names(repo: &Repository) -> HashMap<String, Vec<String>> {
+fn get_branch_tip_names(repo: &Repository) -> HashMap<Oid, Vec<String>> {
+    let mut names_by_tip: HashMap<Oid, Vec<String>> = HashMap::new();
+
+    if let Ok(branches) = repo.branches(Some(BranchType::Local)) {
+        for (branch, _) in branches.flatten() {
+            let Some(target) = branch.get().target() else {
+                continue;
+            };
+
+            let Ok(Some(name)) = branch.name() else {
+                continue;
+            };
+
+            names_by_tip
+                .entry(target)
+                .or_default()
+                .push(name.to_string());
+        }
+    }
+
+    for names in names_by_tip.values_mut() {
+        names.sort_unstable();
+    }
+
+    names_by_tip
+}
+
+fn get_branch_tip_names_cli(repo: &Repository) -> HashMap<String, Vec<String>> {
     let output = run_git_command(
         repo,
         [
@@ -89,11 +116,15 @@ fn get_branch_tip_names(repo: &Repository) -> HashMap<String, Vec<String>> {
 
 pub fn get_recent_commits(
     repo: &Repository,
-    _capabilities: GitCapabilities,
+    capabilities: GitCapabilities,
     offset: usize,
     limit: usize,
 ) -> Result<Vec<CommitInfo>> {
-    let branch_tip_names = get_branch_tip_names(repo);
+    if !capabilities.requires_git_cli() {
+        return get_recent_commits_libgit2(repo, offset, limit);
+    }
+
+    let branch_tip_names = get_branch_tip_names_cli(repo);
     let output = run_git_command(
         repo,
         [
@@ -109,14 +140,18 @@ pub fn get_recent_commits(
 
 pub fn get_commits_info(
     repo: &Repository,
-    _capabilities: GitCapabilities,
+    capabilities: GitCapabilities,
     ids: &[String],
 ) -> Result<Vec<CommitInfo>> {
+    if !capabilities.requires_git_cli() {
+        return get_commits_info_libgit2(repo, ids);
+    }
+
     if ids.is_empty() {
         return Ok(Vec::new());
     }
 
-    let branch_tip_names = get_branch_tip_names(repo);
+    let branch_tip_names = get_branch_tip_names_cli(repo);
     let mut args = vec![
         "show".to_string(),
         "-s".to_string(),
@@ -135,9 +170,13 @@ pub fn get_commits_info(
 /// For a single revision, returns just that commit.
 pub fn resolve_revisions(
     repo: &Repository,
-    _capabilities: GitCapabilities,
+    capabilities: GitCapabilities,
     revisions: &str,
 ) -> Result<Vec<String>> {
+    if !capabilities.requires_git_cli() {
+        return resolve_revisions_libgit2(repo, revisions);
+    }
+
     let commit_ids = if revisions.contains("..") {
         let output = run_git_command(repo, ["rev-list", "--reverse", revisions])?;
         output
@@ -155,6 +194,124 @@ pub fn resolve_revisions(
         return Err(TuicrError::NoChanges);
     }
 
+    Ok(commit_ids)
+}
+
+fn get_recent_commits_libgit2(
+    repo: &Repository,
+    offset: usize,
+    limit: usize,
+) -> Result<Vec<CommitInfo>> {
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+    let branch_tip_names = get_branch_tip_names(repo);
+
+    let mut commits = Vec::new();
+    for oid in revwalk.skip(offset).take(limit) {
+        let oid = oid?;
+        let commit = repo.find_commit(oid)?;
+
+        let id = oid.to_string();
+        let short_id = id[..7.min(id.len())].to_string();
+        let full_message = commit.message().unwrap_or("(no message)");
+        let (summary, body) = parse_commit_message(full_message);
+        let author = commit.author().name().unwrap_or("Unknown").to_string();
+        let branch_name = branch_tip_names
+            .get(&oid)
+            .and_then(|names| names.first().cloned());
+        let time = Utc
+            .timestamp_opt(commit.time().seconds(), 0)
+            .single()
+            .unwrap_or_else(Utc::now);
+
+        commits.push(CommitInfo {
+            id,
+            short_id,
+            branch_name,
+            summary,
+            body,
+            author,
+            time,
+        });
+    }
+
+    Ok(commits)
+}
+
+fn get_commits_info_libgit2(repo: &Repository, ids: &[String]) -> Result<Vec<CommitInfo>> {
+    let branch_tip_names = get_branch_tip_names(repo);
+    let mut commits = Vec::new();
+
+    for id_str in ids {
+        let oid = Oid::from_str(id_str)
+            .map_err(|e| TuicrError::VcsCommand(format!("Invalid commit ID {}: {}", id_str, e)))?;
+        let commit = repo
+            .find_commit(oid)
+            .map_err(|e| TuicrError::VcsCommand(format!("Commit not found {}: {}", id_str, e)))?;
+
+        let id = oid.to_string();
+        let short_id = id[..7.min(id.len())].to_string();
+        let full_message = commit.message().unwrap_or("(no message)");
+        let (summary, body) = parse_commit_message(full_message);
+        let author = commit.author().name().unwrap_or("Unknown").to_string();
+        let branch_name = branch_tip_names
+            .get(&oid)
+            .and_then(|names| names.first().cloned());
+        let time = Utc
+            .timestamp_opt(commit.time().seconds(), 0)
+            .single()
+            .unwrap_or_else(Utc::now);
+
+        commits.push(CommitInfo {
+            id,
+            short_id,
+            branch_name,
+            summary,
+            body,
+            author,
+            time,
+        });
+    }
+
+    Ok(commits)
+}
+
+fn resolve_revisions_libgit2(repo: &Repository, revisions: &str) -> Result<Vec<String>> {
+    let revspec = repo.revparse(revisions)?;
+
+    let mut commit_ids = if revspec.mode().contains(git2::RevparseMode::RANGE) {
+        let from = revspec.from().ok_or_else(|| {
+            TuicrError::VcsCommand("Invalid revision range: missing 'from'".into())
+        })?;
+        let to = revspec
+            .to()
+            .ok_or_else(|| TuicrError::VcsCommand("Invalid revision range: missing 'to'".into()))?;
+
+        let mut revwalk = repo.revwalk()?;
+        revwalk.push(to.id())?;
+        revwalk.hide(from.id())?;
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+
+        let mut ids = Vec::new();
+        for oid in revwalk {
+            ids.push(oid?.to_string());
+        }
+        ids
+    } else {
+        let obj = revspec
+            .from()
+            .ok_or_else(|| TuicrError::VcsCommand("Invalid revision expression".into()))?;
+        let commit = obj
+            .peel_to_commit()
+            .map_err(|e| TuicrError::VcsCommand(format!("Not a commit: {}", e)))?;
+        vec![commit.id().to_string()]
+    };
+
+    if commit_ids.is_empty() {
+        return Err(TuicrError::NoChanges);
+    }
+
+    commit_ids.reverse();
     Ok(commit_ids)
 }
 

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -442,6 +442,8 @@ mod tests {
     fn sparse_index_capabilities() -> GitCapabilities {
         GitCapabilities {
             mode: GitRepoMode::SparseIndex,
+            untracked_cache: false,
+            fsmonitor: false,
         }
     }
 

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, TimeZone, Utc};
-use git2::{BranchType, Oid, Repository};
+use git2::Repository;
 use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 
@@ -33,21 +35,44 @@ fn parse_commit_message(message: &str) -> (String, Option<String>) {
     (summary, body)
 }
 
-fn get_branch_tip_names(repo: &Repository) -> HashMap<Oid, Vec<String>> {
-    let mut names_by_tip: HashMap<Oid, Vec<String>> = HashMap::new();
+const COMMIT_FORMAT: &str = "--format=%H%x00%h%x00%an%x00%ct%x00%B%x1e";
 
-    if let Ok(branches) = repo.branches(Some(BranchType::Local)) {
-        for (branch, _) in branches.flatten() {
-            let Some(target) = branch.get().target() else {
-                continue;
-            };
+fn run_git_command<I, S>(repo: &Repository, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
 
-            let Ok(Some(name)) = branch.name() else {
-                continue;
-            };
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(TuicrError::VcsCommand(stderr.trim().to_string()));
+    }
 
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn get_branch_tip_names(repo: &Repository) -> HashMap<String, Vec<String>> {
+    let output = run_git_command(
+        repo,
+        [
+            "for-each-ref",
+            "--format=%(objectname)%00%(refname:short)",
+            "refs/heads",
+        ],
+    )
+    .unwrap_or_default();
+    let mut names_by_tip: HashMap<String, Vec<String>> = HashMap::new();
+
+    for line in output.lines() {
+        if let Some((oid, name)) = line.split_once('\0') {
             names_by_tip
-                .entry(target)
+                .entry(oid.to_string())
                 .or_default()
                 .push(name.to_string());
         }
@@ -65,80 +90,37 @@ pub fn get_recent_commits(
     offset: usize,
     limit: usize,
 ) -> Result<Vec<CommitInfo>> {
-    let mut revwalk = repo.revwalk()?;
-    revwalk.push_head()?;
     let branch_tip_names = get_branch_tip_names(repo);
+    let output = run_git_command(
+        repo,
+        [
+            "log".to_string(),
+            format!("--skip={offset}"),
+            format!("--max-count={limit}"),
+            COMMIT_FORMAT.to_string(),
+        ],
+    )?;
 
-    let mut commits = Vec::new();
-    for oid in revwalk.skip(offset).take(limit) {
-        let oid = oid?;
-        let commit = repo.find_commit(oid)?;
-
-        let id = oid.to_string();
-        let short_id = id[..7.min(id.len())].to_string();
-        let full_message = commit.message().unwrap_or("(no message)");
-        let (summary, body) = parse_commit_message(full_message);
-        let author = commit.author().name().unwrap_or("Unknown").to_string();
-        let branch_name = branch_tip_names
-            .get(&oid)
-            .and_then(|names| names.first().cloned());
-        let time = Utc
-            .timestamp_opt(commit.time().seconds(), 0)
-            .single()
-            .unwrap_or_else(Utc::now);
-
-        commits.push(CommitInfo {
-            id,
-            short_id,
-            branch_name,
-            summary,
-            body,
-            author,
-            time,
-        });
-    }
-
-    Ok(commits)
+    Ok(parse_commit_records(&output, &branch_tip_names))
 }
 
 /// Get commit info for specific commit IDs.
 /// Returns CommitInfo in the same order as the input IDs.
 pub fn get_commits_info(repo: &Repository, ids: &[String]) -> Result<Vec<CommitInfo>> {
-    let branch_tip_names = get_branch_tip_names(repo);
-    let mut commits = Vec::new();
-
-    for id_str in ids {
-        let oid = Oid::from_str(id_str)
-            .map_err(|e| TuicrError::VcsCommand(format!("Invalid commit ID {}: {}", id_str, e)))?;
-        let commit = repo
-            .find_commit(oid)
-            .map_err(|e| TuicrError::VcsCommand(format!("Commit not found {}: {}", id_str, e)))?;
-
-        let id = oid.to_string();
-        let short_id = id[..7.min(id.len())].to_string();
-        let full_message = commit.message().unwrap_or("(no message)");
-        let (summary, body) = parse_commit_message(full_message);
-        let author = commit.author().name().unwrap_or("Unknown").to_string();
-        let branch_name = branch_tip_names
-            .get(&oid)
-            .and_then(|names| names.first().cloned());
-        let time = Utc
-            .timestamp_opt(commit.time().seconds(), 0)
-            .single()
-            .unwrap_or_else(Utc::now);
-
-        commits.push(CommitInfo {
-            id,
-            short_id,
-            branch_name,
-            summary,
-            body,
-            author,
-            time,
-        });
+    if ids.is_empty() {
+        return Ok(Vec::new());
     }
 
-    Ok(commits)
+    let branch_tip_names = get_branch_tip_names(repo);
+    let mut args = vec![
+        "show".to_string(),
+        "-s".to_string(),
+        COMMIT_FORMAT.to_string(),
+    ];
+    args.extend(ids.iter().cloned());
+    let output = run_git_command(repo, args)?;
+
+    Ok(parse_commit_records(&output, &branch_tip_names))
 }
 
 /// Resolve a git revision range expression to a list of commit IDs (oldest first).
@@ -147,44 +129,165 @@ pub fn get_commits_info(repo: &Repository, ids: &[String]) -> Result<Vec<CommitI
 /// For a range A..B, walks from B back to (but not including) A.
 /// For a single revision, returns just that commit.
 pub fn resolve_revisions(repo: &Repository, revisions: &str) -> Result<Vec<String>> {
-    // Try parsing as a range first (e.g., "A..B")
-    let revspec = repo.revparse(revisions)?;
-
-    let mut commit_ids = if revspec.mode().contains(git2::RevparseMode::RANGE) {
-        // Range: walk from `to` back, stopping before `from`
-        let from = revspec.from().ok_or_else(|| {
-            TuicrError::VcsCommand("Invalid revision range: missing 'from'".into())
-        })?;
-        let to = revspec
-            .to()
-            .ok_or_else(|| TuicrError::VcsCommand("Invalid revision range: missing 'to'".into()))?;
-
-        let mut revwalk = repo.revwalk()?;
-        revwalk.push(to.id())?;
-        revwalk.hide(from.id())?;
-        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
-
-        let mut ids = Vec::new();
-        for oid in revwalk {
-            ids.push(oid?.to_string());
-        }
-        ids
+    let commit_ids = if revisions.contains("..") {
+        let output = run_git_command(repo, ["rev-list", "--reverse", revisions])?;
+        output
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(str::to_string)
+            .collect()
     } else {
-        // Single revision
-        let obj = revspec
-            .from()
-            .ok_or_else(|| TuicrError::VcsCommand("Invalid revision expression".into()))?;
-        let commit = obj
-            .peel_to_commit()
-            .map_err(|e| TuicrError::VcsCommand(format!("Not a commit: {}", e)))?;
-        vec![commit.id().to_string()]
+        let revision = format!("{revisions}^{{commit}}");
+        let output = run_git_command(repo, ["rev-parse", "--verify", &revision])?;
+        vec![output.trim().to_string()]
     };
 
     if commit_ids.is_empty() {
         return Err(TuicrError::NoChanges);
     }
 
-    // revwalk outputs newest first; reverse so oldest is first
-    commit_ids.reverse();
     Ok(commit_ids)
+}
+
+fn parse_commit_records(
+    output: &str,
+    branch_tip_names: &HashMap<String, Vec<String>>,
+) -> Vec<CommitInfo> {
+    output
+        .split('\x1e')
+        .filter_map(|record| parse_commit_record(record, branch_tip_names))
+        .collect()
+}
+
+fn parse_commit_record(
+    record: &str,
+    branch_tip_names: &HashMap<String, Vec<String>>,
+) -> Option<CommitInfo> {
+    let record = record.trim_start_matches('\n').trim_end_matches('\n');
+    if record.is_empty() {
+        return None;
+    }
+
+    let mut fields = record.splitn(5, '\0');
+    let id = fields.next()?.to_string();
+    let short_id = fields.next()?.to_string();
+    let author = fields.next().unwrap_or("Unknown").to_string();
+    let timestamp = fields
+        .next()
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or_default();
+    let full_message = fields.next().unwrap_or("(no message)");
+    let (summary, body) = parse_commit_message(full_message);
+    let branch_name = branch_tip_names
+        .get(&id)
+        .and_then(|names| names.first().cloned());
+    let time = Utc
+        .timestamp_opt(timestamp, 0)
+        .single()
+        .unwrap_or_else(Utc::now);
+
+    Some(CommitInfo {
+        id,
+        short_id,
+        branch_name,
+        summary,
+        body,
+        author,
+        time,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    fn git(repo: &Repository, args: &[&str]) {
+        let workdir = repo.workdir().expect("test repo should have workdir");
+        let output = Command::new("git")
+            .current_dir(workdir)
+            .args(args)
+            .output()
+            .expect("failed to run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn write_file(repo: &Repository, path: &str, content: &str) {
+        let workdir = repo.workdir().expect("test repo should have workdir");
+        let full_path = workdir.join(path);
+        fs::create_dir_all(full_path.parent().expect("test path should have parent"))
+            .expect("failed to create parent");
+        fs::write(full_path, content).expect("failed to write file");
+    }
+
+    fn setup_sparse_index_repo() -> (tempfile::TempDir, Repository, Vec<String>) {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        git(&repo, &["config", "user.email", "test@example.com"]);
+        git(&repo, &["config", "user.name", "Test User"]);
+        write_file(&repo, "keep/file.txt", "keep base\n");
+        write_file(&repo, "hidden/file.txt", "hidden base\n");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "initial"]);
+        let first_id = run_git_command(&repo, ["rev-parse", "HEAD"])
+            .expect("failed to resolve first commit")
+            .trim()
+            .to_string();
+
+        write_file(&repo, "keep/file.txt", "keep next\n");
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "second"]);
+        let second_id = run_git_command(&repo, ["rev-parse", "HEAD"])
+            .expect("failed to resolve second commit")
+            .trim()
+            .to_string();
+
+        git(&repo, &["sparse-checkout", "init", "--cone"]);
+        git(&repo, &["sparse-checkout", "set", "keep"]);
+        git(&repo, &["sparse-checkout", "reapply", "--sparse-index"]);
+
+        (temp_dir, repo, vec![first_id, second_id])
+    }
+
+    #[test]
+    fn get_recent_commits_supports_sparse_index() {
+        let (_temp_dir, repo, _ids) = setup_sparse_index_repo();
+
+        let commits = get_recent_commits(&repo, 0, 10).expect("failed to get commits");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].summary, "second");
+        assert_eq!(commits[1].summary, "initial");
+    }
+
+    #[test]
+    fn get_commits_info_supports_sparse_index() {
+        let (_temp_dir, repo, ids) = setup_sparse_index_repo();
+
+        let commits = get_commits_info(&repo, &[ids[0].clone(), ids[1].clone()])
+            .expect("failed to get commit info");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].id, ids[0]);
+        assert_eq!(commits[0].summary, "initial");
+        assert_eq!(commits[1].id, ids[1]);
+        assert_eq!(commits[1].summary, "second");
+    }
+
+    #[test]
+    fn resolve_revisions_supports_sparse_index() {
+        let (_temp_dir, repo, ids) = setup_sparse_index_repo();
+        let revset = format!("{}..{}", ids[0], ids[1]);
+
+        let resolved = resolve_revisions(&repo, &revset).expect("failed to resolve revisions");
+
+        assert_eq!(resolved, vec![ids[1].clone()]);
+    }
 }

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -120,10 +120,18 @@ pub fn get_recent_commits(
     offset: usize,
     limit: usize,
 ) -> Result<Vec<CommitInfo>> {
-    if !capabilities.requires_git_cli() {
-        return get_recent_commits_libgit2(repo, offset, limit);
+    if capabilities.requires_git_cli() {
+        return get_recent_commits_cli(repo, offset, limit);
     }
 
+    get_recent_commits_libgit2(repo, offset, limit)
+}
+
+fn get_recent_commits_cli(
+    repo: &Repository,
+    offset: usize,
+    limit: usize,
+) -> Result<Vec<CommitInfo>> {
     let branch_tip_names = get_branch_tip_names_cli(repo);
     let output = run_git_command(
         repo,
@@ -143,10 +151,14 @@ pub fn get_commits_info(
     capabilities: GitCapabilities,
     ids: &[String],
 ) -> Result<Vec<CommitInfo>> {
-    if !capabilities.requires_git_cli() {
-        return get_commits_info_libgit2(repo, ids);
+    if capabilities.requires_git_cli() {
+        return get_commits_info_cli(repo, ids);
     }
 
+    get_commits_info_libgit2(repo, ids)
+}
+
+fn get_commits_info_cli(repo: &Repository, ids: &[String]) -> Result<Vec<CommitInfo>> {
     if ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -173,10 +185,14 @@ pub fn resolve_revisions(
     capabilities: GitCapabilities,
     revisions: &str,
 ) -> Result<Vec<String>> {
-    if !capabilities.requires_git_cli() {
-        return resolve_revisions_libgit2(repo, revisions);
+    if capabilities.requires_git_cli() {
+        return resolve_revisions_cli(repo, revisions);
     }
 
+    resolve_revisions_libgit2(repo, revisions)
+}
+
+fn resolve_revisions_cli(repo: &Repository, revisions: &str) -> Result<Vec<String>> {
     let commit_ids = if revisions.contains("..") {
         let output = run_git_command(repo, ["rev-list", "--reverse", revisions])?;
         output

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -120,6 +120,8 @@ pub fn get_recent_commits(
     offset: usize,
     limit: usize,
 ) -> Result<Vec<CommitInfo>> {
+    // Standard repos keep the original libgit2 path. Sparse checkouts use CLI
+    // revision helpers because opening sparse indexes through libgit2 can fail.
     if capabilities.requires_git_cli() {
         return get_recent_commits_cli(repo, offset, limit);
     }
@@ -151,6 +153,7 @@ pub fn get_commits_info(
     capabilities: GitCapabilities,
     ids: &[String],
 ) -> Result<Vec<CommitInfo>> {
+    // Returns CommitInfo in the same order as the input IDs.
     if capabilities.requires_git_cli() {
         return get_commits_info_cli(repo, ids);
     }
@@ -293,9 +296,11 @@ fn get_commits_info_libgit2(repo: &Repository, ids: &[String]) -> Result<Vec<Com
 }
 
 fn resolve_revisions_libgit2(repo: &Repository, revisions: &str) -> Result<Vec<String>> {
+    // Try parsing as a range first (e.g., "A..B").
     let revspec = repo.revparse(revisions)?;
 
     let mut commit_ids = if revspec.mode().contains(git2::RevparseMode::RANGE) {
+        // Range: walk from `to` back, stopping before `from`.
         let from = revspec.from().ok_or_else(|| {
             TuicrError::VcsCommand("Invalid revision range: missing 'from'".into())
         })?;
@@ -314,6 +319,7 @@ fn resolve_revisions_libgit2(repo: &Repository, revisions: &str) -> Result<Vec<S
         }
         ids
     } else {
+        // Single revision.
         let obj = revspec
             .from()
             .ok_or_else(|| TuicrError::VcsCommand("Invalid revision expression".into()))?;
@@ -327,6 +333,7 @@ fn resolve_revisions_libgit2(repo: &Repository, revisions: &str) -> Result<Vec<S
         return Err(TuicrError::NoChanges);
     }
 
+    // revwalk outputs newest first; reverse so oldest is first.
     commit_ids.reverse();
     Ok(commit_ids)
 }

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -6,6 +6,8 @@ use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 
+use super::GitCapabilities;
+
 #[derive(Debug, Clone)]
 pub struct CommitInfo {
     pub id: String,
@@ -87,6 +89,7 @@ fn get_branch_tip_names(repo: &Repository) -> HashMap<String, Vec<String>> {
 
 pub fn get_recent_commits(
     repo: &Repository,
+    _capabilities: GitCapabilities,
     offset: usize,
     limit: usize,
 ) -> Result<Vec<CommitInfo>> {
@@ -104,9 +107,11 @@ pub fn get_recent_commits(
     Ok(parse_commit_records(&output, &branch_tip_names))
 }
 
-/// Get commit info for specific commit IDs.
-/// Returns CommitInfo in the same order as the input IDs.
-pub fn get_commits_info(repo: &Repository, ids: &[String]) -> Result<Vec<CommitInfo>> {
+pub fn get_commits_info(
+    repo: &Repository,
+    _capabilities: GitCapabilities,
+    ids: &[String],
+) -> Result<Vec<CommitInfo>> {
     if ids.is_empty() {
         return Ok(Vec::new());
     }
@@ -128,7 +133,11 @@ pub fn get_commits_info(repo: &Repository, ids: &[String]) -> Result<Vec<CommitI
 /// Supports both single revisions ("HEAD~3") and ranges ("main..feature").
 /// For a range A..B, walks from B back to (but not including) A.
 /// For a single revision, returns just that commit.
-pub fn resolve_revisions(repo: &Repository, revisions: &str) -> Result<Vec<String>> {
+pub fn resolve_revisions(
+    repo: &Repository,
+    _capabilities: GitCapabilities,
+    revisions: &str,
+) -> Result<Vec<String>> {
     let commit_ids = if revisions.contains("..") {
         let output = run_git_command(repo, ["rev-list", "--reverse", revisions])?;
         output
@@ -200,6 +209,7 @@ fn parse_commit_record(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::git::GitRepoMode;
     use std::fs;
     use std::process::Command;
 
@@ -256,11 +266,18 @@ mod tests {
         (temp_dir, repo, vec![first_id, second_id])
     }
 
+    fn sparse_index_capabilities() -> GitCapabilities {
+        GitCapabilities {
+            mode: GitRepoMode::SparseIndex,
+        }
+    }
+
     #[test]
     fn get_recent_commits_supports_sparse_index() {
         let (_temp_dir, repo, _ids) = setup_sparse_index_repo();
 
-        let commits = get_recent_commits(&repo, 0, 10).expect("failed to get commits");
+        let commits = get_recent_commits(&repo, sparse_index_capabilities(), 0, 10)
+            .expect("failed to get commits");
 
         assert_eq!(commits.len(), 2);
         assert_eq!(commits[0].summary, "second");
@@ -271,8 +288,12 @@ mod tests {
     fn get_commits_info_supports_sparse_index() {
         let (_temp_dir, repo, ids) = setup_sparse_index_repo();
 
-        let commits = get_commits_info(&repo, &[ids[0].clone(), ids[1].clone()])
-            .expect("failed to get commit info");
+        let commits = get_commits_info(
+            &repo,
+            sparse_index_capabilities(),
+            &[ids[0].clone(), ids[1].clone()],
+        )
+        .expect("failed to get commit info");
 
         assert_eq!(commits.len(), 2);
         assert_eq!(commits[0].id, ids[0]);
@@ -286,7 +307,8 @@ mod tests {
         let (_temp_dir, repo, ids) = setup_sparse_index_repo();
         let revset = format!("{}..{}", ids[0], ids[1]);
 
-        let resolved = resolve_revisions(&repo, &revset).expect("failed to resolve revisions");
+        let resolved = resolve_revisions(&repo, sparse_index_capabilities(), &revset)
+            .expect("failed to resolve revisions");
 
         assert_eq!(resolved, vec![ids[1].clone()]);
     }

--- a/src/vcs/git/staging.rs
+++ b/src/vcs/git/staging.rs
@@ -6,7 +6,22 @@ use crate::error::{Result, TuicrError};
 
 use super::GitCapabilities;
 
-pub fn stage_file(repo: &Repository, _capabilities: GitCapabilities, path: &Path) -> Result<()> {
+pub fn stage_file(repo: &Repository, capabilities: GitCapabilities, path: &Path) -> Result<()> {
+    if capabilities.requires_git_cli() {
+        return stage_file_cli(repo, path);
+    }
+
+    stage_file_libgit2(repo, path)
+}
+
+fn stage_file_libgit2(repo: &Repository, path: &Path) -> Result<()> {
+    let mut index = repo.index()?;
+    index.add_path(path)?;
+    index.write()?;
+    Ok(())
+}
+
+fn stage_file_cli(repo: &Repository, path: &Path) -> Result<()> {
     let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
     let output = Command::new("git")
         .current_dir(workdir)
@@ -57,12 +72,8 @@ mod tests {
 
         stage_file(&repo, standard_capabilities(), Path::new("test.txt")).unwrap();
 
-        let output = Command::new("git")
-            .current_dir(temp_dir.path())
-            .args(["diff", "--cached", "--name-only"])
-            .output()
-            .expect("failed to run git");
-        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "test.txt");
+        let index = repo.index().unwrap();
+        assert!(index.get_path(Path::new("test.txt"), 0).is_some());
     }
 
     #[test]

--- a/src/vcs/git/staging.rs
+++ b/src/vcs/git/staging.rs
@@ -4,7 +4,9 @@ use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 
-pub fn stage_file(repo: &Repository, path: &Path) -> Result<()> {
+use super::GitCapabilities;
+
+pub fn stage_file(repo: &Repository, _capabilities: GitCapabilities, path: &Path) -> Result<()> {
     let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
     let output = Command::new("git")
         .current_dir(workdir)
@@ -26,7 +28,20 @@ pub fn stage_file(repo: &Repository, path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::git::GitRepoMode;
     use std::fs;
+
+    fn standard_capabilities() -> GitCapabilities {
+        GitCapabilities {
+            mode: GitRepoMode::Standard,
+        }
+    }
+
+    fn sparse_index_capabilities() -> GitCapabilities {
+        GitCapabilities {
+            mode: GitRepoMode::SparseIndex,
+        }
+    }
 
     #[test]
     fn stage_file_adds_to_index() {
@@ -36,7 +51,7 @@ mod tests {
         let file_path = temp_dir.path().join("test.txt");
         fs::write(&file_path, "hello\n").unwrap();
 
-        stage_file(&repo, Path::new("test.txt")).unwrap();
+        stage_file(&repo, standard_capabilities(), Path::new("test.txt")).unwrap();
 
         let output = Command::new("git")
             .current_dir(temp_dir.path())
@@ -84,7 +99,12 @@ mod tests {
 
         fs::write(temp_dir.path().join("keep/file.txt"), "keep staged\n").unwrap();
 
-        stage_file(&repo, Path::new("keep/file.txt")).unwrap();
+        stage_file(
+            &repo,
+            sparse_index_capabilities(),
+            Path::new("keep/file.txt"),
+        )
+        .unwrap();
 
         let output = Command::new("git")
             .current_dir(temp_dir.path())

--- a/src/vcs/git/staging.rs
+++ b/src/vcs/git/staging.rs
@@ -34,12 +34,16 @@ mod tests {
     fn standard_capabilities() -> GitCapabilities {
         GitCapabilities {
             mode: GitRepoMode::Standard,
+            untracked_cache: false,
+            fsmonitor: false,
         }
     }
 
     fn sparse_index_capabilities() -> GitCapabilities {
         GitCapabilities {
             mode: GitRepoMode::SparseIndex,
+            untracked_cache: false,
+            fsmonitor: false,
         }
     }
 

--- a/src/vcs/git/staging.rs
+++ b/src/vcs/git/staging.rs
@@ -1,12 +1,25 @@
 use git2::Repository;
 use std::path::Path;
+use std::process::Command;
 
-use crate::error::Result;
+use crate::error::{Result, TuicrError};
 
 pub fn stage_file(repo: &Repository, path: &Path) -> Result<()> {
-    let mut index = repo.index()?;
-    index.add_path(path)?;
-    index.write()?;
+    let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .arg("add")
+        .arg("--")
+        .arg(path)
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {}", e)))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
     Ok(())
 }
 
@@ -25,7 +38,62 @@ mod tests {
 
         stage_file(&repo, Path::new("test.txt")).unwrap();
 
-        let index = repo.index().unwrap();
-        assert!(index.get_path(Path::new("test.txt"), 0).is_some());
+        let output = Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["diff", "--cached", "--name-only"])
+            .output()
+            .expect("failed to run git");
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "test.txt");
+    }
+
+    #[test]
+    fn stage_file_supports_sparse_index() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        for args in [
+            &["config", "user.email", "test@example.com"][..],
+            &["config", "user.name", "Test User"],
+        ] {
+            let status = Command::new("git")
+                .current_dir(temp_dir.path())
+                .args(args)
+                .status()
+                .expect("failed to run git");
+            assert!(status.success());
+        }
+
+        fs::create_dir_all(temp_dir.path().join("keep")).unwrap();
+        fs::create_dir_all(temp_dir.path().join("hidden")).unwrap();
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep base\n").unwrap();
+        fs::write(temp_dir.path().join("hidden/file.txt"), "hidden base\n").unwrap();
+        for args in [
+            &["add", "."][..],
+            &["commit", "-m", "initial"],
+            &["sparse-checkout", "init", "--cone"],
+            &["sparse-checkout", "set", "keep"],
+            &["sparse-checkout", "reapply", "--sparse-index"],
+        ] {
+            let status = Command::new("git")
+                .current_dir(temp_dir.path())
+                .args(args)
+                .status()
+                .expect("failed to run git");
+            assert!(status.success(), "git {args:?} failed");
+        }
+
+        fs::write(temp_dir.path().join("keep/file.txt"), "keep staged\n").unwrap();
+
+        stage_file(&repo, Path::new("keep/file.txt")).unwrap();
+
+        let output = Command::new("git")
+            .current_dir(temp_dir.path())
+            .args(["diff", "--cached", "--name-only"])
+            .output()
+            .expect("failed to run git");
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "keep/file.txt"
+        );
     }
 }

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -22,7 +22,7 @@ pub use file::FileBackend;
 pub use git::GitBackend;
 pub use hg::HgBackend;
 pub use jj::JjBackend;
-pub use traits::{CommitInfo, VcsBackend, VcsInfo};
+pub use traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -61,6 +61,11 @@ pub trait VcsBackend: Send {
     /// Get repository information
     fn info(&self) -> &VcsInfo;
 
+    /// Non-fatal notices that should be shown after startup.
+    fn startup_warnings(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Get the working tree diff (staged + unstaged changes)
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>>;
 

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -49,6 +49,13 @@ pub struct CommitInfo {
     pub time: DateTime<Utc>,
 }
 
+/// Cheap repository change summary used by selection UIs before loading full diffs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct VcsChangeStatus {
+    pub staged: bool,
+    pub unstaged: bool,
+}
+
 /// Trait for VCS backend implementations
 pub trait VcsBackend: Send {
     /// Get repository information
@@ -68,6 +75,13 @@ pub trait VcsBackend: Send {
     fn get_unstaged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Unstaged diff not supported for this VCS".into(),
+        ))
+    }
+
+    /// Get a cheap staged/unstaged summary without parsing or highlighting diffs.
+    fn get_change_status(&self) -> Result<VcsChangeStatus> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "Change status not supported for this VCS".into(),
         ))
     }
 


### PR DESCRIPTION
## Summary
- Add sparse checkout/sparse-index capability detection for Git and route only those repos through Git CLI diff/revision helpers; standard Git repos continue to use the existing libgit2 paths.
- Parse Git-style CLI diffs through the shared streaming parser so sparse checkouts avoid libgit2 sparse-index failures such as unsupported mandatory `sdir` index extensions.
- Preserve sparse checkout untracked-file handling, including binary and large-file cases, while narrowing untracked scans to sparse checkout pathspecs when the sparse patterns are simple cone paths.
- Add startup/profile instrumentation for the critical paths we used to debug large sparse repos, and surface an in-app warning when a sparse checkout does not have `core.untrackedCache` enabled.

## Profiling
This PR keeps temporary `TUICR_PROFILE` support because the sparse checkout path is highly sensitive to repo size and filesystem state. The profiler writes to a file instead of stderr/stdout so it does not corrupt the TUI:

- `TUICR_PROFILE=1` appends to `$TMPDIR/tuicr-profile.log`.
- `TUICR_PROFILE=/path/to/profile.log` writes to that exact file.
- `TUICR_PROFILE_FILE=/path/to/profile.log` overrides the default path when `TUICR_PROFILE` is enabled.

The profiler now covers startup, VCS detection, status probes, diff loading, commit selection, view rebuilds, sparse untracked pathspec selection, untracked enumeration, and cache/fsmonitor metadata. This made it clear that exact untracked enumeration is the remaining expensive operation in very large sparse monorepos; enabling Git's untracked cache reduced the observed untracked scan substantially, but the scan is still real filesystem work.

`core.fsmonitor` can be either a boolean or a custom hook path, so capability detection treats custom non-false fsmonitor values as enabled. `core.untrackedCache` is checked as a boolean because that is the Git knob that makes repeated untracked scans avoid re-reading unchanged directories.

## Git Backend Behavior
The intended branch point is:

- sparse checkout or sparse index: use Git CLI helpers for diff/revision operations that libgit2 cannot reliably handle in sparse mode.
- standard Git repos: keep the previous libgit2 behavior, including the original libgit2 staging path.

That keeps the sparse support additive instead of changing the normal Git backend behavior.

## Test Plan
- `cargo fmt --all --check`
- `cargo test --no-default-features`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo test`
- `cargo clippy -- -D warnings`
- `git diff --check`

Fixes https://github.com/agavra/tuicr/issues/279