### PR TITLE
Advance cursor after toggling a commit into the selection

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3665,6 +3665,34 @@ impl App {
         }
     }
 
+    /// Toggle the cursor commit's membership in the selection range, then
+    /// (only if the cursor commit was newly added to the selection) move the
+    /// cursor past the end of the range. Lets the user press Enter/Space
+    /// repeatedly to sweep a contiguous run of commits.
+    ///
+    /// Other toggle outcomes leave the cursor in place: edge presses
+    /// (deselect the cursor commit), middle presses (truncate the range
+    /// without unselecting the cursor commit), and clearing the last
+    /// selection. Those aren't "sweep" actions, so advancing would surprise.
+    pub fn toggle_commit_selection_and_advance(&mut self) {
+        let cursor = self.commit_list_cursor;
+        let was_selected = self.is_commit_selected(cursor);
+        self.toggle_commit_selection();
+        let now_selected = self.is_commit_selected(cursor);
+        if was_selected || !now_selected {
+            return;
+        }
+        if let Some((_, end)) = self.commit_selection_range {
+            while self.commit_list_cursor <= end {
+                let before = self.commit_list_cursor;
+                self.commit_select_down();
+                if self.commit_list_cursor == before {
+                    return;
+                }
+            }
+        }
+    }
+
     // Check if cursor is on the commit expand row
     pub fn is_on_expand_row(&self) -> bool {
         self.can_show_more_commits() && self.commit_list_cursor == self.visible_commit_count

--- a/src/app.rs
+++ b/src/app.rs
@@ -3761,9 +3761,8 @@ impl App {
                         // At end edge - shrink from end
                         self.commit_selection_range = Some((start, end - 1));
                     } else {
-                        // In the middle - shrink towards cursor (exclude everything after cursor)
-                        // This makes the cursor the new end of the range
-                        self.commit_selection_range = Some((start, cursor));
+                        // In the middle - deselect cursor and everything after it
+                        self.commit_selection_range = Some((start, cursor - 1));
                     }
                 } else {
                     // Cursor is outside the range - extend to include it

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -577,7 +577,8 @@ pub fn handle_commit_select_action(app: &mut App, action: Action) {
                     app.set_error(format!("Failed to load commits: {e}"));
                 }
             } else {
-                app.toggle_commit_selection()
+                // Toggle + auto-advance so repeated Space sweeps a range.
+                app.toggle_commit_selection_and_advance();
             }
         }
         Action::ConfirmCommitSelect => {
@@ -608,9 +609,9 @@ pub fn handle_commit_selector_action(app: &mut App, action: Action) {
     match action {
         Action::CursorDown(_) => app.commit_select_down(),
         Action::CursorUp(_) => app.commit_select_up(),
-        // Space/Enter toggle selection
+        // Toggle + auto-advance so repeated presses sweep a contiguous run.
         Action::ToggleExpand | Action::ToggleCommitSelect | Action::SelectFile => {
-            app.toggle_commit_selection();
+            app.toggle_commit_selection_and_advance();
             if let Err(e) = app.reload_inline_selection() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }


### PR DESCRIPTION
Hi! I did not open an issue for this before hand, so if this feature is not desirable, then feel free to close!

The tool [`jjui`](https://github.com/idursun/jjui) has really nice UX when you're selecting sets of commit, it auto moves the cursor to the next commit after selection. This makes it very easy to select a bunch of commits by just pressing `Space` or `Enter` several times in a row (vs having to interleave with `j`, ie `Space`, `j`, `Space`, `j`, and so on).

The semantics are: When the user presses Enter (inline picker) or Space (inline + full-screen picker) to toggle a commit's selection, add the cursor commit to the selection range, *then* move the cursor past the end of the range to the next unselected commit. Lets the user press repeatedly to select a contiguous run of commits without alternating with `j`.

Only "extending" presses advance the cursor. Pressing Enter/Space on an:
* Edge commit deselects the commit
* Middle commit truncate the range while leaving the cursor commit selected

Here's before (must select, then move down, then select, then move down, etc)

https://github.com/user-attachments/assets/b85674d0-f6e5-49c2-bcfb-b53bea044612




Then after (just pressing select repeatedly):


https://github.com/user-attachments/assets/7f3580bb-3cab-496e-bcac-75ad60a13850

