### PR TITLE
Add tracing profile instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2050,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2443,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "tree_magic_mini"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,6 +2529,8 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "two-face",
  "unicode-width",
  "ureq",
@@ -2588,6 +2674,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ uuid = { version = "1.0", features = ["v4"] }
 arboard = { version = "3.4", features = ["wayland-data-control"] }
 base64 = "0.22"
 ignore = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 # Syntax highlighting
 syntect = "5.2"

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,27 @@ fn gap_annotation_line_count(is_top_of_file: bool, remaining: usize) -> usize {
     }
 }
 
+fn profile_diff_result(result: &Result<Vec<DiffFile>>) -> String {
+    match result {
+        Ok(files) => format!("files={}", files.len()),
+        Err(e) => format!("error={e}"),
+    }
+}
+
+fn profile_commit_result(result: &Result<Vec<CommitInfo>>) -> String {
+    match result {
+        Ok(commits) => format!("commits={}", commits.len()),
+        Err(e) => format!("error={e}"),
+    }
+}
+
+fn profile_unit_result(result: &Result<()>) -> String {
+    match result {
+        Ok(()) => "result=ok".to_string(),
+        Err(e) => format!("error={e}"),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum FileTreeItem {
     Directory {
@@ -627,9 +648,10 @@ impl App {
             return Ok(app);
         }
 
-        let vcs = detect_vcs()?;
+        let vcs = crate::profile::time("startup.detect_vcs", detect_vcs)?;
         let vcs_info = vcs.info().clone();
-        let highlighter = theme.syntax_highlighter();
+        let highlighter =
+            crate::profile::time("startup.syntax_highlighter", || theme.syntax_highlighter());
         // Determine the diff source, files, and session based on input.
         // Four paths:
         //   1. -r + -w: combined commit range and uncommitted changes
@@ -637,7 +659,14 @@ impl App {
         //   3. -w only: working tree directly (skip commit selector)
         //   4. neither: commit selection UI
         if let Some(revisions) = revisions {
-            let commit_ids = vcs.resolve_revisions(revisions)?;
+            let commit_ids = crate::profile::time_with(
+                "startup.resolve_revisions",
+                || vcs.resolve_revisions(revisions),
+                |result| match result {
+                    Ok(ids) => format!("commits={}", ids.len()),
+                    Err(e) => format!("error={e}"),
+                },
+            )?;
 
             if working_tree {
                 // Combined: commit range + staged/unstaged changes
@@ -652,11 +681,14 @@ impl App {
                     &vcs_info,
                     &commit_ids,
                 );
-                let review_commits: Vec<CommitInfo> = vcs
-                    .get_commits_info(&commit_ids)?
-                    .into_iter()
-                    .rev()
-                    .collect();
+                let review_commits: Vec<CommitInfo> = crate::profile::time_with(
+                    "startup.selected_commit_info",
+                    || vcs.get_commits_info(&commit_ids),
+                    profile_commit_result,
+                )?
+                .into_iter()
+                .rev()
+                .collect();
                 // Prepend staged/unstaged entries only when the backend supports them
                 let has_staged = Self::get_staged_diff_with_ignore(
                     vcs.as_ref(),
@@ -727,7 +759,11 @@ impl App {
             )?;
             let session = Self::load_or_create_commit_range_session(&vcs_info, &commit_ids);
             // Get commit info for the inline commit selector
-            let review_commits = vcs.get_commits_info(&commit_ids)?;
+            let review_commits = crate::profile::time_with(
+                "startup.selected_commit_info",
+                || vcs.get_commits_info(&commit_ids),
+                profile_commit_result,
+            )?;
             // Reverse to newest-first display order
             let review_commits: Vec<CommitInfo> = review_commits.into_iter().rev().collect();
 
@@ -830,7 +866,11 @@ impl App {
                 None
             };
 
-            let commits = vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT)?;
+            let commits = crate::profile::time_with(
+                "startup.recent_commits",
+                || vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT),
+                profile_commit_result,
+            )?;
             if !has_staged_changes && !has_unstaged_changes && commits.is_empty() {
                 return Err(TuicrError::NoChanges);
             }
@@ -1382,7 +1422,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_working_tree_diff(highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff.load_working_tree",
+            || vcs.get_working_tree_diff(highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1398,7 +1442,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_staged_diff(highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff.load_staged",
+            || vcs.get_staged_diff(highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1414,9 +1462,17 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = match vcs.get_unstaged_diff(highlighter) {
+        let diff_files = match crate::profile::time_with(
+            "diff.load_unstaged",
+            || vcs.get_unstaged_diff(highlighter),
+            profile_diff_result,
+        ) {
             Ok(diff_files) => diff_files,
-            Err(TuicrError::UnsupportedOperation(_)) => vcs.get_working_tree_diff(highlighter)?,
+            Err(TuicrError::UnsupportedOperation(_)) => crate::profile::time_with(
+                "diff.load_unstaged_fallback_working_tree",
+                || vcs.get_working_tree_diff(highlighter),
+                profile_diff_result,
+            )?,
             Err(e) => return Err(e),
         };
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
@@ -1435,7 +1491,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_commit_range_diff(commit_ids, highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff.load_commit_range",
+            || vcs.get_commit_range_diff(commit_ids, highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -1452,7 +1512,11 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_working_tree_with_commits_diff(commit_ids, highlighter)?;
+        let diff_files = crate::profile::time_with(
+            "diff.load_working_tree_with_commits",
+            || vcs.get_working_tree_with_commits_diff(commit_ids, highlighter),
+            profile_diff_result,
+        )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
         let diff_files = if let Some(path) = path_filter {
             Self::filter_by_path(diff_files, path)
@@ -3826,6 +3890,21 @@ impl App {
     }
 
     pub fn confirm_commit_selection(&mut self) -> Result<()> {
+        let selection = match self.commit_selection_range {
+            Some((start, end)) => format!(
+                "range={start}..={end}, rows={}",
+                end.saturating_sub(start) + 1
+            ),
+            None => "range=none, rows=0".to_string(),
+        };
+        crate::profile::time_with(
+            "commit_select.confirm_selection",
+            || self.confirm_commit_selection_inner(),
+            |result| format!("{selection}, {}", profile_unit_result(result)),
+        )
+    }
+
+    fn confirm_commit_selection_inner(&mut self) -> Result<()> {
         let Some((start, end)) = self.commit_selection_range else {
             self.set_message("Select at least one commit");
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod input;
 mod model;
 mod output;
 mod persistence;
+mod profile;
 mod syntax;
 mod text_edit;
 mod theme;
@@ -49,6 +50,8 @@ const CTRL_C_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
 const MIN_WIDTH_FOR_FILE_LIST: u16 = 100;
 
 fn main() -> anyhow::Result<()> {
+    profile::init_from_env();
+
     // Setup panic hook to restore terminal on panic
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
@@ -61,7 +64,7 @@ fn main() -> anyhow::Result<()> {
 
     // Parse CLI arguments and resolve theme
     // This also configures syntax highlighting colors before diff parsing
-    let mut cli_args = parse_cli_args();
+    let mut cli_args = profile::time("startup.parse_cli_args", parse_cli_args);
 
     // Check keyboard enhancement support before enabling raw mode.
     // Skip when --stdout is used because the probe writes escape sequences to stdout,
@@ -93,34 +96,36 @@ fn main() -> anyhow::Result<()> {
         cli_args.working_tree = true;
     }
     let mut startup_warnings = Vec::new();
-    let config_outcome = match config::load_config() {
+    let config_outcome = profile::time("startup.load_config", || match config::load_config() {
         Ok(outcome) => outcome,
         Err(e) => {
             startup_warnings.push(format!("Failed to load config: {e}"));
             config::ConfigLoadOutcome::default()
         }
-    };
+    });
     startup_warnings.extend(config_outcome.warnings);
-    let (mut theme, theme_warnings) = resolve_theme_with_config(
-        cli_args.theme,
-        cli_args.appearance,
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.theme.as_deref()),
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.theme_dark.as_deref()),
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.theme_light.as_deref()),
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.appearance.as_deref()),
-    );
+    let (mut theme, theme_warnings) = profile::time("startup.resolve_theme", || {
+        resolve_theme_with_config(
+            cli_args.theme,
+            cli_args.appearance,
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.theme.as_deref()),
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.theme_dark.as_deref()),
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.theme_light.as_deref()),
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.appearance.as_deref()),
+        )
+    });
     startup_warnings.extend(theme_warnings);
 
     let transparent = config_outcome
@@ -145,18 +150,20 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Initialize app
-    let mut app = match App::new(
-        theme,
-        config_outcome
-            .config
-            .as_ref()
-            .and_then(|cfg| cfg.comment_types.clone()),
-        cli_args.output_to_stdout,
-        cli_args.revisions.as_deref(),
-        cli_args.working_tree,
-        cli_args.path_filter.as_deref(),
-        cli_args.file_path.as_deref(),
-    ) {
+    let mut app = match profile::time("startup.app_init", || {
+        App::new(
+            theme,
+            config_outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.comment_types.clone()),
+            cli_args.output_to_stdout,
+            cli_args.revisions.as_deref(),
+            cli_args.working_tree,
+            cli_args.path_filter.as_deref(),
+            cli_args.file_path.as_deref(),
+        )
+    }) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
             if let Some(message) = startup_warnings.first() {

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+use chrono::{DateTime, Utc};
 use tracing::field;
 use tracing_subscriber::fmt::format::FmtSpan;
 
@@ -90,8 +91,35 @@ fn profile_path() -> Option<PathBuf> {
     }
 
     if matches!(normalized.as_str(), "1" | "true" | "on" | "yes") {
-        return Some(std::env::temp_dir().join("tuicr-profile.log"));
+        return Some(std::env::temp_dir().join(default_profile_filename(Utc::now())));
     }
 
     Some(PathBuf::from(value.as_ref()))
+}
+
+fn default_profile_filename(started_at: DateTime<Utc>) -> String {
+    format!(
+        "tuicr-profile.{}.log",
+        started_at.format("%Y%m%dT%H%M%S%.3fZ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::default_profile_filename;
+
+    #[test]
+    fn default_profile_filename_includes_start_timestamp() {
+        let started_at = Utc
+            .with_ymd_and_hms(2026, 5, 12, 22, 24, 41)
+            .single()
+            .expect("valid timestamp");
+
+        assert_eq!(
+            default_profile_filename(started_at),
+            "tuicr-profile.20260512T222441.000Z.log"
+        );
+    }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use tracing::field;
+use tracing_subscriber::fmt::format::FmtSpan;
+
+static PROFILE_ENABLED: OnceLock<bool> = OnceLock::new();
+
+pub fn init_from_env() {
+    let Some(path) = profile_path() else {
+        let _ = PROFILE_ENABLED.set(false);
+        return;
+    };
+
+    let directory = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .to_path_buf();
+    let _ = std::fs::create_dir_all(&directory);
+
+    let Ok(file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    else {
+        let _ = PROFILE_ENABLED.set(false);
+        return;
+    };
+
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(file)
+        .with_ansi(false)
+        .with_target(false)
+        .with_level(false)
+        .with_span_events(FmtSpan::CLOSE)
+        .finish();
+
+    if tracing::subscriber::set_global_default(subscriber).is_ok() {
+        let _ = PROFILE_ENABLED.set(true);
+    } else {
+        let _ = PROFILE_ENABLED.set(false);
+    }
+}
+
+pub fn enabled() -> bool {
+    *PROFILE_ENABLED.get_or_init(|| profile_path().is_some())
+}
+
+pub fn time<T, F>(operation: &'static str, f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    if !enabled() {
+        return f();
+    }
+
+    let span = tracing::info_span!("tuicr_profile", operation);
+    let _enter = span.enter();
+    f()
+}
+
+pub fn time_with<T, F, M>(operation: &'static str, f: F, metadata: M) -> T
+where
+    F: FnOnce() -> T,
+    M: FnOnce(&T) -> String,
+{
+    if !enabled() {
+        return f();
+    }
+
+    let span = tracing::info_span!("tuicr_profile", operation, metadata = field::Empty);
+    let _enter = span.enter();
+    let result = f();
+    span.record("metadata", metadata(&result));
+    result
+}
+
+fn profile_path() -> Option<PathBuf> {
+    let value = std::env::var_os("TUICR_PROFILE")?;
+    let value = value.to_string_lossy();
+    let normalized = value.trim().to_ascii_lowercase();
+
+    if normalized.is_empty() || matches!(normalized.as_str(), "0" | "false" | "off" | "no") {
+        return None;
+    }
+
+    if let Some(path) = std::env::var_os("TUICR_PROFILE_FILE") {
+        return Some(PathBuf::from(path));
+    }
+
+    if matches!(normalized.as_str(), "1" | "true" | "on" | "yes") {
+        return Some(std::env::temp_dir().join("tuicr-profile.log"));
+    }
+
+    Some(PathBuf::from(value.as_ref()))
+}


### PR DESCRIPTION
Splits the profiling work out of #281 and switches it to tracing-backed spans instead of the previous custom profiler.

`TUICR_PROFILE=1` writes to the temp profile log, `TUICR_PROFILE=/path/to/log` writes to that path, and `TUICR_PROFILE_FILE` can override the default file path. The instrumentation covers startup, VCS detection, diff loading, revision resolution, recent commits, and commit-selection confirmation without writing to the TUI terminal.

Validation:
- `cargo fmt --all --check`
- `cargo test --no-default-features`
- `cargo test`
- `cargo clippy --no-default-features -- -D warnings`
- `cargo clippy -- -D warnings`
- `git diff --check`
- Smoke-tested `TUICR_PROFILE` file output with `target/debug/tuicr -w --stdout`
