### PR TITLE
add more Z viewport positioning commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ For full native terminal selection across the whole UI, hold your terminal's byp
 | `/` | Search within diff |
 | `n` / `N` | Next/previous search match |
 | `Enter` | Expand/collapse hidden context between hunks |
+| `zt` | Scroll cursor to top of screen |
 | `zz` | Center cursor on screen |
+| `zb` | Scroll cursor to bottom of screen |
 
 #### File Tree
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2300,6 +2300,27 @@ impl App {
             .min(max_scroll);
     }
 
+    pub fn cursor_to_top(&mut self) {
+        let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
+        let max_scroll = self.max_scroll_offset();
+        self.diff_state.scroll_offset = self
+            .diff_state
+            .cursor_line
+            .saturating_sub(scroll_margin)
+            .min(max_scroll);
+    }
+
+    pub fn cursor_to_bottom(&mut self) {
+        let visible_lines = self.diff_state.effective_visible_lines();
+        let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
+        let max_scroll = self.max_scroll_offset();
+        self.diff_state.scroll_offset = self
+            .diff_state
+            .cursor_line
+            .saturating_sub(visible_lines.saturating_sub(1 + scroll_margin))
+            .min(max_scroll);
+    }
+
     pub fn go_to_source_line(&mut self, target_lineno: u32) {
         let current_file = self.diff_state.current_file_idx;
         let result = find_source_line(&self.line_annotations, current_file, target_lineno);

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,14 +327,24 @@ fn main() -> anyhow::Result<()> {
                         app.message = None;
                     }
 
-                    // Handle pending z command for zz centering
+                    // Handle pending z command for zz/zt/zb viewport positioning
                     if pending_z {
                         pending_z = false;
-                        if key.code == crossterm::event::KeyCode::Char('z') {
-                            app.center_cursor();
-                            continue;
+                        match key.code {
+                            crossterm::event::KeyCode::Char('z') => {
+                                app.center_cursor();
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('t') => {
+                                app.cursor_to_top();
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('b') => {
+                                app.cursor_to_bottom();
+                                continue;
+                            }
+                            _ => {} // Fall through to normal handling
                         }
-                        // Otherwise fall through to normal handling
                     }
 
                     // Handle pending Z command for ZZ (export+quit) / ZQ (quit)


### PR DESCRIPTION
Adds support for `zt` (move cursor to top) & `zb` (move cursor to bottom):

https://github.com/user-attachments/assets/95fe26f7-9b46-4d8f-bf4f-a5d612e5a2b0