### PR TITLE
Add sparse Git CLI backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,12 @@ src/
 ├── vcs/                 # VCS abstraction layer
 │   ├── mod.rs           # detect_vcs(): auto-detect VCS (jj first, then git, then hg)
 │   ├── traits.rs        # VcsBackend trait, VcsInfo, VcsType, CommitInfo
-│   ├── diff_parser.rs   # Unified diff text parser (shared by hg/jj)
+│   ├── diff_parser.rs   # Unified diff text parser (shared by hg/jj and Git CLI)
 │   │                    # DiffFormat enum: Hg (with timestamps), GitStyle (jj/git patches)
-│   ├── git/             # Git backend (uses native git2 library, not diff_parser)
-│   │   ├── mod.rs       # GitBackend: wraps git2 library
+│   ├── git/             # Git backend selector (libgit2 by default, CLI for sparse/opt-in)
+│   │   ├── mod.rs       # GitBackend wrapper, backend preference, repo mode detection
+│   │   ├── cli.rs       # Git CLI backend used for sparse checkouts and backend = "cli"
+│   │   ├── libgit2.rs   # libgit2-backed implementation used for normal Git repos by default
 │   │   ├── repository.rs # CommitInfo, get_recent_commits()
 │   │   ├── diff.rs      # get_working_tree_diff(), get_commit_range_diff()
 │   │   └── context.rs   # fetch_context_lines() for gap expansion
@@ -99,7 +101,7 @@ Repository-managed agent integrations:
 
 ### Data Flow
 
-1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), ignore unknown config keys with startup warnings, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), filters diff files via repo-root `.tuicrignore`, then enters commit selection mode by default. If staged/unstaged changes exist, the first selection rows are "Staged changes" and/or "Unstaged changes". With `-r/--revisions`, it opens the requested commit range directly. Config `show_file_list = false` hides the file list panel on startup (toggleable with `;e`). Config `diff_view = "side-by-side"` sets the default diff layout (toggleable with `:diff`). Config `wrap = true` enables line wrapping (toggleable with `:set wrap!`).
+1. **Startup**: Parse CLI args (invalid `--theme` exits non-zero), load config from `$XDG_CONFIG_HOME/tuicr/config.toml` (default `~/.config/tuicr/config.toml`, or `%APPDATA%\tuicr\config.toml` on Windows), ignore unknown config keys with startup warnings, resolve theme precedence (`--theme` > config > dark), then call `App::new()`. `App::new()` calls `detect_vcs()` (Jujutsu first, then Git, then Mercurial), using config `backend = "libgit2"` or `backend = "cli"` for Git. Normal Git repos default to libgit2; sparse checkout repos automatically use the Git CLI backend and show a startup warning when that overrides the default. It filters diff files via repo-root `.tuicrignore`, then enters commit selection mode by default. If staged/unstaged changes exist, the first selection rows are "Staged changes" and/or "Unstaged changes". With `-r/--revisions`, it opens the requested commit range directly. Config `show_file_list = false` hides the file list panel on startup (toggleable with `;e`). Config `diff_view = "side-by-side"` sets the default diff layout (toggleable with `:diff`). Config `wrap = true` enables line wrapping (toggleable with `:set wrap!`).
 2. **Render**: `ui::render()` draws the TUI based on `App` state
 3. **Input**: `crossterm` events → `map_key_to_action` → match on Action in main loop
 4. **Persistence**: `:w` calls `save_session()`, writes JSON to `~/.local/share/tuicr/reviews/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Repository-managed agent integrations:
 **VcsBackend** (`src/vcs/traits.rs`):
 - Trait abstracting VCS operations
 - Methods: `info()`, `get_working_tree_diff()`, `fetch_context_lines()`, `get_recent_commits()`, `get_commit_range_diff()`
+- Capability hooks: `supports_sparse_checkout()` advertises whether the selected backend can operate on Git sparse-checkout repos
 - Implementations: `GitBackend`, `HgBackend`, `JjBackend` (all always compiled)
 
 **InputMode** (`src/app.rs`):

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ theme_light = "gruvbox-light"
 
 show_file_list = false
 diff_view = "side-by-side"
+backend = "libgit2"
 wrap = true
 cursor_line = false
 transparent_background = false
@@ -146,6 +147,8 @@ comment_types = [
 `show_file_list` controls whether the file list panel is visible on startup (default: `true`). Toggle at runtime with `;e`.
 
 `diff_view` sets the default diff layout: `"unified"` (default) or `"side-by-side"`. Toggle at runtime with `:diff`.
+
+`backend` selects the Git implementation: `"libgit2"` (default for normal Git repos) or `"cli"`. Sparse checkout repositories are automatically routed to the Git CLI backend because libgit2 does not support sparse-index checkouts reliably.
 
 `wrap` enables line wrapping in the diff view (default: `false`). Toggle at runtime with `:set wrap!`.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,9 @@ use crate::syntax::SyntaxHighlighter;
 use crate::theme::Theme;
 use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
-use crate::vcs::{CommitInfo, FileBackend, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs};
+use crate::vcs::{
+    CommitInfo, FileBackend, GitBackendPreference, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
+};
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
 const COMMIT_PAGE_SIZE: usize = 10;
@@ -609,18 +611,23 @@ enum CommentLocation {
     },
 }
 
+pub struct AppStartupOptions<'a> {
+    pub revisions: Option<&'a str>,
+    pub working_tree: bool,
+    pub path_filter: Option<&'a str>,
+    pub file_path: Option<&'a str>,
+    pub git_backend_preference: GitBackendPreference,
+}
+
 impl App {
     pub fn new(
         theme: Theme,
         comment_type_configs: Option<Vec<CommentTypeConfig>>,
         output_to_stdout: bool,
-        revisions: Option<&str>,
-        working_tree: bool,
-        path_filter: Option<&str>,
-        file_path: Option<&str>,
+        options: AppStartupOptions<'_>,
     ) -> Result<Self> {
         // --file mode: open a single file for annotation without VCS
-        if let Some(file_path) = file_path {
+        if let Some(file_path) = options.file_path {
             let vcs = Box::new(FileBackend::new(file_path)?);
             let vcs_info = vcs.info().clone();
             let highlighter = theme.syntax_highlighter();
@@ -648,7 +655,9 @@ impl App {
             return Ok(app);
         }
 
-        let vcs = crate::profile::time("startup.detect_vcs", detect_vcs)?;
+        let vcs = crate::profile::time("startup.detect_vcs", || {
+            detect_vcs(options.git_backend_preference)
+        })?;
         let vcs_info = vcs.info().clone();
         let highlighter =
             crate::profile::time("startup.syntax_highlighter", || theme.syntax_highlighter());
@@ -658,7 +667,7 @@ impl App {
         //   2. -r only: commit range
         //   3. -w only: working tree directly (skip commit selector)
         //   4. neither: commit selection UI
-        if let Some(revisions) = revisions {
+        if let Some(revisions) = options.revisions {
             let commit_ids = crate::profile::time_with(
                 "startup.resolve_revisions",
                 || vcs.resolve_revisions(revisions),
@@ -668,14 +677,14 @@ impl App {
                 },
             )?;
 
-            if working_tree {
+            if options.working_tree {
                 // Combined: commit range + staged/unstaged changes
                 let diff_files = Self::get_working_tree_with_commits_diff_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
                     &commit_ids,
                     highlighter,
-                    path_filter,
+                    options.path_filter,
                 )?;
                 let session = Self::load_or_create_staged_unstaged_and_commits_session(
                     &vcs_info,
@@ -694,7 +703,7 @@ impl App {
                     vcs.as_ref(),
                     &vcs_info.root_path,
                     highlighter,
-                    path_filter,
+                    options.path_filter,
                 )?;
                 let mut all_commits = Vec::new();
                 if change_status.staged {
@@ -716,7 +725,7 @@ impl App {
                     DiffSource::StagedUnstagedAndCommits(commit_ids),
                     InputMode::Normal,
                     Vec::new(),
-                    path_filter,
+                    options.path_filter,
                 )?;
 
                 app.range_diff_files = Some(app.diff_files.clone());
@@ -747,7 +756,7 @@ impl App {
                 &vcs_info.root_path,
                 &commit_ids,
                 highlighter,
-                path_filter,
+                options.path_filter,
             )?;
             let session = Self::load_or_create_commit_range_session(&vcs_info, &commit_ids);
             // Get commit info for the inline commit selector
@@ -770,7 +779,7 @@ impl App {
                 DiffSource::CommitRange(commit_ids),
                 InputMode::Normal,
                 Vec::new(),
-                path_filter,
+                options.path_filter,
             )?;
 
             // Set up inline commit selector for multi-commit reviews
@@ -792,13 +801,13 @@ impl App {
             app.rebuild_annotations();
 
             Ok(app)
-        } else if working_tree {
+        } else if options.working_tree {
             // Skip commit selector, go straight to working tree diff
             let diff_files = Self::get_working_tree_diff_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
                 highlighter,
-                path_filter,
+                options.path_filter,
             )?;
             let session =
                 Self::load_or_create_session(&vcs_info, SessionDiffSource::StagedAndUnstaged);
@@ -814,7 +823,7 @@ impl App {
                 DiffSource::StagedAndUnstaged,
                 InputMode::Normal,
                 Vec::new(),
-                path_filter,
+                options.path_filter,
             )?;
 
             Ok(app)
@@ -823,7 +832,7 @@ impl App {
                 vcs.as_ref(),
                 &vcs_info.root_path,
                 highlighter,
-                path_filter,
+                options.path_filter,
             )?;
             let has_staged_changes = change_status.staged;
             let has_unstaged_changes = change_status.unstaged;
@@ -834,7 +843,7 @@ impl App {
                         vcs.as_ref(),
                         &vcs_info.root_path,
                         highlighter,
-                        path_filter,
+                        options.path_filter,
                     ) {
                         Ok(diff_files) => Some(diff_files),
                         Err(TuicrError::NoChanges) => None,
@@ -894,7 +903,7 @@ impl App {
                 diff_source,
                 InputMode::CommitSelect,
                 commit_list,
-                path_filter,
+                options.path_filter,
             )?;
 
             app.has_more_commit = commits.len() >= VISIBLE_COMMIT_COUNT;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1394,6 +1394,14 @@ impl App {
         Ok(diff_files)
     }
 
+    fn diff_exists(diff_files: Result<Vec<DiffFile>>) -> Result<bool> {
+        match diff_files {
+            Ok(_) => Ok(true),
+            Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => Ok(false),
+            Err(e) => Err(e),
+        }
+    }
+
     fn get_working_tree_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
@@ -1512,24 +1520,45 @@ impl App {
     ) -> Result<(VcsChangeStatus, bool)> {
         if path_filter.is_none() {
             match vcs.get_change_status() {
-                Ok(status) => return Ok((status, true)),
+                Ok(status) => {
+                    if !crate::tuicrignore::has_ignore_rules(repo_root) {
+                        return Ok((status, true));
+                    }
+
+                    let staged = status.staged
+                        && Self::diff_exists(Self::get_staged_diff_with_ignore(
+                            vcs,
+                            repo_root,
+                            highlighter,
+                            path_filter,
+                        ))?;
+                    let unstaged = status.unstaged
+                        && Self::diff_exists(Self::get_unstaged_diff_with_ignore(
+                            vcs,
+                            repo_root,
+                            highlighter,
+                            path_filter,
+                        ))?;
+
+                    return Ok((VcsChangeStatus { staged, unstaged }, true));
+                }
                 Err(TuicrError::UnsupportedOperation(_)) => {}
                 Err(e) => return Err(e),
             }
         }
 
-        let staged =
-            match Self::get_staged_diff_with_ignore(vcs, repo_root, highlighter, path_filter) {
-                Ok(_) => true,
-                Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => false,
-                Err(e) => return Err(e),
-            };
-        let unstaged =
-            match Self::get_unstaged_diff_with_ignore(vcs, repo_root, highlighter, path_filter) {
-                Ok(_) => true,
-                Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => false,
-                Err(e) => return Err(e),
-            };
+        let staged = Self::diff_exists(Self::get_staged_diff_with_ignore(
+            vcs,
+            repo_root,
+            highlighter,
+            path_filter,
+        ))?;
+        let unstaged = Self::diff_exists(Self::get_unstaged_diff_with_ignore(
+            vcs,
+            repo_root,
+            highlighter,
+            path_filter,
+        ))?;
 
         Ok((VcsChangeStatus { staged, unstaged }, false))
     }
@@ -5804,6 +5833,143 @@ mod find_source_line_tests {
 
         let result = find_source_line(&annotations, 0, 20);
         assert_eq!(result, FindSourceLineResult::Nearest(0));
+    }
+}
+
+#[cfg(test)]
+mod change_status_tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+    use crate::vcs::traits::VcsType;
+
+    struct StatusProbeMock {
+        info: VcsInfo,
+        status: VcsChangeStatus,
+        staged_files: Vec<DiffFile>,
+        unstaged_files: Vec<DiffFile>,
+    }
+
+    impl VcsBackend for StatusProbeMock {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+
+        fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+
+        fn get_staged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+            if self.staged_files.is_empty() {
+                Err(TuicrError::NoChanges)
+            } else {
+                Ok(self.staged_files.clone())
+            }
+        }
+
+        fn get_unstaged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+            if self.unstaged_files.is_empty() {
+                Err(TuicrError::NoChanges)
+            } else {
+                Ok(self.unstaged_files.clone())
+            }
+        }
+
+        fn get_change_status(&self) -> Result<VcsChangeStatus> {
+            Ok(self.status)
+        }
+
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _start_line: u32,
+            _end_line: u32,
+        ) -> Result<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn diff_file(path: &str) -> DiffFile {
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from(path)),
+            status: FileStatus::Modified,
+            hunks: Vec::new(),
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash: 0,
+        }
+    }
+
+    fn mock_vcs(root_path: PathBuf) -> StatusProbeMock {
+        StatusProbeMock {
+            info: VcsInfo {
+                root_path,
+                head_commit: "HEAD".to_string(),
+                branch_name: Some("main".to_string()),
+                vcs_type: VcsType::Git,
+            },
+            status: VcsChangeStatus {
+                staged: true,
+                unstaged: true,
+            },
+            staged_files: Vec::new(),
+            unstaged_files: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn status_probe_rechecks_positive_rows_when_ignore_rules_exist() {
+        let dir = tempdir().expect("failed to create temp dir");
+        fs::write(dir.path().join(".tuicrignore"), "ignored/\n")
+            .expect("failed to write .tuicrignore");
+        let mut vcs = mock_vcs(dir.path().to_path_buf());
+        vcs.staged_files = vec![diff_file("ignored/generated.rs")];
+        vcs.unstaged_files = vec![diff_file("src/lib.rs")];
+
+        let (status, used_probe) = App::get_change_status_with_ignore(
+            &vcs,
+            dir.path(),
+            &SyntaxHighlighter::default(),
+            None,
+        )
+        .expect("failed to get change status");
+
+        assert!(used_probe);
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+    }
+
+    #[test]
+    fn status_probe_does_not_load_diffs_without_ignore_rules() {
+        let dir = tempdir().expect("failed to create temp dir");
+        let vcs = mock_vcs(dir.path().to_path_buf());
+
+        let (status, used_probe) = App::get_change_status_with_ignore(
+            &vcs,
+            dir.path(),
+            &SyntaxHighlighter::default(),
+            None,
+        )
+        .expect("failed to get change status");
+
+        assert!(used_probe);
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: true,
+                unstaged: true,
+            }
+        );
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use crate::syntax::SyntaxHighlighter;
 use crate::theme::Theme;
 use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
-use crate::vcs::{CommitInfo, FileBackend, VcsBackend, VcsInfo, detect_vcs};
+use crate::vcs::{CommitInfo, FileBackend, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs};
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
 const COMMIT_PAGE_SIZE: usize = 10;
@@ -690,25 +690,17 @@ impl App {
                 .rev()
                 .collect();
                 // Prepend staged/unstaged entries only when the backend supports them
-                let has_staged = Self::get_staged_diff_with_ignore(
+                let (change_status, _) = Self::get_change_status_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
                     highlighter,
                     path_filter,
-                )
-                .is_ok();
-                let has_unstaged = Self::get_unstaged_diff_with_ignore(
-                    vcs.as_ref(),
-                    &vcs_info.root_path,
-                    highlighter,
-                    path_filter,
-                )
-                .is_ok();
+                )?;
                 let mut all_commits = Vec::new();
-                if has_staged {
+                if change_status.staged {
                     all_commits.push(Self::staged_commit_entry());
                 }
-                if has_unstaged {
+                if change_status.unstaged {
                     all_commits.push(Self::unstaged_commit_entry());
                 }
                 all_commits.extend(review_commits);
@@ -827,44 +819,30 @@ impl App {
 
             Ok(app)
         } else {
-            let has_staged_changes = match Self::get_staged_diff_with_ignore(
+            let (change_status, used_backend_status_probe) = Self::get_change_status_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
                 highlighter,
                 path_filter,
-            ) {
-                Ok(_) => true,
-                Err(TuicrError::NoChanges) => false,
-                Err(TuicrError::UnsupportedOperation(_)) => false,
-                Err(e) => return Err(e),
-            };
+            )?;
+            let has_staged_changes = change_status.staged;
+            let has_unstaged_changes = change_status.unstaged;
 
-            let has_unstaged_changes = match Self::get_unstaged_diff_with_ignore(
-                vcs.as_ref(),
-                &vcs_info.root_path,
-                highlighter,
-                path_filter,
-            ) {
-                Ok(_) => true,
-                Err(TuicrError::NoChanges) => false,
-                Err(TuicrError::UnsupportedOperation(_)) => false,
-                Err(e) => return Err(e),
-            };
-
-            let working_tree_diff = if has_staged_changes || has_unstaged_changes {
-                match Self::get_working_tree_diff_with_ignore(
-                    vcs.as_ref(),
-                    &vcs_info.root_path,
-                    highlighter,
-                    path_filter,
-                ) {
-                    Ok(diff_files) => Some(diff_files),
-                    Err(TuicrError::NoChanges) => None,
-                    Err(e) => return Err(e),
-                }
-            } else {
-                None
-            };
+            let working_tree_diff =
+                if (has_staged_changes || has_unstaged_changes) && !used_backend_status_probe {
+                    match Self::get_working_tree_diff_with_ignore(
+                        vcs.as_ref(),
+                        &vcs_info.root_path,
+                        highlighter,
+                        path_filter,
+                    ) {
+                        Ok(diff_files) => Some(diff_files),
+                        Err(TuicrError::NoChanges) => None,
+                        Err(e) => return Err(e),
+                    }
+                } else {
+                    None
+                };
 
             let commits = crate::profile::time_with(
                 "startup.recent_commits",
@@ -1524,6 +1502,36 @@ impl App {
             diff_files
         };
         Self::require_non_empty_diff_files(diff_files)
+    }
+
+    fn get_change_status_with_ignore(
+        vcs: &dyn VcsBackend,
+        repo_root: &Path,
+        highlighter: &SyntaxHighlighter,
+        path_filter: Option<&str>,
+    ) -> Result<(VcsChangeStatus, bool)> {
+        if path_filter.is_none() {
+            match vcs.get_change_status() {
+                Ok(status) => return Ok((status, true)),
+                Err(TuicrError::UnsupportedOperation(_)) => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        let staged =
+            match Self::get_staged_diff_with_ignore(vcs, repo_root, highlighter, path_filter) {
+                Ok(_) => true,
+                Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => false,
+                Err(e) => return Err(e),
+            };
+        let unstaged =
+            match Self::get_unstaged_diff_with_ignore(vcs, repo_root, highlighter, path_filter) {
+                Ok(_) => true,
+                Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => false,
+                Err(e) => return Err(e),
+            };
+
+        Ok((VcsChangeStatus { staged, unstaged }, false))
     }
 
     fn load_staged_and_unstaged_selection(&mut self) -> Result<()> {
@@ -3563,29 +3571,14 @@ impl App {
         }
 
         let highlighter = self.theme.syntax_highlighter();
-        let has_staged_changes = match Self::get_staged_diff_with_ignore(
+        let (change_status, _) = Self::get_change_status_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
             highlighter,
             self.path_filter.as_deref(),
-        ) {
-            Ok(_) => true,
-            Err(TuicrError::NoChanges) => false,
-            Err(TuicrError::UnsupportedOperation(_)) => false,
-            Err(e) => return Err(e),
-        };
-
-        let has_unstaged_changes = match Self::get_unstaged_diff_with_ignore(
-            self.vcs.as_ref(),
-            &self.vcs_info.root_path,
-            highlighter,
-            self.path_filter.as_deref(),
-        ) {
-            Ok(_) => true,
-            Err(TuicrError::NoChanges) => false,
-            Err(TuicrError::UnsupportedOperation(_)) => false,
-            Err(e) => return Err(e),
-        };
+        )?;
+        let has_staged_changes = change_status.staged;
+        let has_unstaged_changes = change_status.unstaged;
 
         let commits = self.vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT)?;
         if commits.is_empty() && !has_staged_changes && !has_unstaged_changes {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -22,6 +22,7 @@ pub struct AppConfig {
     pub theme_dark: Option<String>,
     pub theme_light: Option<String>,
     pub appearance: Option<String>,
+    pub backend: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
     pub diff_view: Option<String>,
@@ -39,6 +40,7 @@ const KNOWN_KEYS: &[&str] = &[
     "theme_dark",
     "theme_light",
     "appearance",
+    "backend",
     "comment_types",
     "show_file_list",
     "diff_view",
@@ -196,6 +198,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         theme_dark: read_string(table, "theme_dark", &mut warnings),
         theme_light: read_string(table, "theme_light", &mut warnings),
         appearance: read_string(table, "appearance", &mut warnings),
+        backend: read_enum(table, "backend", &["libgit2", "cli"], &mut warnings),
         comment_types: table
             .get("comment_types")
             .and_then(|v| parse_comment_types(v, &mut warnings)),
@@ -442,6 +445,48 @@ mod tests {
         assert_eq!(cfg.theme_light.as_deref(), Some("gruvbox-light"));
         assert_eq!(cfg.appearance.as_deref(), Some("system"));
         assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_backend_option() {
+        let cli = parse_config("backend = \"cli\"\n");
+        assert_eq!(
+            cli.config.as_ref().and_then(|cfg| cfg.backend.as_deref()),
+            Some("cli")
+        );
+        assert!(cli.warnings.is_empty());
+
+        let libgit2 = parse_config("backend = \"libgit2\"\n");
+        assert_eq!(
+            libgit2
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.backend.as_deref()),
+            Some("libgit2")
+        );
+        assert!(libgit2.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_invalid_backend_option() {
+        let outcome = parse_config("backend = \"gitoxide\"\n");
+        assert_eq!(outcome.config, Some(AppConfig::default()));
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'backend' must be \"libgit2\" or \"cli\"; got \"gitoxide\", ignoring"
+        );
+    }
+
+    #[test]
+    fn should_warn_and_ignore_backend_with_invalid_type() {
+        let outcome = parse_config("backend = true\n");
+        assert_eq!(outcome.config, Some(AppConfig::default()));
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'backend' must be a string; ignoring value"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ use crossterm::{
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use app::{App, FocusedPanel, InputMode};
+use app::{App, AppStartupOptions, FocusedPanel, InputMode};
 use handler::{
     handle_command_action, handle_comment_action, handle_commit_select_action,
     handle_commit_selector_action, handle_confirm_action, handle_diff_action,
@@ -43,6 +43,7 @@ use handler::{
 };
 use input::{Action, map_key_to_action};
 use theme::{parse_cli_args, resolve_theme_with_config};
+use vcs::GitBackendPreference;
 
 /// Timeout for the "press Ctrl+C again to exit" feature
 const CTRL_C_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
@@ -150,6 +151,13 @@ fn main() -> anyhow::Result<()> {
     };
 
     // Initialize app
+    let git_backend_preference = GitBackendPreference::from_config(
+        config_outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.backend.as_deref()),
+    );
+
     let mut app = match profile::time("startup.app_init", || {
         App::new(
             theme,
@@ -158,18 +166,18 @@ fn main() -> anyhow::Result<()> {
                 .as_ref()
                 .and_then(|cfg| cfg.comment_types.clone()),
             cli_args.output_to_stdout,
-            cli_args.revisions.as_deref(),
-            cli_args.working_tree,
-            cli_args.path_filter.as_deref(),
-            cli_args.file_path.as_deref(),
+            AppStartupOptions {
+                revisions: cli_args.revisions.as_deref(),
+                working_tree: cli_args.working_tree,
+                path_filter: cli_args.path_filter.as_deref(),
+                file_path: cli_args.file_path.as_deref(),
+                git_backend_preference,
+            },
         )
     }) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
             startup_warnings.extend(app.vcs.startup_warnings());
-            if let Some(message) = startup_warnings.first() {
-                app.set_warning(message.clone());
-            }
             app
         }
         Err(e) => {
@@ -239,6 +247,10 @@ fn main() -> anyhow::Result<()> {
     {
         app.show_file_list = false;
         app.focused_panel = FocusedPanel::Diff;
+    }
+
+    if let Some(message) = startup_warnings.first() {
+        app.set_warning(message.clone());
     }
 
     // Track pending z command for zz centering

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,7 @@ fn main() -> anyhow::Result<()> {
     }) {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
+            startup_warnings.extend(app.vcs.startup_warnings());
             if let Some(message) = startup_warnings.first() {
                 app.set_warning(message.clone());
             }

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -20,11 +20,16 @@ pub fn filter_diff_files(repo_root: &Path, diff_files: Vec<DiffFile>) -> Vec<Dif
         .collect()
 }
 
+/// Return true when repo-level ignore rules can affect tuicr's diff file list.
+pub fn has_ignore_rules(repo_root: &Path) -> bool {
+    repo_root.join(".gitignore").is_file() || repo_root.join(".tuicrignore").is_file()
+}
+
 fn load_matcher(repo_root: &Path) -> Option<ignore::gitignore::Gitignore> {
     let gitignore_file = repo_root.join(".gitignore");
     let tuicrignore_file = repo_root.join(".tuicrignore");
 
-    if !gitignore_file.is_file() && !tuicrignore_file.is_file() {
+    if !has_ignore_rules(repo_root) {
         return None;
     }
 
@@ -75,6 +80,15 @@ mod tests {
         let filtered = filter_diff_files(dir.path(), files);
 
         assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn detects_ignore_rule_files() {
+        let dir = tempdir().expect("failed to create temp dir");
+        assert!(!has_ignore_rules(dir.path()));
+
+        fs::write(dir.path().join(".gitignore"), "target/\n").expect("failed to write .gitignore");
+        assert!(has_ignore_rules(dir.path()));
     }
 
     #[test]

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -229,7 +229,11 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
     } else {
         String::new()
     };
-    let hints = format!(" j/k:navigate  Space:select range  Enter:confirm  q:quit{selection_info}");
+    let hints = if app.message.is_some() {
+        String::new()
+    } else {
+        format!(" j/k:navigate  Space:select range  Enter:confirm  q:quit{selection_info}")
+    };
     let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 
     let left_spans = vec![mode_span, hints_span];

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -208,19 +208,23 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
         let mode_span = Span::styled(mode_str, styles::mode_style(theme));
 
-        let hints = match app.input_mode {
-            InputMode::Normal => {
-                " j/k:scroll  {/}:file  r:reviewed  c:comment  ;c:review  V:visual  /:search  ?:help  :q:quit "
+        let hints = if app.message.is_some() {
+            ""
+        } else {
+            match app.input_mode {
+                InputMode::Normal => {
+                    " j/k:scroll  {/}:file  r:reviewed  c:comment  ;c:review  V:visual  /:search  ?:help  :q:quit "
+                }
+                InputMode::Command => " Enter:execute  Esc:cancel ",
+                InputMode::Search => " Enter:search  Esc:cancel ",
+                InputMode::Comment => " Ctrl-S:save  Esc:cancel ",
+                InputMode::Help => " q/?/Esc:close ",
+                InputMode::Confirm => " y:yes  n:no ",
+                InputMode::CommitSelect => {
+                    " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit "
+                }
+                InputMode::VisualSelect => " j/k:extend  c/Enter:comment  y:yank  Esc/V:cancel ",
             }
-            InputMode::Command => " Enter:execute  Esc:cancel ",
-            InputMode::Search => " Enter:search  Esc:cancel ",
-            InputMode::Comment => " Ctrl-S:save  Esc:cancel ",
-            InputMode::Help => " q/?/Esc:close ",
-            InputMode::Confirm => " y:yes  n:no ",
-            InputMode::CommitSelect => {
-                " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit "
-            }
-            InputMode::VisualSelect => " j/k:extend  c/Enter:comment  y:yank  Esc/V:cancel ",
         };
         let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -1,8 +1,10 @@
-//! Unified diff parser for text-based VCS backends (hg, jj).
+//! Unified diff parser for text-based VCS backends (hg, jj, sparse Git).
 //!
 //! Parses unified diff format output from CLI tools into DiffFile structures.
-//! Git uses the native git2 library instead and has its own parser.
+//! Standard Git uses the native git2 library; sparse Git feeds CLI diff output
+//! through this parser to avoid sparse-index limitations in libgit2.
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
@@ -24,24 +26,45 @@ pub fn parse_unified_diff(
     format: DiffFormat,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
+    parse_unified_diff_lines(
+        diff_text.lines().map(|line| Ok(Cow::Borrowed(line))),
+        format,
+        highlighter,
+    )
+}
+
+/// Parse unified diff lines into DiffFile structures.
+///
+/// This entry point is used by Git's sparse-checkout backend so large diffs can
+/// be parsed directly from command stdout instead of buffering the whole patch.
+pub fn parse_unified_diff_lines<'a, I>(
+    diff_lines: I,
+    format: DiffFormat,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>>
+where
+    I: Iterator<Item = Result<Cow<'a, str>>>,
+{
     let mut files: Vec<DiffFile> = Vec::new();
-    let mut lines = diff_text.lines().peekable();
+    let mut lines = diff_lines.peekable();
 
     let header_prefix = match format {
         DiffFormat::Hg => "diff ",
         DiffFormat::GitStyle => "diff --git ",
     };
 
-    while let Some(line) = lines.next() {
+    // `diff_lines` may stream from a child process, so each read can fail. Use
+    // `next_line` instead of `lines.next()` to propagate I/O errors.
+    while let Some(line) = next_line(&mut lines)? {
         if line.starts_with(header_prefix) {
-            let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format);
+            let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format)?;
 
             // For git-style diffs (jj, git patches), if parse_file_header didn't find
             // ---/+++ or rename/copy lines (e.g. empty new files, mode-only changes),
             // fall back to parsing paths from the "diff --git a/X b/X" header.
             if old_path.is_none()
                 && new_path.is_none()
-                && let Some((a, b)) = parse_diff_git_header(line)
+                && let Some((a, b)) = parse_diff_git_header(&line)
             {
                 match status {
                     FileStatus::Deleted => old_path = Some(a),
@@ -53,9 +76,11 @@ pub fn parse_unified_diff(
                 }
             }
 
-            // Check if binary - hg uses "Binary file", jj/git use just "Binary"
-            if lines.peek().is_some_and(|l| l.contains("Binary")) {
-                lines.next(); // consume binary message
+            // Check if binary. `git diff --binary` can emit lowercase
+            // "GIT binary patch", so keep this check explicit instead of a
+            // case-sensitive substring search.
+            if peek_line(&mut lines)?.is_some_and(is_binary_patch_line) {
+                next_line(&mut lines)?; // consume binary message
                 files.push(DiffFile {
                     old_path,
                     new_path,
@@ -73,17 +98,15 @@ pub fn parse_unified_diff(
             let mut hunks = Vec::new();
 
             // Parse hunks until next file or end
-            while lines.peek().is_some() {
-                if let Some(peek_line) = lines.peek() {
-                    if peek_line.starts_with("diff ") {
-                        break;
-                    } else if peek_line.starts_with("@@") {
-                        if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter) {
-                            hunks.push(hunk);
-                        }
-                    } else {
-                        lines.next(); // skip non-hunk, non-diff lines
+            while let Some(line) = peek_line(&mut lines)? {
+                if line.starts_with("diff ") {
+                    break;
+                } else if line.starts_with("@@") {
+                    if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter)? {
+                        hunks.push(hunk);
                     }
+                } else {
+                    next_line(&mut lines)?; // skip non-hunk, non-diff lines
                 }
             }
 
@@ -108,19 +131,50 @@ pub fn parse_unified_diff(
     Ok(files)
 }
 
+fn next_line<'a, I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<Cow<'a, str>>>
+where
+    I: Iterator<Item = Result<Cow<'a, str>>>,
+{
+    lines.next().transpose()
+}
+
+fn peek_line<'lines, 'a, I>(
+    lines: &'lines mut std::iter::Peekable<I>,
+) -> Result<Option<&'lines str>>
+where
+    I: Iterator<Item = Result<Cow<'a, str>>>,
+    'a: 'lines,
+{
+    if matches!(lines.peek(), Some(Err(_)))
+        && let Some(Err(err)) = lines.next()
+    {
+        return Err(err);
+    }
+
+    Ok(lines.peek().map(|line| {
+        line.as_ref()
+            .expect("peeked line errors are consumed before borrowing")
+            .as_ref()
+    }))
+}
+
+fn is_binary_patch_line(line: &str) -> bool {
+    line.contains("Binary") || line.starts_with("GIT binary patch")
+}
+
 fn parse_file_header<'a, I>(
     lines: &mut std::iter::Peekable<I>,
     format: DiffFormat,
-) -> (Option<PathBuf>, Option<PathBuf>, FileStatus)
+) -> Result<(Option<PathBuf>, Option<PathBuf>, FileStatus)>
 where
-    I: Iterator<Item = &'a str>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
 {
     let mut old_path: Option<PathBuf> = None;
     let mut new_path: Option<PathBuf> = None;
     let mut status = FileStatus::Modified;
 
     // Parse --- and +++ lines and metadata
-    while let Some(line) = lines.peek() {
+    while let Some(line) = peek_line(lines)?.map(str::to_string) {
         if line.starts_with("---") {
             let path_str = line.trim_start_matches("--- ").trim_start_matches("a/");
             if path_str != "/dev/null" {
@@ -132,7 +186,7 @@ where
                 };
                 old_path = Some(PathBuf::from(path));
             }
-            lines.next();
+            next_line(lines)?;
         } else if line.starts_with("+++") {
             let path_str = line.trim_start_matches("+++ ").trim_start_matches("b/");
             if path_str != "/dev/null" {
@@ -143,34 +197,34 @@ where
                 };
                 new_path = Some(PathBuf::from(path));
             }
-            lines.next();
+            next_line(lines)?;
             break; // Done with file header
         } else if line.starts_with("new file") {
             status = FileStatus::Added;
-            lines.next();
+            next_line(lines)?;
         } else if line.starts_with("deleted file") {
             status = FileStatus::Deleted;
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("rename from ") {
             status = FileStatus::Renamed;
             old_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("rename to ") {
             new_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("copy from ") {
             status = FileStatus::Copied;
             old_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if let Some(path) = line.strip_prefix("copy to ") {
             new_path = Some(PathBuf::from(path));
-            lines.next();
+            next_line(lines)?;
         } else if line.starts_with("@@") || line.starts_with("diff ") {
             break;
-        } else if line.starts_with("Binary file") {
+        } else if line.starts_with("Binary file") || line.starts_with("GIT binary patch") {
             // Hg format: "Binary file <path> has changed"
             // Git format: "Binary files a/<old> and b/<new> differ"
-            if let Some((old, new)) = parse_binary_file_line(line) {
+            if let Some((old, new)) = parse_binary_file_line(&line) {
                 if old_path.is_none() {
                     old_path = old;
                 }
@@ -180,7 +234,7 @@ where
             }
             break;
         } else {
-            lines.next(); // Skip other metadata lines (rename to, copy to, index, etc.)
+            next_line(lines)?; // Skip other metadata lines (rename to, copy to, index, etc.)
         }
     }
 
@@ -193,21 +247,25 @@ where
         }
     }
 
-    (old_path, new_path, status)
+    Ok((old_path, new_path, status))
 }
 
 fn parse_hunk<'a, I>(
     lines: &mut std::iter::Peekable<I>,
     file_path: Option<&PathBuf>,
     highlighter: &SyntaxHighlighter,
-) -> Option<DiffHunk>
+) -> Result<Option<DiffHunk>>
 where
-    I: Iterator<Item = &'a str>,
+    I: Iterator<Item = Result<Cow<'a, str>>>,
 {
-    let header_line = lines.next()?;
+    let Some(header_line) = next_line(lines)? else {
+        return Ok(None);
+    };
 
     // Parse @@ -old_start,old_count +new_start,new_count @@
-    let (old_start, old_count, new_start, new_count) = parse_hunk_header(header_line)?;
+    let Some((old_start, old_count, new_start, new_count)) = parse_hunk_header(&header_line) else {
+        return Ok(None);
+    };
 
     let mut line_contents: Vec<String> = Vec::new();
     let mut line_origins: Vec<LineOrigin> = Vec::new();
@@ -217,12 +275,12 @@ where
     let mut new_lineno = new_start;
 
     // Collect lines until next hunk or file
-    while let Some(line) = lines.peek() {
+    while let Some(line) = peek_line(lines)?.map(str::to_string) {
         if line.starts_with("@@") || line.starts_with("diff ") {
             break;
         }
 
-        let line = lines.next().unwrap();
+        next_line(lines)?;
 
         if line.starts_with('\\') {
             // "\ No newline at end of file" - skip
@@ -304,14 +362,14 @@ where
         });
     }
 
-    Some(DiffHunk {
+    Ok(Some(DiffHunk {
         header: header_line.to_string(),
         lines: diff_lines,
         old_start,
         old_count,
         new_start,
         new_count,
-    })
+    }))
 }
 
 fn parse_hunk_header(line: &str) -> Option<(u32, u32, u32, u32)> {
@@ -1052,5 +1110,49 @@ new mode 100755
         assert_eq!(files[0].new_path, Some(PathBuf::from("script.sh")));
         assert!(files[0].hunks.is_empty());
         let _path = files[0].display_path();
+    }
+
+    #[test]
+    fn git_should_parse_binary_patch_as_binary_file() {
+        let diff = r#"diff --git a/image.bin b/image.bin
+index 1234567..89abcde 100644
+GIT binary patch
+literal 4
+LcmeZB000M*0RR91
+
+literal 4
+LcmeZB000M*0RR91
+"#;
+
+        let files =
+            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].old_path, Some(PathBuf::from("image.bin")));
+        assert_eq!(files[0].new_path, Some(PathBuf::from("image.bin")));
+        assert!(files[0].is_binary);
+        assert!(files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn should_parse_unified_diff_from_streamed_lines() {
+        let lines = [
+            "diff --git a/file.txt b/file.txt",
+            "--- a/file.txt",
+            "+++ b/file.txt",
+            "@@ -1 +1 @@",
+            "-old",
+            "+new",
+        ]
+        .into_iter()
+        .map(|line| Ok(Cow::Owned(line.to_string())));
+
+        let files =
+            parse_unified_diff_lines(lines, DiffFormat::GitStyle, &SyntaxHighlighter::default())
+                .unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].new_path, Some(PathBuf::from("file.txt")));
+        assert_eq!(files[0].hunks[0].lines.len(), 2);
     }
 }

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -133,7 +133,7 @@ impl VcsBackend for GitCliBackend {
     }
 
     fn startup_warnings(&self) -> Vec<String> {
-        if !self.repo_mode.is_sparse_checkout() {
+        if !self.repo_mode().is_sparse_checkout() {
             return Vec::new();
         }
 
@@ -151,6 +151,10 @@ impl VcsBackend for GitCliBackend {
         }
 
         warnings
+    }
+
+    fn supports_sparse_checkout(&self) -> bool {
+        true
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -97,6 +97,7 @@ impl GitCliBackend {
         if include_untracked {
             append_untracked_cli_diffs(&self.root_path, &mut files, highlighter)?;
         }
+        normalize_git_cli_paths(&mut files);
 
         if files.is_empty() {
             return Err(TuicrError::NoChanges);
@@ -193,7 +194,13 @@ impl VcsBackend for GitCliBackend {
         // have not already proven the "unstaged" row should be shown.
         let staged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--cached", "--"])?;
         let tracked_unstaged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--"])?;
-        let unstaged = tracked_unstaged || has_untracked_changes(&self.root_path)?;
+        let untracked_pathspecs = if tracked_unstaged {
+            Vec::new()
+        } else {
+            sparse_checkout_untracked_pathspecs(&self.root_path)?
+        };
+        let unstaged =
+            tracked_unstaged || has_untracked_changes(&self.root_path, &untracked_pathspecs)?;
 
         Ok(VcsChangeStatus { staged, unstaged })
     }
@@ -254,7 +261,10 @@ impl VcsBackend for GitCliBackend {
 
     fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
         let commit_ids = if revisions.contains("..") {
-            let output = run_git_command(&self.root_path, &["rev-list", "--reverse", revisions])?;
+            let output = run_git_command(
+                &self.root_path,
+                &["rev-list", "--topo-order", "--reverse", revisions],
+            )?;
             output
                 .lines()
                 .filter(|line| !line.is_empty())
@@ -422,16 +432,22 @@ fn has_diff_changes(workdir: &Path, args: &[&str]) -> Result<bool> {
     }
 }
 
-fn has_untracked_changes(workdir: &Path) -> Result<bool> {
+fn has_untracked_changes(workdir: &Path, pathspecs: &[String]) -> Result<bool> {
+    let mut args = vec![
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        "--directory",
+    ];
+    if !pathspecs.is_empty() {
+        args.push("--");
+        args.extend(pathspecs.iter().map(String::as_str));
+    }
+
     let mut child = Command::new("git")
         .current_dir(workdir)
-        .args([
-            "ls-files",
-            "--others",
-            "--exclude-standard",
-            "-z",
-            "--directory",
-        ])
+        .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
@@ -651,6 +667,20 @@ fn diff_file_without_hunks(path: &Path, is_binary: bool, is_too_large: bool) -> 
     }
 }
 
+fn normalize_git_cli_paths(files: &mut [DiffFile]) {
+    for file in files {
+        match file.status {
+            FileStatus::Added if file.old_path.is_none() => {
+                file.old_path = file.new_path.clone();
+            }
+            FileStatus::Deleted if file.new_path.is_none() => {
+                file.new_path = file.old_path.clone();
+            }
+            _ => {}
+        }
+    }
+}
+
 fn for_each_untracked_path<F>(workdir: &Path, pathspecs: &[String], mut visit: F) -> Result<()>
 where
     F: FnMut(PathBuf) -> Result<()>,
@@ -665,6 +695,7 @@ where
         .current_dir(workdir)
         .args(args)
         .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
 
@@ -697,11 +728,13 @@ where
         visit(PathBuf::from(String::from_utf8_lossy(&path).into_owned()))?;
     }
 
-    let status = child.wait()?;
-    if !status.success() {
-        return Err(TuicrError::VcsCommand(format!(
-            "git ls-files failed with status {status}"
-        )));
+    let output = child
+        .wait_with_output()
+        .map_err(|e| TuicrError::VcsCommand(format!("git ls-files failed: {e}")))?;
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
     }
 
     Ok(())
@@ -969,6 +1002,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::git::{diff, repository};
 
     fn git(workdir: &Path, args: &[&str]) {
         let output = Command::new("git")
@@ -989,6 +1023,26 @@ mod tests {
         fs::create_dir_all(full_path.parent().expect("test path should have parent"))
             .expect("failed to create parent");
         fs::write(full_path, content).expect("failed to write file");
+    }
+
+    fn remove_file(workdir: &Path, path: &str) {
+        fs::remove_file(workdir.join(path)).expect("failed to remove file");
+    }
+
+    fn summarize_files(
+        files: Vec<DiffFile>,
+    ) -> Vec<(Option<PathBuf>, Option<PathBuf>, FileStatus)> {
+        let mut summary: Vec<_> = files
+            .into_iter()
+            .map(|file| (file.old_path, file.new_path, file.status))
+            .collect();
+        summary.sort_by(|left, right| {
+            left.0
+                .cmp(&right.0)
+                .then_with(|| left.1.cmp(&right.1))
+                .then_with(|| left.2.as_char().cmp(&right.2.as_char()))
+        });
+        summary
     }
 
     fn setup_sparse_index_repo() -> (tempfile::TempDir, GitCliBackend, Vec<String>) {
@@ -1022,6 +1076,49 @@ mod tests {
 
         let backend = GitCliBackend::discover_from(workdir).expect("failed to discover backend");
         (temp_dir, backend, vec![first_id, second_id])
+    }
+
+    fn setup_standard_parity_repo() -> (
+        tempfile::TempDir,
+        GitCliBackend,
+        git2::Repository,
+        Vec<String>,
+    ) {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+
+        git(workdir, &["init"]);
+        git(workdir, &["config", "user.email", "test@example.com"]);
+        git(workdir, &["config", "user.name", "Test User"]);
+        write_file(workdir, "modified.txt", "modified base\n");
+        write_file(workdir, "deleted.txt", "deleted base\n");
+        write_file(workdir, "staged.txt", "staged base\n");
+        write_file(workdir, "range.txt", "range base\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "initial"]);
+        let first_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve first commit")
+            .trim()
+            .to_string();
+
+        write_file(workdir, "range.txt", "range changed\n");
+        git(workdir, &["add", "range.txt"]);
+        git(workdir, &["commit", "-m", "second"]);
+        let second_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve second commit")
+            .trim()
+            .to_string();
+
+        write_file(workdir, "modified.txt", "modified changed\n");
+        remove_file(workdir, "deleted.txt");
+        write_file(workdir, "staged.txt", "staged changed\n");
+        git(workdir, &["add", "staged.txt"]);
+        write_file(workdir, "untracked.txt", "untracked\n");
+
+        let cli_backend =
+            GitCliBackend::discover_from(workdir).expect("failed to discover cli backend");
+        let repo = git2::Repository::open(workdir).expect("failed to open git2 repo");
+        (temp_dir, cli_backend, repo, vec![first_id, second_id])
     }
 
     #[test]
@@ -1156,6 +1253,108 @@ mod tests {
                 staged: false,
                 unstaged: true,
             }
+        );
+    }
+
+    #[test]
+    fn ignores_untracked_files_outside_sparse_cone_in_change_status() {
+        let (temp_dir, backend, _ids) = setup_sparse_index_repo();
+        write_file(temp_dir.path(), "hidden/outside.txt", "outside cone\n");
+
+        let status = backend
+            .get_change_status()
+            .expect("failed to get change status");
+
+        assert_eq!(status, VcsChangeStatus::default());
+    }
+
+    #[test]
+    fn detects_untracked_files_inside_sparse_cone_in_change_status() {
+        let (temp_dir, backend, _ids) = setup_sparse_index_repo();
+        write_file(temp_dir.path(), "keep/new.txt", "inside cone\n");
+
+        let status = backend
+            .get_change_status()
+            .expect("failed to get change status");
+
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+    }
+
+    #[test]
+    fn cli_diff_outputs_match_libgit2_for_shared_git_operations() {
+        let (_temp_dir, cli_backend, repo, ids) = setup_standard_parity_repo();
+        let highlighter = SyntaxHighlighter::default();
+
+        assert_eq!(
+            summarize_files(cli_backend.get_working_tree_diff(&highlighter).unwrap()),
+            summarize_files(diff::get_working_tree_diff(&repo, &highlighter).unwrap())
+        );
+        assert_eq!(
+            summarize_files(cli_backend.get_staged_diff(&highlighter).unwrap()),
+            summarize_files(diff::get_staged_diff(&repo, &highlighter).unwrap())
+        );
+        assert_eq!(
+            summarize_files(cli_backend.get_unstaged_diff(&highlighter).unwrap()),
+            summarize_files(diff::get_unstaged_diff(&repo, &highlighter).unwrap())
+        );
+        assert_eq!(
+            summarize_files(
+                cli_backend
+                    .get_commit_range_diff(&[ids[1].clone()], &highlighter)
+                    .unwrap()
+            ),
+            summarize_files(
+                diff::get_commit_range_diff(&repo, &[ids[1].clone()], &highlighter).unwrap()
+            )
+        );
+        assert_eq!(
+            summarize_files(
+                cli_backend
+                    .get_working_tree_with_commits_diff(&[ids[1].clone()], &highlighter)
+                    .unwrap()
+            ),
+            summarize_files(
+                diff::get_working_tree_with_commits_diff(&repo, &[ids[1].clone()], &highlighter)
+                    .unwrap()
+            )
+        );
+
+        let cli_commits = cli_backend.get_recent_commits(0, 10).unwrap();
+        let libgit2_commits = repository::get_recent_commits(&repo, 0, 10).unwrap();
+        assert_eq!(
+            cli_commits
+                .iter()
+                .map(|commit| (&commit.id, &commit.summary, &commit.body))
+                .collect::<Vec<_>>(),
+            libgit2_commits
+                .iter()
+                .map(|commit| (&commit.id, &commit.summary, &commit.body))
+                .collect::<Vec<_>>()
+        );
+
+        let revset = format!("{}..{}", ids[0], ids[1]);
+        assert_eq!(
+            cli_backend.resolve_revisions(&revset).unwrap(),
+            repository::resolve_revisions(&repo, &revset).unwrap()
+        );
+
+        let cli_commit_info = cli_backend.get_commits_info(&ids).unwrap();
+        let libgit2_commit_info = repository::get_commits_info(&repo, &ids).unwrap();
+        assert_eq!(
+            cli_commit_info
+                .iter()
+                .map(|commit| (&commit.id, &commit.summary, &commit.body))
+                .collect::<Vec<_>>(),
+            libgit2_commit_info
+                .iter()
+                .map(|commit| (&commit.id, &commit.summary, &commit.body))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -41,12 +41,7 @@ enum GitContentSource<'a> {
 }
 
 impl GitCliBackend {
-    pub fn discover() -> Result<Self> {
-        let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
-        Self::discover_from(&cwd)
-    }
-
-    fn discover_from(cwd: &Path) -> Result<Self> {
+    pub(super) fn discover_from(cwd: &Path) -> Result<Self> {
         let root_path =
             PathBuf::from(run_git_command(cwd, &["rev-parse", "--show-toplevel"])?.trim());
         let repo_mode = GitRepoMode::detect(&root_path)?;
@@ -138,18 +133,24 @@ impl VcsBackend for GitCliBackend {
     }
 
     fn startup_warnings(&self) -> Vec<String> {
-        if self.repo_mode.is_sparse_checkout() && !self.untracked_cache {
+        if !self.repo_mode.is_sparse_checkout() {
+            return Vec::new();
+        }
+
+        let mut warnings = vec!["Sparse checkout detected; using Git CLI backend.".to_string()];
+
+        if !self.untracked_cache {
             let fsmonitor_state = if self.fsmonitor {
                 "enabled"
             } else {
                 "not enabled"
             };
-            vec![format!(
+            warnings.push(format!(
                 "Sparse checkout without core.untrackedCache can make untracked scans slow; run `git update-index --test-untracked-cache` then `git config core.untrackedCache true` if it passes (fsmonitor: {fsmonitor_state})."
-            )]
-        } else {
-            Vec::new()
+            ));
         }
+
+        warnings
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -1,0 +1,1161 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use chrono::{TimeZone, Utc};
+
+use crate::error::{Result, TuicrError};
+use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide};
+use crate::syntax::SyntaxHighlighter;
+use crate::vcs::diff_parser::{self, DiffFormat};
+use crate::vcs::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
+
+use super::{GitRepoMode, git_bool_config_enabled, git_fsmonitor_config_enabled, run_git_command};
+
+// Untracked files larger than this are shown in the file list but their
+// content is not parsed: they are likely logs, dumps, or build artefacts.
+const MAX_UNTRACKED_FILE_SIZE: u64 = 10 * 1_024 * 1_024;
+const EMPTY_TREE_OID: &str = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const COMMIT_FORMAT: &str = "--format=%H%x00%h%x00%an%x00%ct%x00%B%x1e";
+
+#[derive(Debug)]
+pub struct GitCliBackend {
+    root_path: PathBuf,
+    info: VcsInfo,
+    repo_mode: GitRepoMode,
+    untracked_cache: bool,
+    fsmonitor: bool,
+}
+
+#[derive(Clone, Copy)]
+enum GitContentSource<'a> {
+    None,
+    Workdir,
+    Index,
+    Revision(&'a str),
+}
+
+impl GitCliBackend {
+    pub fn discover() -> Result<Self> {
+        let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
+        Self::discover_from(&cwd)
+    }
+
+    fn discover_from(cwd: &Path) -> Result<Self> {
+        let root_path =
+            PathBuf::from(run_git_command(cwd, &["rev-parse", "--show-toplevel"])?.trim());
+        let repo_mode = GitRepoMode::detect(&root_path)?;
+        let head_commit = run_git_command(&root_path, &["rev-parse", "HEAD"])
+            .map(|head| head.trim().to_string())
+            .unwrap_or_else(|_| "HEAD".to_string());
+        let branch_name =
+            run_git_command(&root_path, &["symbolic-ref", "--quiet", "--short", "HEAD"])
+                .ok()
+                .map(|branch| branch.trim().to_string())
+                .filter(|branch| !branch.is_empty());
+        let (untracked_cache, fsmonitor) = detect_git_runtime_flags(&root_path);
+
+        let info = VcsInfo {
+            root_path: root_path.clone(),
+            head_commit,
+            branch_name,
+            vcs_type: crate::vcs::traits::VcsType::Git,
+        };
+
+        Ok(Self {
+            root_path,
+            info,
+            repo_mode,
+            untracked_cache,
+            fsmonitor,
+        })
+    }
+
+    pub fn repo_mode(&self) -> GitRepoMode {
+        self.repo_mode
+    }
+
+    fn get_cli_diff(
+        &self,
+        args: Vec<String>,
+        include_untracked: bool,
+        old_source: GitContentSource<'_>,
+        new_source: GitContentSource<'_>,
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        let mut files = match run_git_diff_command(&self.root_path, args, highlighter) {
+            Ok(files) => files,
+            Err(TuicrError::NoChanges) => Vec::new(),
+            Err(err) => return Err(err),
+        };
+
+        if include_untracked {
+            append_untracked_cli_diffs(&self.root_path, &mut files, highlighter)?;
+        }
+
+        if files.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        let old_cache =
+            git_source_content_cache(&self.root_path, old_source, &files, LineSide::Old);
+        let new_cache =
+            git_source_content_cache(&self.root_path, new_source, &files, LineSide::New);
+
+        enhance_with_full_file_highlight(
+            &mut files,
+            highlighter,
+            |path| {
+                read_path_from_git_source_cached(
+                    &self.root_path,
+                    old_source,
+                    old_cache.as_ref(),
+                    path,
+                )
+            },
+            |path| {
+                read_path_from_git_source_cached(
+                    &self.root_path,
+                    new_source,
+                    new_cache.as_ref(),
+                    path,
+                )
+            },
+        );
+        Ok(files)
+    }
+}
+
+impl VcsBackend for GitCliBackend {
+    fn info(&self) -> &VcsInfo {
+        &self.info
+    }
+
+    fn startup_warnings(&self) -> Vec<String> {
+        if self.repo_mode.is_sparse_checkout() && !self.untracked_cache {
+            let fsmonitor_state = if self.fsmonitor {
+                "enabled"
+            } else {
+                "not enabled"
+            };
+            vec![format!(
+                "Sparse checkout without core.untrackedCache can make untracked scans slow; run `git update-index --test-untracked-cache` then `git config core.untrackedCache true` if it passes (fsmonitor: {fsmonitor_state})."
+            )]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        self.get_cli_diff(
+            strings(["diff", "--no-ext-diff", "--binary", "HEAD", "--"]),
+            true,
+            GitContentSource::Revision("HEAD"),
+            GitContentSource::Workdir,
+            highlighter,
+        )
+    }
+
+    fn get_staged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        let old_source =
+            if run_git_command(&self.root_path, &["rev-parse", "--verify", "HEAD"]).is_ok() {
+                GitContentSource::Revision("HEAD")
+            } else {
+                GitContentSource::None
+            };
+        self.get_cli_diff(
+            strings(["diff", "--no-ext-diff", "--binary", "--cached", "--"]),
+            false,
+            old_source,
+            GitContentSource::Index,
+            highlighter,
+        )
+    }
+
+    fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        self.get_cli_diff(
+            strings(["diff", "--no-ext-diff", "--binary", "--"]),
+            true,
+            GitContentSource::Index,
+            GitContentSource::Workdir,
+            highlighter,
+        )
+    }
+
+    fn get_change_status(&self) -> Result<VcsChangeStatus> {
+        // Tracked changes have cheap exact probes. Untracked files require a
+        // working-tree scan, so only pay that cost when tracked unstaged changes
+        // have not already proven the "unstaged" row should be shown.
+        let staged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--cached", "--"])?;
+        let tracked_unstaged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--"])?;
+        let unstaged = tracked_unstaged || has_untracked_changes(&self.root_path)?;
+
+        Ok(VcsChangeStatus { staged, unstaged })
+    }
+
+    fn fetch_context_lines(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        start_line: u32,
+        end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        if start_line > end_line || start_line == 0 {
+            return Ok(Vec::new());
+        }
+
+        let content = match file_status {
+            FileStatus::Deleted => read_git_object(
+                &self.root_path,
+                &format!("HEAD:{}", file_path.to_string_lossy()),
+            )
+            .ok_or_else(|| {
+                TuicrError::VcsCommand("failed to read deleted file from HEAD".into())
+            })?,
+            _ => fs::read_to_string(self.root_path.join(file_path))?,
+        };
+
+        let lines: Vec<&str> = content.lines().collect();
+        let mut result = Vec::new();
+        for line_num in start_line..=end_line {
+            let idx = (line_num - 1) as usize;
+            if idx < lines.len() {
+                result.push(DiffLine {
+                    origin: LineOrigin::Context,
+                    content: lines[idx].to_string(),
+                    old_lineno: Some(line_num),
+                    new_lineno: Some(line_num),
+                    highlighted_spans: None,
+                });
+            }
+        }
+        Ok(result)
+    }
+
+    fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
+        let branch_tip_names = get_branch_tip_names(&self.root_path);
+        let output = run_git_command_args(
+            &self.root_path,
+            [
+                OsStr::new("log"),
+                OsStr::new(&format!("--skip={offset}")),
+                OsStr::new(&format!("--max-count={limit}")),
+                OsStr::new(COMMIT_FORMAT),
+            ],
+        )?;
+
+        Ok(parse_commit_records(&output, &branch_tip_names))
+    }
+
+    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
+        let commit_ids = if revisions.contains("..") {
+            let output = run_git_command(&self.root_path, &["rev-list", "--reverse", revisions])?;
+            output
+                .lines()
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect()
+        } else {
+            let revision = format!("{revisions}^{{commit}}");
+            let output = run_git_command(&self.root_path, &["rev-parse", "--verify", &revision])?;
+            vec![output.trim().to_string()]
+        };
+
+        if commit_ids.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        Ok(commit_ids)
+    }
+
+    fn get_commit_range_diff(
+        &self,
+        commit_ids: &[String],
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        if commit_ids.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        let base_rev = parent_rev_or_empty(&self.root_path, &commit_ids[0]);
+        let newest_rev = commit_ids.last().unwrap();
+        self.get_cli_diff(
+            vec![
+                "diff".into(),
+                "--no-ext-diff".into(),
+                "--binary".into(),
+                base_rev.clone(),
+                newest_rev.clone(),
+                "--".into(),
+            ],
+            false,
+            GitContentSource::Revision(&base_rev),
+            GitContentSource::Revision(newest_rev),
+            highlighter,
+        )
+    }
+
+    fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let branch_tip_names = get_branch_tip_names(&self.root_path);
+        let mut args = vec![
+            "show".to_string(),
+            "-s".to_string(),
+            COMMIT_FORMAT.to_string(),
+        ];
+        args.extend(ids.iter().cloned());
+        let output = run_git_command_strings(&self.root_path, args)?;
+
+        Ok(parse_commit_records(&output, &branch_tip_names))
+    }
+
+    fn get_working_tree_with_commits_diff(
+        &self,
+        commit_ids: &[String],
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        if commit_ids.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        let base_rev = parent_rev_or_empty(&self.root_path, &commit_ids[0]);
+        self.get_cli_diff(
+            vec![
+                "diff".into(),
+                "--no-ext-diff".into(),
+                "--binary".into(),
+                base_rev.clone(),
+                "--".into(),
+            ],
+            true,
+            GitContentSource::Revision(&base_rev),
+            GitContentSource::Workdir,
+            highlighter,
+        )
+    }
+
+    fn stage_file(&self, path: &Path) -> Result<()> {
+        let output = Command::new("git")
+            .current_dir(&self.root_path)
+            .arg("add")
+            .arg("--")
+            .arg(path)
+            .output()
+            .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+        if !output.status.success() {
+            return Err(TuicrError::VcsCommand(
+                String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+fn strings<const N: usize>(args: [&str; N]) -> Vec<String> {
+    args.into_iter().map(str::to_string).collect()
+}
+
+fn detect_git_runtime_flags(workdir: &Path) -> (bool, bool) {
+    let output = run_git_command(
+        workdir,
+        &[
+            "config",
+            "--get-regexp",
+            r"^(core\.untrackedcache|core\.fsmonitor|feature\.manyfiles)$",
+        ],
+    )
+    .unwrap_or_default();
+
+    parse_git_runtime_flags(&output)
+}
+
+fn parse_git_runtime_flags(output: &str) -> (bool, bool) {
+    let mut untracked_cache = None;
+    let mut fsmonitor = false;
+    let mut many_files = false;
+
+    for line in output.lines() {
+        let mut parts = line.splitn(2, char::is_whitespace);
+        let Some(key) = parts.next() else {
+            continue;
+        };
+        let raw_value = parts.next().unwrap_or_default();
+
+        match key {
+            "core.untrackedcache" => untracked_cache = Some(git_bool_config_enabled(raw_value)),
+            "core.fsmonitor" => fsmonitor = git_fsmonitor_config_enabled(raw_value),
+            "feature.manyfiles" => many_files = git_bool_config_enabled(raw_value),
+            _ => {}
+        }
+    }
+
+    // `feature.manyFiles` makes core.untrackedCache default to true, but
+    // `git config --get core.untrackedCache` does not print that implied value.
+    (untracked_cache.unwrap_or(many_files), fsmonitor)
+}
+
+fn has_diff_changes(workdir: &Path, args: &[&str]) -> Result<bool> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    match output.status.code() {
+        Some(0) => Ok(false),
+        Some(1) => Ok(true),
+        _ => Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        )),
+    }
+}
+
+fn has_untracked_changes(workdir: &Path) -> Result<bool> {
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args([
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--directory",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git ls-files stdout unavailable".into()))?;
+    let mut reader = BufReader::new(stdout);
+    let mut record = Vec::new();
+    if reader.read_until(0, &mut record)? > 0 {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Ok(true);
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| TuicrError::VcsCommand(format!("git ls-files failed: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(false)
+}
+
+fn run_git_diff_command(
+    workdir: &Path,
+    args: Vec<String>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>> {
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git diff stdout unavailable".into()))?;
+    let mut stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git diff stderr unavailable".into()))?;
+    let stderr_reader = std::thread::spawn(move || {
+        let mut bytes = Vec::new();
+        let _ = stderr.read_to_end(&mut bytes);
+        bytes
+    });
+
+    let diff_lines = BufReader::new(stdout)
+        .lines()
+        .map(|line| line.map(Cow::Owned).map_err(TuicrError::from));
+    let parse_result =
+        diff_parser::parse_unified_diff_lines(diff_lines, DiffFormat::GitStyle, highlighter);
+
+    let status = child.wait()?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| TuicrError::VcsCommand("git diff stderr reader panicked".into()))?;
+
+    if !status.success() {
+        return Err(TuicrError::VcsCommand(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&stderr)
+        )));
+    }
+
+    parse_result
+}
+
+fn append_untracked_cli_diffs(
+    workdir: &Path,
+    files: &mut Vec<DiffFile>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<usize> {
+    let pathspecs = sparse_checkout_untracked_pathspecs(workdir)?;
+    let previous_len = files.len();
+    for_each_untracked_path(workdir, &pathspecs, |path| {
+        let full_path = workdir.join(&path);
+        let Some(file) = build_untracked_diff_file(&path, &full_path, highlighter) else {
+            return Ok(());
+        };
+        files.push(file);
+        Ok(())
+    })?;
+    Ok(files.len().saturating_sub(previous_len))
+}
+
+fn sparse_checkout_untracked_pathspecs(workdir: &Path) -> Result<Vec<String>> {
+    // Simple cone sparse patterns can narrow `git ls-files --others` to the
+    // checked-out cones. Complex patterns fall back to Git's full scan so we do
+    // not accidentally hide valid untracked files.
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(["sparse-checkout", "list"])
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Ok(Vec::new());
+    }
+
+    let mut pathspecs = Vec::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let pattern = line.trim();
+        if pattern.is_empty() {
+            continue;
+        }
+
+        if !is_simple_sparse_path(pattern) {
+            return Ok(Vec::new());
+        }
+
+        let pathspec = pattern.trim_start_matches('/').trim_end_matches('/');
+        if !pathspec.is_empty() {
+            pathspecs.push(pathspec.to_string());
+        }
+    }
+
+    Ok(pathspecs)
+}
+
+fn is_simple_sparse_path(pattern: &str) -> bool {
+    !pattern.starts_with('!')
+        && !pattern.contains('*')
+        && !pattern.contains('?')
+        && !pattern.contains('[')
+        && !pattern.contains('\\')
+}
+
+fn build_untracked_diff_file(
+    path: &Path,
+    full_path: &Path,
+    highlighter: &SyntaxHighlighter,
+) -> Option<DiffFile> {
+    let metadata = full_path.metadata().ok()?;
+    if metadata.len() > MAX_UNTRACKED_FILE_SIZE {
+        return Some(diff_file_without_hunks(path, false, true));
+    }
+
+    let bytes = fs::read(full_path).ok()?;
+    if bytes.contains(&0) {
+        return Some(diff_file_without_hunks(path, true, false));
+    }
+
+    let content = String::from_utf8_lossy(&bytes);
+    let lines: Vec<String> = content
+        .lines()
+        .map(|line| tabify(line.trim_end_matches('\r')))
+        .collect();
+
+    if lines.is_empty() {
+        return Some(diff_file_without_hunks(path, false, false));
+    }
+
+    let highlighted = highlighter.highlight_file_lines(path, &lines);
+    let diff_lines: Vec<DiffLine> = lines
+        .into_iter()
+        .enumerate()
+        .map(|(idx, content)| DiffLine {
+            origin: LineOrigin::Addition,
+            content,
+            old_lineno: None,
+            new_lineno: Some((idx + 1) as u32),
+            highlighted_spans: highlighter.highlighted_line_for_diff_with_background(
+                None,
+                highlighted.as_deref(),
+                None,
+                Some(idx),
+                LineOrigin::Addition,
+            ),
+        })
+        .collect();
+
+    let new_count = diff_lines.len() as u32;
+    let hunks = vec![DiffHunk {
+        header: format!("@@ -0,0 +1,{new_count} @@"),
+        lines: diff_lines,
+        old_start: 0,
+        old_count: 0,
+        new_start: 1,
+        new_count,
+    }];
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+
+    Some(DiffFile {
+        old_path: None,
+        new_path: Some(path.to_path_buf()),
+        status: FileStatus::Added,
+        hunks,
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash,
+    })
+}
+
+fn diff_file_without_hunks(path: &Path, is_binary: bool, is_too_large: bool) -> DiffFile {
+    DiffFile {
+        old_path: None,
+        new_path: Some(path.to_path_buf()),
+        status: FileStatus::Added,
+        hunks: Vec::new(),
+        is_binary,
+        is_too_large,
+        is_commit_message: false,
+        content_hash: 0,
+    }
+}
+
+fn for_each_untracked_path<F>(workdir: &Path, pathspecs: &[String], mut visit: F) -> Result<()>
+where
+    F: FnMut(PathBuf) -> Result<()>,
+{
+    let mut args = vec!["ls-files", "--others", "--exclude-standard", "-z"];
+    if !pathspecs.is_empty() {
+        args.push("--");
+        args.extend(pathspecs.iter().map(String::as_str));
+    }
+
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git ls-files stdout unavailable".into()))?;
+    let mut buffer = [0; 8192];
+    let mut path = Vec::new();
+
+    loop {
+        let read = stdout.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+
+        for &byte in &buffer[..read] {
+            if byte == 0 {
+                if !path.is_empty() {
+                    visit(PathBuf::from(String::from_utf8_lossy(&path).into_owned()))?;
+                    path.clear();
+                }
+            } else {
+                path.push(byte);
+            }
+        }
+    }
+
+    if !path.is_empty() {
+        visit(PathBuf::from(String::from_utf8_lossy(&path).into_owned()))?;
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        return Err(TuicrError::VcsCommand(format!(
+            "git ls-files failed with status {status}"
+        )));
+    }
+
+    Ok(())
+}
+
+fn read_path_from_git_source(
+    workdir: &Path,
+    source: GitContentSource<'_>,
+    path: &Path,
+) -> Option<String> {
+    match source {
+        GitContentSource::None => None,
+        GitContentSource::Workdir => crate::vcs::read_workdir_file(workdir, path),
+        GitContentSource::Index => {
+            read_git_object(workdir, &format!(":0:{}", path.to_string_lossy()))
+        }
+        GitContentSource::Revision(rev) => {
+            read_git_object(workdir, &format!("{rev}:{}", path.to_string_lossy()))
+        }
+    }
+}
+
+fn read_path_from_git_source_cached(
+    workdir: &Path,
+    source: GitContentSource<'_>,
+    cache: Option<&HashMap<PathBuf, String>>,
+    path: &Path,
+) -> Option<String> {
+    cache
+        .and_then(|contents| contents.get(path).cloned())
+        .or_else(|| read_path_from_git_source(workdir, source, path))
+}
+
+fn git_source_content_cache(
+    workdir: &Path,
+    source: GitContentSource<'_>,
+    files: &[DiffFile],
+    side: LineSide,
+) -> Option<HashMap<PathBuf, String>> {
+    let paths = container_file_paths(files, side);
+    match source {
+        GitContentSource::Revision(rev) => {
+            let requests = paths
+                .into_iter()
+                .map(|path| {
+                    let spec = format!("{rev}:{}", path.to_string_lossy());
+                    (path, spec)
+                })
+                .collect();
+            read_git_objects(workdir, requests).ok()
+        }
+        GitContentSource::Index => {
+            let requests = paths
+                .into_iter()
+                .map(|path| {
+                    let spec = format!(":0:{}", path.to_string_lossy());
+                    (path, spec)
+                })
+                .collect();
+            read_git_objects(workdir, requests).ok()
+        }
+        GitContentSource::None | GitContentSource::Workdir => None,
+    }
+}
+
+fn read_git_objects(
+    workdir: &Path,
+    requests: Vec<(PathBuf, String)>,
+) -> Result<HashMap<PathBuf, String>> {
+    if requests.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut child = Command::new("git")
+        .current_dir(workdir)
+        .args(["cat-file", "--batch"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    {
+        let mut stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| TuicrError::VcsCommand("git cat-file stdin unavailable".into()))?;
+        for (_, spec) in &requests {
+            writeln!(stdin, "{spec}")?;
+        }
+    }
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| TuicrError::VcsCommand("git cat-file stdout unavailable".into()))?;
+    let mut reader = BufReader::new(stdout);
+    let mut contents = HashMap::new();
+
+    for (path, _) in requests {
+        let mut header = String::new();
+        if reader.read_line(&mut header)? == 0 {
+            break;
+        }
+
+        let header = header.trim_end();
+        if header.ends_with(" missing") {
+            continue;
+        }
+
+        let mut parts = header.split_whitespace();
+        let _oid = parts.next();
+        let kind = parts.next();
+        let size = parts
+            .next()
+            .and_then(|value| value.parse::<usize>().ok())
+            .ok_or_else(|| TuicrError::VcsCommand("invalid git cat-file header".into()))?;
+
+        let mut bytes = vec![0; size];
+        reader.read_exact(&mut bytes)?;
+        let mut trailing_newline = [0; 1];
+        reader.read_exact(&mut trailing_newline)?;
+
+        if kind == Some("blob") {
+            contents.insert(path, String::from_utf8_lossy(&bytes).into_owned());
+        }
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
+        return Err(TuicrError::VcsCommand(format!(
+            "git cat-file failed with status {status}"
+        )));
+    }
+
+    Ok(contents)
+}
+
+fn read_git_object(workdir: &Path, spec: &str) -> Option<String> {
+    run_git_command(workdir, &["show", spec]).ok()
+}
+
+fn get_branch_tip_names(workdir: &Path) -> HashMap<String, Vec<String>> {
+    let output = run_git_command(
+        workdir,
+        &[
+            "for-each-ref",
+            "--format=%(objectname)%00%(refname:short)",
+            "refs/heads",
+        ],
+    )
+    .unwrap_or_default();
+    let mut names_by_tip: HashMap<String, Vec<String>> = HashMap::new();
+
+    for line in output.lines() {
+        if let Some((oid, name)) = line.split_once('\0') {
+            names_by_tip
+                .entry(oid.to_string())
+                .or_default()
+                .push(name.to_string());
+        }
+    }
+
+    for names in names_by_tip.values_mut() {
+        names.sort_unstable();
+    }
+
+    names_by_tip
+}
+
+fn parse_commit_records(
+    output: &str,
+    branch_tip_names: &HashMap<String, Vec<String>>,
+) -> Vec<CommitInfo> {
+    output
+        .split('\x1e')
+        .filter_map(|record| parse_commit_record(record, branch_tip_names))
+        .collect()
+}
+
+fn parse_commit_record(
+    record: &str,
+    branch_tip_names: &HashMap<String, Vec<String>>,
+) -> Option<CommitInfo> {
+    let record = record.trim_start_matches('\n').trim_end_matches('\n');
+    if record.is_empty() {
+        return None;
+    }
+
+    let mut fields = record.splitn(5, '\0');
+    let id = fields.next()?.to_string();
+    let short_id = fields.next()?.to_string();
+    let author = fields.next().unwrap_or("Unknown").to_string();
+    let timestamp = fields
+        .next()
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or_default();
+    let full_message = fields.next().unwrap_or("(no message)");
+    let (summary, body) = parse_commit_message(full_message);
+    let branch_name = branch_tip_names
+        .get(&id)
+        .and_then(|names| names.first().cloned());
+    let time = Utc
+        .timestamp_opt(timestamp, 0)
+        .single()
+        .unwrap_or_else(Utc::now);
+
+    Some(CommitInfo {
+        id,
+        short_id,
+        branch_name,
+        summary,
+        body,
+        author,
+        time,
+    })
+}
+
+fn parse_commit_message(message: &str) -> (String, Option<String>) {
+    let mut lines = message.lines();
+    let summary = lines.next().unwrap_or("(no message)").to_string();
+    let body_text: String = lines
+        .skip_while(|l| l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let body = if body_text.trim().is_empty() {
+        None
+    } else {
+        Some(body_text)
+    };
+    (summary, body)
+}
+
+fn parent_rev_or_empty(workdir: &Path, commit_id: &str) -> String {
+    let parent_spec = format!("{commit_id}^");
+    run_git_command(workdir, &["rev-parse", &parent_spec])
+        .map(|rev| rev.trim().to_string())
+        .unwrap_or_else(|_| EMPTY_TREE_OID.to_string())
+}
+
+fn run_git_command_strings(workdir: &Path, args: Vec<String>) -> Result<String> {
+    run_git_command_args(workdir, args.iter().map(String::as_str))
+}
+
+fn run_git_command_args<I, S>(workdir: &Path, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn git(workdir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(workdir)
+            .args(args)
+            .output()
+            .expect("failed to run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn write_file(workdir: &Path, path: &str, content: &str) {
+        let full_path = workdir.join(path);
+        fs::create_dir_all(full_path.parent().expect("test path should have parent"))
+            .expect("failed to create parent");
+        fs::write(full_path, content).expect("failed to write file");
+    }
+
+    fn setup_sparse_index_repo() -> (tempfile::TempDir, GitCliBackend, Vec<String>) {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+
+        git(workdir, &["init"]);
+        git(workdir, &["config", "user.email", "test@example.com"]);
+        git(workdir, &["config", "user.name", "Test User"]);
+        write_file(workdir, "keep/file.txt", "keep base\n");
+        write_file(workdir, "hidden/file.txt", "hidden base\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "initial"]);
+        let first_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve first commit")
+            .trim()
+            .to_string();
+
+        write_file(workdir, "keep/file.txt", "keep next\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "second"]);
+        let second_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve second commit")
+            .trim()
+            .to_string();
+
+        git(workdir, &["sparse-checkout", "init", "--cone"]);
+        git(workdir, &["sparse-checkout", "set", "keep"]);
+        git(workdir, &["sparse-checkout", "reapply", "--sparse-index"]);
+        git(workdir, &["config", "advice.sparseIndexExpanded", "false"]);
+
+        let backend = GitCliBackend::discover_from(workdir).expect("failed to discover backend");
+        (temp_dir, backend, vec![first_id, second_id])
+    }
+
+    #[test]
+    fn parses_runtime_flags_from_single_config_read() {
+        let output = "core.untrackedcache true\ncore.fsmonitor .git/hooks/fsmonitor-watchman\n";
+
+        assert_eq!(parse_git_runtime_flags(output), (true, true));
+    }
+
+    #[test]
+    fn treats_feature_many_files_as_untracked_cache_default() {
+        assert_eq!(
+            parse_git_runtime_flags("feature.manyfiles true\n"),
+            (true, false)
+        );
+        assert_eq!(
+            parse_git_runtime_flags("feature.manyfiles true\ncore.untrackedcache keep\n"),
+            (false, false)
+        );
+    }
+
+    #[test]
+    fn discovers_sparse_index_repo_mode() {
+        let (_temp_dir, backend, _ids) = setup_sparse_index_repo();
+
+        assert_eq!(backend.repo_mode(), GitRepoMode::SparseIndex);
+    }
+
+    #[test]
+    fn gets_recent_commits_in_sparse_index() {
+        let (_temp_dir, backend, _ids) = setup_sparse_index_repo();
+
+        let commits = backend
+            .get_recent_commits(0, 10)
+            .expect("failed to get commits");
+
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].summary, "second");
+        assert_eq!(commits[1].summary, "initial");
+    }
+
+    #[test]
+    fn resolves_revisions_in_sparse_index() {
+        let (_temp_dir, backend, ids) = setup_sparse_index_repo();
+        let revset = format!("{}..{}", ids[0], ids[1]);
+
+        let resolved = backend
+            .resolve_revisions(&revset)
+            .expect("failed to resolve revisions");
+
+        assert_eq!(resolved, vec![ids[1].clone()]);
+    }
+
+    #[test]
+    fn reads_commit_range_diff_in_sparse_index() {
+        let (_temp_dir, backend, ids) = setup_sparse_index_repo();
+
+        let files = backend
+            .get_commit_range_diff(&[ids[1].clone()], &SyntaxHighlighter::default())
+            .expect("failed to get sparse commit range diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/file.txt"))
+        );
+    }
+
+    #[test]
+    fn returns_no_changes_for_clean_sparse_index() {
+        let (_temp_dir, backend, _ids) = setup_sparse_index_repo();
+
+        assert!(matches!(
+            backend.get_working_tree_diff(&SyntaxHighlighter::default()),
+            Err(TuicrError::NoChanges)
+        ));
+    }
+
+    #[test]
+    fn reads_working_tree_diff_and_untracked_files_in_sparse_index() {
+        let (temp_dir, backend, _ids) = setup_sparse_index_repo();
+        let workdir = temp_dir.path();
+        write_file(workdir, "keep/file.txt", "keep changed\n");
+        write_file(workdir, "keep/new.txt", "new sparse file\n");
+        write_file(workdir, "hidden/outside.txt", "outside cone\n");
+
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("failed to get sparse working tree diff");
+
+        let paths: Vec<_> = files
+            .iter()
+            .filter_map(|file| file.new_path.as_deref())
+            .collect();
+        assert!(paths.contains(&Path::new("keep/file.txt")));
+        assert!(paths.contains(&Path::new("keep/new.txt")));
+        assert!(!paths.contains(&Path::new("hidden/outside.txt")));
+    }
+
+    #[test]
+    fn reads_staged_diff_and_stages_files_in_sparse_index() {
+        let (temp_dir, backend, _ids) = setup_sparse_index_repo();
+        let workdir = temp_dir.path();
+        write_file(workdir, "keep/file.txt", "keep staged\n");
+
+        backend
+            .stage_file(Path::new("keep/file.txt"))
+            .expect("failed to stage file");
+        let files = backend
+            .get_staged_diff(&SyntaxHighlighter::default())
+            .expect("failed to get sparse staged diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("keep/file.txt"))
+        );
+    }
+
+    #[test]
+    fn detects_change_status_without_loading_diff() {
+        let (temp_dir, backend, _ids) = setup_sparse_index_repo();
+        write_file(temp_dir.path(), "keep/file.txt", "keep modified\n");
+
+        let status = backend
+            .get_change_status()
+            .expect("failed to get change status");
+
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+    }
+}

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -15,10 +15,8 @@ pub struct Libgit2Backend {
 }
 
 impl Libgit2Backend {
-    /// Discover a git repository from the current directory.
-    pub fn discover() -> Result<Self> {
-        let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
-        let repo = Repository::discover(&cwd).map_err(|_| TuicrError::NotARepository)?;
+    pub(super) fn discover_from(cwd: &Path) -> Result<Self> {
+        let repo = Repository::discover(cwd).map_err(|_| TuicrError::NotARepository)?;
 
         let root_path = repo
             .workdir()

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -54,6 +54,10 @@ impl VcsBackend for Libgit2Backend {
         &self.info
     }
 
+    fn supports_sparse_checkout(&self) -> bool {
+        false
+    }
+
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         diff::get_working_tree_diff(&self.repo, highlighter)
     }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -30,6 +30,21 @@ pub enum GitBackend {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitBackendPreference {
+    Libgit2,
+    Cli,
+}
+
+impl GitBackendPreference {
+    pub fn from_config(value: Option<&str>) -> Self {
+        match value {
+            Some("cli") => Self::Cli,
+            _ => Self::Libgit2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitRepoMode {
     Standard,
     SparseCheckout,
@@ -85,14 +100,23 @@ impl GitRepoMode {
 
 impl GitBackend {
     /// Discover a git repository from the current directory.
-    pub fn discover() -> Result<Self> {
-        if let Ok(cli_backend) = GitCliBackend::discover()
+    pub fn discover(preference: GitBackendPreference) -> Result<Self> {
+        let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
+        Self::discover_from(&cwd, preference)
+    }
+
+    fn discover_from(cwd: &Path, preference: GitBackendPreference) -> Result<Self> {
+        if preference == GitBackendPreference::Cli {
+            return Ok(Self::Cli(GitCliBackend::discover_from(cwd)?));
+        }
+
+        if let Ok(cli_backend) = GitCliBackend::discover_from(cwd)
             && cli_backend.repo_mode().is_sparse_checkout()
         {
             return Ok(Self::Cli(cli_backend));
         }
 
-        Ok(Self::Libgit2(Libgit2Backend::discover()?))
+        Ok(Self::Libgit2(Libgit2Backend::discover_from(cwd)?))
     }
 }
 
@@ -240,6 +264,8 @@ impl VcsBackend for GitBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn derives_git_repo_mode_from_config() {
@@ -252,5 +278,74 @@ mod tests {
             GitRepoMode::from_config("core.sparsecheckout true\nindex.sparse true\n"),
             GitRepoMode::SparseIndex
         );
+    }
+
+    #[test]
+    fn derives_backend_preference_from_config() {
+        assert_eq!(
+            GitBackendPreference::from_config(None),
+            GitBackendPreference::Libgit2
+        );
+        assert_eq!(
+            GitBackendPreference::from_config(Some("libgit2")),
+            GitBackendPreference::Libgit2
+        );
+        assert_eq!(
+            GitBackendPreference::from_config(Some("cli")),
+            GitBackendPreference::Cli
+        );
+    }
+
+    #[test]
+    fn default_preference_routes_sparse_index_repo_to_cli_with_warning() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let root = temp_dir.path();
+        setup_standard_repo(root);
+        run_git_command(
+            root,
+            &["sparse-checkout", "init", "--cone", "--sparse-index"],
+        )
+        .expect("failed to enable sparse checkout");
+        run_git_command(root, &["sparse-checkout", "set", "src"])
+            .expect("failed to set sparse checkout paths");
+
+        let backend = GitBackend::discover_from(root, GitBackendPreference::Libgit2)
+            .expect("failed to discover backend");
+
+        match backend {
+            GitBackend::Cli(backend) => assert_eq!(
+                backend.startup_warnings().first().map(String::as_str),
+                Some("Sparse checkout detected; using Git CLI backend.")
+            ),
+            GitBackend::Libgit2(_) => panic!("sparse-index repo should use Git CLI backend"),
+        }
+    }
+
+    #[test]
+    fn default_preference_keeps_standard_repo_on_libgit2() {
+        let temp_dir = tempdir().expect("failed to create temp dir");
+        let root = temp_dir.path();
+        setup_standard_repo(root);
+
+        let backend = GitBackend::discover_from(root, GitBackendPreference::Libgit2)
+            .expect("failed to discover backend");
+
+        match backend {
+            GitBackend::Libgit2(_) => {}
+            GitBackend::Cli(_) => panic!("standard repo should use libgit2 by default"),
+        }
+    }
+
+    fn setup_standard_repo(root: &Path) {
+        fs::create_dir(root.join("src")).expect("failed to create src dir");
+        fs::write(root.join("src/file.txt"), "one\n").expect("failed to write file");
+
+        run_git_command(root, &["init"]).expect("failed to init repo");
+        run_git_command(root, &["config", "user.name", "Tuicr Test"])
+            .expect("failed to set user name");
+        run_git_command(root, &["config", "user.email", "tuicr@example.com"])
+            .expect("failed to set user email");
+        run_git_command(root, &["add", "src/file.txt"]).expect("failed to add file");
+        run_git_command(root, &["commit", "-m", "initial"]).expect("failed to commit");
     }
 }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -110,13 +110,13 @@ impl GitBackend {
             return Ok(Self::Cli(GitCliBackend::discover_from(cwd)?));
         }
 
-        if let Ok(cli_backend) = GitCliBackend::discover_from(cwd)
-            && cli_backend.repo_mode().is_sparse_checkout()
-        {
-            return Ok(Self::Cli(cli_backend));
+        let backend = Self::Libgit2(Libgit2Backend::discover_from(cwd)?);
+        let repo_mode = GitRepoMode::detect(&backend.info().root_path)?;
+        if repo_mode.is_sparse_checkout() && !backend.supports_sparse_checkout() {
+            return Ok(Self::Cli(GitCliBackend::discover_from(cwd)?));
         }
 
-        Ok(Self::Libgit2(Libgit2Backend::discover_from(cwd)?))
+        Ok(backend)
     }
 }
 
@@ -158,6 +158,13 @@ impl VcsBackend for GitBackend {
         match self {
             Self::Libgit2(backend) => backend.startup_warnings(),
             Self::Cli(backend) => backend.startup_warnings(),
+        }
+    }
+
+    fn supports_sparse_checkout(&self) -> bool {
+        match self {
+            Self::Libgit2(backend) => backend.supports_sparse_checkout(),
+            Self::Cli(backend) => backend.supports_sparse_checkout(),
         }
     }
 
@@ -313,10 +320,13 @@ mod tests {
             .expect("failed to discover backend");
 
         match backend {
-            GitBackend::Cli(backend) => assert_eq!(
-                backend.startup_warnings().first().map(String::as_str),
-                Some("Sparse checkout detected; using Git CLI backend.")
-            ),
+            GitBackend::Cli(backend) => {
+                assert!(backend.supports_sparse_checkout());
+                assert_eq!(
+                    backend.startup_warnings().first().map(String::as_str),
+                    Some("Sparse checkout detected; using Git CLI backend.")
+                );
+            }
             GitBackend::Libgit2(_) => panic!("sparse-index repo should use Git CLI backend"),
         }
     }
@@ -331,7 +341,7 @@ mod tests {
             .expect("failed to discover backend");
 
         match backend {
-            GitBackend::Libgit2(_) => {}
+            GitBackend::Libgit2(backend) => assert!(!backend.supports_sparse_checkout()),
             GitBackend::Cli(_) => panic!("standard repo should use libgit2 by default"),
         }
     }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -1,3 +1,4 @@
+mod cli;
 pub mod context;
 pub mod diff;
 mod libgit2;
@@ -5,12 +6,14 @@ pub mod repository;
 pub mod staging;
 
 use std::path::Path;
+use std::process::Command;
 
-use crate::error::Result;
+use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 
-use super::traits::{CommitInfo, VcsBackend, VcsInfo};
+use super::traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+use cli::GitCliBackend;
 pub use libgit2::Libgit2Backend;
 
 // Re-exported for UI/app gap calculations.
@@ -23,37 +26,142 @@ pub use context::calculate_gap;
 /// variant without pushing backend-specific branches into every operation.
 pub enum GitBackend {
     Libgit2(Libgit2Backend),
+    Cli(GitCliBackend),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitRepoMode {
+    Standard,
+    SparseCheckout,
+    SparseIndex,
+}
+
+impl GitRepoMode {
+    fn detect(root_path: &Path) -> Result<Self> {
+        let output = run_git_command(
+            root_path,
+            &[
+                "config",
+                "--get-regexp",
+                r"^(core\.sparsecheckout|index\.sparse)$",
+            ],
+        )
+        .unwrap_or_default();
+
+        Ok(Self::from_config(&output))
+    }
+
+    fn from_config(output: &str) -> Self {
+        let mut sparse_checkout = false;
+        let mut sparse_index = false;
+
+        for line in output.lines() {
+            let mut parts = line.splitn(2, char::is_whitespace);
+            let Some(key) = parts.next() else {
+                continue;
+            };
+            let raw_value = parts.next().unwrap_or_default();
+
+            match key {
+                "core.sparsecheckout" => sparse_checkout = git_bool_config_enabled(raw_value),
+                "index.sparse" => sparse_index = git_bool_config_enabled(raw_value),
+                _ => {}
+            }
+        }
+
+        if sparse_index {
+            Self::SparseIndex
+        } else if sparse_checkout {
+            Self::SparseCheckout
+        } else {
+            Self::Standard
+        }
+    }
+
+    fn is_sparse_checkout(self) -> bool {
+        matches!(self, Self::SparseCheckout | Self::SparseIndex)
+    }
 }
 
 impl GitBackend {
     /// Discover a git repository from the current directory.
     pub fn discover() -> Result<Self> {
+        if let Ok(cli_backend) = GitCliBackend::discover()
+            && cli_backend.repo_mode().is_sparse_checkout()
+        {
+            return Ok(Self::Cli(cli_backend));
+        }
+
         Ok(Self::Libgit2(Libgit2Backend::discover()?))
     }
+}
+
+fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn git_bool_config_enabled(value: &str) -> bool {
+    matches!(value.trim(), "true" | "1" | "yes" | "on")
+}
+
+fn git_fsmonitor_config_enabled(value: &str) -> bool {
+    let value = value.trim();
+    git_bool_config_enabled(value)
+        || (!value.is_empty() && !matches!(value, "false" | "0" | "no" | "off"))
 }
 
 impl VcsBackend for GitBackend {
     fn info(&self) -> &VcsInfo {
         match self {
             Self::Libgit2(backend) => backend.info(),
+            Self::Cli(backend) => backend.info(),
+        }
+    }
+
+    fn startup_warnings(&self) -> Vec<String> {
+        match self {
+            Self::Libgit2(backend) => backend.startup_warnings(),
+            Self::Cli(backend) => backend.startup_warnings(),
         }
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         match self {
             Self::Libgit2(backend) => backend.get_working_tree_diff(highlighter),
+            Self::Cli(backend) => backend.get_working_tree_diff(highlighter),
         }
     }
 
     fn get_staged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         match self {
             Self::Libgit2(backend) => backend.get_staged_diff(highlighter),
+            Self::Cli(backend) => backend.get_staged_diff(highlighter),
         }
     }
 
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         match self {
             Self::Libgit2(backend) => backend.get_unstaged_diff(highlighter),
+            Self::Cli(backend) => backend.get_unstaged_diff(highlighter),
+        }
+    }
+
+    fn get_change_status(&self) -> Result<VcsChangeStatus> {
+        match self {
+            Self::Libgit2(backend) => backend.get_change_status(),
+            Self::Cli(backend) => backend.get_change_status(),
         }
     }
 
@@ -68,18 +176,23 @@ impl VcsBackend for GitBackend {
             Self::Libgit2(backend) => {
                 backend.fetch_context_lines(file_path, file_status, start_line, end_line)
             }
+            Self::Cli(backend) => {
+                backend.fetch_context_lines(file_path, file_status, start_line, end_line)
+            }
         }
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
         match self {
             Self::Libgit2(backend) => backend.get_recent_commits(offset, limit),
+            Self::Cli(backend) => backend.get_recent_commits(offset, limit),
         }
     }
 
     fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
         match self {
             Self::Libgit2(backend) => backend.resolve_revisions(revisions),
+            Self::Cli(backend) => backend.resolve_revisions(revisions),
         }
     }
 
@@ -90,12 +203,14 @@ impl VcsBackend for GitBackend {
     ) -> Result<Vec<DiffFile>> {
         match self {
             Self::Libgit2(backend) => backend.get_commit_range_diff(commit_ids, highlighter),
+            Self::Cli(backend) => backend.get_commit_range_diff(commit_ids, highlighter),
         }
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
         match self {
             Self::Libgit2(backend) => backend.get_commits_info(ids),
+            Self::Cli(backend) => backend.get_commits_info(ids),
         }
     }
 
@@ -108,12 +223,34 @@ impl VcsBackend for GitBackend {
             Self::Libgit2(backend) => {
                 backend.get_working_tree_with_commits_diff(commit_ids, highlighter)
             }
+            Self::Cli(backend) => {
+                backend.get_working_tree_with_commits_diff(commit_ids, highlighter)
+            }
         }
     }
 
     fn stage_file(&self, path: &Path) -> Result<()> {
         match self {
             Self::Libgit2(backend) => backend.stage_file(path),
+            Self::Cli(backend) => backend.stage_file(path),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_git_repo_mode_from_config() {
+        assert_eq!(GitRepoMode::from_config(""), GitRepoMode::Standard);
+        assert_eq!(
+            GitRepoMode::from_config("core.sparsecheckout true\n"),
+            GitRepoMode::SparseCheckout
+        );
+        assert_eq!(
+            GitRepoMode::from_config("core.sparsecheckout true\nindex.sparse true\n"),
+            GitRepoMode::SparseIndex
+        );
     }
 }

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -19,7 +19,7 @@ mod jj;
 pub(crate) mod traits;
 
 pub use file::FileBackend;
-pub use git::GitBackend;
+pub use git::{GitBackend, GitBackendPreference};
 pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
@@ -295,14 +295,14 @@ fn apply_full_file_spans(
 ///
 /// Detection order: Jujutsu → Git → Mercurial.
 /// Jujutsu is tried first because jj repos are Git-backed.
-pub fn detect_vcs() -> Result<Box<dyn VcsBackend>> {
+pub fn detect_vcs(git_backend_preference: GitBackendPreference) -> Result<Box<dyn VcsBackend>> {
     // Try jj first since jj repos are Git-backed
     if let Ok(backend) = JjBackend::discover() {
         return Ok(Box::new(backend));
     }
 
     // Try git
-    if let Ok(backend) = GitBackend::discover() {
+    if let Ok(backend) = GitBackend::discover(git_backend_preference) {
         return Ok(Box::new(backend));
     }
 
@@ -323,7 +323,7 @@ mod tests {
     #[test]
     fn exports_are_accessible() {
         // Verify that public types are properly exported
-        let _: fn() -> Result<Box<dyn VcsBackend>> = detect_vcs;
+        let _: fn(GitBackendPreference) -> Result<Box<dyn VcsBackend>> = detect_vcs;
 
         // VcsInfo can be constructed
         let info = VcsInfo {
@@ -353,7 +353,7 @@ mod tests {
         // Note: This test may pass or fail depending on where tests are run
         // In CI or outside a repo, it should fail with NotARepository
         // Inside the tuicr repo (which is git), it will succeed
-        let result = detect_vcs();
+        let result = detect_vcs(GitBackendPreference::Libgit2);
 
         // We just verify the function runs without panic
         // The actual result depends on the environment

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -22,7 +22,7 @@ pub use file::FileBackend;
 pub use git::GitBackend;
 pub use hg::HgBackend;
 pub use jj::JjBackend;
-pub use traits::{CommitInfo, VcsBackend, VcsInfo};
+pub use traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -49,10 +49,22 @@ pub struct CommitInfo {
     pub time: DateTime<Utc>,
 }
 
+/// Cheap repository change summary used by selection UIs before loading full diffs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct VcsChangeStatus {
+    pub staged: bool,
+    pub unstaged: bool,
+}
+
 /// Trait for VCS backend implementations
 pub trait VcsBackend: Send {
     /// Get repository information
     fn info(&self) -> &VcsInfo;
+
+    /// Non-fatal notices that should be shown after startup.
+    fn startup_warnings(&self) -> Vec<String> {
+        Vec::new()
+    }
 
     /// Get the working tree diff (staged + unstaged changes)
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>>;
@@ -68,6 +80,13 @@ pub trait VcsBackend: Send {
     fn get_unstaged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Unstaged diff not supported for this VCS".into(),
+        ))
+    }
+
+    /// Get a cheap staged/unstaged summary without parsing or highlighting diffs.
+    fn get_change_status(&self) -> Result<VcsChangeStatus> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "Change status not supported for this VCS".into(),
         ))
     }
 

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -66,6 +66,14 @@ pub trait VcsBackend: Send {
         Vec::new()
     }
 
+    /// Whether this concrete backend can operate on Git sparse-checkout repos.
+    ///
+    /// Non-Git VCS implementations keep the default `false`; Git backends
+    /// override this based on the selected implementation.
+    fn supports_sparse_checkout(&self) -> bool {
+        false
+    }
+
     /// Get the working tree diff (staged + unstaged changes)
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>>;
 


### PR DESCRIPTION
Replaces #281's sparse-checkout support with a separate Git CLI backend selected once during Git discovery.

This is part 3 of the #281 replacement stack:
- #283 isolates tracing/profile instrumentation.
- #284 splits the existing libgit2 implementation into `Libgit2Backend`.
- This PR adds `GitCliBackend` and uses it for sparse checkout / sparse-index repos.

What changed:
- Keeps standard Git on the libgit2 path by default.
- Adds `backend = "libgit2" | "cli"` config, with `libgit2` as the normal default and `cli` available as an explicit override.
- Detects sparse Git mode at startup and uses the CLI backend all-or-nothing when the selected backend does not support sparse checkout.
- Adds `VcsBackend::supports_sparse_checkout()` so backend capability checks are centralized instead of inferred at each call site.
- Implements CLI-backed working tree, staged, unstaged, commit range, commits + working tree, revision resolution, commit metadata, context expansion, and staging paths.
- Adds a cheap staged/unstaged status probe so sparse repos do not have to parse/highlight full diffs on startup.
- Narrows untracked scans to simple sparse-checkout cones when possible.
- Surfaces startup warnings for sparse CLI routing and for sparse repos without `core.untrackedCache`.
- Streams `git diff --binary` output into the shared parser instead of buffering the full patch.
- Fixes `GIT binary patch` parsing from the original review feedback.

This addresses the original maintainer feedback:
- https://github.com/agavra/tuicr/pull/281#discussion_r3229513530
- https://github.com/agavra/tuicr/pull/281#discussion_r3229615387

Validation:
- `cargo fmt --all --check`
- `cargo test --no-default-features`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build`
- `git diff --check`
- Dogfooded `target/debug/tuicr -w` and the `$tuicr` wrapper against a local LLVM sparse-index checkout with a temporary modified file inside the sparse cone; the checkout was restored clean afterward.

Note: the LLVM sparse checkout is local dogfood only and is not cloned or used in CI.
