### PR TITLE
perf: streaming highlight + perceived-latency fixes for large diffs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2540,7 +2540,9 @@ impl App {
         use std::path::Path;
 
         if idx < self.diff_files.len() {
+            let prev = self.diff_state.current_file_idx;
             self.diff_state.current_file_idx = idx;
+            self.reprioritize_highlights_if_file_changed(prev);
             self.diff_state.cursor_line = self.calculate_file_scroll_offset(idx);
             let max_scroll = self.max_scroll_offset();
             self.diff_state.scroll_offset = self.diff_state.cursor_line.min(max_scroll);
@@ -2909,26 +2911,38 @@ impl App {
     }
 
     fn update_current_file_from_cursor(&mut self) {
+        let prev = self.diff_state.current_file_idx;
+        if let Some(new_idx) = self.file_idx_at_cursor() {
+            self.diff_state.current_file_idx = new_idx;
+            self.file_list_state.select(new_idx);
+        }
+        self.reprioritize_highlights_if_file_changed(prev);
+    }
+
+    fn file_idx_at_cursor(&self) -> Option<usize> {
+        if self.diff_files.is_empty() {
+            return None;
+        }
         let mut cumulative = self.review_comments_render_height();
         if self.diff_state.cursor_line < cumulative {
-            if !self.diff_files.is_empty() {
-                self.diff_state.current_file_idx = 0;
-                self.file_list_state.select(0);
-            }
-            return;
+            return Some(0);
         }
         for (i, file) in self.diff_files.iter().enumerate() {
             let height = self.file_render_height(i, file);
             if cumulative + height > self.diff_state.cursor_line {
-                self.diff_state.current_file_idx = i;
-                self.file_list_state.select(i);
-                return;
+                return Some(i);
             }
             cumulative += height;
         }
-        if !self.diff_files.is_empty() {
-            self.diff_state.current_file_idx = self.diff_files.len() - 1;
-            self.file_list_state.select(self.diff_files.len() - 1);
+        Some(self.diff_files.len() - 1)
+    }
+
+    fn reprioritize_highlights_if_file_changed(&self, prev: usize) {
+        if prev == self.diff_state.current_file_idx {
+            return;
+        }
+        if let Some(session) = self.highlight_session.as_ref() {
+            session.prioritize_around(self.diff_state.current_file_idx);
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::mpsc::TryRecvError;
 use std::time::{Duration, Instant};
 
 use chrono::Utc;
@@ -12,11 +14,11 @@ use crate::model::{
     LineRange, LineSide, ReviewSession, SessionDiffSource,
 };
 use crate::persistence::load_latest_session_for_context;
-use crate::syntax::SyntaxHighlighter;
+use crate::syntax::streaming::{self, HighlightJob, HighlightSession};
 use crate::theme::Theme;
 use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
-use crate::vcs::{CommitInfo, FileBackend, VcsBackend, VcsInfo, detect_vcs};
+use crate::vcs::{CommitInfo, DiffWithJobs, FileBackend, VcsBackend, VcsInfo, detect_vcs};
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
 const COMMIT_PAGE_SIZE: usize = 10;
@@ -374,6 +376,18 @@ pub struct App {
     pub diff_files: Vec<DiffFile>,
     pub diff_source: DiffSource,
 
+    /// Background syntax-highlight worker. `None` once the current diff is
+    /// fully highlighted (or had nothing to highlight). Replacing the diff
+    /// cancels the old session so its in-flight work is discarded.
+    pub(crate) highlight_session: Option<HighlightSession>,
+
+    /// Jobs handed to `install_diff` but not yet given to a worker. Holding
+    /// them here lets follow-up `diff_files` reorderings (commit-message
+    /// insert, directory sort) settle before the worker starts emitting
+    /// updates keyed by `file_idx`; the first `drain_highlight_updates` call
+    /// resolves indices by `syntax_path` and spawns the worker.
+    pub(crate) pending_highlight_jobs: Vec<HighlightJob>,
+
     pub input_mode: InputMode,
     pub focused_panel: FocusedPanel,
     pub diff_view_mode: DiffViewMode,
@@ -602,8 +616,7 @@ impl App {
         if let Some(file_path) = file_path {
             let vcs = Box::new(FileBackend::new(file_path)?);
             let vcs_info = vcs.info().clone();
-            let highlighter = theme.syntax_highlighter();
-            let diff_files = vcs.get_working_tree_diff(highlighter)?;
+            let diff = vcs.get_working_tree_diff()?;
             let session = Self::load_or_create_session(&vcs_info, SessionDiffSource::WorkingTree);
 
             let mut app = Self::build(
@@ -612,7 +625,7 @@ impl App {
                 theme,
                 comment_type_configs,
                 output_to_stdout,
-                diff_files,
+                diff,
                 session,
                 DiffSource::WorkingTree,
                 InputMode::Normal,
@@ -629,7 +642,6 @@ impl App {
 
         let vcs = detect_vcs()?;
         let vcs_info = vcs.info().clone();
-        let highlighter = theme.syntax_highlighter();
         // Determine the diff source, files, and session based on input.
         // Four paths:
         //   1. -r + -w: combined commit range and uncommitted changes
@@ -641,11 +653,10 @@ impl App {
 
             if working_tree {
                 // Combined: commit range + staged/unstaged changes
-                let diff_files = Self::get_working_tree_with_commits_diff_with_ignore(
+                let diff = Self::get_working_tree_with_commits_diff_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
                     &commit_ids,
-                    highlighter,
                     path_filter,
                 )?;
                 let session = Self::load_or_create_staged_unstaged_and_commits_session(
@@ -661,14 +672,12 @@ impl App {
                 let has_staged = Self::get_staged_diff_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
-                    highlighter,
                     path_filter,
                 )
                 .is_ok();
                 let has_unstaged = Self::get_unstaged_diff_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
-                    highlighter,
                     path_filter,
                 )
                 .is_ok();
@@ -687,7 +696,7 @@ impl App {
                     theme,
                     comment_type_configs.clone(),
                     output_to_stdout,
-                    diff_files,
+                    diff,
                     session,
                     DiffSource::StagedUnstagedAndCommits(commit_ids),
                     InputMode::Normal,
@@ -718,11 +727,10 @@ impl App {
             }
 
             // Resolve the revisions to commits and diff as a commit range
-            let diff_files = Self::get_commit_range_diff_with_ignore(
+            let diff = Self::get_commit_range_diff_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
                 &commit_ids,
-                highlighter,
                 path_filter,
             )?;
             let session = Self::load_or_create_commit_range_session(&vcs_info, &commit_ids);
@@ -737,7 +745,7 @@ impl App {
                 theme,
                 comment_type_configs.clone(),
                 output_to_stdout,
-                diff_files,
+                diff,
                 session,
                 DiffSource::CommitRange(commit_ids),
                 InputMode::Normal,
@@ -766,10 +774,9 @@ impl App {
             Ok(app)
         } else if working_tree {
             // Skip commit selector, go straight to working tree diff
-            let diff_files = Self::get_working_tree_diff_with_ignore(
+            let diff = Self::get_working_tree_diff_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
-                highlighter,
                 path_filter,
             )?;
             let session =
@@ -781,7 +788,7 @@ impl App {
                 theme,
                 comment_type_configs,
                 output_to_stdout,
-                diff_files,
+                diff,
                 session,
                 DiffSource::StagedAndUnstaged,
                 InputMode::Normal,
@@ -794,7 +801,6 @@ impl App {
             let has_staged_changes = match Self::get_staged_diff_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
-                highlighter,
                 path_filter,
             ) {
                 Ok(_) => true,
@@ -806,7 +812,6 @@ impl App {
             let has_unstaged_changes = match Self::get_unstaged_diff_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
-                highlighter,
                 path_filter,
             ) {
                 Ok(_) => true,
@@ -819,10 +824,9 @@ impl App {
                 match Self::get_working_tree_diff_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
-                    highlighter,
                     path_filter,
                 ) {
-                    Ok(diff_files) => Some(diff_files),
+                    Ok(diff) => Some(diff),
                     Err(TuicrError::NoChanges) => None,
                     Err(e) => return Err(e),
                 }
@@ -893,15 +897,14 @@ impl App {
         theme: Theme,
         comment_type_configs: Option<Vec<CommentTypeConfig>>,
         output_to_stdout: bool,
-        diff_files: Vec<DiffFile>,
+        diff: DiffWithJobs,
         mut session: ReviewSession,
         diff_source: DiffSource,
         input_mode: InputMode,
         commit_list: Vec<CommitInfo>,
         path_filter: Option<&str>,
     ) -> Result<Self> {
-        // Ensure all diff files are registered in the session
-        for file in &diff_files {
+        for file in &diff.0 {
             session.add_file(file.display_path().clone(), file.status, file.content_hash);
         }
 
@@ -920,8 +923,10 @@ impl App {
             vcs,
             vcs_info,
             session,
-            diff_files,
+            diff_files: Vec::new(),
             diff_source,
+            highlight_session: None,
+            pending_highlight_jobs: Vec::new(),
             input_mode,
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
@@ -984,6 +989,7 @@ impl App {
             export_legend: true,
         };
         // Auto-hide file list when path filter matches exactly one file
+        app.install_diff(diff);
         if app.path_filter.is_some() && app.diff_files.len() == 1 {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
@@ -1354,123 +1360,152 @@ impl App {
             .saturating_sub(self.special_commit_count())
     }
 
-    fn filter_ignored_diff_files(repo_root: &Path, diff_files: Vec<DiffFile>) -> Vec<DiffFile> {
-        crate::tuicrignore::filter_diff_files(repo_root, diff_files)
+    fn filter_ignored_diff(repo_root: &Path, diff: DiffWithJobs) -> DiffWithJobs {
+        crate::tuicrignore::filter_diff_files(repo_root, diff)
     }
 
-    fn filter_by_path(diff_files: Vec<DiffFile>, path: &str) -> Vec<DiffFile> {
-        let path = path.trim_end_matches('/');
-        diff_files
-            .into_iter()
-            .filter(|f| {
-                let display = f.display_path().to_string_lossy();
-                display == path || display.starts_with(&format!("{path}/"))
-            })
-            .collect()
+    fn filter_by_path(diff: DiffWithJobs, path: &str) -> DiffWithJobs {
+        let path = path.trim_end_matches('/').to_string();
+        crate::vcs::filter_diff_with_jobs(diff, |f| {
+            let display = f.display_path().to_string_lossy();
+            display == path || display.starts_with(&format!("{path}/"))
+        })
     }
 
-    fn require_non_empty_diff_files(diff_files: Vec<DiffFile>) -> Result<Vec<DiffFile>> {
-        if diff_files.is_empty() {
+    fn finalize_diff(
+        diff: DiffWithJobs,
+        repo_root: &Path,
+        path_filter: Option<&str>,
+    ) -> Result<DiffWithJobs> {
+        let diff = Self::filter_ignored_diff(repo_root, diff);
+        let diff = match path_filter {
+            Some(path) => Self::filter_by_path(diff, path),
+            None => diff,
+        };
+        if diff.0.is_empty() {
             return Err(TuicrError::NoChanges);
         }
-        Ok(diff_files)
+        Ok(diff)
+    }
+
+    /// Replace the current diff in place. Cancels any prior highlight session
+    /// and stages the new jobs; the worker is spawned on the first
+    /// `drain_highlight_updates` call so any `diff_files` mutations queued for
+    /// after this call settle before updates start flowing.
+    fn install_diff(&mut self, diff: DiffWithJobs) {
+        if let Some(session) = self.highlight_session.take() {
+            session.cancel();
+        }
+        let (files, jobs) = diff;
+        self.diff_files = files;
+        self.pending_highlight_jobs = jobs;
+    }
+
+    fn start_pending_highlight_session(&mut self) {
+        if self.highlight_session.is_some() || self.pending_highlight_jobs.is_empty() {
+            return;
+        }
+        let jobs = std::mem::take(&mut self.pending_highlight_jobs);
+        let highlighter_arc = Arc::clone(self.theme.syntax_highlighter_arc());
+        self.highlight_session =
+            HighlightSession::start_resolved(jobs, &self.diff_files, highlighter_arc);
+    }
+
+    /// Drain pending highlight results and patch them into `diff_files`.
+    /// Spawns the worker lazily on first call after `install_diff`, so all
+    /// synchronous `diff_files` reorderings have completed before any update
+    /// is produced.
+    pub fn drain_highlight_updates(&mut self) {
+        self.start_pending_highlight_session();
+        let Some(session) = self.highlight_session.as_ref() else {
+            return;
+        };
+        loop {
+            match session.try_recv() {
+                Ok(update) => streaming::apply_update(
+                    &mut self.diff_files,
+                    self.theme.syntax_highlighter(),
+                    update,
+                ),
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => {
+                    self.highlight_session = None;
+                    break;
+                }
+            }
+        }
+    }
+
+    /// True while the background highlight worker still has pending results,
+    /// or while jobs are staged awaiting their first drain. Used by the main
+    /// loop to shorten its event-poll timeout so streamed results land on
+    /// screen with low latency.
+    pub fn highlight_streaming(&self) -> bool {
+        self.highlight_session.is_some() || !self.pending_highlight_jobs.is_empty()
     }
 
     fn get_working_tree_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
-        highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
-    ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_working_tree_diff(highlighter)?;
-        let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
-        let diff_files = if let Some(path) = path_filter {
-            Self::filter_by_path(diff_files, path)
-        } else {
-            diff_files
-        };
-        Self::require_non_empty_diff_files(diff_files)
+    ) -> Result<DiffWithJobs> {
+        Self::finalize_diff(vcs.get_working_tree_diff()?, repo_root, path_filter)
     }
 
     fn get_staged_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
-        highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
-    ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_staged_diff(highlighter)?;
-        let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
-        let diff_files = if let Some(path) = path_filter {
-            Self::filter_by_path(diff_files, path)
-        } else {
-            diff_files
-        };
-        Self::require_non_empty_diff_files(diff_files)
+    ) -> Result<DiffWithJobs> {
+        Self::finalize_diff(vcs.get_staged_diff()?, repo_root, path_filter)
     }
 
     fn get_unstaged_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
-        highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
-    ) -> Result<Vec<DiffFile>> {
-        let diff_files = match vcs.get_unstaged_diff(highlighter) {
-            Ok(diff_files) => diff_files,
-            Err(TuicrError::UnsupportedOperation(_)) => vcs.get_working_tree_diff(highlighter)?,
+    ) -> Result<DiffWithJobs> {
+        let diff = match vcs.get_unstaged_diff() {
+            Ok(d) => d,
+            Err(TuicrError::UnsupportedOperation(_)) => vcs.get_working_tree_diff()?,
             Err(e) => return Err(e),
         };
-        let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
-        let diff_files = if let Some(path) = path_filter {
-            Self::filter_by_path(diff_files, path)
-        } else {
-            diff_files
-        };
-        Self::require_non_empty_diff_files(diff_files)
+        Self::finalize_diff(diff, repo_root, path_filter)
     }
 
     fn get_commit_range_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
         commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
-    ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_commit_range_diff(commit_ids, highlighter)?;
-        let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
-        let diff_files = if let Some(path) = path_filter {
-            Self::filter_by_path(diff_files, path)
-        } else {
-            diff_files
-        };
-        Self::require_non_empty_diff_files(diff_files)
+    ) -> Result<DiffWithJobs> {
+        Self::finalize_diff(
+            vcs.get_commit_range_diff(commit_ids)?,
+            repo_root,
+            path_filter,
+        )
     }
 
     fn get_working_tree_with_commits_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
         commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
-    ) -> Result<Vec<DiffFile>> {
-        let diff_files = vcs.get_working_tree_with_commits_diff(commit_ids, highlighter)?;
-        let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
-        let diff_files = if let Some(path) = path_filter {
-            Self::filter_by_path(diff_files, path)
-        } else {
-            diff_files
-        };
-        Self::require_non_empty_diff_files(diff_files)
+    ) -> Result<DiffWithJobs> {
+        Self::finalize_diff(
+            vcs.get_working_tree_with_commits_diff(commit_ids)?,
+            repo_root,
+            path_filter,
+        )
     }
 
     fn load_staged_and_unstaged_selection(&mut self) -> Result<()> {
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = match Self::get_working_tree_diff_with_ignore(
+        let diff = match Self::get_working_tree_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            highlighter,
             self.path_filter.as_deref(),
         ) {
-            Ok(diff_files) => diff_files,
+            Ok(diff) => diff,
             Err(TuicrError::NoChanges) => {
                 self.set_message("No staged or unstaged changes");
                 return Ok(());
@@ -1480,12 +1515,12 @@ impl App {
 
         self.session =
             Self::load_or_create_session(&self.vcs_info, SessionDiffSource::StagedAndUnstaged);
-        for file in &diff_files {
+        for file in &diff.0 {
             let path = file.display_path().clone();
             self.session.add_file(path, file.status, file.content_hash);
         }
 
-        self.diff_files = diff_files;
+        self.install_diff(diff);
         self.diff_source = DiffSource::StagedAndUnstaged;
         self.input_mode = InputMode::Normal;
         self.diff_state = DiffState::default();
@@ -1499,14 +1534,12 @@ impl App {
     }
 
     fn load_staged_selection(&mut self) -> Result<()> {
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = match Self::get_staged_diff_with_ignore(
+        let diff = match Self::get_staged_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            highlighter,
             self.path_filter.as_deref(),
         ) {
-            Ok(diff_files) => diff_files,
+            Ok(diff) => diff,
             Err(TuicrError::NoChanges) => {
                 self.set_message("No staged changes");
                 return Ok(());
@@ -1515,12 +1548,12 @@ impl App {
         };
 
         self.session = Self::load_or_create_session(&self.vcs_info, SessionDiffSource::Staged);
-        for file in &diff_files {
+        for file in &diff.0 {
             let path = file.display_path().clone();
             self.session.add_file(path, file.status, file.content_hash);
         }
 
-        self.diff_files = diff_files;
+        self.install_diff(diff);
         self.diff_source = DiffSource::Staged;
         self.input_mode = InputMode::Normal;
         self.diff_state = DiffState::default();
@@ -1534,14 +1567,12 @@ impl App {
     }
 
     fn load_unstaged_selection(&mut self) -> Result<()> {
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = match Self::get_unstaged_diff_with_ignore(
+        let diff = match Self::get_unstaged_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            highlighter,
             self.path_filter.as_deref(),
         ) {
-            Ok(diff_files) => diff_files,
+            Ok(diff) => diff,
             Err(TuicrError::NoChanges) => {
                 self.set_message("No unstaged changes");
                 return Ok(());
@@ -1550,12 +1581,12 @@ impl App {
         };
 
         self.session = Self::load_or_create_session(&self.vcs_info, SessionDiffSource::Unstaged);
-        for file in &diff_files {
+        for file in &diff.0 {
             let path = file.display_path().clone();
             self.session.add_file(path, file.status, file.content_hash);
         }
 
-        self.diff_files = diff_files;
+        self.install_diff(diff);
         self.diff_source = DiffSource::Unstaged;
         self.input_mode = InputMode::Normal;
         self.diff_state = DiffState::default();
@@ -1585,13 +1616,11 @@ impl App {
             prev_cursor_line.saturating_sub(start)
         };
 
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = match &self.diff_source {
+        let diff = match &self.diff_source {
             DiffSource::CommitRange(commit_ids) => Self::get_commit_range_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
                 commit_ids,
-                highlighter,
                 self.path_filter.as_deref(),
             )?,
             DiffSource::StagedUnstagedAndCommits(commit_ids) => {
@@ -1600,41 +1629,37 @@ impl App {
                     self.vcs.as_ref(),
                     &self.vcs_info.root_path,
                     &ids,
-                    highlighter,
                     self.path_filter.as_deref(),
                 )?
             }
             DiffSource::Staged => Self::get_staged_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                highlighter,
                 self.path_filter.as_deref(),
             )?,
             DiffSource::Unstaged => Self::get_unstaged_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                highlighter,
                 self.path_filter.as_deref(),
             )?,
             DiffSource::StagedAndUnstaged | DiffSource::WorkingTree => {
                 Self::get_working_tree_diff_with_ignore(
                     self.vcs.as_ref(),
                     &self.vcs_info.root_path,
-                    highlighter,
                     self.path_filter.as_deref(),
                 )?
             }
         };
 
         let mut invalidated = 0;
-        for file in &diff_files {
+        for file in &diff.0 {
             let path = file.display_path().clone();
             if self.session.add_file(path, file.status, file.content_hash) {
                 invalidated += 1;
             }
         }
 
-        self.diff_files = diff_files;
+        self.install_diff(diff);
         self.clear_expanded_gaps();
 
         self.sort_files_by_directory(false);
@@ -3498,11 +3523,9 @@ impl App {
             self.saved_inline_selection = self.commit_selection_range;
         }
 
-        let highlighter = self.theme.syntax_highlighter();
         let has_staged_changes = match Self::get_staged_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            highlighter,
             self.path_filter.as_deref(),
         ) {
             Ok(_) => true,
@@ -3514,7 +3537,6 @@ impl App {
         let has_unstaged_changes = match Self::get_unstaged_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            highlighter,
             self.path_filter.as_deref(),
         ) {
             Ok(_) => true,
@@ -3571,23 +3593,18 @@ impl App {
             self.diff_source,
             DiffSource::CommitRange(_) | DiffSource::StagedUnstagedAndCommits(_)
         ) {
-            let highlighter = self.theme.syntax_highlighter();
             match Self::get_working_tree_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                highlighter,
                 self.path_filter.as_deref(),
             ) {
-                Ok(diff_files) => {
-                    self.diff_files = diff_files;
-                    self.diff_source = DiffSource::StagedAndUnstaged;
-
-                    // Update session for new files
-                    for file in &self.diff_files {
+                Ok(diff) => {
+                    for file in &diff.0 {
                         let path = file.display_path().clone();
                         self.session.add_file(path, file.status, file.content_hash);
                     }
-
+                    self.install_diff(diff);
+                    self.diff_source = DiffSource::StagedAndUnstaged;
                     self.sort_files_by_directory(true);
                     self.expand_all_dirs();
                 }
@@ -3832,9 +3849,11 @@ impl App {
         };
 
         // Collect selected entries in order from oldest to newest (end..start).
-        let selected_commits: Vec<&CommitInfo> = (start..=end)
+        // Cloned eagerly so the immutable borrow of `self.commit_list` is
+        // released before any `&mut self` calls (install_diff, set_message).
+        let selected_commits: Vec<CommitInfo> = (start..=end)
             .rev()
-            .filter_map(|i| self.commit_list.get(i))
+            .filter_map(|i| self.commit_list.get(i).cloned())
             .collect();
 
         if selected_commits.is_empty() {
@@ -3842,8 +3861,8 @@ impl App {
             return Ok(());
         }
 
-        let selected_staged = selected_commits.iter().any(|c| Self::is_staged_commit(c));
-        let selected_unstaged = selected_commits.iter().any(|c| Self::is_unstaged_commit(c));
+        let selected_staged = selected_commits.iter().any(Self::is_staged_commit);
+        let selected_unstaged = selected_commits.iter().any(Self::is_unstaged_commit);
         let selected_ids: Vec<String> = selected_commits
             .iter()
             .filter(|c| !Self::is_special_commit(c))
@@ -3851,8 +3870,7 @@ impl App {
             .collect();
 
         if (selected_staged || selected_unstaged) && !selected_ids.is_empty() {
-            let all_selected: Vec<CommitInfo> = selected_commits.into_iter().cloned().collect();
-            return self.load_staged_unstaged_and_commits_selection(selected_ids, all_selected);
+            return self.load_staged_unstaged_and_commits_selection(selected_ids, selected_commits);
         }
 
         if selected_staged && selected_unstaged {
@@ -3868,16 +3886,14 @@ impl App {
         }
 
         // Get the diff for the selected commits
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = Self::get_commit_range_diff_with_ignore(
+        let diff = Self::get_commit_range_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
             &selected_ids,
-            highlighter,
             self.path_filter.as_deref(),
         )?;
 
-        if diff_files.is_empty() {
+        if diff.0.is_empty() {
             self.set_message("No changes in selected commits");
             return Ok(());
         }
@@ -3913,13 +3929,12 @@ impl App {
         self.session = session;
 
         // Add files to session
-        for file in &diff_files {
+        for file in &diff.0 {
             let path = file.display_path().clone();
             self.session.add_file(path, file.status, file.content_hash);
         }
 
-        // Update app state
-        self.diff_files = diff_files;
+        self.install_diff(diff);
         self.diff_source = DiffSource::CommitRange(selected_ids);
         self.input_mode = InputMode::Normal;
 
@@ -3928,11 +3943,7 @@ impl App {
         self.file_list_state = FileListState::default();
 
         // Set up inline commit selector for multi-commit reviews (newest-first display order)
-        self.review_commits = selected_commits
-            .iter()
-            .rev()
-            .map(|c| (*c).clone())
-            .collect();
+        self.review_commits = selected_commits.into_iter().rev().collect();
         self.range_diff_files = Some(self.diff_files.clone());
         self.commit_list = self.review_commits.clone();
         self.commit_list_cursor = 0;
@@ -3965,9 +3976,9 @@ impl App {
         // Check if all commits selected -> use cached range_diff_files
         if start == 0
             && end == self.review_commits.len() - 1
-            && let Some(ref files) = self.range_diff_files
+            && let Some(files) = self.range_diff_files.clone()
         {
-            self.diff_files = files.clone();
+            self.install_diff((files, Vec::new()));
             let wrap = self.diff_state.wrap_lines;
             self.diff_state = DiffState::default();
             self.diff_state.wrap_lines = wrap;
@@ -3982,8 +3993,8 @@ impl App {
         }
 
         // Check cache for this subrange
-        if let Some(files) = self.commit_diff_cache.get(&(start, end)) {
-            self.diff_files = files.clone();
+        if let Some(files) = self.commit_diff_cache.get(&(start, end)).cloned() {
+            self.install_diff((files, Vec::new()));
             let wrap = self.diff_state.wrap_lines;
             self.diff_state = DiffState::default();
             self.diff_state.wrap_lines = wrap;
@@ -4015,50 +4026,46 @@ impl App {
             .map(|c| c.id.clone())
             .collect();
 
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = if (has_staged || has_unstaged) && !selected_ids.is_empty() {
+        let empty: DiffWithJobs = (Vec::new(), Vec::new());
+        let diff = if (has_staged || has_unstaged) && !selected_ids.is_empty() {
             match Self::get_working_tree_with_commits_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
                 &selected_ids,
-                highlighter,
                 self.path_filter.as_deref(),
             ) {
-                Ok(files) => files,
-                Err(TuicrError::NoChanges) => Vec::new(),
+                Ok(d) => d,
+                Err(TuicrError::NoChanges) => empty,
                 Err(e) => return Err(e),
             }
         } else if has_staged && has_unstaged {
             match Self::get_working_tree_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                highlighter,
                 self.path_filter.as_deref(),
             ) {
-                Ok(files) => files,
-                Err(TuicrError::NoChanges) => Vec::new(),
+                Ok(d) => d,
+                Err(TuicrError::NoChanges) => empty,
                 Err(e) => return Err(e),
             }
         } else if has_staged {
             match Self::get_staged_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                highlighter,
                 self.path_filter.as_deref(),
             ) {
-                Ok(files) => files,
-                Err(TuicrError::NoChanges) => Vec::new(),
+                Ok(d) => d,
+                Err(TuicrError::NoChanges) => empty,
                 Err(e) => return Err(e),
             }
         } else if has_unstaged {
             match Self::get_unstaged_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                highlighter,
                 self.path_filter.as_deref(),
             ) {
-                Ok(files) => files,
-                Err(TuicrError::NoChanges) => Vec::new(),
+                Ok(d) => d,
+                Err(TuicrError::NoChanges) => empty,
                 Err(e) => return Err(e),
             }
         } else {
@@ -4066,17 +4073,15 @@ impl App {
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
                 &selected_ids,
-                highlighter,
                 self.path_filter.as_deref(),
             ) {
-                Ok(files) => files,
-                Err(TuicrError::NoChanges) => Vec::new(),
+                Ok(d) => d,
+                Err(TuicrError::NoChanges) => empty,
                 Err(e) => return Err(e),
             }
         };
-        self.commit_diff_cache
-            .insert((start, end), diff_files.clone());
-        self.diff_files = diff_files;
+        self.commit_diff_cache.insert((start, end), diff.0.clone());
+        self.install_diff(diff);
 
         // Reset navigation, rebuild file tree + annotations
         let wrap = self.diff_state.wrap_lines;
@@ -4098,15 +4103,13 @@ impl App {
         selected_ids: Vec<String>,
         selected_commits: Vec<CommitInfo>,
     ) -> Result<()> {
-        let highlighter = self.theme.syntax_highlighter();
-        let diff_files = match Self::get_working_tree_with_commits_diff_with_ignore(
+        let diff = match Self::get_working_tree_with_commits_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
             &selected_ids,
-            highlighter,
             self.path_filter.as_deref(),
         ) {
-            Ok(diff_files) => diff_files,
+            Ok(d) => d,
             Err(TuicrError::NoChanges) => {
                 self.set_message("No changes in selected commits + staged/unstaged");
                 return Ok(());
@@ -4117,12 +4120,12 @@ impl App {
         self.session =
             Self::load_or_create_staged_unstaged_and_commits_session(&self.vcs_info, &selected_ids);
 
-        for file in &diff_files {
+        for file in &diff.0 {
             let path = file.display_path().clone();
             self.session.add_file(path, file.status, file.content_hash);
         }
 
-        self.diff_files = diff_files;
+        self.install_diff(diff);
         self.diff_source = DiffSource::StagedUnstagedAndCommits(selected_ids);
         self.input_mode = InputMode::Normal;
         self.diff_state = DiffState::default();
@@ -5046,7 +5049,7 @@ mod commit_selection_tests {
             &self.info
         }
 
-        fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        fn get_working_tree_diff(&self) -> Result<crate::vcs::DiffWithJobs> {
             Err(TuicrError::NoChanges)
         }
 
@@ -5083,7 +5086,7 @@ mod commit_selection_tests {
             Theme::dark(),
             None,
             false,
-            Vec::new(),
+            (Vec::new(), Vec::new()),
             session,
             DiffSource::WorkingTree,
             InputMode::CommitSelect,
@@ -5166,7 +5169,7 @@ mod scroll_behavior_tests {
             &self.info
         }
 
-        fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        fn get_working_tree_diff(&self) -> Result<crate::vcs::DiffWithJobs> {
             Err(TuicrError::NoChanges)
         }
 
@@ -5237,7 +5240,7 @@ mod scroll_behavior_tests {
             Theme::dark(),
             None,
             false,
-            vec![file],
+            (vec![file], Vec::new()),
             session,
             DiffSource::WorkingTree,
             InputMode::Normal,
@@ -5752,7 +5755,7 @@ mod expand_gap_tests {
             &self.info
         }
 
-        fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        fn get_working_tree_diff(&self) -> Result<crate::vcs::DiffWithJobs> {
             Err(TuicrError::NoChanges)
         }
 
@@ -5821,7 +5824,7 @@ mod expand_gap_tests {
             Theme::dark(),
             None,
             false,
-            files,
+            (files, Vec::new()),
             session,
             DiffSource::WorkingTree,
             InputMode::Normal,

--- a/src/app.rs
+++ b/src/app.rs
@@ -393,6 +393,13 @@ pub struct App {
     pub diff_view_mode: DiffViewMode,
 
     pub file_list_state: FileListState,
+    /// True while the user has manually scrolled the file list independently
+    /// of the diff cursor. Suppresses the render-time "sync selection to
+    /// diff's current file" path so wheel scrolls aren't snapped back by
+    /// ratatui's auto-adjust-on-selection-change. Cleared when something
+    /// else changes the diff's current file (cursor moving into a new file,
+    /// click jump, } / { navigation).
+    pub manual_file_list_scroll: bool,
     pub diff_state: DiffState,
     pub help_state: HelpState,
     pub command_buffer: String,
@@ -931,6 +938,7 @@ impl App {
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
             file_list_state: FileListState::default(),
+            manual_file_list_scroll: false,
             diff_state: DiffState::default(),
             help_state: HelpState::default(),
             command_buffer: String::new(),
@@ -2260,6 +2268,7 @@ impl App {
         if self.file_list_state.selected() < new_offset {
             self.file_list_state.select(new_offset);
         }
+        self.manual_file_list_scroll = true;
     }
 
     /// Scroll the file-list viewport up by `lines` without moving the
@@ -2276,6 +2285,7 @@ impl App {
         if self.file_list_state.selected() > max_visible {
             self.file_list_state.select(max_visible);
         }
+        self.manual_file_list_scroll = true;
     }
 
     pub fn diff_annotation_at_screen_row(&self, screen_row: u16) -> Option<usize> {
@@ -2937,10 +2947,11 @@ impl App {
         Some(self.diff_files.len() - 1)
     }
 
-    fn reprioritize_highlights_if_file_changed(&self, prev: usize) {
+    fn reprioritize_highlights_if_file_changed(&mut self, prev: usize) {
         if prev == self.diff_state.current_file_idx {
             return;
         }
+        self.manual_file_list_scroll = false;
         if let Some(session) = self.highlight_session.as_ref() {
             session.prioritize_around(self.diff_state.current_file_idx);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,11 @@ const IDLE_POLL_TIMEOUT: Duration = Duration::from_millis(100);
 /// ~30 ms keeps perceived latency between worker emit and on-screen update
 /// under one frame; CPU cost of the extra wakeups is negligible.
 const STREAMING_POLL_TIMEOUT: Duration = Duration::from_millis(30);
+/// Cap on events drained per tick. Holding j or wheel-scrolling fast queues
+/// events faster than the per-event render can consume them; processing the
+/// batch and rendering once kills perceived input lag. A cap keeps a paste
+/// or stuck-key from monopolising the loop for too long before redraw.
+const MAX_EVENTS_PER_TICK: usize = 64;
 
 fn main() -> anyhow::Result<()> {
     // Setup panic hook to restore terminal on panic
@@ -252,7 +257,7 @@ fn main() -> anyhow::Result<()> {
     let mut pending_ctrl_c: Option<Instant> = None;
 
     // Main loop
-    loop {
+    'main: loop {
         // Check for update result (non-blocking)
         if let Some(ref rx) = update_rx
             && let Ok(
@@ -290,194 +295,202 @@ fn main() -> anyhow::Result<()> {
             IDLE_POLL_TIMEOUT
         };
 
-        // Handle events
+        // Drain queued events before redrawing; see MAX_EVENTS_PER_TICK.
         if event::poll(poll_timeout)? {
-            let event = event::read()?;
-            match event {
-                Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    // Handle Ctrl+C twice to exit (works across all input modes)
-                    // In Comment mode, first Ctrl+C also cancels the comment
-                    if key.code == crossterm::event::KeyCode::Char('c')
-                        && key
-                            .modifiers
-                            .contains(crossterm::event::KeyModifiers::CONTROL)
-                    {
-                        // If in comment mode, cancel the comment first
-                        if app.input_mode == InputMode::Comment {
-                            app.exit_comment_mode();
-                        }
-
-                        if let Some(first_press) = pending_ctrl_c
-                            && first_press.elapsed() < CTRL_C_EXIT_TIMEOUT
+            for _ in 0..MAX_EVENTS_PER_TICK {
+                let event = event::read()?;
+                match event {
+                    Event::Key(key) if key.kind == KeyEventKind::Press => {
+                        // Handle Ctrl+C twice to exit (works across all input modes)
+                        // In Comment mode, first Ctrl+C also cancels the comment
+                        if key.code == crossterm::event::KeyCode::Char('c')
+                            && key
+                                .modifiers
+                                .contains(crossterm::event::KeyModifiers::CONTROL)
                         {
-                            // Second Ctrl+C within timeout - exit immediately
-                            app.should_quit = true;
-                            continue;
-                        }
-                        // First Ctrl+C (or timeout expired) - show warning and start timer
-                        pending_ctrl_c = Some(Instant::now());
-                        app.set_message("Press Ctrl+C again to exit");
-                        continue;
-                    }
-
-                    // Any other key clears the pending Ctrl+C state and message
-                    if pending_ctrl_c.is_some() {
-                        pending_ctrl_c = None;
-                        app.message = None;
-                    }
-
-                    // Handle pending z command for zz centering
-                    if pending_z {
-                        pending_z = false;
-                        if key.code == crossterm::event::KeyCode::Char('z') {
-                            app.center_cursor();
-                            continue;
-                        }
-                        // Otherwise fall through to normal handling
-                    }
-
-                    // Handle pending Z command for ZZ (export+quit) / ZQ (quit)
-                    if pending_shift_z {
-                        pending_shift_z = false;
-                        match key.code {
-                            crossterm::event::KeyCode::Char('Z') => {
-                                // ZZ: save session, export, and quit (same as :wq)
-                                let _ = persistence::save_session(&app.session);
-                                app.dirty = false;
-                                if app.session.has_comments() {
-                                    handler::handle_export_and_quit(&mut app);
-                                } else {
-                                    app.should_quit = true;
-                                }
-                                continue;
+                            // If in comment mode, cancel the comment first
+                            if app.input_mode == InputMode::Comment {
+                                app.exit_comment_mode();
                             }
-                            crossterm::event::KeyCode::Char('Q') => {
-                                // ZQ: quit without exporting (same as q)
+
+                            if let Some(first_press) = pending_ctrl_c
+                                && first_press.elapsed() < CTRL_C_EXIT_TIMEOUT
+                            {
+                                // Second Ctrl+C within timeout - exit immediately
                                 app.should_quit = true;
-                                continue;
+                                continue 'main;
                             }
-                            _ => {} // Fall through to normal handling
+                            // First Ctrl+C (or timeout expired) - show warning and start timer
+                            pending_ctrl_c = Some(Instant::now());
+                            app.set_message("Press Ctrl+C again to exit");
+                            continue 'main;
                         }
-                    }
 
-                    // Handle pending d command for dd delete comment
-                    if pending_d {
-                        pending_d = false;
-                        if key.code == crossterm::event::KeyCode::Char('d') {
-                            if !app.delete_comment_at_cursor() {
-                                app.set_message("No comment at cursor");
-                            }
-                            continue;
+                        // Any other key clears the pending Ctrl+C state and message
+                        if pending_ctrl_c.is_some() {
+                            pending_ctrl_c = None;
+                            app.message = None;
                         }
-                        // Otherwise fall through to normal handling
-                    }
 
-                    // Handle pending ; command for panel focus, file list toggle, and review comments
-                    if pending_semicolon {
-                        pending_semicolon = false;
-                        match key.code {
-                            crossterm::event::KeyCode::Char('e') => {
-                                app.toggle_file_list();
-                                continue;
+                        // Handle pending z command for zz centering
+                        if pending_z {
+                            pending_z = false;
+                            if key.code == crossterm::event::KeyCode::Char('z') {
+                                app.center_cursor();
+                                continue 'main;
                             }
-                            crossterm::event::KeyCode::Char('h') => {
-                                app.focused_panel = app::FocusedPanel::FileList;
-                                continue;
-                            }
-                            crossterm::event::KeyCode::Char('l') => {
-                                app.focused_panel = app::FocusedPanel::Diff;
-                                continue;
-                            }
-                            crossterm::event::KeyCode::Char('k') => {
-                                if app.has_inline_commit_selector() {
-                                    app.focused_panel = app::FocusedPanel::CommitSelector;
+                            // Otherwise fall through to normal handling
+                        }
+
+                        // Handle pending Z command for ZZ (export+quit) / ZQ (quit)
+                        if pending_shift_z {
+                            pending_shift_z = false;
+                            match key.code {
+                                crossterm::event::KeyCode::Char('Z') => {
+                                    // ZZ: save session, export, and quit (same as :wq)
+                                    let _ = persistence::save_session(&app.session);
+                                    app.dirty = false;
+                                    if app.session.has_comments() {
+                                        handler::handle_export_and_quit(&mut app);
+                                    } else {
+                                        app.should_quit = true;
+                                    }
+                                    continue 'main;
                                 }
-                                continue;
+                                crossterm::event::KeyCode::Char('Q') => {
+                                    // ZQ: quit without exporting (same as q)
+                                    app.should_quit = true;
+                                    continue 'main;
+                                }
+                                _ => {} // Fall through to normal handling
                             }
-                            crossterm::event::KeyCode::Char('j') => {
-                                app.focused_panel = app::FocusedPanel::Diff;
-                                continue;
+                        }
+
+                        // Handle pending d command for dd delete comment
+                        if pending_d {
+                            pending_d = false;
+                            if key.code == crossterm::event::KeyCode::Char('d') {
+                                if !app.delete_comment_at_cursor() {
+                                    app.set_message("No comment at cursor");
+                                }
+                                continue 'main;
                             }
-                            crossterm::event::KeyCode::Char('c') => {
-                                app.enter_review_comment_mode();
-                                continue;
+                            // Otherwise fall through to normal handling
+                        }
+
+                        // Handle pending ; command for panel focus, file list toggle, and review comments
+                        if pending_semicolon {
+                            pending_semicolon = false;
+                            match key.code {
+                                crossterm::event::KeyCode::Char('e') => {
+                                    app.toggle_file_list();
+                                    continue 'main;
+                                }
+                                crossterm::event::KeyCode::Char('h') => {
+                                    app.focused_panel = app::FocusedPanel::FileList;
+                                    continue 'main;
+                                }
+                                crossterm::event::KeyCode::Char('l') => {
+                                    app.focused_panel = app::FocusedPanel::Diff;
+                                    continue 'main;
+                                }
+                                crossterm::event::KeyCode::Char('k') => {
+                                    if app.has_inline_commit_selector() {
+                                        app.focused_panel = app::FocusedPanel::CommitSelector;
+                                    }
+                                    continue 'main;
+                                }
+                                crossterm::event::KeyCode::Char('j') => {
+                                    app.focused_panel = app::FocusedPanel::Diff;
+                                    continue 'main;
+                                }
+                                crossterm::event::KeyCode::Char('c') => {
+                                    app.enter_review_comment_mode();
+                                    continue 'main;
+                                }
+                                _ => {}
+                            }
+                            // Otherwise fall through to normal handling
+                        }
+
+                        let action = map_key_to_action(key, app.input_mode);
+
+                        // Handle pending command setters (these work in any mode)
+                        match action {
+                            Action::PendingZCommand => {
+                                pending_z = true;
+                                app.pending_count = None;
+                                continue 'main;
+                            }
+                            Action::PendingShiftZCommand => {
+                                pending_shift_z = true;
+                                app.pending_count = None;
+                                continue 'main;
+                            }
+                            Action::PendingDCommand => {
+                                pending_d = true;
+                                app.pending_count = None;
+                                continue 'main;
+                            }
+                            Action::PendingSemicolonCommand => {
+                                pending_semicolon = true;
+                                app.pending_count = None;
+                                continue 'main;
                             }
                             _ => {}
                         }
-                        // Otherwise fall through to normal handling
-                    }
 
-                    let action = map_key_to_action(key, app.input_mode);
-
-                    // Handle pending command setters (these work in any mode)
-                    match action {
-                        Action::PendingZCommand => {
-                            pending_z = true;
-                            app.pending_count = None;
-                            continue;
-                        }
-                        Action::PendingShiftZCommand => {
-                            pending_shift_z = true;
-                            app.pending_count = None;
-                            continue;
-                        }
-                        Action::PendingDCommand => {
-                            pending_d = true;
-                            app.pending_count = None;
-                            continue;
-                        }
-                        Action::PendingSemicolonCommand => {
-                            pending_semicolon = true;
-                            app.pending_count = None;
-                            continue;
-                        }
-                        _ => {}
-                    }
-
-                    // Handle digit accumulation for {N}G jump-to-line (Normal mode only)
-                    if app.input_mode == InputMode::Normal {
-                        match action {
-                            Action::Digit(d) => {
-                                let n = app.pending_count.unwrap_or(0);
-                                app.pending_count = Some(
-                                    (n.saturating_mul(10).saturating_add(d as usize)).min(999_999),
-                                );
-                                continue;
-                            }
-                            Action::GoToBottom if app.pending_count.is_some() => {
-                                // Clamp to 1 since source lines are 1-indexed; 0G behaves like 1G
-                                let count = app.pending_count.unwrap().max(1);
-                                app.pending_count = None;
-                                // Safe cast: count is clamped to 999_999 which fits in u32
-                                app.go_to_source_line(count as u32);
-                                continue;
-                            }
-                            _ => {
-                                app.pending_count = None;
+                        // Handle digit accumulation for {N}G jump-to-line (Normal mode only)
+                        if app.input_mode == InputMode::Normal {
+                            match action {
+                                Action::Digit(d) => {
+                                    let n = app.pending_count.unwrap_or(0);
+                                    app.pending_count = Some(
+                                        (n.saturating_mul(10).saturating_add(d as usize))
+                                            .min(999_999),
+                                    );
+                                    continue 'main;
+                                }
+                                Action::GoToBottom if app.pending_count.is_some() => {
+                                    // Clamp to 1 since source lines are 1-indexed; 0G behaves like 1G
+                                    let count = app.pending_count.unwrap().max(1);
+                                    app.pending_count = None;
+                                    // Safe cast: count is clamped to 999_999 which fits in u32
+                                    app.go_to_source_line(count as u32);
+                                    continue 'main;
+                                }
+                                _ => {
+                                    app.pending_count = None;
+                                }
                             }
                         }
-                    }
 
-                    // Dispatch by input mode
-                    match app.input_mode {
-                        InputMode::Help => handle_help_action(&mut app, action),
-                        InputMode::Command => handle_command_action(&mut app, action),
-                        InputMode::Search => handle_search_action(&mut app, action),
-                        InputMode::Comment => handle_comment_action(&mut app, action),
-                        InputMode::Confirm => handle_confirm_action(&mut app, action),
-                        InputMode::CommitSelect => handle_commit_select_action(&mut app, action),
-                        InputMode::VisualSelect => handle_visual_action(&mut app, action),
-                        InputMode::Normal => match app.focused_panel {
-                            FocusedPanel::FileList => handle_file_list_action(&mut app, action),
-                            FocusedPanel::Diff => handle_diff_action(&mut app, action),
-                            FocusedPanel::CommitSelector => {
-                                handle_commit_selector_action(&mut app, action)
+                        // Dispatch by input mode
+                        match app.input_mode {
+                            InputMode::Help => handle_help_action(&mut app, action),
+                            InputMode::Command => handle_command_action(&mut app, action),
+                            InputMode::Search => handle_search_action(&mut app, action),
+                            InputMode::Comment => handle_comment_action(&mut app, action),
+                            InputMode::Confirm => handle_confirm_action(&mut app, action),
+                            InputMode::CommitSelect => {
+                                handle_commit_select_action(&mut app, action)
                             }
-                        },
+                            InputMode::VisualSelect => handle_visual_action(&mut app, action),
+                            InputMode::Normal => match app.focused_panel {
+                                FocusedPanel::FileList => handle_file_list_action(&mut app, action),
+                                FocusedPanel::Diff => handle_diff_action(&mut app, action),
+                                FocusedPanel::CommitSelector => {
+                                    handle_commit_selector_action(&mut app, action)
+                                }
+                            },
+                        }
                     }
+                    Event::Mouse(mouse_event) => handle_mouse_event(&mut app, mouse_event),
+                    _ => {}
                 }
-                Event::Mouse(mouse_event) => handle_mouse_event(&mut app, mouse_event),
-                _ => {}
+                if app.should_quit || !event::poll(Duration::ZERO)? {
+                    break;
+                }
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,13 @@ use theme::{parse_cli_args, resolve_theme_with_config};
 const CTRL_C_EXIT_TIMEOUT: Duration = Duration::from_secs(2);
 /// Hide the file list by default on narrow terminals.
 const MIN_WIDTH_FOR_FILE_LIST: u16 = 100;
+/// Idle event-poll cadence: long enough to keep CPU usage trivial while no
+/// input or background highlight results are pending.
+const IDLE_POLL_TIMEOUT: Duration = Duration::from_millis(100);
+/// Poll cadence while the highlight worker is still streaming results.
+/// ~30 ms keeps perceived latency between worker emit and on-screen update
+/// under one frame; CPU cost of the extra wakeups is negligible.
+const STREAMING_POLL_TIMEOUT: Duration = Duration::from_millis(30);
 
 fn main() -> anyhow::Result<()> {
     // Setup panic hook to restore terminal on panic
@@ -266,13 +273,25 @@ fn main() -> anyhow::Result<()> {
 
         app.clear_expired_message();
 
+        // Drain any streaming highlight results before rendering so newly
+        // arrived spans land on screen this frame.
+        app.drain_highlight_updates();
+
         // Render
         terminal.draw(|frame| {
             ui::render(frame, &mut app);
         })?;
 
+        // Shorter poll while highlight work is in flight keeps streaming
+        // latency under one frame; longer poll when idle to avoid wakeups.
+        let poll_timeout = if app.highlight_streaming() {
+            STREAMING_POLL_TIMEOUT
+        } else {
+            IDLE_POLL_TIMEOUT
+        };
+
         // Handle events
-        if event::poll(Duration::from_millis(100))? {
+        if event::poll(poll_timeout)? {
             let event = event::read()?;
             match event {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -4,6 +4,9 @@ use two_face::theme::EmbeddedThemeName;
 
 use crate::model::diff_types::LineOrigin;
 
+pub(crate) mod streaming;
+pub(crate) use streaming::{HighlightJob, HighlightJobKind};
+
 /// A single line of highlighted spans (style + text pairs).
 pub(crate) type HighlightedSpans = Vec<(Style, String)>;
 

--- a/src/syntax/streaming.rs
+++ b/src/syntax/streaming.rs
@@ -10,11 +10,11 @@
 //! `SyntaxSet` / `Theme` are `Sync`, so the highlight phase parallelises
 //! cleanly across threads as long as inputs are owned strings.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Sender};
+use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::model::diff_types::LineOrigin;
@@ -68,16 +68,21 @@ pub(crate) enum HighlightUpdateKind {
     },
 }
 
+/// Shared queue of pending jobs. Workers pop from the front under the
+/// mutex; the App can reorder the queue by file-index proximity when the
+/// user navigates, so visible files get highlighted first.
+pub(crate) type SharedQueue = Arc<Mutex<VecDeque<HighlightJob>>>;
+
 /// Spawn the highlight worker. Returns the join handle; the caller usually
 /// doesn't need to wait on it (the worker exits when its send fails on a
 /// dropped receiver, or when `cancel` is set).
 pub(crate) fn spawn_highlight_worker(
-    jobs: Vec<HighlightJob>,
+    queue: SharedQueue,
     highlighter: Arc<SyntaxHighlighter>,
     cancel: Arc<AtomicBool>,
     tx: Sender<HighlightUpdate>,
 ) -> thread::JoinHandle<()> {
-    thread::spawn(move || run_worker(jobs, highlighter, cancel, tx))
+    thread::spawn(move || run_worker(queue, highlighter, cancel, tx))
 }
 
 /// Run the highlight pipeline synchronously on the current thread. Used by
@@ -87,54 +92,31 @@ pub(crate) fn run_blocking(
     jobs: Vec<HighlightJob>,
     highlighter: &SyntaxHighlighter,
 ) -> Vec<HighlightUpdate> {
-    let mut out = Vec::with_capacity(jobs.len());
-    for job in jobs {
-        if let Some(update) = run_job(&job, highlighter) {
-            out.push(update);
-        }
-    }
-    out
+    jobs.iter()
+        .filter_map(|job| run_job(job, highlighter))
+        .collect()
 }
 
 fn run_worker(
-    jobs: Vec<HighlightJob>,
+    queue: SharedQueue,
     highlighter: Arc<SyntaxHighlighter>,
     cancel: Arc<AtomicBool>,
     tx: Sender<HighlightUpdate>,
 ) {
-    if jobs.is_empty() {
+    let initial_len = queue.lock().unwrap().len();
+    if initial_len == 0 {
         return;
     }
 
     let parallelism = thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(1)
-        .min(jobs.len())
+        .min(initial_len)
         .max(1);
 
-    if parallelism <= 1 {
-        for job in &jobs {
-            if cancel.load(Ordering::Relaxed) {
-                return;
-            }
-            if let Some(update) = run_job(job, &highlighter)
-                && tx.send(update).is_err()
-            {
-                return;
-            }
-        }
-        return;
-    }
-
-    // Atomic-cursor work stealing: every worker pulls the next index from
-    // a shared counter. Beats static chunking when job sizes are skewed
-    // (e.g. one giant file + many small ones).
-    let cursor = Arc::new(AtomicUsize::new(0));
-    let jobs = Arc::new(jobs);
     thread::scope(|s| {
         for _ in 0..parallelism {
-            let cursor = Arc::clone(&cursor);
-            let jobs = Arc::clone(&jobs);
+            let queue = Arc::clone(&queue);
             let cancel = Arc::clone(&cancel);
             let tx = tx.clone();
             let highlighter = Arc::clone(&highlighter);
@@ -143,11 +125,11 @@ fn run_worker(
                     if cancel.load(Ordering::Relaxed) {
                         return;
                     }
-                    let idx = cursor.fetch_add(1, Ordering::Relaxed);
-                    if idx >= jobs.len() {
+                    let job = queue.lock().unwrap().pop_front();
+                    let Some(job) = job else {
                         return;
-                    }
-                    if let Some(update) = run_job(&jobs[idx], &highlighter)
+                    };
+                    if let Some(update) = run_job(&job, &highlighter)
                         && tx.send(update).is_err()
                     {
                         return;
@@ -222,12 +204,13 @@ fn highlight_full(
     h.highlight_file_lines(path, &lines)
 }
 
-/// A running highlight session: receiver for streamed results plus the
-/// cancel token shared with the worker. The two are always twinned, so they
-/// live behind a single `Option<HighlightSession>` on `App`.
+/// A running highlight session: receiver for streamed results, the cancel
+/// token shared with the worker, and the shared job queue (so the App can
+/// reprioritize pending work when the user navigates).
 pub(crate) struct HighlightSession {
     rx: mpsc::Receiver<HighlightUpdate>,
     cancel: Arc<AtomicBool>,
+    queue: SharedQueue,
 }
 
 impl HighlightSession {
@@ -240,10 +223,11 @@ impl HighlightSession {
         if jobs.is_empty() {
             return None;
         }
+        let queue: SharedQueue = Arc::new(Mutex::new(VecDeque::from(jobs)));
         let cancel = Arc::new(AtomicBool::new(false));
         let (tx, rx) = mpsc::channel();
-        spawn_highlight_worker(jobs, highlighter, Arc::clone(&cancel), tx);
-        Some(Self { rx, cancel })
+        spawn_highlight_worker(Arc::clone(&queue), highlighter, Arc::clone(&cancel), tx);
+        Some(Self { rx, cancel, queue })
     }
 
     /// Re-resolve each job's `file_idx` by `syntax_path` against
@@ -283,6 +267,15 @@ impl HighlightSession {
 
     pub(crate) fn try_recv(&self) -> Result<HighlightUpdate, mpsc::TryRecvError> {
         self.rx.try_recv()
+    }
+
+    /// Reorder the pending queue so jobs nearest `file_idx` run next.
+    /// Called when the user navigates to a new file, so the visible
+    /// viewport gets highlighted before far-away files.
+    pub(crate) fn prioritize_around(&self, file_idx: usize) {
+        let mut q = self.queue.lock().unwrap();
+        q.make_contiguous()
+            .sort_by_key(|job| job.file_idx.abs_diff(file_idx));
     }
 }
 

--- a/src/syntax/streaming.rs
+++ b/src/syntax/streaming.rs
@@ -1,0 +1,332 @@
+//! Streaming syntax-highlight pipeline.
+//!
+//! The diff is parsed (and rendered) without highlighting; a background
+//! worker thread then produces highlight results and streams them to the
+//! main thread via an mpsc channel. The main loop drains the channel each
+//! iteration and patches the model in place, then redraws.
+//!
+//! Why this shape: VCS access (git2, jj/hg subprocess) is often `!Send`,
+//! so the parse phase has to stay on the main thread; syntect's
+//! `SyntaxSet` / `Theme` are `Sync`, so the highlight phase parallelises
+//! cleanly across threads as long as inputs are owned strings.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::mpsc::{self, Sender};
+use std::thread;
+
+use crate::model::diff_types::LineOrigin;
+use crate::syntax::{HighlightedLines, HighlightedSpans, SyntaxHighlighter};
+
+/// Same cost ceiling as the previous synchronous full-file pass: skip
+/// highlighting for files over this size to keep runaway diffs cheap.
+const MAX_HIGHLIGHT_FILE_BYTES: usize = 1024 * 1024;
+
+/// A single unit of highlight work, produced during the (serial) parse phase
+/// and consumed on the background worker.
+pub(crate) struct HighlightJob {
+    pub file_idx: usize,
+    pub syntax_path: PathBuf,
+    pub kind: HighlightJobKind,
+}
+
+pub(crate) enum HighlightJobKind {
+    /// Per-hunk highlight using only the lines inside the hunk.
+    Hunk {
+        hunk_idx: usize,
+        old_lines: Vec<String>,
+        new_lines: Vec<String>,
+        old_line_indices: Vec<Option<usize>>,
+        new_line_indices: Vec<Option<usize>>,
+        line_origins: Vec<LineOrigin>,
+    },
+    /// Container-grammar (Vue, Svelte, ...) full-file context. Content is
+    /// fetched during parse so the worker never touches VCS state.
+    FullFile {
+        old_content: Option<String>,
+        new_content: Option<String>,
+    },
+}
+
+/// A highlight result the worker streams back. Each variant patches one
+/// file in place.
+pub(crate) struct HighlightUpdate {
+    pub file_idx: usize,
+    pub kind: HighlightUpdateKind,
+}
+
+pub(crate) enum HighlightUpdateKind {
+    Hunk {
+        hunk_idx: usize,
+        line_spans: Vec<Option<HighlightedSpans>>,
+    },
+    FullFile {
+        old: Option<HighlightedLines>,
+        new: Option<HighlightedLines>,
+    },
+}
+
+/// Spawn the highlight worker. Returns the join handle; the caller usually
+/// doesn't need to wait on it (the worker exits when its send fails on a
+/// dropped receiver, or when `cancel` is set).
+pub(crate) fn spawn_highlight_worker(
+    jobs: Vec<HighlightJob>,
+    highlighter: Arc<SyntaxHighlighter>,
+    cancel: Arc<AtomicBool>,
+    tx: Sender<HighlightUpdate>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || run_worker(jobs, highlighter, cancel, tx))
+}
+
+/// Run the highlight pipeline synchronously on the current thread. Used by
+/// tests that want spans populated deterministically without a worker thread.
+#[cfg(test)]
+pub(crate) fn run_blocking(
+    jobs: Vec<HighlightJob>,
+    highlighter: &SyntaxHighlighter,
+) -> Vec<HighlightUpdate> {
+    let mut out = Vec::with_capacity(jobs.len());
+    for job in jobs {
+        if let Some(update) = run_job(&job, highlighter) {
+            out.push(update);
+        }
+    }
+    out
+}
+
+fn run_worker(
+    jobs: Vec<HighlightJob>,
+    highlighter: Arc<SyntaxHighlighter>,
+    cancel: Arc<AtomicBool>,
+    tx: Sender<HighlightUpdate>,
+) {
+    if jobs.is_empty() {
+        return;
+    }
+
+    let parallelism = thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1)
+        .min(jobs.len())
+        .max(1);
+
+    if parallelism <= 1 {
+        for job in &jobs {
+            if cancel.load(Ordering::Relaxed) {
+                return;
+            }
+            if let Some(update) = run_job(job, &highlighter)
+                && tx.send(update).is_err()
+            {
+                return;
+            }
+        }
+        return;
+    }
+
+    // Atomic-cursor work stealing: every worker pulls the next index from
+    // a shared counter. Beats static chunking when job sizes are skewed
+    // (e.g. one giant file + many small ones).
+    let cursor = Arc::new(AtomicUsize::new(0));
+    let jobs = Arc::new(jobs);
+    thread::scope(|s| {
+        for _ in 0..parallelism {
+            let cursor = Arc::clone(&cursor);
+            let jobs = Arc::clone(&jobs);
+            let cancel = Arc::clone(&cancel);
+            let tx = tx.clone();
+            let highlighter = Arc::clone(&highlighter);
+            s.spawn(move || {
+                loop {
+                    if cancel.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    let idx = cursor.fetch_add(1, Ordering::Relaxed);
+                    if idx >= jobs.len() {
+                        return;
+                    }
+                    if let Some(update) = run_job(&jobs[idx], &highlighter)
+                        && tx.send(update).is_err()
+                    {
+                        return;
+                    }
+                }
+            });
+        }
+    });
+}
+
+fn run_job(job: &HighlightJob, h: &SyntaxHighlighter) -> Option<HighlightUpdate> {
+    match &job.kind {
+        HighlightJobKind::Hunk {
+            hunk_idx,
+            old_lines,
+            new_lines,
+            old_line_indices,
+            new_line_indices,
+            line_origins,
+        } => {
+            let old_highlighted = h.highlight_file_lines(&job.syntax_path, old_lines);
+            let new_highlighted = h.highlight_file_lines(&job.syntax_path, new_lines);
+            if old_highlighted.is_none() && new_highlighted.is_none() {
+                return None;
+            }
+            let line_spans: Vec<Option<HighlightedSpans>> = (0..line_origins.len())
+                .map(|i| {
+                    h.highlighted_line_for_diff_with_background(
+                        old_highlighted.as_deref(),
+                        new_highlighted.as_deref(),
+                        old_line_indices[i],
+                        new_line_indices[i],
+                        line_origins[i],
+                    )
+                })
+                .collect();
+            Some(HighlightUpdate {
+                file_idx: job.file_idx,
+                kind: HighlightUpdateKind::Hunk {
+                    hunk_idx: *hunk_idx,
+                    line_spans,
+                },
+            })
+        }
+        HighlightJobKind::FullFile {
+            old_content,
+            new_content,
+        } => {
+            let old = highlight_full(h, &job.syntax_path, old_content.as_deref());
+            let new = highlight_full(h, &job.syntax_path, new_content.as_deref());
+            if old.is_none() && new.is_none() {
+                return None;
+            }
+            Some(HighlightUpdate {
+                file_idx: job.file_idx,
+                kind: HighlightUpdateKind::FullFile { old, new },
+            })
+        }
+    }
+}
+
+fn highlight_full(
+    h: &SyntaxHighlighter,
+    path: &std::path::Path,
+    content: Option<&str>,
+) -> Option<HighlightedLines> {
+    let content = content?;
+    if content.len() > MAX_HIGHLIGHT_FILE_BYTES || content.as_bytes().contains(&0u8) {
+        return None;
+    }
+    let lines: Vec<String> = content.lines().map(crate::vcs::tabify).collect();
+    h.highlight_file_lines(path, &lines)
+}
+
+/// A running highlight session: receiver for streamed results plus the
+/// cancel token shared with the worker. The two are always twinned, so they
+/// live behind a single `Option<HighlightSession>` on `App`.
+pub(crate) struct HighlightSession {
+    rx: mpsc::Receiver<HighlightUpdate>,
+    cancel: Arc<AtomicBool>,
+}
+
+impl HighlightSession {
+    /// Start a new session. Returns `None` if there is nothing to highlight,
+    /// in which case no worker is spawned.
+    pub(crate) fn start(
+        jobs: Vec<HighlightJob>,
+        highlighter: Arc<SyntaxHighlighter>,
+    ) -> Option<Self> {
+        if jobs.is_empty() {
+            return None;
+        }
+        let cancel = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = mpsc::channel();
+        spawn_highlight_worker(jobs, highlighter, Arc::clone(&cancel), tx);
+        Some(Self { rx, cancel })
+    }
+
+    /// Re-resolve each job's `file_idx` by `syntax_path` against
+    /// `diff_files.display_path()`, drop jobs whose path is no longer present,
+    /// then start the session. Used after the parse-time `file_idx` may have
+    /// drifted from its file's position (commit-message insert, directory
+    /// sort, `.tuicrignore` re-filter). `HighlightJob::syntax_path` and
+    /// `DiffFile::display_path` are both `new_path or old_path`, so the keys
+    /// line up.
+    pub(crate) fn start_resolved(
+        mut jobs: Vec<HighlightJob>,
+        diff_files: &[crate::model::DiffFile],
+        highlighter: Arc<SyntaxHighlighter>,
+    ) -> Option<Self> {
+        let path_to_idx: HashMap<&Path, usize> = diff_files
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (f.display_path().as_path(), i))
+            .collect();
+        jobs.retain_mut(|job| match path_to_idx.get(job.syntax_path.as_path()) {
+            Some(&idx) => {
+                job.file_idx = idx;
+                true
+            }
+            None => false,
+        });
+        Self::start(jobs, highlighter)
+    }
+
+    /// Signal the worker to stop. The receiver is also dropped, so any
+    /// in-flight result the worker tries to send will fail and the worker
+    /// exits at its next channel send.
+    pub(crate) fn cancel(self) {
+        self.cancel.store(true, Ordering::Relaxed);
+        // drop self → rx dropped
+    }
+
+    pub(crate) fn try_recv(&self) -> Result<HighlightUpdate, mpsc::TryRecvError> {
+        self.rx.try_recv()
+    }
+}
+
+/// Patch a streamed highlight result into the in-memory diff. Idempotent:
+/// applying the same update twice produces the same final state.
+pub(crate) fn apply_update(
+    files: &mut [crate::model::DiffFile],
+    highlighter: &SyntaxHighlighter,
+    update: HighlightUpdate,
+) {
+    let Some(file) = files.get_mut(update.file_idx) else {
+        return;
+    };
+    match update.kind {
+        HighlightUpdateKind::Hunk {
+            hunk_idx,
+            line_spans,
+        } => {
+            let Some(hunk) = file.hunks.get_mut(hunk_idx) else {
+                return;
+            };
+            for (line, spans) in hunk.lines.iter_mut().zip(line_spans) {
+                if let Some(spans) = spans {
+                    line.highlighted_spans = Some(spans);
+                }
+            }
+        }
+        HighlightUpdateKind::FullFile { old, new } => {
+            for hunk in &mut file.hunks {
+                for line in &mut hunk.lines {
+                    let old_idx = line.old_lineno.map(|n| n.saturating_sub(1) as usize);
+                    let new_idx = line.new_lineno.map(|n| n.saturating_sub(1) as usize);
+                    let spans = highlighter.highlighted_line_for_diff_with_background(
+                        old.as_deref(),
+                        new.as_deref(),
+                        old_idx,
+                        new_idx,
+                        line.origin,
+                    );
+                    if spans.is_some() {
+                        line.highlighted_spans = spans;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -13,7 +13,7 @@ use crate::syntax::SyntaxHighlighter;
 /// Complete color theme for the application
 pub struct Theme {
     /// Cached syntax highlighter (lazily initialized)
-    highlighter: OnceLock<SyntaxHighlighter>,
+    highlighter: OnceLock<std::sync::Arc<SyntaxHighlighter>>,
 
     // Base colors
     pub panel_bg: Color,
@@ -1686,8 +1686,18 @@ pub fn resolve_theme_with_config(
 impl Theme {
     /// Get the syntax highlighter for this theme (lazily initialized, cached)
     pub fn syntax_highlighter(&self) -> &SyntaxHighlighter {
+        self.syntax_highlighter_arc().as_ref()
+    }
+
+    /// Same as `syntax_highlighter`, but yields an `Arc` clone that can be
+    /// moved into the highlight worker thread.
+    pub fn syntax_highlighter_arc(&self) -> &std::sync::Arc<SyntaxHighlighter> {
         self.highlighter.get_or_init(|| {
-            SyntaxHighlighter::new(self.syntect_theme, self.syntax_add_bg, self.syntax_del_bg)
+            std::sync::Arc::new(SyntaxHighlighter::new(
+                self.syntect_theme,
+                self.syntax_add_bg,
+                self.syntax_del_bg,
+            ))
         })
     }
 }

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -2,22 +2,19 @@ use std::path::Path;
 
 use ignore::gitignore::GitignoreBuilder;
 
-use crate::model::DiffFile;
+use crate::vcs::DiffWithJobs;
 
-/// Apply `.tuicrignore` rules from the repository root to a diff file set.
-pub fn filter_diff_files(repo_root: &Path, diff_files: Vec<DiffFile>) -> Vec<DiffFile> {
+/// Apply `.tuicrignore` rules from the repository root to a diff file set,
+/// re-indexing the accompanying highlight jobs.
+pub fn filter_diff_files(repo_root: &Path, diff: DiffWithJobs) -> DiffWithJobs {
     let Some(matcher) = load_matcher(repo_root) else {
-        return diff_files;
+        return diff;
     };
-
-    diff_files
-        .into_iter()
-        .filter(|file| {
-            !matcher
-                .matched_path_or_any_parents(file.display_path(), false)
-                .is_ignore()
-        })
-        .collect()
+    crate::vcs::filter_diff_with_jobs(diff, |file| {
+        !matcher
+            .matched_path_or_any_parents(file.display_path(), false)
+            .is_ignore()
+    })
 }
 
 fn load_matcher(repo_root: &Path) -> Option<ignore::gitignore::Gitignore> {
@@ -49,7 +46,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::model::FileStatus;
+    use crate::model::{DiffFile, FileStatus};
 
     fn make_diff_file(path: &str) -> DiffFile {
         DiffFile {
@@ -64,6 +61,10 @@ mod tests {
         }
     }
 
+    fn filter_just_files(repo_root: &Path, files: Vec<DiffFile>) -> Vec<DiffFile> {
+        filter_diff_files(repo_root, (files, Vec::new())).0
+    }
+
     #[test]
     fn keeps_all_files_when_tuicrignore_is_missing() {
         let dir = tempdir().expect("failed to create temp dir");
@@ -72,7 +73,7 @@ mod tests {
             make_diff_file("target/debug/app"),
         ];
 
-        let filtered = filter_diff_files(dir.path(), files);
+        let filtered = filter_just_files(dir.path(), files);
 
         assert_eq!(filtered.len(), 2);
     }
@@ -89,7 +90,7 @@ mod tests {
             make_diff_file("Cargo.lock"),
         ];
 
-        let filtered = filter_diff_files(dir.path(), files);
+        let filtered = filter_just_files(dir.path(), files);
         let kept_paths: Vec<String> = filtered
             .iter()
             .map(|f| f.display_path().display().to_string())
@@ -111,7 +112,7 @@ mod tests {
             make_diff_file("src/main.rs"),
         ];
 
-        let filtered = filter_diff_files(dir.path(), files);
+        let filtered = filter_just_files(dir.path(), files);
         let kept_paths: Vec<String> = filtered
             .iter()
             .map(|f| f.display_path().display().to_string())
@@ -132,7 +133,7 @@ mod tests {
             make_diff_file("build.log"),
         ];
 
-        let filtered = filter_diff_files(dir.path(), files);
+        let filtered = filter_just_files(dir.path(), files);
         let kept: Vec<String> = filtered
             .iter()
             .map(|f| f.display_path().display().to_string())
@@ -155,7 +156,7 @@ mod tests {
             make_diff_file("src/lib.rs"),
         ];
 
-        let filtered = filter_diff_files(dir.path(), files);
+        let filtered = filter_just_files(dir.path(), files);
         let kept: Vec<String> = filtered
             .iter()
             .map(|f| f.display_path().display().to_string())
@@ -176,7 +177,7 @@ mod tests {
             make_diff_file("dist/bundle.js"),
         ];
 
-        let filtered = filter_diff_files(dir.path(), files);
+        let filtered = filter_just_files(dir.path(), files);
         let kept: Vec<String> = filtered
             .iter()
             .map(|f| f.display_path().display().to_string())
@@ -203,7 +204,7 @@ mod tests {
         };
         let kept = make_diff_file("src/lib.rs");
 
-        let filtered = filter_diff_files(dir.path(), vec![deleted, kept]);
+        let filtered = filter_just_files(dir.path(), vec![deleted, kept]);
         let kept_paths: Vec<String> = filtered
             .iter()
             .map(|f| f.display_path().display().to_string())

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -447,20 +447,16 @@ fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     let scroll_x = app.file_list_state.scroll_x;
 
-    // When diff panel is focused, sync file list selection to current file
-    // But preserve the current offset to not interfere with manual scrolling
-    if app.focused_panel == FocusedPanel::Diff {
+    // Skip when the user has wheel-scrolled the file list independently;
+    // see App::manual_file_list_scroll.
+    if app.focused_panel == FocusedPanel::Diff && !app.manual_file_list_scroll {
         let current_file_idx = app.diff_state.current_file_idx;
         for (tree_idx, item) in visible_items.iter().enumerate() {
             if let FileTreeItem::File { file_idx, .. } = item
                 && *file_idx == current_file_idx
             {
                 if app.file_list_state.selected() != tree_idx {
-                    // Save current offset before changing selection
-                    let current_offset = app.file_list_state.list_state.offset();
                     app.file_list_state.select(tree_idx);
-                    // Restore offset to prevent auto-scrolling
-                    *app.file_list_state.list_state.offset_mut() = current_offset;
                 }
                 break;
             }

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -7,7 +7,8 @@ use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
+use crate::syntax::{HighlightJob, HighlightJobKind, SyntaxHighlighter, needs_full_file_highlight};
+use crate::vcs::DiffWithJobs;
 
 /// Diff format variants for different VCS tools.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -18,13 +19,12 @@ pub enum DiffFormat {
     GitStyle,
 }
 
-/// Parse unified diff output into DiffFile structures.
-pub fn parse_unified_diff(
-    diff_text: &str,
-    format: DiffFormat,
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>> {
+/// Parse unified diff output into DiffFile structures plus highlight jobs.
+/// DiffLines come back with `highlighted_spans = None`; the streaming worker
+/// fills them in.
+pub fn parse_unified_diff(diff_text: &str, format: DiffFormat) -> Result<DiffWithJobs> {
     let mut files: Vec<DiffFile> = Vec::new();
+    let mut jobs: Vec<HighlightJob> = Vec::new();
     let mut lines = diff_text.lines().peekable();
 
     let header_prefix = match format {
@@ -69,8 +69,9 @@ pub fn parse_unified_diff(
                 continue;
             }
 
-            let file_path = new_path.as_ref().or(old_path.as_ref());
-            let mut hunks = Vec::new();
+            let file_path = new_path.as_ref().or(old_path.as_ref()).cloned();
+            let file_idx = files.len();
+            let mut hunks: Vec<DiffHunk> = Vec::new();
 
             // Parse hunks until next file or end
             while lines.peek().is_some() {
@@ -78,7 +79,14 @@ pub fn parse_unified_diff(
                     if peek_line.starts_with("diff ") {
                         break;
                     } else if peek_line.starts_with("@@") {
-                        if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter) {
+                        let hunk_idx = hunks.len();
+                        if let Some(hunk) = parse_hunk(
+                            &mut lines,
+                            file_idx,
+                            hunk_idx,
+                            file_path.as_deref(),
+                            &mut jobs,
+                        ) {
                             hunks.push(hunk);
                         }
                     } else {
@@ -105,7 +113,7 @@ pub fn parse_unified_diff(
         return Err(TuicrError::NoChanges);
     }
 
-    Ok(files)
+    Ok((files, jobs))
 }
 
 fn parse_file_header<'a, I>(
@@ -198,8 +206,10 @@ where
 
 fn parse_hunk<'a, I>(
     lines: &mut std::iter::Peekable<I>,
-    file_path: Option<&PathBuf>,
-    highlighter: &SyntaxHighlighter,
+    file_idx: usize,
+    hunk_idx: usize,
+    file_path: Option<&std::path::Path>,
+    jobs: &mut Vec<HighlightJob>,
 ) -> Option<DiffHunk>
 where
     I: Iterator<Item = &'a str>,
@@ -268,39 +278,39 @@ where
         line_numbers.push((old_ln, new_ln));
     }
 
-    // Apply syntax highlighting by side-specific sequence to keep parser state valid.
+    let diff_lines: Vec<DiffLine> = line_contents
+        .iter()
+        .enumerate()
+        .map(|(idx, content)| {
+            let (old_lineno, new_lineno) = line_numbers[idx];
+            DiffLine {
+                origin: line_origins[idx],
+                content: content.clone(),
+                old_lineno,
+                new_lineno,
+                highlighted_spans: None,
+            }
+        })
+        .collect();
+
     // Container grammars skip per-hunk highlighting; the full-file post-pass
-    // (`enhance_with_full_file_highlight`) overwrites these spans anyway.
-    let highlight_sequences =
-        SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
-    let (old_highlighted_lines, new_highlighted_lines) = match file_path {
-        Some(path) if !needs_full_file_highlight(path) => (
-            highlighter.highlight_file_lines(path, &highlight_sequences.old_lines),
-            highlighter.highlight_file_lines(path, &highlight_sequences.new_lines),
-        ),
-        _ => (None, None),
-    };
-
-    // Build DiffLines
-    let mut diff_lines: Vec<DiffLine> = Vec::with_capacity(line_contents.len());
-    for (idx, content) in line_contents.into_iter().enumerate() {
-        let origin = line_origins[idx];
-        let (old_lineno, new_lineno) = line_numbers[idx];
-
-        let highlighted_spans = highlighter.highlighted_line_for_diff_with_background(
-            old_highlighted_lines.as_deref(),
-            new_highlighted_lines.as_deref(),
-            highlight_sequences.old_line_indices[idx],
-            highlight_sequences.new_line_indices[idx],
-            origin,
-        );
-
-        diff_lines.push(DiffLine {
-            origin,
-            content,
-            old_lineno,
-            new_lineno,
-            highlighted_spans,
+    // emitted by the backend will fill spans for the whole file.
+    if let Some(path) = file_path
+        && !needs_full_file_highlight(path)
+    {
+        let sequences =
+            SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
+        jobs.push(HighlightJob {
+            file_idx,
+            syntax_path: path.to_path_buf(),
+            kind: HighlightJobKind::Hunk {
+                hunk_idx,
+                old_lines: sequences.old_lines,
+                new_lines: sequences.new_lines,
+                old_line_indices: sequences.old_line_indices,
+                new_line_indices: sequences.new_line_indices,
+                line_origins,
+            },
         });
     }
 
@@ -407,11 +417,11 @@ mod tests {
     #[test]
     fn should_return_no_changes_for_empty_diff() {
         assert!(matches!(
-            parse_unified_diff("", DiffFormat::Hg, &SyntaxHighlighter::default()),
+            parse_unified_diff("", DiffFormat::Hg),
             Err(TuicrError::NoChanges)
         ));
         assert!(matches!(
-            parse_unified_diff("", DiffFormat::GitStyle, &SyntaxHighlighter::default()),
+            parse_unified_diff("", DiffFormat::GitStyle),
             Err(TuicrError::NoChanges)
         ));
     }
@@ -473,8 +483,7 @@ mod tests {
  }
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Modified);
         assert_eq!(result[0].hunks.len(), 1);
@@ -491,8 +500,7 @@ mod tests {
 +	new
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         let lines = &result[0].hunks[0].lines;
 
         assert_eq!(lines[0].content, "    old");
@@ -510,8 +518,7 @@ mod tests {
 +}
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Added);
         assert!(result[0].old_path.is_none());
@@ -531,8 +538,7 @@ mod tests {
 -}
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Deleted);
         assert_eq!(
@@ -558,8 +564,7 @@ diff -r abc123 file2.rs
 -remove
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 2);
         assert_eq!(
             result[0].new_path.as_ref().unwrap().to_str().unwrap(),
@@ -587,8 +592,7 @@ diff -r abc123 file2.rs
  }
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].hunks.len(), 2);
         assert_eq!(result[0].hunks[0].old_start, 1);
@@ -607,8 +611,7 @@ rename to new_name.rs
 +new content
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Renamed);
         assert_eq!(
@@ -627,8 +630,7 @@ rename to new_name.rs
 Binary file image.png has changed
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert!(result[0].is_binary);
         assert!(result[0].hunks.is_empty());
@@ -642,8 +644,7 @@ rename from old_name.rs
 rename to new_name.rs
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Renamed);
         assert_eq!(result[0].old_path, Some(PathBuf::from("old_name.rs")));
@@ -659,8 +660,7 @@ copy from source.rs
 copy to dest.rs
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Copied);
         assert_eq!(result[0].old_path, Some(PathBuf::from("source.rs")));
@@ -681,8 +681,7 @@ copy to dest.rs
 +added line
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].status, FileStatus::Copied);
         assert_eq!(result[0].old_path, Some(PathBuf::from("source.rs")));
@@ -702,8 +701,7 @@ copy to dest.rs
 \ No newline at end of file
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].hunks[0].lines.len(), 2);
     }
@@ -721,8 +719,7 @@ copy to dest.rs
  context at 7->8
 "#;
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
+        let result = parse_unified_diff(diff, DiffFormat::Hg).unwrap().0;
         let lines = &result[0].hunks[0].lines;
 
         assert_eq!(lines[0].origin, LineOrigin::Context);
@@ -759,8 +756,7 @@ copy to dest.rs
  line2
  line3
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].new_path, Some(PathBuf::from("file.txt")));
         assert_eq!(files[0].status, FileStatus::Modified);
@@ -777,8 +773,7 @@ copy to dest.rs
 -	old
 +	new
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         let lines = &files[0].hunks[0].lines;
 
         assert_eq!(lines[0].content, "    old");
@@ -799,8 +794,11 @@ copy to dest.rs
  );
 "#;
 
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let (mut files, jobs) = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap();
+        let highlighter = SyntaxHighlighter::default();
+        for update in crate::syntax::streaming::run_blocking(jobs, &highlighter) {
+            crate::syntax::streaming::apply_update(&mut files, &highlighter, update);
+        }
         let lines = &files[0].hunks[0].lines;
 
         assert_eq!(lines.len(), 5);
@@ -822,8 +820,7 @@ new file mode 100644
 +line1
 +line2
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Added);
     }
@@ -838,8 +835,7 @@ deleted file mode 100644
 -line1
 -line2
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Deleted);
     }
@@ -851,8 +847,7 @@ deleted file mode 100644
 rename from old.txt
 rename to new.txt
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Renamed);
         assert_eq!(files[0].old_path, Some(PathBuf::from("old.txt")));
@@ -872,8 +867,7 @@ rename to new.txt
 -old content
 +new content
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Renamed);
         assert_eq!(files[0].old_path, Some(PathBuf::from("old.txt")));
@@ -888,8 +882,7 @@ rename to new.txt
 copy from source.txt
 copy to dest.txt
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Copied);
         assert_eq!(files[0].old_path, Some(PathBuf::from("source.txt")));
@@ -909,8 +902,7 @@ copy to dest.txt
  original
 +added line
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Copied);
         assert_eq!(files[0].old_path, Some(PathBuf::from("source.txt")));
@@ -925,8 +917,7 @@ new file mode 100644
 index 0000000000..abc1234567
 Binary files /dev/null and b/image.png differ
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert!(files[0].is_binary);
         assert_eq!(files[0].status, FileStatus::Added);
@@ -941,8 +932,7 @@ deleted file mode 100644
 index abc1234567..0000000000
 Binary files a/image.png and /dev/null differ
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert!(files[0].is_binary);
         assert_eq!(files[0].status, FileStatus::Deleted);
@@ -956,8 +946,7 @@ Binary files a/image.png and /dev/null differ
 index abc1234567..def7890123 100644
 Binary files a/image.png and b/image.png differ
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert!(files[0].is_binary);
         assert_eq!(files[0].status, FileStatus::Modified);
@@ -980,8 +969,7 @@ diff --git a/b.txt b/b.txt
 -foo
 +bar
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 2);
         assert_eq!(files[0].new_path, Some(PathBuf::from("a.txt")));
         assert_eq!(files[1].new_path, Some(PathBuf::from("b.txt")));
@@ -999,8 +987,7 @@ diff --git a/b.txt b/b.txt
 +added2
  more
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         let hunk = &files[0].hunks[0];
 
         assert_eq!(hunk.lines[0].old_lineno, Some(5));
@@ -1026,8 +1013,7 @@ diff --git a/b.txt b/b.txt
 new file mode 100644
 index 0000000000..e69de29bb2
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Added);
         assert!(files[0].old_path.is_none());
@@ -1044,8 +1030,7 @@ index 0000000000..e69de29bb2
 old mode 100644
 new mode 100755
 "#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let files = parse_unified_diff(diff, DiffFormat::GitStyle).unwrap().0;
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].status, FileStatus::Modified);
         assert_eq!(files[0].old_path, Some(PathBuf::from("script.sh")));

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -2,9 +2,9 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::SyntaxHighlighter;
+use crate::syntax::{HighlightJob, HighlightJobKind, SyntaxHighlighter};
 
-use super::traits::{VcsBackend, VcsInfo, VcsType};
+use super::traits::{DiffWithJobs, VcsBackend, VcsInfo, VcsType};
 
 /// A backend for reviewing a single file without a VCS repository.
 ///
@@ -54,7 +54,7 @@ impl VcsBackend for FileBackend {
         &self.info
     }
 
-    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+    fn get_working_tree_diff(&self) -> Result<DiffWithJobs> {
         let content = std::fs::read_to_string(&self.file_path)?;
         let lines: Vec<&str> = content.lines().collect();
 
@@ -62,41 +62,25 @@ impl VcsBackend for FileBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        // Build line contents and origins for syntax highlighting
         let line_contents: Vec<String> = lines.iter().map(|l| super::tabify(l)).collect();
         let line_origins: Vec<LineOrigin> = vec![LineOrigin::Addition; line_contents.len()];
-
-        // Apply syntax highlighting
-        let highlight_sequences =
+        let sequences =
             SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
-        let new_highlighted_lines =
-            highlighter.highlight_file_lines(&self.file_path, &highlight_sequences.new_lines);
 
-        // Build DiffLines
-        let mut diff_lines = Vec::with_capacity(lines.len());
-        for (i, content) in line_contents.iter().enumerate() {
-            let line_num = (i + 1) as u32;
-
-            let highlighted_spans = highlighter.highlighted_line_for_diff_with_background(
-                None,
-                new_highlighted_lines.as_deref(),
-                None,
-                highlight_sequences.new_line_indices[i],
-                LineOrigin::Addition,
-            );
-
-            diff_lines.push(DiffLine {
+        let diff_lines: Vec<DiffLine> = line_contents
+            .iter()
+            .enumerate()
+            .map(|(i, content)| DiffLine {
                 origin: LineOrigin::Addition,
                 content: content.clone(),
                 old_lineno: None,
-                new_lineno: Some(line_num),
-                highlighted_spans,
-            });
-        }
+                new_lineno: Some((i + 1) as u32),
+                highlighted_spans: None,
+            })
+            .collect();
 
         let total_lines = lines.len() as u32;
 
-        // Relative path from root (just the filename)
         let rel_path = self
             .file_path
             .file_name()
@@ -125,7 +109,20 @@ impl VcsBackend for FileBackend {
             content_hash,
         };
 
-        Ok(vec![file])
+        let job = HighlightJob {
+            file_idx: 0,
+            syntax_path: self.file_path.clone(),
+            kind: HighlightJobKind::Hunk {
+                hunk_idx: 0,
+                old_lines: sequences.old_lines,
+                new_lines: sequences.new_lines,
+                old_line_indices: sequences.old_line_indices,
+                new_line_indices: sequences.new_line_indices,
+                line_origins,
+            },
+        };
+
+        Ok((vec![file], vec![job]))
     }
 
     fn fetch_context_lines(

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -3,13 +3,10 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
-use crate::vcs::{enhance_with_full_file_highlight, tabify};
+use crate::syntax::{HighlightJob, HighlightJobKind, SyntaxHighlighter, needs_full_file_highlight};
+use crate::vcs::{DiffWithJobs, append_container_full_file_jobs, tabify};
 
-pub fn get_working_tree_diff(
-    repo: &Repository,
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>> {
+pub fn get_working_tree_diff(repo: &Repository) -> Result<DiffWithJobs> {
     let head = repo.head()?.peel_to_tree()?;
 
     let mut opts = DiffOptions::new();
@@ -18,43 +15,37 @@ pub fn get_working_tree_diff(
     opts.recurse_untracked_dirs(true);
 
     let diff = repo.diff_tree_to_workdir_with_index(Some(&head), Some(&mut opts))?;
-    let mut files = parse_diff(&diff, highlighter)?;
-    enhance_with_full_file_highlight(
-        &mut files,
-        highlighter,
+    let (files, mut jobs) = parse_diff(&diff)?;
+    append_container_full_file_jobs(
+        &files,
+        &mut jobs,
         |path| read_path_from_tree(repo, &head, path),
         |path| read_path_from_workdir(repo, path),
     );
-    Ok(files)
+    Ok((files, jobs))
 }
 
 /// Get the staged diff (index vs HEAD)
 /// On repos with no commits (unborn HEAD), diffs against an empty tree.
-pub fn get_staged_diff(
-    repo: &Repository,
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>> {
+pub fn get_staged_diff(repo: &Repository) -> Result<DiffWithJobs> {
     let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
     let index = repo.index()?;
     let diff = repo.diff_tree_to_index(head.as_ref(), Some(&index), None)?;
-    let mut files = parse_diff(&diff, highlighter)?;
-    enhance_with_full_file_highlight(
-        &mut files,
-        highlighter,
+    let (files, mut jobs) = parse_diff(&diff)?;
+    append_container_full_file_jobs(
+        &files,
+        &mut jobs,
         |path| {
             head.as_ref()
                 .and_then(|tree| read_path_from_tree(repo, tree, path))
         },
         |path| read_path_from_index(repo, &index, path),
     );
-    Ok(files)
+    Ok((files, jobs))
 }
 
 /// Get the unstaged diff (working tree vs index)
-pub fn get_unstaged_diff(
-    repo: &Repository,
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>> {
+pub fn get_unstaged_diff(repo: &Repository) -> Result<DiffWithJobs> {
     let index = repo.index()?;
     let mut opts = DiffOptions::new();
     opts.include_untracked(true);
@@ -62,24 +53,20 @@ pub fn get_unstaged_diff(
     opts.recurse_untracked_dirs(true);
 
     let diff = repo.diff_index_to_workdir(Some(&index), Some(&mut opts))?;
-    let mut files = parse_diff(&diff, highlighter)?;
-    enhance_with_full_file_highlight(
-        &mut files,
-        highlighter,
+    let (files, mut jobs) = parse_diff(&diff)?;
+    append_container_full_file_jobs(
+        &files,
+        &mut jobs,
         |path| read_path_from_index(repo, &index, path),
         |path| read_path_from_workdir(repo, path),
     );
-    Ok(files)
+    Ok((files, jobs))
 }
 
 /// Get the diff for a range of commits.
 /// `commit_ids` should be ordered from oldest to newest.
 /// The diff compares the oldest commit's parent to the newest commit.
-pub fn get_commit_range_diff(
-    repo: &Repository,
-    commit_ids: &[String],
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>> {
+pub fn get_commit_range_diff(repo: &Repository, commit_ids: &[String]) -> Result<DiffWithJobs> {
     if commit_ids.is_empty() {
         return Err(TuicrError::NoChanges);
     }
@@ -99,10 +86,10 @@ pub fn get_commit_range_diff(
     let new_tree = newest_commit.tree()?;
 
     let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), None)?;
-    let mut files = parse_diff(&diff, highlighter)?;
-    enhance_with_full_file_highlight(
-        &mut files,
-        highlighter,
+    let (files, mut jobs) = parse_diff(&diff)?;
+    append_container_full_file_jobs(
+        &files,
+        &mut jobs,
         |path| {
             old_tree
                 .as_ref()
@@ -110,7 +97,7 @@ pub fn get_commit_range_diff(
         },
         |path| read_path_from_tree(repo, &new_tree, path),
     );
-    Ok(files)
+    Ok((files, jobs))
 }
 
 /// Get a combined diff from the parent of the oldest commit through to the working tree.
@@ -118,8 +105,7 @@ pub fn get_commit_range_diff(
 pub fn get_working_tree_with_commits_diff(
     repo: &Repository,
     commit_ids: &[String],
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>> {
+) -> Result<DiffWithJobs> {
     if commit_ids.is_empty() {
         return Err(TuicrError::NoChanges);
     }
@@ -139,10 +125,10 @@ pub fn get_working_tree_with_commits_diff(
     opts.recurse_untracked_dirs(true);
 
     let diff = repo.diff_tree_to_workdir_with_index(old_tree.as_ref(), Some(&mut opts))?;
-    let mut files = parse_diff(&diff, highlighter)?;
-    enhance_with_full_file_highlight(
-        &mut files,
-        highlighter,
+    let (files, mut jobs) = parse_diff(&diff)?;
+    append_container_full_file_jobs(
+        &files,
+        &mut jobs,
         |path| {
             old_tree
                 .as_ref()
@@ -150,7 +136,7 @@ pub fn get_working_tree_with_commits_diff(
         },
         |path| read_path_from_workdir(repo, path),
     );
-    Ok(files)
+    Ok((files, jobs))
 }
 
 fn read_path_from_tree(repo: &Repository, tree: &git2::Tree, path: &Path) -> Option<String> {
@@ -169,11 +155,12 @@ fn read_path_from_index(repo: &Repository, index: &git2::Index, path: &Path) -> 
     Some(String::from_utf8_lossy(blob.content()).into_owned())
 }
 
-fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+fn parse_diff(diff: &Diff) -> Result<DiffWithJobs> {
     let mut files: Vec<DiffFile> = Vec::new();
+    let mut jobs: Vec<HighlightJob> = Vec::new();
 
     // Untracked files larger than this are shown in the file list but their
-    // content is not parsed — they are likely logs, dumps, or build artefacts.
+    // content is not parsed - they are likely logs, dumps, or build artefacts.
     const MAX_UNTRACKED_FILE_SIZE: u64 = 10 * 1_024 * 1_024;
 
     for (delta_idx, delta) in diff.deltas().enumerate() {
@@ -193,10 +180,11 @@ fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFi
             delta.status() == Delta::Untracked && delta.new_file().size() > MAX_UNTRACKED_FILE_SIZE;
 
         let syntax_path = new_path.as_ref().or(old_path.as_ref()).map(|p| p.as_path());
+        let file_idx = files.len();
         let hunks = if is_binary || is_too_large {
             Vec::new()
         } else {
-            parse_hunks(diff, delta_idx, highlighter, syntax_path)?
+            parse_hunks(diff, delta_idx, file_idx, syntax_path, &mut jobs)?
         };
 
         let content_hash = DiffFile::compute_content_hash(&hunks);
@@ -216,14 +204,15 @@ fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFi
         return Err(TuicrError::NoChanges);
     }
 
-    Ok(files)
+    Ok((files, jobs))
 }
 
 fn parse_hunks(
     diff: &Diff,
     delta_idx: usize,
-    highlighter: &SyntaxHighlighter,
+    file_idx: usize,
     file_path: Option<&Path>,
+    jobs: &mut Vec<HighlightJob>,
 ) -> Result<Vec<DiffHunk>> {
     let mut hunks: Vec<DiffHunk> = Vec::new();
 
@@ -261,37 +250,38 @@ fn parse_hunks(
                 line_numbers.push((line.old_lineno(), line.new_lineno()));
             }
 
-            let sequences =
-                SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
-            // Container grammars skip per-hunk highlighting; the full-file
-            // post-pass overwrites these spans anyway.
-            let (old_highlighted, new_highlighted) = match file_path {
-                Some(path) if !needs_full_file_highlight(path) => (
-                    highlighter.highlight_file_lines(path, &sequences.old_lines),
-                    highlighter.highlight_file_lines(path, &sequences.new_lines),
-                ),
-                _ => (None, None),
-            };
-
             let mut lines: Vec<DiffLine> = Vec::with_capacity(line_contents.len());
-            for (idx, content) in line_contents.into_iter().enumerate() {
-                let origin = line_origins[idx];
+            for (idx, content) in line_contents.iter().enumerate() {
                 let (old_lineno, new_lineno) = line_numbers[idx];
-
-                let highlighted_spans = highlighter.highlighted_line_for_diff_with_background(
-                    old_highlighted.as_deref(),
-                    new_highlighted.as_deref(),
-                    sequences.old_line_indices[idx],
-                    sequences.new_line_indices[idx],
-                    origin,
-                );
-
                 lines.push(DiffLine {
-                    origin,
-                    content,
+                    origin: line_origins[idx],
+                    content: content.clone(),
                     old_lineno,
                     new_lineno,
-                    highlighted_spans,
+                    highlighted_spans: None,
+                });
+            }
+
+            // Container grammars skip per-hunk highlighting; the full-file
+            // post-pass will fill spans for the whole file in one shot.
+            if let Some(path) = file_path
+                && !needs_full_file_highlight(path)
+            {
+                let sequences = SyntaxHighlighter::split_diff_lines_for_highlighting(
+                    &line_contents,
+                    &line_origins,
+                );
+                jobs.push(HighlightJob {
+                    file_idx,
+                    syntax_path: path.to_path_buf(),
+                    kind: HighlightJobKind::Hunk {
+                        hunk_idx,
+                        old_lines: sequences.old_lines,
+                        new_lines: sequences.new_lines,
+                        old_line_indices: sequences.old_line_indices,
+                        new_line_indices: sequences.new_line_indices,
+                        line_origins,
+                    },
                 });
             }
 
@@ -341,9 +331,8 @@ mod tests {
         let diff = repo
             .diff_tree_to_tree(Some(&head), Some(&head), None)
             .unwrap();
-        let highlighter = SyntaxHighlighter::default();
 
-        let result = parse_diff(&diff, &highlighter);
+        let result = parse_diff(&diff);
 
         assert!(matches!(result, Err(TuicrError::NoChanges)));
     }
@@ -365,8 +354,7 @@ mod tests {
         )
         .expect("failed to update file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get diff");
+        let (files, _jobs) = get_working_tree_diff(&repo).expect("failed to get diff");
 
         assert_eq!(files.len(), 1);
         let lines = &files[0].hunks[0].lines;
@@ -389,9 +377,15 @@ mod tests {
         let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
         fs::write(temp_dir.path().join("App.vue"), edited).expect("failed to update file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get diff");
+        let (mut files, jobs) = get_working_tree_diff(&repo).expect("failed to get diff");
         assert_eq!(files.len(), 1);
+
+        // Drive the streaming highlight pipeline synchronously so we can
+        // assert on the populated spans.
+        let highlighter = SyntaxHighlighter::default();
+        for update in crate::syntax::streaming::run_blocking(jobs, &highlighter) {
+            crate::syntax::streaming::apply_update(&mut files, &highlighter, update);
+        }
 
         let changed_lines: Vec<_> = files[0].hunks[0]
             .lines
@@ -423,14 +417,9 @@ mod tests {
 
         fs::write(temp_dir.path().join("file.txt"), "unstaged\n").expect("failed to update file");
 
-        let highlighter = SyntaxHighlighter::default();
-
-        let unstaged = get_unstaged_diff(&repo, &highlighter).expect("unstaged diff failed");
-        assert_eq!(unstaged.len(), 1);
-        assert!(matches!(
-            get_staged_diff(&repo, &highlighter),
-            Err(TuicrError::NoChanges)
-        ));
+        let (unstaged_files, _) = get_unstaged_diff(&repo).expect("unstaged diff failed");
+        assert_eq!(unstaged_files.len(), 1);
+        assert!(matches!(get_staged_diff(&repo), Err(TuicrError::NoChanges)));
 
         let mut index = repo.index().expect("failed to open index");
         index
@@ -438,10 +427,10 @@ mod tests {
             .expect("failed to add file to index");
         index.write().expect("failed to write index");
 
-        let staged = get_staged_diff(&repo, &highlighter).expect("staged diff failed");
-        assert_eq!(staged.len(), 1);
+        let (staged_files, _) = get_staged_diff(&repo).expect("staged diff failed");
+        assert_eq!(staged_files.len(), 1);
         assert!(matches!(
-            get_unstaged_diff(&repo, &highlighter),
+            get_unstaged_diff(&repo),
             Err(TuicrError::NoChanges)
         ));
     }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -7,10 +7,9 @@ use git2::Repository;
 use std::path::Path;
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffLine, FileStatus};
-use crate::syntax::SyntaxHighlighter;
+use crate::model::{DiffLine, FileStatus};
 
-use super::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use super::traits::{CommitInfo, DiffWithJobs, VcsBackend, VcsInfo, VcsType};
 
 // Re-export commonly used functions
 pub use context::{calculate_gap, fetch_context_lines};
@@ -67,16 +66,16 @@ impl VcsBackend for GitBackend {
         &self.info
     }
 
-    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        get_working_tree_diff(&self.repo, highlighter)
+    fn get_working_tree_diff(&self) -> Result<DiffWithJobs> {
+        get_working_tree_diff(&self.repo)
     }
 
-    fn get_staged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        get_staged_diff(&self.repo, highlighter)
+    fn get_staged_diff(&self) -> Result<DiffWithJobs> {
+        get_staged_diff(&self.repo)
     }
 
-    fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        get_unstaged_diff(&self.repo, highlighter)
+    fn get_unstaged_diff(&self) -> Result<DiffWithJobs> {
+        get_unstaged_diff(&self.repo)
     }
 
     fn fetch_context_lines(
@@ -109,12 +108,8 @@ impl VcsBackend for GitBackend {
         repository::resolve_revisions(&self.repo, revisions)
     }
 
-    fn get_commit_range_diff(
-        &self,
-        commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
-        get_commit_range_diff(&self.repo, commit_ids, highlighter)
+    fn get_commit_range_diff(&self, commit_ids: &[String]) -> Result<DiffWithJobs> {
+        get_commit_range_diff(&self.repo, commit_ids)
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
@@ -133,12 +128,8 @@ impl VcsBackend for GitBackend {
             .collect())
     }
 
-    fn get_working_tree_with_commits_diff(
-        &self,
-        commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
-        get_working_tree_with_commits_diff(&self.repo, commit_ids, highlighter)
+    fn get_working_tree_with_commits_diff(&self, commit_ids: &[String]) -> Result<DiffWithJobs> {
+        get_working_tree_with_commits_diff(&self.repo, commit_ids)
     }
 
     fn stage_file(&self, path: &Path) -> Result<()> {

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -5,11 +5,10 @@ use std::process::Command;
 use chrono::{TimeZone, Utc};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::SyntaxHighlighter;
+use crate::model::{DiffLine, FileStatus, LineOrigin};
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
-use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
+use crate::vcs::traits::{CommitInfo, DiffWithJobs, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::{BATCH_BOUNDARY, append_container_full_file_jobs_from_rev, parse_batched_files};
 
 /// Parse an hg description into (summary, optional body).
 fn parse_hg_description(desc: &str) -> (String, Option<String>) {
@@ -81,23 +80,23 @@ impl VcsBackend for HgBackend {
         &self.info
     }
 
-    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+    fn get_working_tree_diff(&self) -> Result<DiffWithJobs> {
         let diff_output = run_hg_command(&self.info.root_path, &["diff"])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
-        apply_container_full_file_highlight(
+        let (files, mut jobs) = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg)?;
+        append_container_full_file_jobs_from_rev(
             &self.info.root_path,
             ".",
             None,
-            &mut files,
-            highlighter,
+            &files,
+            &mut jobs,
             hg_cat_batch,
         )?;
-        Ok(files)
+        Ok((files, jobs))
     }
 
     fn fetch_context_lines(
@@ -228,11 +227,7 @@ impl VcsBackend for HgBackend {
         Ok(commits.into_iter().skip(offset).collect())
     }
 
-    fn get_commit_range_diff(
-        &self,
-        commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
+    fn get_commit_range_diff(&self, commit_ids: &[String]) -> Result<DiffWithJobs> {
         if commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
@@ -285,16 +280,16 @@ impl VcsBackend for HgBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
-        apply_container_full_file_highlight(
+        let (files, mut jobs) = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg)?;
+        append_container_full_file_jobs_from_rev(
             &self.info.root_path,
             &from_rev,
             Some(newest_short),
-            &mut files,
-            highlighter,
+            &files,
+            &mut jobs,
             hg_cat_batch,
         )?;
-        Ok(files)
+        Ok((files, jobs))
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
@@ -358,11 +353,7 @@ impl VcsBackend for HgBackend {
         Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
     }
 
-    fn get_working_tree_with_commits_diff(
-        &self,
-        commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
+    fn get_working_tree_with_commits_diff(&self, commit_ids: &[String]) -> Result<DiffWithJobs> {
         if commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
@@ -398,16 +389,16 @@ impl VcsBackend for HgBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
-        apply_container_full_file_highlight(
+        let (files, mut jobs) = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg)?;
+        append_container_full_file_jobs_from_rev(
             &self.info.root_path,
             &from_rev,
             None,
-            &mut files,
-            highlighter,
+            &files,
+            &mut jobs,
             hg_cat_batch,
         )?;
-        Ok(files)
+        Ok((files, jobs))
     }
 }
 
@@ -556,9 +547,7 @@ mod tests {
         assert_eq!(backend.info().root_path, expected_path);
         assert_eq!(backend.info().vcs_type, VcsType::Mercurial);
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -692,11 +681,11 @@ mod tests {
 
         // Get diff for the last two commits (Second and Third)
         let commit_ids = vec![commits[1].id.clone(), commits[0].id.clone()];
-        let diff_result = backend.get_commit_range_diff(&commit_ids, &SyntaxHighlighter::default());
+        let diff_result = backend.get_commit_range_diff(&commit_ids);
 
         // Note: Sapling (Meta's hg fork) may fail with "id_dag_snapshot()" error
         // in certain temporary directory configurations. Skip the test in that case.
-        let diff = match diff_result {
+        let (diff, _jobs) = match diff_result {
             Ok(d) => d,
             Err(TuicrError::VcsCommand(msg)) if msg.contains("id_dag_snapshot") => {
                 eprintln!("Skipping test: Sapling-specific issue with tempdir repos");
@@ -776,9 +765,7 @@ mod tests {
         let backend =
             HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         // hg should show the rename
         assert!(!files.is_empty(), "Expected at least one file change");
@@ -849,9 +836,7 @@ mod tests {
         let backend =
             HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert!(!files.is_empty(), "Expected at least one file change");
 
@@ -909,9 +894,7 @@ mod tests {
         let backend =
             HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert_eq!(files.len(), 1, "Expected one file");
 
@@ -965,10 +948,13 @@ mod tests {
 
         let backend =
             HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (mut files, jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
         assert_eq!(files.len(), 1);
+
+        let highlighter = crate::syntax::SyntaxHighlighter::default();
+        for update in crate::syntax::streaming::run_blocking(jobs, &highlighter) {
+            crate::syntax::streaming::apply_update(&mut files, &highlighter, update);
+        }
 
         let changed_lines: Vec<_> = files[0].hunks[0]
             .lines
@@ -1017,9 +1003,7 @@ mod tests {
         let backend =
             HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert_eq!(files.len(), 1, "Expected one file");
 

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -7,11 +7,10 @@ use std::process::Command;
 use chrono::{DateTime, Utc};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
-use crate::syntax::SyntaxHighlighter;
+use crate::model::{DiffLine, FileStatus, LineOrigin};
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
-use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
+use crate::vcs::traits::{CommitInfo, DiffWithJobs, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::{BATCH_BOUNDARY, append_container_full_file_jobs_from_rev, parse_batched_files};
 
 /// Parse a jj description into (summary, optional body).
 fn parse_description(desc: &str) -> (String, Option<String>) {
@@ -118,24 +117,24 @@ impl VcsBackend for JjBackend {
         &self.info
     }
 
-    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+    fn get_working_tree_diff(&self) -> Result<DiffWithJobs> {
         let diff_output = run_jj_command(&self.info.root_path, &["diff", "--git"])?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        let mut files =
-            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
-        apply_container_full_file_highlight(
+        let (files, mut jobs) =
+            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle)?;
+        append_container_full_file_jobs_from_rev(
             &self.info.root_path,
             "@-",
             None,
-            &mut files,
-            highlighter,
+            &files,
+            &mut jobs,
             jj_show_batch,
         )?;
-        Ok(files)
+        Ok((files, jobs))
     }
 
     fn fetch_context_lines(
@@ -273,11 +272,7 @@ impl VcsBackend for JjBackend {
         Ok(commits.into_iter().skip(offset).collect())
     }
 
-    fn get_commit_range_diff(
-        &self,
-        commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
+    fn get_commit_range_diff(&self, commit_ids: &[String]) -> Result<DiffWithJobs> {
         if commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
@@ -298,17 +293,17 @@ impl VcsBackend for JjBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        let mut files =
-            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
-        apply_container_full_file_highlight(
+        let (files, mut jobs) =
+            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle)?;
+        append_container_full_file_jobs_from_rev(
             &self.info.root_path,
             &from_rev,
             Some(newest),
-            &mut files,
-            highlighter,
+            &files,
+            &mut jobs,
             jj_show_batch,
         )?;
-        Ok(files)
+        Ok((files, jobs))
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
@@ -362,11 +357,7 @@ impl VcsBackend for JjBackend {
         Ok(ids.iter().filter_map(|id| by_id.remove(id)).collect())
     }
 
-    fn get_working_tree_with_commits_diff(
-        &self,
-        commit_ids: &[String],
-        highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
+    fn get_working_tree_with_commits_diff(&self, commit_ids: &[String]) -> Result<DiffWithJobs> {
         if commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
@@ -385,17 +376,17 @@ impl VcsBackend for JjBackend {
             return Err(TuicrError::NoChanges);
         }
 
-        let mut files =
-            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
-        apply_container_full_file_highlight(
+        let (files, mut jobs) =
+            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle)?;
+        append_container_full_file_jobs_from_rev(
             &self.info.root_path,
             &from_rev,
             None,
-            &mut files,
-            highlighter,
+            &files,
+            &mut jobs,
             jj_show_batch,
         )?;
-        Ok(files)
+        Ok((files, jobs))
     }
 }
 
@@ -544,9 +535,7 @@ mod tests {
         assert_eq!(backend.info().root_path, expected_path);
         assert_eq!(backend.info().vcs_type, VcsType::Jujutsu);
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert_eq!(files.len(), 1);
         assert_eq!(
@@ -706,8 +695,8 @@ mod tests {
             let newest = &named_commits[0]; // Third commit
 
             let commit_ids = vec![oldest.id.clone(), newest.id.clone()];
-            let diff = backend
-                .get_commit_range_diff(&commit_ids, &SyntaxHighlighter::default())
+            let (diff, _jobs) = backend
+                .get_commit_range_diff(&commit_ids)
                 .expect("Failed to get commit range diff");
 
             // Should have changes
@@ -760,9 +749,7 @@ mod tests {
         let backend =
             JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         // jj should detect the rename
         // Note: jj may show this as delete + add if it doesn't detect the rename
@@ -811,9 +798,7 @@ mod tests {
         let backend =
             JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert_eq!(files.len(), 1, "Expected one file");
 
@@ -846,9 +831,7 @@ mod tests {
         let backend =
             JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
 
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (files, _jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
 
         assert_eq!(files.len(), 1, "Expected one file");
 
@@ -939,10 +922,13 @@ mod tests {
 
         let backend =
             JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
-        let files = backend
-            .get_working_tree_diff(&SyntaxHighlighter::default())
-            .expect("Failed to get diff");
+        let (mut files, jobs) = backend.get_working_tree_diff().expect("Failed to get diff");
         assert_eq!(files.len(), 1);
+
+        let highlighter = crate::syntax::SyntaxHighlighter::default();
+        for update in crate::syntax::streaming::run_blocking(jobs, &highlighter) {
+            crate::syntax::streaming::apply_update(&mut files, &highlighter, update);
+        }
 
         let changed_lines: Vec<_> = files[0].hunks[0]
             .lines

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -22,16 +22,14 @@ pub use file::FileBackend;
 pub use git::GitBackend;
 pub use hg::HgBackend;
 pub use jj::JjBackend;
-pub use traits::{CommitInfo, VcsBackend, VcsInfo};
+pub use traits::{CommitInfo, DiffWithJobs, VcsBackend, VcsInfo};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, LineSide};
-use crate::syntax::{
-    HighlightedLines, HighlightedSpans, SyntaxHighlighter, needs_full_file_highlight,
-};
+use crate::syntax::{HighlightJob, HighlightJobKind, needs_full_file_highlight};
 
 /// Boundary marker emitted between files in batched `hg cat` / `jj file show`
 /// output. The long random suffix makes accidental collision with real source
@@ -69,6 +67,29 @@ pub(crate) fn read_workdir_file(root: &Path, rel: &Path) -> Option<String> {
     std::fs::read_to_string(root.join(rel)).ok()
 }
 
+/// Drop files for which `keep` returns false, then re-index highlight jobs to
+/// match the kept files' new positions. Jobs whose file was dropped are also
+/// dropped. Order of kept files (and remaining jobs) is preserved.
+pub fn filter_diff_with_jobs(diff: DiffWithJobs, keep: impl Fn(&DiffFile) -> bool) -> DiffWithJobs {
+    let (files, mut jobs) = diff;
+    let mut remap: HashMap<usize, usize> = HashMap::with_capacity(files.len());
+    let mut kept: Vec<DiffFile> = Vec::with_capacity(files.len());
+    for (old_idx, file) in files.into_iter().enumerate() {
+        if keep(&file) {
+            remap.insert(old_idx, kept.len());
+            kept.push(file);
+        }
+    }
+    jobs.retain_mut(|job| match remap.get(&job.file_idx) {
+        Some(&new_idx) => {
+            job.file_idx = new_idx;
+            true
+        }
+        None => false,
+    });
+    (kept, jobs)
+}
+
 /// Parse the output of a batched `hg cat` / `jj file show` invocation whose
 /// template prefixed each file with `\n{BATCH_BOUNDARY}\n{path}\n` before
 /// emitting `{data}`. Returns a `path → data` map.
@@ -86,17 +107,20 @@ pub(crate) fn parse_batched_files(output: &str) -> HashMap<PathBuf, String> {
         .collect()
 }
 
-/// Re-highlight container-grammar files (Vue, Svelte, etc) using their full
-/// content at the requested revisions. `new_rev = None` reads the new side
-/// from the working tree on disk instead of calling `fetch_batch`. The
-/// `fetch_batch` closure is the backend-specific batched-fetch primitive
-/// (`hg cat -r REV ...` or `jj file show -r REV ...`).
-pub(crate) fn apply_container_full_file_highlight<F>(
+/// Batch-fetch container-grammar files from a VCS at a given revision, then
+/// emit a `FullFile` highlight job for each. `new_rev = None` reads the new
+/// side from disk instead of calling `fetch_batch`. The `fetch_batch` closure
+/// is the backend-specific batched-fetch primitive (`hg cat -r REV ...` or
+/// `jj file show -r REV ...`).
+///
+/// The fetch happens on the parse thread because backends here drive
+/// subprocesses; the actual highlighting runs later on the worker thread.
+pub(crate) fn append_container_full_file_jobs_from_rev<F>(
     root: &Path,
     old_rev: &str,
     new_rev: Option<&str>,
-    files: &mut [DiffFile],
-    highlighter: &SyntaxHighlighter,
+    files: &[DiffFile],
+    jobs: &mut Vec<HighlightJob>,
     fetch_batch: F,
 ) -> Result<()>
 where
@@ -117,9 +141,9 @@ where
 
     let workdir = new_rev.is_none().then(|| root.to_path_buf());
 
-    enhance_with_full_file_highlight(
+    append_container_full_file_jobs(
         files,
-        highlighter,
+        jobs,
         |p| old_map.get(p).cloned(),
         |p| match (new_map.get(p), workdir.as_deref()) {
             (Some(content), _) => Some(content.clone()),
@@ -131,36 +155,23 @@ where
     Ok(())
 }
 
-/// Files larger than this skip the full-file highlight pass and fall back to
-/// per-hunk highlighting. Keeps a runaway-cost ceiling on diffs that include
-/// huge generated artefacts (lockfiles, vendored bundles, fixtures).
-const MAX_HIGHLIGHT_FILE_BYTES: usize = 1024 * 1024;
-
-/// Re-highlight each diff line using full-file context, for files whose
-/// grammar needs it (Vue, Svelte, Astro, MDX). Other files keep their existing
-/// per-hunk highlighting unchanged.
+/// Walk `files` and append one `FullFile` highlight job per container-grammar
+/// file (Vue, Svelte, ...). The closures fetch the file's full content on
+/// each side; either may return `None` if that side is unavailable.
 ///
-/// `fetch_old`/`fetch_new` return the entire content of the file at the old
-/// and new sides respectively (or `None` if unavailable). When a side is
-/// available, every diff line on that side is replaced with the span at its
-/// 1-based lineno from the full-file highlight. Lines whose side could not be
-/// fetched keep whatever the parser already assigned.
-///
-/// Runs in three phases: fetch (serial, since fetch closures may close over
-/// `!Send` state such as `git2::Repository`), highlight (parallel via
-/// `std::thread::scope`, since syntect's `SyntaxSet` and `Theme` are `Sync`
-/// and each file's syntect work is independent), and apply spans (serial,
-/// needs `&mut files`).
-pub(crate) fn enhance_with_full_file_highlight<F, G>(
-    files: &mut [DiffFile],
-    highlighter: &SyntaxHighlighter,
+/// Fetching happens here, in the parse phase, because the closures may close
+/// over VCS state that is `!Send` (e.g. `git2::Repository`, an `hg` child
+/// process). The highlighting itself runs later on the worker thread, against
+/// the `String`s embedded in the job.
+pub(crate) fn append_container_full_file_jobs<F, G>(
+    files: &[DiffFile],
+    jobs: &mut Vec<HighlightJob>,
     mut fetch_old: F,
     mut fetch_new: G,
 ) where
     F: FnMut(&Path) -> Option<String>,
     G: FnMut(&Path) -> Option<String>,
 {
-    let mut jobs: Vec<HighlightJob> = Vec::new();
     for (idx, file) in files.iter().enumerate() {
         if file.is_binary || file.is_too_large || file.hunks.is_empty() {
             continue;
@@ -179,115 +190,11 @@ pub(crate) fn enhance_with_full_file_highlight<F, G>(
         jobs.push(HighlightJob {
             file_idx: idx,
             syntax_path: syntax_path.to_path_buf(),
-            old_content,
-            new_content,
+            kind: HighlightJobKind::FullFile {
+                old_content,
+                new_content,
+            },
         });
-    }
-
-    if jobs.is_empty() {
-        return;
-    }
-
-    let results = highlight_jobs_parallel(&jobs, highlighter);
-
-    for (idx, old, new) in results {
-        if old.is_none() && new.is_none() {
-            continue;
-        }
-        apply_full_file_spans(&mut files[idx], highlighter, old.as_deref(), new.as_deref());
-    }
-}
-
-struct HighlightJob {
-    file_idx: usize,
-    syntax_path: PathBuf,
-    old_content: Option<String>,
-    new_content: Option<String>,
-}
-
-type HighlightResult = (usize, Option<HighlightedLines>, Option<HighlightedLines>);
-
-fn highlight_jobs_parallel(
-    jobs: &[HighlightJob],
-    highlighter: &SyntaxHighlighter,
-) -> Vec<HighlightResult> {
-    let parallelism = std::thread::available_parallelism()
-        .map(|n| n.get())
-        .unwrap_or(1)
-        .min(jobs.len());
-
-    if parallelism <= 1 {
-        return jobs
-            .iter()
-            .map(|j| highlight_single_job(j, highlighter))
-            .collect();
-    }
-
-    let chunk_size = jobs.len().div_ceil(parallelism);
-    std::thread::scope(|scope| {
-        let handles: Vec<_> = jobs
-            .chunks(chunk_size)
-            .map(|chunk| {
-                scope.spawn(move || {
-                    chunk
-                        .iter()
-                        .map(|j| highlight_single_job(j, highlighter))
-                        .collect::<Vec<_>>()
-                })
-            })
-            .collect();
-        handles
-            .into_iter()
-            .flat_map(|h| h.join().expect("highlight thread panicked"))
-            .collect()
-    })
-}
-
-fn highlight_single_job(job: &HighlightJob, highlighter: &SyntaxHighlighter) -> HighlightResult {
-    let old = job
-        .old_content
-        .as_deref()
-        .and_then(|c| highlight_content(highlighter, &job.syntax_path, c));
-    let new = job
-        .new_content
-        .as_deref()
-        .and_then(|c| highlight_content(highlighter, &job.syntax_path, c));
-    (job.file_idx, old, new)
-}
-
-fn highlight_content(
-    highlighter: &SyntaxHighlighter,
-    path: &Path,
-    content: &str,
-) -> Option<HighlightedLines> {
-    if content.len() > MAX_HIGHLIGHT_FILE_BYTES || content.as_bytes().contains(&0u8) {
-        return None;
-    }
-    let lines: Vec<String> = content.lines().map(tabify).collect();
-    highlighter.highlight_file_lines(path, &lines)
-}
-
-fn apply_full_file_spans(
-    file: &mut DiffFile,
-    highlighter: &SyntaxHighlighter,
-    old_highlight: Option<&[Option<HighlightedSpans>]>,
-    new_highlight: Option<&[Option<HighlightedSpans>]>,
-) {
-    for hunk in &mut file.hunks {
-        for line in &mut hunk.lines {
-            let old_idx = line.old_lineno.map(|n| n.saturating_sub(1) as usize);
-            let new_idx = line.new_lineno.map(|n| n.saturating_sub(1) as usize);
-            let spans = highlighter.highlighted_line_for_diff_with_background(
-                old_highlight,
-                new_highlight,
-                old_idx,
-                new_idx,
-                line.origin,
-            );
-            if spans.is_some() {
-                line.highlighted_spans = spans;
-            }
-        }
     }
 }
 
@@ -426,6 +333,7 @@ mod tests {
 
     fn highlight_n_vue_files(n: usize) -> Vec<DiffFile> {
         use crate::syntax::SyntaxHighlighter;
+        use crate::syntax::streaming::{apply_update, run_blocking};
 
         let mut files = Vec::with_capacity(n);
         let mut content_map: HashMap<PathBuf, (String, String)> = HashMap::new();
@@ -437,12 +345,16 @@ mod tests {
         }
 
         let highlighter = SyntaxHighlighter::default();
-        enhance_with_full_file_highlight(
-            &mut files,
-            &highlighter,
+        let mut jobs = Vec::new();
+        append_container_full_file_jobs(
+            &files,
+            &mut jobs,
             |p| content_map.get(p).map(|(o, _)| o.clone()),
             |p| content_map.get(p).map(|(_, n)| n.clone()),
         );
+        for update in run_blocking(jobs, &highlighter) {
+            apply_update(&mut files, &highlighter, update);
+        }
         files
     }
 
@@ -467,124 +379,22 @@ mod tests {
     }
 
     #[test]
-    fn enhance_full_file_highlight_serial_path_one_file() {
-        // Single file takes the serial branch in highlight_jobs_parallel.
+    fn streaming_full_file_highlight_serial_one_file() {
+        // Single file takes the serial branch in the streaming worker.
         let files = highlight_n_vue_files(1);
         assert_all_lines_highlighted(&files);
     }
 
     #[test]
-    fn enhance_full_file_highlight_parallel_path_many_files() {
-        // 12 files exceeds typical parallelism, forcing chunked thread::scope.
+    fn streaming_full_file_highlight_parallel_many_files() {
+        // 12 files exceeds typical parallelism, forcing the scoped pool.
         let files = highlight_n_vue_files(12);
         assert_eq!(files.len(), 12);
         assert_all_lines_highlighted(&files);
     }
 
-    fn synth_vue_file(idx: usize) -> (DiffFile, String, String) {
-        let mut html = String::from("<template>\n  <div class=\"app\">\n");
-        for i in 0..80 {
-            html.push_str(&format!("    <span class=\"item-{i}\">item {i}</span>\n"));
-        }
-        html.push_str("  </div>\n</template>\n\n");
-
-        let mut script =
-            String::from("<script setup lang=\"ts\">\nimport { ref, computed } from 'vue'\n\n");
-        for i in 0..90 {
-            script.push_str(&format!("const value{i} = ref({i})\n"));
-        }
-        script.push_str("</script>\n\n");
-
-        let mut style = String::from("<style scoped>\n");
-        for i in 0..30 {
-            style.push_str(&format!(".item-{i} {{ color: rgb({i}, 0, 0); }}\n"));
-        }
-        style.push_str("</style>\n");
-
-        let old = format!("{html}{script}{style}");
-        let new = old.replace("const value0 = ref(0)", "const value0 = ref(42)");
-
-        let target_line = new
-            .lines()
-            .position(|l| l.starts_with("const value0 = ref(42)"))
-            .expect("synth content must contain target line") as u32
-            + 1;
-        let file = vue_diff_file(
-            idx,
-            "const value0 = ref(0)",
-            "const value0 = ref(42)",
-            target_line,
-        );
-        (file, old, new)
-    }
-
-    /// Manual bench: parallel vs serial highlight at realistic scales.
-    /// Run with: `cargo test --release vcs::tests::bench_highlight_parallel_vs_serial -- --ignored --nocapture`
     #[test]
-    #[ignore]
-    fn bench_highlight_parallel_vs_serial() {
-        use crate::syntax::SyntaxHighlighter;
-        use std::time::Instant;
-
-        let highlighter = SyntaxHighlighter::default();
-        let scales = [1usize, 5, 12, 25, 50];
-        let runs = 5;
-
-        for &n in &scales {
-            let mut files_template = Vec::with_capacity(n);
-            let mut content_map: HashMap<PathBuf, (String, String)> = HashMap::new();
-            for i in 0..n {
-                let (file, old, new) = synth_vue_file(i);
-                content_map.insert(file.new_path.clone().unwrap(), (old, new));
-                files_template.push(file);
-            }
-
-            let jobs: Vec<HighlightJob> = files_template
-                .iter()
-                .enumerate()
-                .map(|(idx, f)| {
-                    let path = f.new_path.clone().unwrap();
-                    let (old, new) = content_map.get(&path).unwrap();
-                    HighlightJob {
-                        file_idx: idx,
-                        syntax_path: path,
-                        old_content: Some(old.clone()),
-                        new_content: Some(new.clone()),
-                    }
-                })
-                .collect();
-
-            // Warmup
-            let _ = highlight_jobs_parallel(&jobs, &highlighter);
-
-            let mut par_total = std::time::Duration::ZERO;
-            for _ in 0..runs {
-                let t = Instant::now();
-                let _ = highlight_jobs_parallel(&jobs, &highlighter);
-                par_total += t.elapsed();
-            }
-            let par_mean = par_total / runs as u32;
-
-            let mut ser_total = std::time::Duration::ZERO;
-            for _ in 0..runs {
-                let t = Instant::now();
-                let _: Vec<HighlightResult> = jobs
-                    .iter()
-                    .map(|j| highlight_single_job(j, &highlighter))
-                    .collect();
-                ser_total += t.elapsed();
-            }
-            let ser_mean = ser_total / runs as u32;
-
-            let speedup = ser_mean.as_secs_f64() / par_mean.as_secs_f64().max(1e-9);
-            println!(
-                "N={n:>3}: serial={ser_mean:>10.2?}  parallel={par_mean:>10.2?}  speedup={speedup:.2}x"
-            );
-        }
-    }
-
-    #[test]
-    fn enhance_full_file_highlight_results_match_input_order() {
+    fn streaming_full_file_highlight_results_match_input_order() {
         // Each file's highlighted spans must land on that file's hunk lines,
         // not a neighbour's. Distinguishable by line content.
         let files = highlight_n_vue_files(6);

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -3,7 +3,11 @@ use std::path::{Path, PathBuf};
 
 use crate::error::Result;
 use crate::model::{DiffFile, DiffLine, FileStatus};
-use crate::syntax::SyntaxHighlighter;
+use crate::syntax::HighlightJob;
+
+/// Result of a diff fetch: parsed files (with `highlighted_spans = None` on
+/// every line) plus the highlight work the streaming worker will run.
+pub type DiffWithJobs = (Vec<DiffFile>, Vec<HighlightJob>);
 
 /// Information about the VCS type
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,18 +58,20 @@ pub trait VcsBackend: Send {
     /// Get repository information
     fn info(&self) -> &VcsInfo;
 
-    /// Get the working tree diff (staged + unstaged changes)
-    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>>;
+    /// Get the working tree diff (staged + unstaged changes).
+    /// Returns the parsed diff plus highlight jobs the streaming worker
+    /// will run on a background thread.
+    fn get_working_tree_diff(&self) -> Result<DiffWithJobs>;
 
     /// Get the staged diff (index vs HEAD)
-    fn get_staged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+    fn get_staged_diff(&self) -> Result<DiffWithJobs> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Staged diff not supported for this VCS".into(),
         ))
     }
 
     /// Get the unstaged diff (working tree vs index)
-    fn get_unstaged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+    fn get_unstaged_diff(&self) -> Result<DiffWithJobs> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Unstaged diff not supported for this VCS".into(),
         ))
@@ -97,11 +103,7 @@ pub trait VcsBackend: Send {
 
     /// Get diff for a commit range.
     /// Returns error if not supported (default).
-    fn get_commit_range_diff(
-        &self,
-        _commit_ids: &[String],
-        _highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
+    fn get_commit_range_diff(&self, _commit_ids: &[String]) -> Result<DiffWithJobs> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Commit range diff not supported for this VCS".into(),
         ))
@@ -116,11 +118,7 @@ pub trait VcsBackend: Send {
     /// Get a combined diff from the parent of the oldest commit through to the working tree.
     /// This shows both committed and working tree changes in a single diff.
     /// Returns error if not supported (default).
-    fn get_working_tree_with_commits_diff(
-        &self,
-        _commit_ids: &[String],
-        _highlighter: &SyntaxHighlighter,
-    ) -> Result<Vec<DiffFile>> {
+    fn get_working_tree_with_commits_diff(&self, _commit_ids: &[String]) -> Result<DiffWithJobs> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Working tree + commits diff not supported for this VCS".into(),
         ))


### PR DESCRIPTION
Four perf/UX fixes that surfaced together while reviewing a 565-file commit (~47k lines, mostly JS/Vue/TS) in a large private repo. tuicr was slow to load, sluggish when switching files, and scrolling was effectively unresponsive (had to kill the process).

Each commit handles one concern. Per-commit messages have the details; quick recap:

- **`perf(syntax): stream syntax highlighting on a background worker`** — parse emits jobs, a background worker highlights them in parallel and streams spans via mpsc; the main loop patches `diff_files` between frames. File list + first diff structure appear after parse alone instead of parse + full sync highlight. Worker spawns lazily on the first drain so `App::new`'s post-`install_diff` reorderings (commit-message insert, directory sort) settle before jobs are resolved against `diff_files` by `syntax_path`.

- **`perf(syntax): prioritize highlight jobs around the focused file`** — pending jobs live in an `Arc<Mutex<VecDeque>>`. When the user jumps files, the App reorders the remaining queue by file-index distance so visible work runs next instead of grinding files near index 0 that aren't on screen.

- **`perf(input): drain queued events before each redraw`** — the loop used to read one event then redraw; on a heavy diff, holding `j` or wheel-scrolling queued 200-600ms of input lag, worst case on direction reversals. Now drains via `event::poll(Duration::ZERO)` after the blocking poll (64-event cap) then redraws once. Atomic-action keys (Ctrl+C, ZQ, dd, `;X`) keep their per-event `continue 'main` shortcut.

- **`fix(ui): preserve manual file-list scroll when diff panel is focused`** — wheel-scrolling the file list was snapping back because the render-time "sync selection to diff's current file" path re-selected each frame and ratatui's `List` auto-adjusted offset to keep selection visible. Track a `manual_file_list_scroll` flag, set on wheel and cleared when `current_file_idx` changes for any other reason. Pre-existing; visible only once the rest of the loop is fast enough.
