### PR TITLE
add github forge backend skeleton

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,9 @@ pub enum TuicrError {
     #[error("VCS command failed: {0}")]
     VcsCommand(String),
 
+    #[error("{0}")]
+    Forge(String),
+
     #[error("Unsupported operation: {0}")]
     UnsupportedOperation(String),
 }

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -1,11 +1,11 @@
 use std::ffi::OsStr;
-use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 use crate::forge::traits::{
     ForgeBackend, ForgeRepository, PagedPullRequests, PullRequestDetails, PullRequestListQuery,
     PullRequestTarget,
 };
+use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 
 use super::models::{GhPullRequestDetails, GhPullRequestSummary};
 
@@ -34,27 +34,21 @@ pub struct SystemGhRunner;
 
 impl GhCommandRunner for SystemGhRunner {
     fn run(&self, args: &[String]) -> GhCommandResult<String> {
-        let output = Command::new("gh")
-            .args(args.iter().map(OsStr::new))
-            .output()
-            .map_err(|err| {
-                if err.kind() == std::io::ErrorKind::NotFound {
-                    GhCommandError::MissingGh
-                } else {
-                    GhCommandError::Failed {
-                        status: None,
-                        stderr: err.to_string(),
-                    }
-                }
-            })?;
+        run_command_output("gh", None, args.iter().map(|arg| OsStr::new(arg.as_str())))
+            .map_err(GhCommandError::from)
+    }
+}
 
-        if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-        } else {
-            Err(GhCommandError::Failed {
-                status: output.status.code(),
-                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
-            })
+impl From<CommandOutputError> for GhCommandError {
+    fn from(error: CommandOutputError) -> Self {
+        match error.kind {
+            CommandOutputErrorKind::NotFound => Self::MissingGh,
+            CommandOutputErrorKind::SpawnFailed | CommandOutputErrorKind::Unsuccessful => {
+                Self::Failed {
+                    status: error.status,
+                    stderr: error.stderr,
+                }
+            }
         }
     }
 }

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -1,0 +1,663 @@
+use std::ffi::OsStr;
+use std::process::Command;
+
+use crate::error::{Result, TuicrError};
+use crate::forge::traits::{
+    ForgeBackend, ForgeRepository, PagedPullRequests, PullRequestDetails, PullRequestListQuery,
+    PullRequestTarget,
+};
+
+use super::models::{GhPullRequestDetails, GhPullRequestSummary};
+
+const DEFAULT_GITHUB_HOST: &str = "github.com";
+const PR_LIST_JSON_FIELDS: &str =
+    "number,title,author,headRefName,baseRefName,updatedAt,url,state,isDraft";
+const PR_VIEW_JSON_FIELDS: &str = concat!(
+    "number,title,url,state,isDraft,author,headRefName,baseRefName,",
+    "headRefOid,baseRefOid,body,updatedAt,closed,mergedAt"
+);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GhCommandError {
+    MissingGh,
+    Failed { status: Option<i32>, stderr: String },
+}
+
+pub type GhCommandResult<T> = std::result::Result<T, GhCommandError>;
+
+pub trait GhCommandRunner {
+    fn run(&self, args: &[String]) -> GhCommandResult<String>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SystemGhRunner;
+
+impl GhCommandRunner for SystemGhRunner {
+    fn run(&self, args: &[String]) -> GhCommandResult<String> {
+        let output = Command::new("gh")
+            .args(args.iter().map(OsStr::new))
+            .output()
+            .map_err(|err| {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    GhCommandError::MissingGh
+                } else {
+                    GhCommandError::Failed {
+                        status: None,
+                        stderr: err.to_string(),
+                    }
+                }
+            })?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        } else {
+            Err(GhCommandError::Failed {
+                status: output.status.code(),
+                stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GitHubGhBackend<R = SystemGhRunner> {
+    default_repository: Option<ForgeRepository>,
+    runner: R,
+}
+
+impl GitHubGhBackend<SystemGhRunner> {
+    pub fn new(default_repository: Option<ForgeRepository>) -> Self {
+        Self {
+            default_repository,
+            runner: SystemGhRunner,
+        }
+    }
+}
+
+impl<R> GitHubGhBackend<R>
+where
+    R: GhCommandRunner,
+{
+    pub fn with_runner(default_repository: Option<ForgeRepository>, runner: R) -> Self {
+        Self {
+            default_repository,
+            runner,
+        }
+    }
+
+    fn resolve_repository(&self, target: &PullRequestTarget) -> Result<ForgeRepository> {
+        target
+            .repository
+            .clone()
+            .or_else(|| self.default_repository.clone())
+            .ok_or_else(|| {
+                TuicrError::Forge(format!(
+                    "GitHub pull request target `{}` does not include a repository",
+                    target.original
+                ))
+            })
+    }
+
+    fn run_gh(&self, args: Vec<String>, host: &str) -> Result<String> {
+        self.runner
+            .run(&args)
+            .map_err(|err| map_gh_error(err, host))
+    }
+}
+
+impl<R> ForgeBackend for GitHubGhBackend<R>
+where
+    R: GhCommandRunner,
+{
+    fn list_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests> {
+        let page_size = query.page_size.max(1);
+        let requested = query.already_loaded + page_size + 1;
+        let output = self.run_gh(
+            vec![
+                "pr".to_string(),
+                "list".to_string(),
+                "--repo".to_string(),
+                gh_repo_arg(&query.repository),
+                "--state".to_string(),
+                "open".to_string(),
+                "--limit".to_string(),
+                requested.to_string(),
+                "--json".to_string(),
+                PR_LIST_JSON_FIELDS.to_string(),
+            ],
+            &query.repository.host,
+        )?;
+        let rows: Vec<GhPullRequestSummary> = serde_json::from_str(&output)?;
+        let has_more = rows.len() > query.already_loaded + page_size;
+        let pull_requests = rows
+            .into_iter()
+            .skip(query.already_loaded)
+            .take(page_size)
+            .map(|row| row.into_summary(&query.repository))
+            .collect::<Vec<_>>();
+        let total_loaded = query.already_loaded + pull_requests.len();
+
+        Ok(PagedPullRequests {
+            pull_requests,
+            has_more,
+            total_loaded,
+        })
+    }
+
+    fn get_pull_request(&self, target: PullRequestTarget) -> Result<PullRequestDetails> {
+        let repository = self.resolve_repository(&target)?;
+        let output = self.run_gh(
+            vec![
+                "pr".to_string(),
+                "view".to_string(),
+                target.number.to_string(),
+                "--repo".to_string(),
+                gh_repo_arg(&repository),
+                "--json".to_string(),
+                PR_VIEW_JSON_FIELDS.to_string(),
+            ],
+            &repository.host,
+        )?;
+        let pr: GhPullRequestDetails = serde_json::from_str(&output)?;
+        pr.into_details(&repository)
+    }
+
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String> {
+        self.run_gh(
+            vec![
+                "pr".to_string(),
+                "diff".to_string(),
+                pr.number.to_string(),
+                "--repo".to_string(),
+                gh_repo_arg(&pr.repository),
+                "--patch".to_string(),
+                "--color".to_string(),
+                "never".to_string(),
+            ],
+            &pr.repository.host,
+        )
+    }
+}
+
+pub fn parse_pull_request_target(input: &str) -> Result<PullRequestTarget> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return malformed_target(input);
+    }
+
+    if let Some(target) = parse_numeric_target(trimmed) {
+        return Ok(target);
+    }
+    if let Some(target) = parse_url_target(trimmed) {
+        return Ok(target);
+    }
+    if let Some(target) = parse_repo_hash_target(trimmed) {
+        return Ok(target);
+    }
+
+    malformed_target(input)
+}
+
+pub fn parse_github_remote_url(remote_url: &str) -> Option<ForgeRepository> {
+    let trimmed = trim_url_suffix(remote_url.trim());
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Some((host, path)) = parse_scp_like_remote(trimmed) {
+        return repository_from_path(host, path);
+    }
+
+    let without_scheme = strip_scheme(trimmed).unwrap_or(trimmed);
+    let without_user = without_scheme
+        .rsplit_once('@')
+        .map(|(_, rest)| rest)
+        .unwrap_or(without_scheme);
+    let (host, path) = without_user.split_once('/')?;
+    repository_from_path(host, path)
+}
+
+fn parse_numeric_target(target: &str) -> Option<PullRequestTarget> {
+    if !target.chars().all(|ch| ch.is_ascii_digit()) {
+        return None;
+    }
+    let number = target.parse::<u64>().ok()?;
+    if number == 0 {
+        return None;
+    }
+    Some(PullRequestTarget::number(number, target))
+}
+
+fn parse_url_target(target: &str) -> Option<PullRequestTarget> {
+    let without_scheme = strip_scheme(target)?;
+    let trimmed = trim_url_suffix(without_scheme);
+    let mut parts = trimmed.split('/').filter(|part| !part.is_empty());
+    let host = parts.next()?;
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if parts.next()? != "pull" {
+        return None;
+    }
+    let number = parts.next()?.parse::<u64>().ok()?;
+    if number == 0 {
+        return None;
+    }
+
+    Some(PullRequestTarget::with_repository(
+        ForgeRepository::github(host, owner, strip_git_suffix(repo)),
+        number,
+        target,
+    ))
+}
+
+fn parse_repo_hash_target(target: &str) -> Option<PullRequestTarget> {
+    let (repo_part, number_part) = target.split_once('#')?;
+    let number = number_part.parse::<u64>().ok()?;
+    if number == 0 {
+        return None;
+    }
+    let parts = repo_part
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    let repository = match parts.as_slice() {
+        [owner, repo] => {
+            ForgeRepository::github(DEFAULT_GITHUB_HOST, *owner, strip_git_suffix(repo))
+        }
+        [host, owner, repo] => ForgeRepository::github(*host, *owner, strip_git_suffix(repo)),
+        _ => return None,
+    };
+
+    Some(PullRequestTarget::with_repository(
+        repository, number, target,
+    ))
+}
+
+fn parse_scp_like_remote(remote_url: &str) -> Option<(&str, &str)> {
+    if remote_url.contains("://") {
+        return None;
+    }
+
+    let (host_part, path) = remote_url.split_once(':')?;
+    if host_part.contains('/') || path.is_empty() {
+        return None;
+    }
+    let host = host_part
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(host_part);
+    Some((host, path))
+}
+
+fn repository_from_path(host: &str, path: &str) -> Option<ForgeRepository> {
+    let mut parts = path.split('/').filter(|part| !part.is_empty());
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    Some(ForgeRepository::github(
+        host,
+        owner,
+        strip_git_suffix(trim_url_suffix(repo)),
+    ))
+}
+
+fn strip_scheme(value: &str) -> Option<&str> {
+    value
+        .strip_prefix("https://")
+        .or_else(|| value.strip_prefix("http://"))
+        .or_else(|| value.strip_prefix("ssh://"))
+}
+
+fn trim_url_suffix(value: &str) -> &str {
+    value
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(value)
+        .trim_end_matches('/')
+}
+
+fn strip_git_suffix(value: &str) -> &str {
+    value.strip_suffix(".git").unwrap_or(value)
+}
+
+fn gh_repo_arg(repository: &ForgeRepository) -> String {
+    if repository.host == DEFAULT_GITHUB_HOST {
+        repository.slug()
+    } else {
+        format!("{}/{}", repository.host, repository.slug())
+    }
+}
+
+fn map_gh_error(error: GhCommandError, host: &str) -> TuicrError {
+    match error {
+        GhCommandError::MissingGh => TuicrError::Forge(
+            "GitHub integration requires `gh`.\nInstall GitHub CLI and run `gh auth login`."
+                .to_string(),
+        ),
+        GhCommandError::Failed { stderr, .. } if looks_like_auth_failure(&stderr) => {
+            TuicrError::Forge(format!(
+                "GitHub authentication failed.\nRun `gh auth login` for {host}."
+            ))
+        }
+        GhCommandError::Failed { stderr, status } => {
+            let detail = if stderr.is_empty() {
+                status
+                    .map(|code| format!("gh exited with status {code}"))
+                    .unwrap_or_else(|| "gh command failed".to_string())
+            } else {
+                stderr
+            };
+            TuicrError::Forge(format!("GitHub command failed: {detail}"))
+        }
+    }
+}
+
+fn looks_like_auth_failure(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("gh auth login")
+        || lower.contains("not logged in")
+        || lower.contains("not logged into")
+        || lower.contains("authentication failed")
+        || lower.contains("requires authentication")
+}
+
+fn malformed_target<T>(input: &str) -> Result<T> {
+    Err(TuicrError::Forge(format!(
+        "Malformed GitHub pull request target: `{input}`"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+    use crate::forge::traits::ForgeBackend;
+
+    const PR_LIST_JSON: &str = r##"
+[
+  {
+    "number": 148,
+    "title": "Add forge-backed PR review",
+    "author": { "login": "alice" },
+    "headRefName": "forge-review",
+    "baseRefName": "main",
+    "updatedAt": "2026-05-12T18:30:00Z",
+    "url": "https://github.com/agavra/tuicr/pull/148",
+    "state": "OPEN",
+    "isDraft": false
+  },
+  {
+    "number": 125,
+    "title": "Support fetching and pushing reviews",
+    "author": { "login": "YPares" },
+    "headRefName": "reviews",
+    "baseRefName": "main",
+    "updatedAt": "2026-05-08T10:00:00Z",
+    "url": "https://github.com/agavra/tuicr/pull/125",
+    "state": "OPEN",
+    "isDraft": true
+  }
+]
+"##;
+
+    const PR_VIEW_JSON: &str = r##"
+{
+  "number": 125,
+  "title": "Support fetching and pushing reviews",
+  "url": "https://github.com/agavra/tuicr/pull/125",
+  "state": "OPEN",
+  "isDraft": false,
+  "author": { "login": "alice" },
+  "headRefName": "reviews",
+  "baseRefName": "main",
+  "headRefOid": "abcdef1234567890",
+  "baseRefOid": "1234567890abcdef",
+  "body": "Review workflow",
+  "updatedAt": "2026-05-12T18:30:00Z",
+  "closed": false,
+  "mergedAt": null
+}
+"##;
+
+    const PR_PATCH: &str = r##"
+diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ pub fn answer() -> u32 {
+-    41
++    42
+ }
+"##;
+
+    #[derive(Default)]
+    struct FakeGhRunner {
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl GhCommandRunner for FakeGhRunner {
+        fn run(&self, args: &[String]) -> GhCommandResult<String> {
+            self.calls.borrow_mut().push(args.to_vec());
+            match args.get(1).map(String::as_str) {
+                Some("list") => Ok(PR_LIST_JSON.to_string()),
+                Some("view") => Ok(PR_VIEW_JSON.to_string()),
+                Some("diff") => Ok(PR_PATCH.to_string()),
+                _ => Err(GhCommandError::Failed {
+                    status: Some(1),
+                    stderr: "unexpected command".to_string(),
+                }),
+            }
+        }
+    }
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    #[test]
+    fn repository_display_name_omits_github_com() {
+        assert_eq!(repo().display_name(), "agavra/tuicr");
+        assert_eq!(
+            ForgeRepository::github("github.example.com", "agavra", "tuicr").display_name(),
+            "github.example.com/agavra/tuicr"
+        );
+    }
+
+    #[test]
+    fn constructs_system_runner_backend() {
+        let _backend = GitHubGhBackend::new(Some(repo()));
+    }
+
+    #[test]
+    fn parses_numeric_pull_request_target() {
+        let target = parse_pull_request_target("125").unwrap();
+        assert_eq!(target.number, 125);
+        assert_eq!(target.repository, None);
+    }
+
+    #[test]
+    fn parses_owner_repo_pull_request_target() {
+        let target = parse_pull_request_target("agavra/tuicr#125").unwrap();
+        assert_eq!(target.number, 125);
+        assert_eq!(target.repository.unwrap(), repo());
+    }
+
+    #[test]
+    fn parses_enterprise_owner_repo_pull_request_target() {
+        let target = parse_pull_request_target("github.example.com/agavra/tuicr#125").unwrap();
+        let repository = target.repository.unwrap();
+        assert_eq!(repository.host, "github.example.com");
+        assert_eq!(repository.slug(), "agavra/tuicr");
+    }
+
+    #[test]
+    fn parses_full_pull_request_url() {
+        let target = parse_pull_request_target("https://github.com/agavra/tuicr/pull/125").unwrap();
+        assert_eq!(target.number, 125);
+        assert_eq!(target.repository.unwrap(), repo());
+    }
+
+    #[test]
+    fn rejects_malformed_pull_request_target() {
+        let err = parse_pull_request_target("agavra/tuicr/pulls/125").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Malformed GitHub pull request target")
+        );
+    }
+
+    #[test]
+    fn parses_https_remote_url() {
+        let repository = parse_github_remote_url("https://github.com/agavra/tuicr.git").unwrap();
+        assert_eq!(repository, repo());
+    }
+
+    #[test]
+    fn parses_scp_like_ssh_remote_url() {
+        let repository = parse_github_remote_url("git@github.com:agavra/tuicr.git").unwrap();
+        assert_eq!(repository, repo());
+    }
+
+    #[test]
+    fn parses_ssh_remote_url() {
+        let repository =
+            parse_github_remote_url("ssh://git@github.example.com/agavra/tuicr.git").unwrap();
+        assert_eq!(repository.host, "github.example.com");
+        assert_eq!(repository.slug(), "agavra/tuicr");
+    }
+
+    #[test]
+    fn list_pull_requests_uses_gh_json_output() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(None, runner);
+        let result = backend
+            .list_pull_requests(PullRequestListQuery::first_page(repo(), 1))
+            .unwrap();
+
+        assert_eq!(result.pull_requests.len(), 1);
+        assert!(result.has_more);
+        assert_eq!(result.total_loaded, 1);
+        assert_eq!(result.pull_requests[0].number, 148);
+        assert_eq!(result.pull_requests[0].author.as_deref(), Some("alice"));
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(
+            calls[0],
+            vec![
+                "pr",
+                "list",
+                "--repo",
+                "agavra/tuicr",
+                "--state",
+                "open",
+                "--limit",
+                "2",
+                "--json",
+                PR_LIST_JSON_FIELDS,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_pull_requests_can_load_next_slice() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(None, runner);
+        let result = backend
+            .list_pull_requests(PullRequestListQuery {
+                repository: repo(),
+                already_loaded: 1,
+                page_size: 1,
+            })
+            .unwrap();
+
+        assert_eq!(result.pull_requests.len(), 1);
+        assert!(!result.has_more);
+        assert_eq!(result.total_loaded, 2);
+        assert_eq!(result.pull_requests[0].number, 125);
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(
+            calls[0],
+            vec![
+                "pr",
+                "list",
+                "--repo",
+                "agavra/tuicr",
+                "--state",
+                "open",
+                "--limit",
+                "3",
+                "--json",
+                PR_LIST_JSON_FIELDS,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_pull_requests_uses_host_qualified_repo_for_enterprise() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(None, runner);
+        let repository = ForgeRepository::github("github.example.com", "agavra", "tuicr");
+        backend
+            .list_pull_requests(PullRequestListQuery::first_page(repository, 1))
+            .unwrap();
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(calls[0][3], "github.example.com/agavra/tuicr");
+    }
+
+    #[test]
+    fn get_pull_request_uses_default_repository_for_numeric_target() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+
+        assert_eq!(details.number, 125);
+        assert_eq!(details.head_sha, "abcdef1234567890");
+        assert!(!details.is_read_only());
+    }
+
+    #[test]
+    fn get_pull_request_requires_repository() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(None, runner);
+        let err = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap_err();
+        assert!(err.to_string().contains("does not include a repository"));
+    }
+
+    #[test]
+    fn get_pull_request_diff_returns_patch_text() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        let patch = backend.get_pull_request_diff(&details).unwrap();
+
+        assert_eq!(patch, PR_PATCH);
+    }
+
+    #[test]
+    fn maps_missing_gh_to_install_message() {
+        let err = map_gh_error(GhCommandError::MissingGh, "github.com");
+        assert!(err.to_string().contains("GitHub integration requires `gh`"));
+    }
+
+    #[test]
+    fn maps_auth_failure_to_login_message() {
+        let err = map_gh_error(
+            GhCommandError::Failed {
+                status: Some(4),
+                stderr: "run `gh auth login` to authenticate".to_string(),
+            },
+            "github.example.com",
+        );
+        assert!(err.to_string().contains("GitHub authentication failed"));
+        assert!(err.to_string().contains("github.example.com"));
+    }
+}

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -1,0 +1,2 @@
+pub mod gh;
+pub mod models;

--- a/src/forge/github/models.rs
+++ b/src/forge/github/models.rs
@@ -1,0 +1,117 @@
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::{Result, TuicrError};
+use crate::forge::traits::{ForgeRepository, PullRequestDetails, PullRequestSummary};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhPullRequestSummary {
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub author: Option<GhAuthor>,
+    #[serde(default)]
+    pub head_ref_name: String,
+    #[serde(default)]
+    pub base_ref_name: String,
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub is_draft: bool,
+}
+
+impl GhPullRequestSummary {
+    pub fn into_summary(self, repository: &ForgeRepository) -> PullRequestSummary {
+        PullRequestSummary {
+            repository: repository.clone(),
+            number: self.number,
+            title: self.title,
+            author: self.author.and_then(|author| author.login),
+            head_ref_name: self.head_ref_name,
+            base_ref_name: self.base_ref_name,
+            updated_at: self.updated_at,
+            url: self.url,
+            state: self.state,
+            is_draft: self.is_draft,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GhPullRequestDetails {
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub is_draft: bool,
+    #[serde(default)]
+    pub author: Option<GhAuthor>,
+    #[serde(default)]
+    pub head_ref_name: String,
+    #[serde(default)]
+    pub base_ref_name: String,
+    #[serde(default)]
+    pub head_ref_oid: String,
+    #[serde(default)]
+    pub base_ref_oid: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub updated_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    pub closed: bool,
+    #[serde(default)]
+    pub merged_at: Option<DateTime<Utc>>,
+}
+
+impl GhPullRequestDetails {
+    pub fn into_details(self, repository: &ForgeRepository) -> Result<PullRequestDetails> {
+        require_field(&self.head_ref_oid, "headRefOid")?;
+        require_field(&self.base_ref_oid, "baseRefOid")?;
+
+        Ok(PullRequestDetails {
+            repository: repository.clone(),
+            number: self.number,
+            title: self.title,
+            url: self.url,
+            state: self.state,
+            is_draft: self.is_draft,
+            author: self.author.and_then(|author| author.login),
+            head_ref_name: self.head_ref_name,
+            base_ref_name: self.base_ref_name,
+            head_sha: self.head_ref_oid,
+            base_sha: self.base_ref_oid,
+            body: self.body,
+            updated_at: self.updated_at,
+            closed: self.closed,
+            merged_at: self.merged_at,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GhAuthor {
+    #[serde(default)]
+    pub login: Option<String>,
+}
+
+fn require_field(value: &str, field: &str) -> Result<()> {
+    if value.is_empty() {
+        Err(TuicrError::Forge(format!(
+            "GitHub response did not include required field `{field}`"
+        )))
+    } else {
+        Ok(())
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -1,0 +1,9 @@
+//! Remote forge integration.
+//!
+//! This module is intentionally transport-focused for the first integration
+//! slice. UI and review submission code should depend on the trait shape here
+//! instead of shelling out to forge-specific tools directly.
+#![allow(dead_code)]
+
+pub mod github;
+pub mod traits;

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -1,0 +1,143 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::Result;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ForgeKind {
+    GitHub,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ForgeRepository {
+    pub kind: ForgeKind,
+    pub host: String,
+    pub owner: String,
+    pub name: String,
+}
+
+impl ForgeRepository {
+    pub fn github(
+        host: impl Into<String>,
+        owner: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: ForgeKind::GitHub,
+            host: host.into(),
+            owner: owner.into(),
+            name: name.into(),
+        }
+    }
+
+    pub fn slug(&self) -> String {
+        format!("{}/{}", self.owner, self.name)
+    }
+
+    pub fn display_name(&self) -> String {
+        if self.host == "github.com" {
+            self.slug()
+        } else {
+            format!("{}/{}", self.host, self.slug())
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestTarget {
+    pub repository: Option<ForgeRepository>,
+    pub number: u64,
+    pub original: String,
+}
+
+impl PullRequestTarget {
+    pub fn number(number: u64, original: impl Into<String>) -> Self {
+        Self {
+            repository: None,
+            number,
+            original: original.into(),
+        }
+    }
+
+    pub fn with_repository(
+        repository: ForgeRepository,
+        number: u64,
+        original: impl Into<String>,
+    ) -> Self {
+        Self {
+            repository: Some(repository),
+            number,
+            original: original.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullRequestListQuery {
+    pub repository: ForgeRepository,
+    pub already_loaded: usize,
+    pub page_size: usize,
+}
+
+impl PullRequestListQuery {
+    pub fn first_page(repository: ForgeRepository, page_size: usize) -> Self {
+        Self {
+            repository,
+            already_loaded: 0,
+            page_size,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestSummary {
+    pub repository: ForgeRepository,
+    pub number: u64,
+    pub title: String,
+    pub author: Option<String>,
+    pub head_ref_name: String,
+    pub base_ref_name: String,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub url: String,
+    pub state: String,
+    pub is_draft: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PagedPullRequests {
+    pub pull_requests: Vec<PullRequestSummary>,
+    pub has_more: bool,
+    pub total_loaded: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestDetails {
+    pub repository: ForgeRepository,
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub state: String,
+    pub is_draft: bool,
+    pub author: Option<String>,
+    pub head_ref_name: String,
+    pub base_ref_name: String,
+    pub head_sha: String,
+    pub base_sha: String,
+    pub body: String,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub closed: bool,
+    pub merged_at: Option<DateTime<Utc>>,
+}
+
+impl PullRequestDetails {
+    pub fn is_read_only(&self) -> bool {
+        self.closed || self.merged_at.is_some()
+    }
+}
+
+pub trait ForgeBackend {
+    fn list_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests>;
+    fn get_pull_request(&self, target: PullRequestTarget) -> Result<PullRequestDetails>;
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String>;
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod input;
 mod model;
 mod output;
 mod persistence;
+mod process;
 mod profile;
 mod syntax;
 mod text_edit;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod config;
 mod error;
+mod forge;
 mod handler;
 mod hash;
 mod input;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,57 @@
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandOutputErrorKind {
+    NotFound,
+    SpawnFailed,
+    Unsuccessful,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutputError {
+    pub kind: CommandOutputErrorKind,
+    pub status: Option<i32>,
+    pub stderr: String,
+}
+
+pub type CommandOutputResult<T> = std::result::Result<T, CommandOutputError>;
+
+pub fn run_command_output<I, S>(
+    program: &str,
+    current_dir: Option<&Path>,
+    args: I,
+) -> CommandOutputResult<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(program);
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+
+    let output = command.args(args).output().map_err(|err| {
+        let kind = if err.kind() == std::io::ErrorKind::NotFound {
+            CommandOutputErrorKind::NotFound
+        } else {
+            CommandOutputErrorKind::SpawnFailed
+        };
+        CommandOutputError {
+            kind,
+            status: None,
+            stderr: err.to_string(),
+        }
+    })?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(CommandOutputError {
+            kind: CommandOutputErrorKind::Unsuccessful,
+            status: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        })
+    }
+}

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -15,7 +15,10 @@ use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
 
-use super::{GitRepoMode, git_bool_config_enabled, git_fsmonitor_config_enabled, run_git_command};
+use super::{
+    GitRepoMode, git_bool_config_enabled, git_command_error, git_fsmonitor_config_enabled,
+    run_git_command,
+};
 
 // Untracked files larger than this are shown in the file list but their
 // content is not parsed: they are likely logs, dumps, or build artefacts.
@@ -989,19 +992,7 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
 {
-    let output = Command::new("git")
-        .current_dir(workdir)
-        .args(args)
-        .output()
-        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
-
-    if !output.status.success() {
-        return Err(TuicrError::VcsCommand(
-            String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        ));
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    crate::process::run_command_output("git", Some(workdir), args).map_err(git_command_error)
 }
 
 #[cfg(test)]

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -5,11 +5,12 @@ mod libgit2;
 pub mod repository;
 pub mod staging;
 
+use std::ffi::OsStr;
 use std::path::Path;
-use std::process::Command;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
+use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 use crate::syntax::SyntaxHighlighter;
 
 use super::traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
@@ -121,19 +122,21 @@ impl GitBackend {
 }
 
 fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
-    let output = Command::new("git")
-        .current_dir(workdir)
-        .args(args)
-        .output()
-        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+    run_command_output(
+        "git",
+        Some(workdir),
+        args.iter().map(|arg| OsStr::new(*arg)),
+    )
+    .map_err(git_command_error)
+}
 
-    if !output.status.success() {
-        return Err(TuicrError::VcsCommand(
-            String::from_utf8_lossy(&output.stderr).trim().to_string(),
-        ));
+pub(super) fn git_command_error(error: CommandOutputError) -> TuicrError {
+    match error.kind {
+        CommandOutputErrorKind::Unsuccessful => TuicrError::VcsCommand(error.stderr),
+        CommandOutputErrorKind::NotFound | CommandOutputErrorKind::SpawnFailed => {
+            TuicrError::VcsCommand(format!("Failed to run git: {}", error.stderr))
+        }
     }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 fn git_bool_config_enabled(value: &str) -> bool {


### PR DESCRIPTION
## Summary

Adds the first forge integration slice for GitHub-backed PR review work:

- introduces a `src/forge` module with forge repository, PR target, PR list, and PR detail models
- adds a `ForgeBackend` trait and `GitHubGhBackend` transport backed by `gh`
- supports parsing numeric, `owner/repo#number`, enterprise-hosted, full PR URL, and common Git remote URL forms
- fetches PR lists, PR metadata, and PR patch text through injectable `gh` command runners
- maps missing `gh`, auth failures, malformed targets, and command failures into clear startup-ready errors

No TUI behavior is wired in this PR; this is intentionally scoped to the backend skeleton from the Forge v1 spec.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test forge::github::gh`
- `cargo test