### PR TITLE
forge: review target selector UX (PR 2 of forge v1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,8 @@ use ratatui::style::Color;
 
 use crate::config::CommentTypeConfig;
 use crate::error::{Result, TuicrError};
+use crate::forge::selector::PullRequestsTab;
+use crate::forge::traits::ForgeRepository;
 use crate::model::{
     ClearScope, Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin,
     LineRange, LineSide, ReviewSession, SessionDiffSource,
@@ -365,6 +367,25 @@ pub enum FocusedPanel {
     CommitSelector,
 }
 
+/// Active tab in the review target selector.
+///
+/// The selector internally still goes through `InputMode::CommitSelect`,
+/// but it shows two tabs to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetTab {
+    Local,
+    PullRequests,
+}
+
+/// Background-thread events that the PR tab consumes through `pr_load_rx`.
+#[derive(Debug)]
+pub enum PrLoadEvent {
+    /// Result of the initial PR list fetch.
+    Initial(std::result::Result<(Vec<crate::forge::traits::PullRequestSummary>, bool), String>),
+    /// Result of a "load more" fetch.
+    LoadMore(std::result::Result<(Vec<crate::forge::traits::PullRequestSummary>, bool), String>),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffViewMode {
     Unified,
@@ -435,6 +456,24 @@ pub struct App {
     pub visible_commit_count: usize,
     pub commit_page_size: usize,
     pub has_more_commit: bool,
+
+    // Review target selector tab state. The selector reuses InputMode::CommitSelect
+    // but is conceptually a "target" picker with Local and Pull Requests tabs.
+    pub target_tab: TargetTab,
+    /// GitHub forge repository detected from the local `origin` remote, if any.
+    pub forge_repository: Option<ForgeRepository>,
+    /// State machine for the Pull Requests tab.
+    pub pr_tab: PullRequestsTab,
+    /// Viewport height of the PR list (set during render).
+    pub pr_list_viewport_height: usize,
+    /// Inner content rect of the PR list panel (set during render).
+    pub pr_list_inner_area: Option<ratatui::layout::Rect>,
+    /// When `Some`, the user is editing the local PR filter. Captured keys
+    /// update this draft; pressing Enter commits it to the tab state.
+    pub pr_filter_draft: Option<String>,
+    /// Background-thread channel that delivers PR list fetch results.
+    /// `Receiver` is only present while a fetch is in flight.
+    pub pr_load_rx: Option<std::sync::mpsc::Receiver<PrLoadEvent>>,
 
     pub should_quit: bool,
     pub dirty: bool,
@@ -977,6 +1016,13 @@ impl App {
             visible_commit_count,
             commit_page_size: COMMIT_PAGE_SIZE,
             has_more_commit,
+            target_tab: TargetTab::Local,
+            forge_repository: None,
+            pr_tab: PullRequestsTab::new(None),
+            pr_list_viewport_height: 0,
+            pr_list_inner_area: None,
+            pr_filter_draft: None,
+            pr_load_rx: None,
             should_quit: false,
             dirty: false,
             quit_warned: false,
@@ -1018,7 +1064,17 @@ impl App {
         app.sort_files_by_directory(true);
         app.expand_all_dirs();
         app.rebuild_annotations();
+        app.detect_forge_repository();
         Ok(app)
+    }
+
+    /// Detect a GitHub forge repository from the local checkout, if any.
+    /// Lazily called during startup — running this synchronously is fine
+    /// because it only reads local config, never the network.
+    fn detect_forge_repository(&mut self) {
+        let repo = crate::forge::detect_github_repository(&self.vcs_info.root_path);
+        self.forge_repository = repo.clone();
+        self.pr_tab = PullRequestsTab::new(repo);
     }
 
     fn resolve_comment_types(
@@ -3623,7 +3679,12 @@ impl App {
         self.pending_confirm = None;
     }
 
-    pub fn enter_commit_select_mode(&mut self) -> Result<()> {
+    /// Open the review target selector on a specific tab.
+    ///
+    /// `Local` loads the recent-commits list (same as the historical commit
+    /// selector). `PullRequests` switches the tab; the actual fetch is
+    /// triggered lazily through `on_target_tab_entered`.
+    pub fn enter_target_selector(&mut self, initial_tab: TargetTab) -> Result<()> {
         // Save inline selection state if we have review commits
         if !self.review_commits.is_empty() {
             self.saved_inline_selection = self.commit_selection_range;
@@ -3640,7 +3701,11 @@ impl App {
         let has_unstaged_changes = change_status.unstaged;
 
         let commits = self.vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT)?;
-        if commits.is_empty() && !has_staged_changes && !has_unstaged_changes {
+        let no_local_targets = commits.is_empty() && !has_staged_changes && !has_unstaged_changes;
+        // Allow opening the selector on the Pull Requests tab even when there
+        // are no local commits or changes — the PR tab is the user's reason
+        // for being here.
+        if no_local_targets && initial_tab == TargetTab::Local {
             self.set_message("No commits or staged/unstaged changes found");
             return Ok(());
         }
@@ -3659,6 +3724,17 @@ impl App {
         self.commit_selection_range = None;
         self.visible_commit_count = self.commit_list.len();
         self.input_mode = InputMode::CommitSelect;
+
+        // Reset the PR tab to Idle each time the selector is opened so the
+        // fetch happens lazily on first visit.
+        self.pr_tab = PullRequestsTab::new(self.forge_repository.clone());
+        self.pr_filter_draft = None;
+        self.pr_load_rx = None;
+
+        self.target_tab = initial_tab;
+        if initial_tab == TargetTab::PullRequests {
+            self.on_target_tab_entered();
+        }
         Ok(())
     }
 
@@ -3714,6 +3790,182 @@ impl App {
         }
 
         Ok(())
+    }
+
+    /// Switch to the next/previous tab in the review target selector.
+    /// With only two tabs, forward and reverse are equivalent; the `_forward`
+    /// arg is kept so callers can pass the natural direction without a cast.
+    /// Triggers the lazy PR fetch the first time the PR tab is entered.
+    pub fn cycle_target_tab(&mut self, _forward: bool) {
+        let next = match self.target_tab {
+            TargetTab::Local => TargetTab::PullRequests,
+            TargetTab::PullRequests => TargetTab::Local,
+        };
+        self.target_tab = next;
+        if next == TargetTab::PullRequests {
+            self.on_target_tab_entered();
+        } else {
+            // Returning to Local: clear any half-typed PR filter draft.
+            self.pr_filter_draft = None;
+        }
+    }
+
+    /// Entry-point hook called when the PR tab becomes visible.
+    /// Triggers the first network call lazily.
+    fn on_target_tab_entered(&mut self) {
+        if let Some(repo) = self.pr_tab.start_initial_load() {
+            self.spawn_pr_initial_load(repo);
+        }
+    }
+
+    /// Spawn a background thread that fetches the initial PR list. The
+    /// resulting `PrLoadEvent::Initial` is delivered through `pr_load_rx`
+    /// and applied in the main loop via `poll_pr_load_events`.
+    fn spawn_pr_initial_load(&mut self, repository: ForgeRepository) {
+        use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::selector::PR_PAGE_SIZE;
+        use crate::forge::traits::{ForgeBackend, PullRequestListQuery};
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_load_rx = Some(rx);
+
+        std::thread::spawn(move || {
+            let backend = GitHubGhBackend::new(Some(repository.clone()));
+            let query = PullRequestListQuery::first_page(repository, PR_PAGE_SIZE);
+            let result = backend
+                .list_pull_requests(query)
+                .map(|page| (page.pull_requests, page.has_more))
+                .map_err(|err| err.to_string());
+            let _ = tx.send(PrLoadEvent::Initial(result));
+        });
+    }
+
+    /// Spawn a background thread that fetches the next page of PRs.
+    fn spawn_pr_load_more(&mut self, repository: ForgeRepository, already_loaded: usize) {
+        use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::selector::PR_PAGE_SIZE;
+        use crate::forge::traits::{ForgeBackend, PullRequestListQuery};
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_load_rx = Some(rx);
+
+        std::thread::spawn(move || {
+            let backend = GitHubGhBackend::new(Some(repository.clone()));
+            let query = PullRequestListQuery {
+                repository,
+                already_loaded,
+                page_size: PR_PAGE_SIZE,
+            };
+            let result = backend
+                .list_pull_requests(query)
+                .map(|page| (page.pull_requests, page.has_more))
+                .map_err(|err| err.to_string());
+            let _ = tx.send(PrLoadEvent::LoadMore(result));
+        });
+    }
+
+    /// Pump any pending PR fetch events into the tab state.
+    /// Called from the main loop each tick; non-blocking.
+    pub fn poll_pr_load_events(&mut self) {
+        let Some(rx) = self.pr_load_rx.as_ref() else {
+            return;
+        };
+        let mut events = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            events.push(event);
+        }
+        if events.is_empty() {
+            return;
+        }
+        // The channel is single-use per fetch; drop the receiver once a
+        // result has arrived so we don't keep checking it.
+        self.pr_load_rx = None;
+        for event in events {
+            match event {
+                PrLoadEvent::Initial(result) => self.pr_tab.apply_initial_load(result),
+                PrLoadEvent::LoadMore(result) => self.pr_tab.apply_load_more(result),
+            }
+        }
+        self.pr_tab.clamp_cursor();
+    }
+
+    pub fn pr_tab_cursor_up(&mut self) {
+        self.pr_tab.cursor_up();
+        self.pr_tab
+            .ensure_cursor_visible(self.pr_list_viewport_height);
+    }
+
+    pub fn pr_tab_cursor_down(&mut self) {
+        self.pr_tab.cursor_down();
+        self.pr_tab
+            .ensure_cursor_visible(self.pr_list_viewport_height);
+    }
+
+    /// Handle Enter on the PR tab. Returns true when the action was handled
+    /// (load more triggered, stub PR open message shown, etc).
+    pub fn pr_tab_select(&mut self) -> bool {
+        if self.pr_tab.cursor_on_load_more() {
+            if let Some((repo, already)) = self.pr_tab.start_load_more() {
+                self.spawn_pr_load_more(repo, already);
+            }
+            return true;
+        }
+        if let Some(pr) = self.pr_tab.cursor_pr() {
+            // PR diff mode lands in PR 3. For now, surface a clean info
+            // message and leave the selector intact.
+            let number = pr.number;
+            self.set_message(format!(
+                "Opening PR #{number} not yet implemented — coming in PR 3"
+            ));
+            return true;
+        }
+        false
+    }
+
+    pub fn begin_pr_filter(&mut self) {
+        if !self.pr_tab.is_loaded() {
+            return;
+        }
+        // Seed the draft from the current applied filter so the user can
+        // refine it. Starting from empty is also reasonable; preserving the
+        // current filter feels less surprising when re-opening.
+        let current = match &self.pr_tab {
+            PullRequestsTab::Loaded { filter, .. } => filter.clone(),
+            _ => String::new(),
+        };
+        self.pr_filter_draft = Some(current);
+    }
+
+    pub fn commit_pr_filter(&mut self) {
+        if let Some(draft) = self.pr_filter_draft.take() {
+            self.pr_tab.set_filter(draft);
+        }
+    }
+
+    pub fn cancel_pr_filter(&mut self) {
+        self.pr_filter_draft = None;
+    }
+
+    pub fn pr_filter_insert_char(&mut self, ch: char) {
+        if let Some(draft) = self.pr_filter_draft.as_mut() {
+            draft.push(ch);
+        }
+    }
+
+    pub fn pr_filter_delete_char(&mut self) {
+        if let Some(draft) = self.pr_filter_draft.as_mut() {
+            draft.pop();
+        }
+    }
+
+    pub fn pr_filter_clear(&mut self) {
+        if let Some(draft) = self.pr_filter_draft.as_mut() {
+            draft.clear();
+        }
+    }
+
+    pub fn pr_filter_editing(&self) -> bool {
+        self.pr_filter_draft.is_some()
     }
 
     pub fn toggle_diff_view_mode(&mut self) {
@@ -5279,6 +5531,299 @@ mod commit_selection_tests {
         let app = build_app(vec![normal_commit("abc123"), App::staged_commit_entry()]);
 
         assert_eq!(app.special_commit_count(), 0);
+    }
+}
+
+#[cfg(test)]
+mod target_selector_tests {
+    use super::*;
+    use crate::forge::selector::PullRequestsTab;
+    use crate::forge::traits::PullRequestSummary;
+    use crate::model::FileStatus;
+    use crate::vcs::traits::{VcsChangeStatus, VcsType};
+
+    struct DummyVcs {
+        info: VcsInfo,
+        commits: Vec<CommitInfo>,
+    }
+
+    impl VcsBackend for DummyVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+
+        fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _start_line: u32,
+            _end_line: u32,
+        ) -> Result<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+
+        fn get_change_status(&self) -> Result<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+
+        fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
+            Ok(self
+                .commits
+                .iter()
+                .skip(offset)
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+    }
+
+    fn build_app() -> App {
+        build_app_with_commits(Vec::new())
+    }
+
+    fn build_app_with_commits(commits: Vec<CommitInfo>) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp"),
+            head_commit: "head".to_string(),
+            branch_name: Some("main".to_string()),
+            vcs_type: VcsType::Git,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::WorkingTree,
+        );
+
+        App::build(
+            Box::new(DummyVcs {
+                info: vcs_info.clone(),
+                commits,
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            Vec::new(),
+            session,
+            DiffSource::WorkingTree,
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("failed to build test app")
+    }
+
+    fn dummy_commit(id: &str) -> CommitInfo {
+        CommitInfo {
+            id: id.to_string(),
+            short_id: id.to_string(),
+            branch_name: None,
+            summary: format!("commit {id}"),
+            body: None,
+            author: "tester".to_string(),
+            time: Utc::now(),
+        }
+    }
+
+    fn sample_pr(number: u64, title: &str) -> PullRequestSummary {
+        PullRequestSummary {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            number,
+            title: title.to_string(),
+            author: Some("alice".to_string()),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            updated_at: None,
+            url: format!("https://github.com/agavra/tuicr/pull/{number}"),
+            state: "OPEN".to_string(),
+            is_draft: false,
+        }
+    }
+
+    #[test]
+    fn should_default_to_local_tab_after_build() {
+        // given / when
+        let app = build_app();
+        // then
+        assert_eq!(app.target_tab, TargetTab::Local);
+        assert!(!app.pr_filter_editing());
+    }
+
+    #[test]
+    fn should_cycle_between_local_and_pull_requests_on_tab_keypress() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        // when
+        app.cycle_target_tab(true);
+        // then
+        assert_eq!(app.target_tab, TargetTab::PullRequests);
+        // when
+        app.cycle_target_tab(false);
+        // then
+        assert_eq!(app.target_tab, TargetTab::Local);
+    }
+
+    #[test]
+    fn should_transition_pr_tab_to_loading_on_first_visit() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        // when
+        app.cycle_target_tab(true);
+        // then — a background fetch is in flight
+        assert!(app.pr_tab.is_loading());
+        assert!(app.pr_load_rx.is_some());
+        // The spawned thread holds a backend that may fail without a real
+        // `gh` binary; cancel by dropping the receiver to avoid touching it.
+        app.pr_load_rx = None;
+    }
+
+    #[test]
+    fn should_keep_pr_tab_disabled_when_no_forge_remote() {
+        // given
+        let mut app = build_app();
+        // No forge_repository set up; default new app has None.
+        // when
+        app.cycle_target_tab(true);
+        // then
+        assert_eq!(app.target_tab, TargetTab::PullRequests);
+        assert!(matches!(app.pr_tab, PullRequestsTab::Disabled { .. }));
+        assert!(app.pr_load_rx.is_none());
+    }
+
+    #[test]
+    fn should_set_filter_after_typing_and_committing() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        app.pr_tab.apply_initial_load(Ok((
+            vec![sample_pr(125, "Forge"), sample_pr(148, "Review")],
+            false,
+        )));
+        app.target_tab = TargetTab::PullRequests;
+        // when
+        app.begin_pr_filter();
+        app.pr_filter_insert_char('f');
+        app.pr_filter_insert_char('o');
+        app.commit_pr_filter();
+        // then
+        assert!(!app.pr_filter_editing());
+        assert_eq!(app.pr_tab.view().rows.len(), 1);
+        assert_eq!(app.pr_tab.view().rows[0].summary.number, 125);
+    }
+
+    #[test]
+    fn should_discard_filter_draft_on_cancel() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        app.pr_tab
+            .apply_initial_load(Ok((vec![sample_pr(1, "alpha")], false)));
+        app.target_tab = TargetTab::PullRequests;
+        // when
+        app.begin_pr_filter();
+        app.pr_filter_insert_char('z');
+        app.cancel_pr_filter();
+        // then
+        assert!(!app.pr_filter_editing());
+        assert_eq!(app.pr_tab.view().filter, "");
+    }
+
+    #[test]
+    fn should_show_stub_message_when_opening_pr_on_pr_tab() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        app.pr_tab
+            .apply_initial_load(Ok((vec![sample_pr(42, "answer")], false)));
+        app.target_tab = TargetTab::PullRequests;
+        // when
+        let handled = app.pr_tab_select();
+        // then
+        assert!(handled);
+        let msg = app.message.as_ref().expect("expected info message");
+        assert!(msg.content.contains("#42"));
+        assert!(msg.content.contains("not yet implemented"));
+    }
+
+    #[test]
+    fn should_apply_initial_load_event_to_pr_tab() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_load_rx = Some(rx);
+        tx.send(PrLoadEvent::Initial(Ok((
+            vec![sample_pr(7, "lucky")],
+            false,
+        ))))
+        .unwrap();
+        drop(tx);
+        // when
+        app.poll_pr_load_events();
+        // then
+        assert!(app.pr_load_rx.is_none());
+        assert_eq!(app.pr_tab.view().rows.len(), 1);
+        assert_eq!(app.pr_tab.view().rows[0].summary.number, 7);
+    }
+
+    #[test]
+    fn should_open_pr_selector_on_prs_command() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.command_buffer = "prs".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::SubmitInput);
+        // then
+        assert_eq!(app.target_tab, TargetTab::PullRequests);
+        assert_eq!(app.input_mode, InputMode::CommitSelect);
+        // Cancel the background fetch handle to avoid surprising real `gh` calls.
+        app.pr_load_rx = None;
+    }
+
+    #[test]
+    fn should_open_local_selector_on_targets_command() {
+        // given
+        let mut app = build_app_with_commits(vec![dummy_commit("abc")]);
+        app.command_buffer = "targets".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::SubmitInput);
+        // then
+        assert_eq!(app.target_tab, TargetTab::Local);
+        assert_eq!(app.input_mode, InputMode::CommitSelect);
+    }
+
+    #[test]
+    fn should_treat_commits_as_alias_for_local_target_selector() {
+        // given
+        let mut app = build_app_with_commits(vec![dummy_commit("abc")]);
+        app.command_buffer = "commits".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::SubmitInput);
+        // then
+        assert_eq!(app.target_tab, TargetTab::Local);
+        assert_eq!(app.input_mode, InputMode::CommitSelect);
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -952,8 +952,12 @@ impl App {
     }
 
     /// Shared constructor: all `App::new` paths converge here.
+    ///
+    /// `pub(crate)` so render-snapshot tests in `ui::app_layout` can drive
+    /// the full app through `render` without going through `App::new`'s
+    /// filesystem/VCS requirements.
     #[allow(clippy::too_many_arguments)]
-    fn build(
+    pub(crate) fn build(
         vcs: Box<dyn VcsBackend>,
         vcs_info: VcsInfo,
         theme: Theme,

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -6,4 +6,36 @@
 #![allow(dead_code)]
 
 pub mod github;
+pub mod selector;
 pub mod traits;
+
+use std::path::Path;
+
+use git2::Repository;
+
+use crate::forge::github::gh::parse_github_remote_url;
+use crate::forge::traits::ForgeRepository;
+
+/// Try to detect a GitHub forge repository for the local checkout at `repo_root`.
+///
+/// Looks at the `origin` remote first, then falls back to any remote whose URL
+/// parses as a GitHub host. Returns `None` when no GitHub remote is configured.
+pub fn detect_github_repository(repo_root: &Path) -> Option<ForgeRepository> {
+    let repo = Repository::discover(repo_root).ok()?;
+    if let Ok(remote) = repo.find_remote("origin")
+        && let Some(url) = remote.url()
+        && let Some(parsed) = parse_github_remote_url(url)
+    {
+        return Some(parsed);
+    }
+    let remotes = repo.remotes().ok()?;
+    for name in remotes.iter().flatten() {
+        if let Ok(remote) = repo.find_remote(name)
+            && let Some(url) = remote.url()
+            && let Some(parsed) = parse_github_remote_url(url)
+        {
+            return Some(parsed);
+        }
+    }
+    None
+}

--- a/src/forge/selector.rs
+++ b/src/forge/selector.rs
@@ -1,0 +1,620 @@
+//! State machine for the Pull Requests tab in the review target selector.
+//!
+//! The state is driven by user navigation (entering the tab triggers an
+//! initial fetch) and by background fetch results delivered through an
+//! `mpsc::Receiver`. UI rendering, filter input, and key dispatch all read
+//! from this state; no I/O happens here.
+#![allow(dead_code)]
+
+use crate::forge::traits::{ForgeRepository, PullRequestSummary};
+
+pub const PR_PAGE_SIZE: usize = 30;
+
+/// High level state for the Pull Requests tab.
+///
+/// The tab is `Disabled` when the current repo has no GitHub remote. It is
+/// `Idle` before the first network call. `Loading` and `LoadingMore` show
+/// the indeterminate progress bar. `Loaded` carries the rows that have been
+/// fetched so far, whether there is more to load, and the active local
+/// filter. `Error` carries a user-facing message.
+#[derive(Debug, Clone)]
+pub enum PullRequestsTab {
+    Disabled {
+        reason: String,
+    },
+    Idle {
+        repository: ForgeRepository,
+    },
+    Loading {
+        repository: ForgeRepository,
+    },
+    Loaded {
+        repository: ForgeRepository,
+        rows: Vec<PullRequestSummary>,
+        has_more: bool,
+        loading_more: bool,
+        filter: String,
+        cursor: usize,
+        scroll_offset: usize,
+    },
+    Error {
+        repository: Option<ForgeRepository>,
+        message: String,
+    },
+}
+
+/// What we want the UI to render next. Computed once per draw so the
+/// renderer does not have to walk the state-machine variants directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrTabView<'a> {
+    pub status: PrTabStatus<'a>,
+    pub rows: Vec<PrRow<'a>>,
+    pub cursor: usize,
+    pub scroll_offset: usize,
+    /// True when an additional `... load more pull requests` row should appear
+    /// after the data rows.
+    pub has_load_more: bool,
+    pub filter: &'a str,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrTabStatus<'a> {
+    Disabled(&'a str),
+    Idle,
+    Loading,
+    LoadingMore,
+    Ready,
+    Error(&'a str),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrRow<'a> {
+    pub summary: &'a PullRequestSummary,
+}
+
+impl PullRequestsTab {
+    pub fn new(repository: Option<ForgeRepository>) -> Self {
+        match repository {
+            Some(repo) => PullRequestsTab::Idle { repository: repo },
+            None => PullRequestsTab::Disabled {
+                reason: "No GitHub remote on this repo".to_string(),
+            },
+        }
+    }
+
+    pub fn repository(&self) -> Option<&ForgeRepository> {
+        match self {
+            PullRequestsTab::Idle { repository, .. }
+            | PullRequestsTab::Loading { repository, .. } => Some(repository),
+            PullRequestsTab::Loaded { repository, .. } => Some(repository),
+            PullRequestsTab::Error { repository, .. } => repository.as_ref(),
+            PullRequestsTab::Disabled { .. } => None,
+        }
+    }
+
+    /// True when the tab is currently waiting on a network call.
+    pub fn is_loading(&self) -> bool {
+        matches!(self, PullRequestsTab::Loading { .. })
+            || matches!(
+                self,
+                PullRequestsTab::Loaded {
+                    loading_more: true,
+                    ..
+                }
+            )
+    }
+
+    /// True when the tab has rows. The filter is allowed to reduce them
+    /// to zero — that still counts as loaded.
+    pub fn is_loaded(&self) -> bool {
+        matches!(self, PullRequestsTab::Loaded { .. })
+    }
+
+    /// Begin the initial fetch. Only meaningful from `Idle`.
+    pub fn start_initial_load(&mut self) -> Option<ForgeRepository> {
+        if let PullRequestsTab::Idle { repository } = self {
+            let repo = repository.clone();
+            *self = PullRequestsTab::Loading {
+                repository: repo.clone(),
+            };
+            Some(repo)
+        } else {
+            None
+        }
+    }
+
+    /// Begin a "load more" fetch. Only meaningful when `Loaded` with `has_more`.
+    pub fn start_load_more(&mut self) -> Option<(ForgeRepository, usize)> {
+        if let PullRequestsTab::Loaded {
+            repository,
+            rows,
+            has_more,
+            loading_more,
+            ..
+        } = self
+            && *has_more
+            && !*loading_more
+        {
+            *loading_more = true;
+            return Some((repository.clone(), rows.len()));
+        }
+        None
+    }
+
+    /// Apply the result of the initial load.
+    pub fn apply_initial_load(&mut self, result: Result<(Vec<PullRequestSummary>, bool), String>) {
+        let repository = match self {
+            PullRequestsTab::Loading { repository } => repository.clone(),
+            _ => return,
+        };
+        match result {
+            Ok((rows, has_more)) => {
+                *self = PullRequestsTab::Loaded {
+                    repository,
+                    rows,
+                    has_more,
+                    loading_more: false,
+                    filter: String::new(),
+                    cursor: 0,
+                    scroll_offset: 0,
+                };
+            }
+            Err(message) => {
+                *self = PullRequestsTab::Error {
+                    repository: Some(repository),
+                    message,
+                };
+            }
+        }
+    }
+
+    /// Apply the result of a load-more fetch. Appends rows.
+    pub fn apply_load_more(&mut self, result: Result<(Vec<PullRequestSummary>, bool), String>) {
+        if let PullRequestsTab::Loaded {
+            rows,
+            has_more,
+            loading_more,
+            ..
+        } = self
+        {
+            *loading_more = false;
+            match result {
+                Ok((new_rows, more)) => {
+                    rows.extend(new_rows);
+                    *has_more = more;
+                }
+                Err(message) => {
+                    // Don't tear down the loaded list on a load-more failure;
+                    // surface the message and clear the busy flag so the user
+                    // can try again.
+                    let repository = self.repository().cloned();
+                    *self = PullRequestsTab::Error {
+                        repository,
+                        message,
+                    };
+                }
+            }
+        }
+    }
+
+    /// Set the local filter and clamp the cursor to the resulting list.
+    pub fn set_filter(&mut self, new_filter: String) {
+        if let PullRequestsTab::Loaded {
+            filter,
+            cursor,
+            scroll_offset,
+            ..
+        } = self
+        {
+            *filter = new_filter;
+            *cursor = 0;
+            *scroll_offset = 0;
+            // The filter changed; visible row count may have shrunk so the
+            // cursor must point inside the new list.
+            self.clamp_cursor();
+        }
+    }
+
+    /// Indexes of `rows` that match the current filter, in order.
+    pub fn visible_indices(&self) -> Vec<usize> {
+        match self {
+            PullRequestsTab::Loaded { rows, filter, .. } => filtered_indices(rows, filter),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Clamp the cursor into `[0, visible + maybe_load_more)`.
+    pub fn clamp_cursor(&mut self) {
+        if let PullRequestsTab::Loaded {
+            rows,
+            filter,
+            has_more,
+            cursor,
+            ..
+        } = self
+        {
+            let visible = filtered_indices(rows, filter).len();
+            let extra = if *has_more && filter.is_empty() { 1 } else { 0 };
+            let max_idx = (visible + extra).saturating_sub(1);
+            if *cursor > max_idx {
+                *cursor = max_idx;
+            }
+        }
+    }
+
+    pub fn cursor_up(&mut self) {
+        if let PullRequestsTab::Loaded { cursor, .. } = self
+            && *cursor > 0
+        {
+            *cursor -= 1;
+        }
+    }
+
+    pub fn cursor_down(&mut self) {
+        if let PullRequestsTab::Loaded {
+            rows,
+            filter,
+            has_more,
+            cursor,
+            ..
+        } = self
+        {
+            let visible = filtered_indices(rows, filter).len();
+            let extra = if *has_more && filter.is_empty() { 1 } else { 0 };
+            let max_idx = (visible + extra).saturating_sub(1);
+            if *cursor < max_idx {
+                *cursor += 1;
+            }
+        }
+    }
+
+    /// True when the cursor is sitting on the trailing `... load more` row.
+    pub fn cursor_on_load_more(&self) -> bool {
+        if let PullRequestsTab::Loaded {
+            rows,
+            filter,
+            has_more,
+            cursor,
+            ..
+        } = self
+        {
+            if !*has_more || !filter.is_empty() {
+                return false;
+            }
+            let visible = filtered_indices(rows, filter).len();
+            *cursor == visible
+        } else {
+            false
+        }
+    }
+
+    /// The PR at the cursor, if any. `None` when on the load-more row or in
+    /// any non-Loaded state.
+    pub fn cursor_pr(&self) -> Option<&PullRequestSummary> {
+        if let PullRequestsTab::Loaded {
+            rows,
+            filter,
+            cursor,
+            ..
+        } = self
+        {
+            let indices = filtered_indices(rows, filter);
+            indices.get(*cursor).and_then(|i| rows.get(*i))
+        } else {
+            None
+        }
+    }
+
+    /// Update scroll so cursor remains visible in a viewport of `height`.
+    pub fn ensure_cursor_visible(&mut self, height: usize) {
+        if let PullRequestsTab::Loaded {
+            cursor,
+            scroll_offset,
+            ..
+        } = self
+        {
+            if height == 0 {
+                return;
+            }
+            if *cursor < *scroll_offset {
+                *scroll_offset = *cursor;
+            } else if *cursor >= *scroll_offset + height {
+                *scroll_offset = *cursor + 1 - height;
+            }
+        }
+    }
+
+    /// Project the current state into a UI-friendly view.
+    pub fn view(&self) -> PrTabView<'_> {
+        match self {
+            PullRequestsTab::Disabled { reason } => PrTabView {
+                status: PrTabStatus::Disabled(reason.as_str()),
+                rows: Vec::new(),
+                cursor: 0,
+                scroll_offset: 0,
+                has_load_more: false,
+                filter: "",
+            },
+            PullRequestsTab::Idle { .. } => PrTabView {
+                status: PrTabStatus::Idle,
+                rows: Vec::new(),
+                cursor: 0,
+                scroll_offset: 0,
+                has_load_more: false,
+                filter: "",
+            },
+            PullRequestsTab::Loading { .. } => PrTabView {
+                status: PrTabStatus::Loading,
+                rows: Vec::new(),
+                cursor: 0,
+                scroll_offset: 0,
+                has_load_more: false,
+                filter: "",
+            },
+            PullRequestsTab::Loaded {
+                rows,
+                has_more,
+                loading_more,
+                filter,
+                cursor,
+                scroll_offset,
+                ..
+            } => {
+                let indices = filtered_indices(rows, filter);
+                let mapped = indices
+                    .into_iter()
+                    .map(|i| PrRow { summary: &rows[i] })
+                    .collect();
+                let status = if *loading_more {
+                    PrTabStatus::LoadingMore
+                } else {
+                    PrTabStatus::Ready
+                };
+                PrTabView {
+                    status,
+                    rows: mapped,
+                    cursor: *cursor,
+                    scroll_offset: *scroll_offset,
+                    has_load_more: *has_more && filter.is_empty(),
+                    filter: filter.as_str(),
+                }
+            }
+            PullRequestsTab::Error { message, .. } => PrTabView {
+                status: PrTabStatus::Error(message.as_str()),
+                rows: Vec::new(),
+                cursor: 0,
+                scroll_offset: 0,
+                has_load_more: false,
+                filter: "",
+            },
+        }
+    }
+}
+
+/// Return the indices into `rows` that match `filter`. An empty filter
+/// returns every index.
+pub fn filtered_indices(rows: &[PullRequestSummary], filter: &str) -> Vec<usize> {
+    if filter.is_empty() {
+        return (0..rows.len()).collect();
+    }
+    let needle = filter.to_lowercase();
+    rows.iter()
+        .enumerate()
+        .filter(|(_, row)| matches_filter(row, &needle))
+        .map(|(i, _)| i)
+        .collect()
+}
+
+fn matches_filter(row: &PullRequestSummary, needle_lower: &str) -> bool {
+    if row.number.to_string().contains(needle_lower) {
+        return true;
+    }
+    if contains_ignore_case(&row.title, needle_lower) {
+        return true;
+    }
+    if let Some(author) = row.author.as_deref()
+        && contains_ignore_case(author, needle_lower)
+    {
+        return true;
+    }
+    if contains_ignore_case(&row.head_ref_name, needle_lower) {
+        return true;
+    }
+    if contains_ignore_case(&row.base_ref_name, needle_lower) {
+        return true;
+    }
+    false
+}
+
+fn contains_ignore_case(haystack: &str, needle_lower: &str) -> bool {
+    haystack.to_lowercase().contains(needle_lower)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    fn pr(number: u64, title: &str, author: &str, head: &str, base: &str) -> PullRequestSummary {
+        PullRequestSummary {
+            repository: repo(),
+            number,
+            title: title.to_string(),
+            author: Some(author.to_string()),
+            head_ref_name: head.to_string(),
+            base_ref_name: base.to_string(),
+            updated_at: Some(Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap()),
+            url: format!("https://github.com/agavra/tuicr/pull/{number}"),
+            state: "OPEN".to_string(),
+            is_draft: false,
+        }
+    }
+
+    #[test]
+    fn should_start_disabled_when_no_repository_present() {
+        // given
+        let mut tab = PullRequestsTab::new(None);
+        // when / then
+        assert!(matches!(tab, PullRequestsTab::Disabled { .. }));
+        assert!(tab.start_initial_load().is_none());
+    }
+
+    #[test]
+    fn should_start_idle_when_repository_present() {
+        // given / when
+        let tab = PullRequestsTab::new(Some(repo()));
+        // then
+        assert!(matches!(tab, PullRequestsTab::Idle { .. }));
+    }
+
+    #[test]
+    fn should_transition_idle_to_loading_on_initial_load() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        // when
+        let requested = tab.start_initial_load();
+        // then
+        assert_eq!(requested.unwrap(), repo());
+        assert!(matches!(tab, PullRequestsTab::Loading { .. }));
+        assert!(tab.is_loading());
+    }
+
+    #[test]
+    fn should_transition_loading_to_loaded_on_success() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        // when
+        tab.apply_initial_load(Ok((vec![pr(1, "title", "alice", "feat", "main")], false)));
+        // then
+        let view = tab.view();
+        assert_eq!(view.rows.len(), 1);
+        assert!(matches!(view.status, PrTabStatus::Ready));
+    }
+
+    #[test]
+    fn should_transition_loading_to_error_on_failure() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        // when
+        tab.apply_initial_load(Err("boom".to_string()));
+        // then
+        assert!(matches!(tab, PullRequestsTab::Error { .. }));
+        assert!(matches!(tab.view().status, PrTabStatus::Error("boom")));
+    }
+
+    #[test]
+    fn should_append_rows_on_load_more_success() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "a", "a", "h", "m")], true)));
+        // when
+        let request = tab.start_load_more();
+        assert!(request.is_some());
+        tab.apply_load_more(Ok((vec![pr(2, "b", "b", "h2", "m")], false)));
+        // then
+        let view = tab.view();
+        assert_eq!(view.rows.len(), 2);
+        assert_eq!(view.rows[1].summary.number, 2);
+        assert!(!view.has_load_more);
+    }
+
+    #[test]
+    fn should_filter_rows_by_number_title_author_head_and_base() {
+        // given
+        let rows = vec![
+            pr(125, "Forge backend", "alice", "feat/forge", "main"),
+            pr(148, "Add review UX", "bob", "review-ux", "develop"),
+        ];
+        // when / then
+        assert_eq!(filtered_indices(&rows, "125"), vec![0]);
+        assert_eq!(filtered_indices(&rows, "review"), vec![1]);
+        assert_eq!(filtered_indices(&rows, "ALICE"), vec![0]);
+        assert_eq!(filtered_indices(&rows, "forge"), vec![0]);
+        assert_eq!(filtered_indices(&rows, "develop"), vec![1]);
+        assert_eq!(filtered_indices(&rows, ""), vec![0, 1]);
+        assert!(filtered_indices(&rows, "no-match").is_empty());
+    }
+
+    #[test]
+    fn should_clamp_cursor_after_filter_narrows_list() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((
+            vec![
+                pr(1, "alpha", "a", "h", "m"),
+                pr(2, "beta", "a", "h", "m"),
+                pr(3, "gamma", "a", "h", "m"),
+            ],
+            false,
+        )));
+        if let PullRequestsTab::Loaded { cursor, .. } = &mut tab {
+            *cursor = 2;
+        }
+        // when
+        tab.set_filter("beta".to_string());
+        // then
+        assert_eq!(tab.view().cursor, 0);
+        assert_eq!(tab.view().rows.len(), 1);
+    }
+
+    #[test]
+    fn should_position_cursor_on_load_more_row_when_at_bottom() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "a", "a", "h", "m")], true)));
+        // when
+        tab.cursor_down();
+        // then
+        assert!(tab.cursor_on_load_more());
+        assert!(tab.cursor_pr().is_none());
+    }
+
+    #[test]
+    fn should_not_show_load_more_row_when_filter_active() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "alpha", "a", "h", "m")], true)));
+        // when
+        tab.set_filter("alpha".to_string());
+        // then
+        let view = tab.view();
+        assert!(!view.has_load_more);
+    }
+
+    #[test]
+    fn should_not_start_load_more_when_already_loading_more() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "a", "a", "h", "m")], true)));
+        // when
+        let first = tab.start_load_more();
+        let second = tab.start_load_more();
+        // then
+        assert!(first.is_some());
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn should_keep_loaded_rows_when_load_more_fails() {
+        // given
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "a", "a", "h", "m")], true)));
+        tab.start_load_more();
+        // when
+        tab.apply_load_more(Err("net down".to_string()));
+        // then — moves into Error but the original rows can be re-fetched
+        assert!(matches!(tab, PullRequestsTab::Error { .. }));
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,7 +2,7 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Position;
 
 use crate::app::{
-    self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit, InputMode,
+    self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit, InputMode, TargetTab,
     VisualSelection,
 };
 use crate::input::Action;
@@ -426,9 +426,16 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                 }
                 "diff" => app.toggle_diff_view_mode(),
                 "stage" => app.stage_reviewed_files(),
-                "commits" => {
-                    if let Err(e) = app.enter_commit_select_mode() {
+                "commits" | "targets" => {
+                    if let Err(e) = app.enter_target_selector(TargetTab::Local) {
                         app.set_error(format!("Failed to load commits: {e}"));
+                    } else {
+                        return;
+                    }
+                }
+                "prs" => {
+                    if let Err(e) = app.enter_target_selector(TargetTab::PullRequests) {
+                        app.set_error(format!("Failed to open PR selector: {e}"));
                     } else {
                         return;
                     }
@@ -565,8 +572,40 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
     }
 }
 
-/// Handle actions in CommitSelect mode
+/// Handle actions in CommitSelect mode.
+///
+/// CommitSelect actually drives the review target selector, which has two
+/// tabs (Local and Pull Requests). Tab-shared actions (switch tab, quit) are
+/// handled first; per-tab dispatch follows.
 pub fn handle_commit_select_action(app: &mut App, action: Action) {
+    // Filter-editing sub-state on the PR tab. Routed before tab dispatch
+    // because typed characters must go to the filter buffer rather than
+    // to local-commit movement.
+    if app.pr_filter_editing() {
+        handle_pr_filter_action(app, action);
+        return;
+    }
+
+    match action {
+        Action::TargetSelectorTabNext => app.cycle_target_tab(true),
+        Action::TargetSelectorTabPrev => app.cycle_target_tab(false),
+        Action::Quit => app.should_quit = true,
+        Action::ExitMode => {
+            if app.commit_selection_range.is_none() {
+                return;
+            }
+            if let Err(e) = app.exit_commit_select_mode() {
+                app.set_error(format!("Failed to reload changes: {e}"));
+            }
+        }
+        other => match app.target_tab {
+            TargetTab::Local => handle_local_target_action(app, other),
+            TargetTab::PullRequests => handle_pr_target_action(app, other),
+        },
+    }
+}
+
+fn handle_local_target_action(app: &mut App, action: Action) {
     match action {
         Action::CommitSelectUp => app.commit_select_up(),
         Action::CommitSelectDown => app.commit_select_down(),
@@ -591,14 +630,38 @@ pub fn handle_commit_select_action(app: &mut App, action: Action) {
                 app.set_error(format!("Failed to load commits: {e}"));
             }
         }
-        Action::ExitMode => {
-            if app.commit_selection_range.is_none() {
-                return;
-            }
-            if let Err(e) = app.exit_commit_select_mode() {
-                app.set_error(format!("Failed to reload changes: {e}"));
-            }
+        _ => {}
+    }
+}
+
+fn handle_pr_target_action(app: &mut App, action: Action) {
+    match action {
+        Action::CommitSelectUp => app.pr_tab_cursor_up(),
+        Action::CommitSelectDown => app.pr_tab_cursor_down(),
+        Action::ConfirmCommitSelect => {
+            app.pr_tab_select();
         }
+        Action::ToggleCommitSelect => {
+            // Space is a no-op on the PR tab (spec).
+        }
+        Action::BeginTargetFilter => {
+            app.begin_pr_filter();
+        }
+        _ => {}
+    }
+}
+
+fn handle_pr_filter_action(app: &mut App, action: Action) {
+    match action {
+        Action::InsertChar(c) => app.pr_filter_insert_char(c),
+        Action::DeleteChar => app.pr_filter_delete_char(),
+        Action::DeleteWord => {
+            // Soft word-delete: collapses to clear-line for the v1 cut.
+            app.pr_filter_clear();
+        }
+        Action::ClearLine => app.pr_filter_clear(),
+        Action::SubmitInput => app.commit_pr_filter(),
+        Action::ExitMode => app.cancel_pr_filter(),
         Action::Quit => app.should_quit = true,
         _ => {}
     }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -87,6 +87,14 @@ pub enum Action {
     /// Cycle inline commit selector to previous individual commit (`(`)
     CycleCommitPrev,
 
+    // Review target selector
+    /// Switch to the next selector tab (Tab key).
+    TargetSelectorTabNext,
+    /// Switch to the previous selector tab (Shift-Tab).
+    TargetSelectorTabPrev,
+    /// Begin editing the local filter inside the PR tab (`/`).
+    BeginTargetFilter,
+
     ToggleExpand,
     ExpandAll,
     CollapseAll,
@@ -290,13 +298,32 @@ fn map_confirm_mode(key: KeyEvent) -> Action {
 }
 
 fn map_commit_select_mode(key: KeyEvent) -> Action {
-    match key.code {
-        KeyCode::Char('j') | KeyCode::Down => Action::CommitSelectDown,
-        KeyCode::Char('k') | KeyCode::Up => Action::CommitSelectUp,
-        KeyCode::Char(' ') => Action::ToggleCommitSelect,
-        KeyCode::Enter => Action::ConfirmCommitSelect,
-        KeyCode::Esc => Action::ExitMode,
-        KeyCode::Char('q') => Action::Quit,
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::CommitSelectDown,
+        (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::CommitSelectUp,
+        (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleCommitSelect,
+        (KeyCode::Enter, KeyModifiers::NONE) => Action::ConfirmCommitSelect,
+        (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
+        (KeyCode::Tab, KeyModifiers::NONE) => Action::TargetSelectorTabNext,
+        (KeyCode::BackTab, _) => Action::TargetSelectorTabPrev,
+        (KeyCode::Char('/'), _) => Action::BeginTargetFilter,
+        _ => Action::None,
+    }
+}
+
+/// Key map used while the user is editing the PR-tab local filter.
+/// This is a sub-state of `InputMode::CommitSelect`; the dispatcher in
+/// `main.rs` routes here when `App::pr_filter_editing()` is true.
+pub fn map_target_filter_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
+        (KeyCode::Backspace, KeyModifiers::NONE) => Action::DeleteChar,
+        (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::ClearLine,
+        (KeyCode::Char('w'), KeyModifiers::CONTROL) => Action::DeleteWord,
+        (KeyCode::Backspace, mods) if mods.contains(KeyModifiers::ALT) => Action::DeleteWord,
+        (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => Action::InsertChar(c),
         _ => Action::None,
     }
 }
@@ -414,6 +441,54 @@ mod tests {
         assert_eq!(map_comment_mode(alt_backspace), Action::DeleteWord);
         assert_eq!(map_command_mode(alt_backspace), Action::DeleteWord);
         assert_eq!(map_search_mode(alt_backspace), Action::DeleteWord);
+    }
+
+    #[test]
+    fn should_map_tab_to_target_selector_tab_next_in_commit_select_mode() {
+        // given / when
+        let action = map_commit_select_mode(key(KeyCode::Tab));
+        // then
+        assert_eq!(action, Action::TargetSelectorTabNext);
+    }
+
+    #[test]
+    fn should_map_back_tab_to_target_selector_tab_prev_in_commit_select_mode() {
+        // given / when
+        let action = map_commit_select_mode(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+        // then
+        assert_eq!(action, Action::TargetSelectorTabPrev);
+    }
+
+    #[test]
+    fn should_map_slash_to_begin_target_filter_in_commit_select_mode() {
+        // given / when
+        let action = map_commit_select_mode(key(KeyCode::Char('/')));
+        // then
+        assert_eq!(action, Action::BeginTargetFilter);
+    }
+
+    #[test]
+    fn should_route_typed_chars_to_insert_in_target_filter_mode() {
+        // given / when
+        let action = map_target_filter_mode(key(KeyCode::Char('a')));
+        // then
+        assert_eq!(action, Action::InsertChar('a'));
+    }
+
+    #[test]
+    fn should_map_enter_to_submit_in_target_filter_mode() {
+        // given / when
+        let action = map_target_filter_mode(key(KeyCode::Enter));
+        // then
+        assert_eq!(action, Action::SubmitInput);
+    }
+
+    #[test]
+    fn should_map_esc_to_exit_in_target_filter_mode() {
+        // given / when
+        let action = map_target_filter_mode(key(KeyCode::Esc));
+        // then
+        assert_eq!(action, Action::ExitMode);
     }
 
     #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,4 +2,4 @@ pub mod handler;
 pub mod keybindings;
 pub mod mode;
 
-pub use keybindings::{Action, map_key_to_action};
+pub use keybindings::{Action, map_key_to_action, map_target_filter_mode};

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use handler::{
     handle_file_list_action, handle_help_action, handle_mouse_event, handle_search_action,
     handle_visual_action,
 };
-use input::{Action, map_key_to_action};
+use input::{Action, map_key_to_action, map_target_filter_mode};
 use theme::{parse_cli_args, resolve_theme_with_config};
 use vcs::GitBackendPreference;
 
@@ -287,6 +287,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         app.clear_expired_message();
+        app.poll_pr_load_events();
 
         // Render
         terminal.draw(|frame| {
@@ -420,7 +421,16 @@ fn main() -> anyhow::Result<()> {
                         // Otherwise fall through to normal handling
                     }
 
-                    let action = map_key_to_action(key, app.input_mode);
+                    // Editing the PR-tab filter is a sub-state of CommitSelect;
+                    // route through the filter-specific key map so typed
+                    // characters update the filter buffer rather than driving
+                    // commit-list navigation.
+                    let action =
+                        if app.input_mode == InputMode::CommitSelect && app.pr_filter_editing() {
+                            map_target_filter_mode(key)
+                        } else {
+                            map_key_to_action(key, app.input_mode)
+                        };
 
                     // Handle pending command setters (these work in any mode)
                     match action {

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -110,21 +110,33 @@ fn render_target_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
     let active_style = Style::default()
         .fg(theme.fg_primary)
         .add_modifier(Modifier::BOLD | Modifier::REVERSED);
-    let inactive_style = Style::default().fg(theme.fg_secondary);
+    let bracket_style = Style::default().fg(theme.fg_secondary);
+    let inactive_label_style = Style::default().fg(theme.fg_primary);
 
-    let local = if active == TargetTab::Local {
-        Span::styled(" Local ", active_style)
-    } else {
-        Span::styled(" Local ", inactive_style)
-    };
-    let prs = if active == TargetTab::PullRequests {
-        Span::styled(" Pull Requests ", active_style)
-    } else {
-        Span::styled(" Pull Requests ", inactive_style)
-    };
-    let sep = Span::styled("  ", Style::default());
+    let mut spans: Vec<Span> = Vec::with_capacity(8);
+    spans.push(Span::raw(" "));
 
-    let line = Line::from(vec![Span::raw(" "), local, sep, prs]);
+    let local_active = active == TargetTab::Local;
+    spans.push(Span::styled("[", bracket_style));
+    if local_active {
+        spans.push(Span::styled(" Local ", active_style));
+    } else {
+        spans.push(Span::styled(" Local ", inactive_label_style));
+    }
+    spans.push(Span::styled("]", bracket_style));
+
+    spans.push(Span::raw("  "));
+
+    let prs_active = active == TargetTab::PullRequests;
+    spans.push(Span::styled("[", bracket_style));
+    if prs_active {
+        spans.push(Span::styled(" Pull Requests ", active_style));
+    } else {
+        spans.push(Span::styled(" Pull Requests ", inactive_label_style));
+    }
+    spans.push(Span::styled("]", bracket_style));
+
+    let line = Line::from(spans);
     let strip = Paragraph::new(line).style(styles::panel_style(theme));
     frame.render_widget(strip, area);
 }

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::Style,
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
@@ -9,8 +9,9 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::{
     AnnotatedLine, App, DiffViewMode, ExpandDirection, FileTreeItem, FocusedPanel,
-    GAP_EXPAND_BATCH, GapId, InputMode, VisualSelection,
+    GAP_EXPAND_BATCH, GapId, InputMode, TargetTab, VisualSelection,
 };
+use crate::forge::selector::{PrTabStatus, PrTabView};
 use crate::model::{LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
 use crate::ui::{comment_panel, help_popup, status_bar, styles};
@@ -81,30 +82,67 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1), // Header
-            Constraint::Min(0),    // Commit list
+            Constraint::Length(1), // Tab strip
+            Constraint::Min(0),    // Active tab body
             Constraint::Length(1), // Footer hints
         ])
         .split(area);
 
     // Header
-    let header = Paragraph::new(" Select commits to review ")
+    let header = Paragraph::new(" Select a review target ")
         .style(styles::header_style(&app.theme))
         .block(Block::default().style(styles::panel_style(&app.theme)));
     frame.render_widget(header, chunks[0]);
 
-    // Commit list
+    render_target_tab_strip(frame, app, chunks[1]);
+
+    match app.target_tab {
+        TargetTab::Local => render_local_target_tab(frame, app, chunks[2]),
+        TargetTab::PullRequests => render_pull_requests_tab(frame, app, chunks[2]),
+    }
+
+    render_target_selector_footer(frame, app, chunks[3]);
+}
+
+fn render_target_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let active = app.target_tab;
+    let active_style = Style::default()
+        .fg(theme.fg_primary)
+        .add_modifier(Modifier::BOLD | Modifier::REVERSED);
+    let inactive_style = Style::default().fg(theme.fg_secondary);
+
+    let local = if active == TargetTab::Local {
+        Span::styled(" Local ", active_style)
+    } else {
+        Span::styled(" Local ", inactive_style)
+    };
+    let prs = if active == TargetTab::PullRequests {
+        Span::styled(" Pull Requests ", active_style)
+    } else {
+        Span::styled(" Pull Requests ", inactive_style)
+    };
+    let sep = Span::styled("  ", Style::default());
+
+    let line = Line::from(vec![Span::raw(" "), local, sep, prs]);
+    let strip = Paragraph::new(line).style(styles::panel_style(theme));
+    frame.render_widget(strip, area);
+}
+
+fn render_local_target_tab(frame: &mut Frame, app: &mut App, area: Rect) {
     let block = Block::default()
         .title(" Recent Commits ")
         .borders(Borders::ALL)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, true));
 
-    let inner = block.inner(chunks[1]);
-    frame.render_widget(block, chunks[1]);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
 
     // Update viewport height for scroll calculations
     app.commit_list_viewport_height = inner.height as usize;
     app.commit_list_inner_area = Some(inner);
+    app.pr_list_inner_area = None;
 
     // Get range info for visual indicators
     let range = app.commit_selection_range;
@@ -215,24 +253,301 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
 
     let list = Paragraph::new(visible_items).style(styles::panel_style(&app.theme));
     frame.render_widget(list, inner);
+}
 
-    // Footer with mode, hints, and right-aligned message
+fn render_pull_requests_tab(frame: &mut Frame, app: &mut App, area: Rect) {
+    let title = match app.forge_repository.as_ref() {
+        Some(repo) => format!(" Pull Requests ({}) ", repo.display_name()),
+        None => " Pull Requests ".to_string(),
+    };
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .style(styles::panel_style(&app.theme))
+        .border_style(styles::border_style(&app.theme, true));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    app.commit_list_inner_area = None;
+    app.pr_list_inner_area = Some(inner);
+    app.pr_list_viewport_height = inner.height.saturating_sub(1) as usize;
+
+    // Reserve one row at the top for the status / filter banner.
+    let body_chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(0)])
+        .split(inner);
+    let banner_area = body_chunks[0];
+    let list_area = body_chunks[1];
+    app.pr_list_viewport_height = list_area.height as usize;
+
+    let view = app.pr_tab.view();
+    render_pr_banner(frame, app, banner_area, &view);
+    render_pr_list(frame, app, list_area, &view);
+}
+
+fn render_pr_banner(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>) {
+    let theme = &app.theme;
+
+    if let Some(draft) = app.pr_filter_draft.as_ref() {
+        let prefix = Span::styled(" filter: ", Style::default().fg(theme.fg_secondary));
+        let value = Span::styled(format!("/{draft}"), Style::default().fg(theme.fg_primary));
+        let hint = Span::styled(
+            "   (Enter: apply  Esc: cancel)",
+            Style::default().fg(theme.fg_secondary),
+        );
+        let line = Line::from(vec![prefix, value, hint]);
+        let banner = Paragraph::new(line).style(styles::panel_style(theme));
+        frame.render_widget(banner, area);
+        return;
+    }
+
+    match &view.status {
+        PrTabStatus::Disabled(reason) => {
+            let line = Line::from(Span::styled(
+                format!(" {reason} — switch back with Shift-Tab "),
+                Style::default().fg(theme.fg_secondary),
+            ));
+            frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
+        }
+        PrTabStatus::Idle => {
+            let line = Line::from(Span::styled(
+                " Press Tab again or wait — loading…",
+                Style::default().fg(theme.fg_secondary),
+            ));
+            frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
+        }
+        PrTabStatus::Loading => {
+            render_pr_progress(frame, app, area, "Fetching pull requests from origin...");
+        }
+        PrTabStatus::LoadingMore => {
+            render_pr_progress(frame, app, area, "Loading more pull requests...");
+        }
+        PrTabStatus::Error(msg) => {
+            let line = Line::from(vec![
+                Span::styled(
+                    " error: ",
+                    Style::default()
+                        .fg(theme.message_error_fg)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled((*msg).to_string(), Style::default().fg(theme.fg_primary)),
+            ]);
+            frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
+        }
+        PrTabStatus::Ready => {
+            let mut spans: Vec<Span> = vec![Span::styled(
+                format!(" {} loaded", view.rows.len()),
+                Style::default().fg(theme.fg_secondary),
+            )];
+            if !view.filter.is_empty() {
+                spans.push(Span::styled(
+                    format!("   filter: /{}", view.filter),
+                    Style::default().fg(theme.fg_primary),
+                ));
+                spans.push(Span::styled(
+                    "   ('/' to edit, Esc to clear)",
+                    Style::default().fg(theme.fg_secondary),
+                ));
+            } else {
+                spans.push(Span::styled(
+                    "   '/' to filter",
+                    Style::default().fg(theme.fg_secondary),
+                ));
+            }
+            frame.render_widget(
+                Paragraph::new(Line::from(spans)).style(styles::panel_style(theme)),
+                area,
+            );
+        }
+    }
+}
+
+fn render_pr_progress(frame: &mut Frame, app: &App, area: Rect, label: &str) {
+    let theme = &app.theme;
+    let width = area.width.saturating_sub(label.len() as u16 + 5).max(4) as usize;
+    // Indeterminate bar: a windowed block of ~width/3 that travels using
+    // wall-clock seconds, so the bar visibly moves between frames without
+    // requiring per-frame state on App.
+    let block_width = (width / 3).max(2);
+    let travel = (width + block_width).max(1);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as usize)
+        .unwrap_or(0);
+    let position = (now / 80) % travel;
+    let mut bar = String::with_capacity(width);
+    for i in 0..width {
+        if position < block_width {
+            if i < position {
+                bar.push(' ');
+            } else if i < position + block_width && i < width {
+                bar.push('#');
+            } else {
+                bar.push(' ');
+            }
+        } else {
+            let start = position.saturating_sub(block_width);
+            if i >= start && i < position && i < width {
+                bar.push('#');
+            } else {
+                bar.push(' ');
+            }
+        }
+    }
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" {label} "),
+            Style::default().fg(theme.fg_secondary),
+        ),
+        Span::styled(
+            format!("[{bar}]"),
+            Style::default().fg(theme.diff_hunk_header),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
+}
+
+fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>) {
+    let theme = &app.theme;
+    if area.height == 0 {
+        return;
+    }
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, row) in view.rows.iter().enumerate() {
+        let is_cursor = i == view.cursor;
+        let pointer = if is_cursor { "> " } else { "  " };
+        let pointer_style = if is_cursor {
+            styles::selected_style(theme)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        let number = format!("#{:<5}", row.summary.number);
+        let title = truncate_str(&row.summary.title, 60);
+        let author = row.summary.author.as_deref().unwrap_or("?");
+        let updated = row
+            .summary
+            .updated_at
+            .map(format_relative_time)
+            .unwrap_or_else(|| "—".to_string());
+        let draft = if row.summary.is_draft { " [draft]" } else { "" };
+
+        let line = Line::from(vec![
+            Span::styled(pointer, pointer_style),
+            Span::styled(number, styles::hash_style(theme)),
+            Span::styled(" ", Style::default()),
+            Span::styled(title, Style::default().fg(theme.fg_primary)),
+            Span::styled(
+                format!("   @{author}"),
+                Style::default().fg(theme.fg_secondary),
+            ),
+            Span::styled(
+                format!("   updated {updated}{draft}"),
+                Style::default().fg(theme.fg_secondary),
+            ),
+        ]);
+        lines.push(line);
+    }
+
+    if view.has_load_more {
+        let load_idx = view.rows.len();
+        let is_cursor = view.cursor == load_idx;
+        let style = if is_cursor {
+            styles::selected_style(theme)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        let pointer = if is_cursor { "> " } else { "  " };
+        lines.push(Line::from(vec![
+            Span::styled(pointer, style),
+            Span::styled("... load more pull requests", style),
+        ]));
+    }
+
+    if lines.is_empty() {
+        // Empty state placeholder under the banner.
+        if !matches!(view.status, PrTabStatus::Ready) {
+            return;
+        }
+        let msg = if view.filter.is_empty() {
+            " No open pull requests"
+        } else {
+            " No pull requests match the filter"
+        };
+        lines.push(Line::from(Span::styled(
+            msg,
+            Style::default().fg(theme.fg_secondary),
+        )));
+    }
+
+    let visible: Vec<Line> = lines
+        .into_iter()
+        .skip(view.scroll_offset)
+        .take(area.height as usize)
+        .collect();
+    let paragraph = Paragraph::new(visible).style(styles::panel_style(theme));
+    frame.render_widget(paragraph, area);
+}
+
+fn format_relative_time(time: chrono::DateTime<chrono::Utc>) -> String {
+    let now = chrono::Utc::now();
+    let delta = now.signed_duration_since(time);
+    if delta.num_seconds() < 0 {
+        return "just now".to_string();
+    }
+    let secs = delta.num_seconds();
+    if secs < 60 {
+        return "just now".to_string();
+    }
+    let mins = delta.num_minutes();
+    if mins < 60 {
+        return format!("{mins}m ago");
+    }
+    let hours = delta.num_hours();
+    if hours < 24 {
+        return format!("{hours}h ago");
+    }
+    let days = delta.num_days();
+    if days < 30 {
+        return format!("{days}d ago");
+    }
+    let months = days / 30;
+    if months < 12 {
+        return format!("{months}mo ago");
+    }
+    let years = days / 365;
+    format!("{years}y ago")
+}
+
+fn render_target_selector_footer(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let mode_span = Span::styled(" SELECT ", styles::mode_style(theme));
 
-    let selected_count = match app.commit_selection_range {
-        Some((start, end)) => end - start + 1,
-        None => 0,
-    };
-    let selection_info = if selected_count > 0 {
-        format!(" ({selected_count} selected)")
-    } else {
-        String::new()
-    };
     let hints = if app.message.is_some() {
         String::new()
+    } else if app.pr_filter_editing() {
+        " Enter:apply  Esc:cancel ".to_string()
     } else {
-        format!(" j/k:navigate  Space:select range  Enter:confirm  q:quit{selection_info}")
+        match app.target_tab {
+            TargetTab::Local => {
+                let selected_count = match app.commit_selection_range {
+                    Some((start, end)) => end - start + 1,
+                    None => 0,
+                };
+                let selection_info = if selected_count > 0 {
+                    format!(" ({selected_count} selected)")
+                } else {
+                    String::new()
+                };
+                format!(
+                    " Tab:tabs  j/k:navigate  Space:select range  Enter:confirm  q:quit{selection_info}"
+                )
+            }
+            TargetTab::PullRequests => {
+                " Tab:tabs  j/k:navigate  Enter:open  /:filter  Esc/q:back ".to_string()
+            }
+        }
     };
     let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 
@@ -243,13 +558,13 @@ fn render_commit_select(frame: &mut Frame, app: &mut App) {
         left_spans,
         message_span,
         message_width,
-        chunks[2].width as usize,
+        area.width as usize,
     );
 
     let footer = Paragraph::new(Line::from(spans))
         .style(styles::status_bar_style(theme))
         .block(Block::default());
-    frame.render_widget(footer, chunks[2]);
+    frame.render_widget(footer, area);
 }
 
 fn truncate_str(s: &str, max_len: usize) -> String {

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -3510,6 +3510,385 @@ fn apply_horizontal_scroll(line: Line, scroll_x: usize) -> Line {
 }
 
 #[cfg(test)]
+mod selector_render_snapshot_tests {
+    //! Render-snapshot tests for the review-target selector. We drive the
+    //! real `render` against ratatui's `TestBackend` and assert on the
+    //! resulting character grid (plus a few style checks for the active
+    //! tab highlight). These tests caught a regression where the inactive
+    //! tab rendered as bare dim text with no bracket / cue, making the
+    //! Pull Requests tab functionally invisible.
+    use super::*;
+    use crate::app::DiffSource;
+    use crate::error::Result as TuicrResult;
+    use crate::error::TuicrError;
+    use crate::forge::selector::PullRequestsTab;
+    use crate::forge::traits::{ForgeRepository, PullRequestSummary};
+    use crate::model::{DiffFile, DiffLine, FileStatus, ReviewSession, SessionDiffSource};
+    use crate::syntax::SyntaxHighlighter;
+    use crate::theme::Theme;
+    use crate::vcs::CommitInfo;
+    use crate::vcs::traits::{VcsBackend, VcsChangeStatus, VcsInfo, VcsType};
+    use chrono::{TimeZone, Utc};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::style::Modifier;
+    use std::path::{Path, PathBuf};
+
+    struct SnapshotVcs {
+        info: VcsInfo,
+    }
+
+    impl VcsBackend for SnapshotVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+
+        fn get_working_tree_diff(
+            &self,
+            _highlighter: &SyntaxHighlighter,
+        ) -> TuicrResult<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _start_line: u32,
+            _end_line: u32,
+        ) -> TuicrResult<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+
+        fn get_change_status(&self) -> TuicrResult<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+    }
+
+    fn commit(i: usize) -> CommitInfo {
+        CommitInfo {
+            id: format!("abc{i}"),
+            short_id: format!("abc{i}"),
+            branch_name: None,
+            summary: format!("commit {i}"),
+            body: None,
+            author: "tester".to_string(),
+            time: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    fn make_app(commits: Vec<CommitInfo>) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp"),
+            head_commit: "head".to_string(),
+            branch_name: Some("main".to_string()),
+            vcs_type: VcsType::Git,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::WorkingTree,
+        );
+        App::build(
+            Box::new(SnapshotVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            Vec::new(),
+            session,
+            DiffSource::WorkingTree,
+            InputMode::CommitSelect,
+            commits,
+            None,
+        )
+        .expect("build app")
+    }
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    fn pr(number: u64, title: &str, author: &str) -> PullRequestSummary {
+        PullRequestSummary {
+            repository: repo(),
+            number,
+            title: title.to_string(),
+            author: Some(author.to_string()),
+            head_ref_name: format!("feat/{number}"),
+            base_ref_name: "main".to_string(),
+            updated_at: Some(Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap()),
+            url: format!("https://github.com/agavra/tuicr/pull/{number}"),
+            state: "OPEN".to_string(),
+            is_draft: false,
+        }
+    }
+
+    fn draw(app: &mut App) -> Buffer {
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app))
+            .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn row_text(buffer: &Buffer, y: u16) -> String {
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect()
+    }
+
+    /// True when at least one cell in [x_start, x_end) on row `y` carries the
+    /// REVERSED modifier — our visual marker for the active tab.
+    fn any_reversed_in_range(buffer: &Buffer, y: u16, x_start: u16, x_end: u16) -> bool {
+        (x_start..x_end.min(buffer.area.width)).any(|x| {
+            buffer[(x, y)]
+                .style()
+                .add_modifier
+                .contains(Modifier::REVERSED)
+        })
+    }
+
+    /// Locate the inclusive x-range of a substring on row `y`. Panics if
+    /// the substring is not present, with a helpful dump.
+    fn locate(buffer: &Buffer, y: u16, needle: &str) -> (u16, u16) {
+        let line = row_text(buffer, y);
+        let byte_idx = line
+            .find(needle)
+            .unwrap_or_else(|| panic!("expected to find {needle:?} on row {y}, got {line:?}"));
+        // Symbols are ASCII in our render so byte index == column index.
+        let start = byte_idx as u16;
+        let end = start + needle.len() as u16;
+        (start, end)
+    }
+
+    #[test]
+    fn should_render_both_tabs_with_brackets_when_local_active_and_no_forge() {
+        // given — plain app with no GitHub remote
+        let mut app = make_app(vec![commit(0), commit(1)]);
+        // when
+        let buffer = draw(&mut app);
+        // then — tab strip has both bracketed labels
+        let strip = row_text(&buffer, 1);
+        assert!(
+            strip.contains("[ Local ]") && strip.contains("[ Pull Requests ]"),
+            "tab strip missing brackets: {strip:?}"
+        );
+        // and — the active "Local" label is REVERSED, inactive PR label is not
+        let (lo, hi) = locate(&buffer, 1, "Local");
+        assert!(
+            any_reversed_in_range(&buffer, 1, lo, hi),
+            "active Local label should be REVERSED"
+        );
+        let (lo, hi) = locate(&buffer, 1, "Pull Requests");
+        assert!(
+            !any_reversed_in_range(&buffer, 1, lo, hi),
+            "inactive Pull Requests label should NOT be REVERSED"
+        );
+    }
+
+    #[test]
+    fn should_show_disabled_banner_when_pr_tab_active_without_forge() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then — banner spells out the reason
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("No GitHub remote on this repo"),
+            "expected disabled banner, got body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_highlight_pr_tab_label_when_pr_tab_active() {
+        // given — forge repo configured, PR tab active in Idle state
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        app.pr_tab = PullRequestsTab::new(Some(repo()));
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then — Pull Requests is the highlighted (REVERSED) label
+        let (lo, hi) = locate(&buffer, 1, "Pull Requests");
+        assert!(
+            any_reversed_in_range(&buffer, 1, lo, hi),
+            "active Pull Requests label should be REVERSED"
+        );
+        let (lo, hi) = locate(&buffer, 1, "Local");
+        assert!(
+            !any_reversed_in_range(&buffer, 1, lo, hi),
+            "inactive Local label should NOT be REVERSED"
+        );
+    }
+
+    #[test]
+    fn should_render_loaded_pr_rows_with_number_title_author() {
+        // given — three loaded PRs, second with no author
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((
+            vec![
+                pr(148, "Add forge-backed PR review", "alice"),
+                pr(125, "Support fetching/pushing reviews", "ypares"),
+            ],
+            false,
+        )));
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then — both rows are present in the rendered body
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for needle in [
+            "#148",
+            "Add forge-backed PR review",
+            "alice",
+            "#125",
+            "Support fetching/pushing reviews",
+            "ypares",
+        ] {
+            assert!(body.contains(needle), "missing {needle:?} in:\n{body}");
+        }
+    }
+
+    #[test]
+    fn should_show_load_more_row_when_has_more_and_no_filter() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "alpha", "a")], true)));
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("load more pull requests"),
+            "expected load-more row, body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_hide_load_more_row_when_filter_active() {
+        // given — has_more is true but a filter is set
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "alpha", "a")], true)));
+        tab.set_filter("alpha".to_string());
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            !body.contains("load more pull requests"),
+            "load-more row should be hidden while filter is active:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_render_filter_draft_banner_when_editing_filter() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((vec![pr(1, "alpha", "a")], false)));
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        app.pr_filter_draft = Some("alp".to_string());
+        // when
+        let buffer = draw(&mut app);
+        // then — the banner shows the in-progress filter expression
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("/alp") && body.contains("filter"),
+            "expected filter draft banner, got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_render_error_banner_when_pr_load_failed() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Err("network down".to_string()));
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("error") && body.contains("network down"),
+            "expected error banner, got:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_render_loading_banner_when_pr_load_in_flight() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        // (stays in Loading until apply_initial_load)
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("Fetching pull requests"),
+            "expected loading banner, got:\n{body}"
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -179,6 +179,54 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
+            "Review Target Selector",
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  Tab/S-Tab ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Switch Local / Pull Requests tab"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  j/k       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Move row"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Space     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Toggle local commit selection (no-op on PR tab)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Enter     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open selected target or load more"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  /         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Local filter for current tab"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Esc/q     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Quit / return"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
             "File Tree",
             Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )),
@@ -419,10 +467,24 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  :targets  ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open the review target selector"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  :commits  ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Select commits or staged/unstaged changes"),
+            Span::raw("Open the selector on Local (commits, staged/unstaged)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :prs      ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open the selector on Pull Requests"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
PR 2 of the forge integration v1 plan (spec: docs/forge-integration-v1-spec.md, PR 2 section). Builds on the backend skeleton from #291.

## Summary

Generalizes the startup commit selector into a tabbed review target selector:

- New \`Local\` and \`Pull Requests\` tabs on the startup selector. \`Local\` preserves the entire existing behaviour (staged/unstaged, recent commits, commit-range selection, load more).
- \`Pull Requests\` lazily fetches open PRs through \`ForgeBackend\` + \`GitHubGhBackend\` on first visit. Page size 30 with a trailing \`... load more pull requests\` row.
- Indeterminate progress bar while \`gh\` runs. Fetch happens on a background thread; the UI stays responsive at the existing 100ms poll cadence.
- \`/\` opens a local filter editor; filter matches over number, title, author, head branch, and base branch.
- Repos with no GitHub remote land in a clean \`Disabled\` state on the PR tab (no errors, no fetch).
- New in-app commands: \`:targets\` opens the selector, \`:prs\` opens it on Pull Requests, \`:commits\` is a compat alias for the Local tab.

## What is out of scope (deferred to later PRs)

- PR diff mode and \`tuicr pr <target>\` CLI form (PR 3). Enter on a PR row currently shows: \`Opening PR #N not yet implemented — coming in PR 3\` and stays in the selector.
- \`DiffSource::PullRequest\`, session persistence for PR mode (PR 3).
- Remote comments (\`:comments unresolved|all|hide\`) (PR 4).
- \`:submit*\` family (PR 5/6).
- README rework (PR 7) — but the new selector keys and \`:targets\`/\`:prs\`/\`:commits\` are already in \`src/ui/help_popup.rs\`.

## Implementation notes

- New module \`src/forge/selector.rs\` holds a \`PullRequestsTab\` state machine (\`Disabled\` / \`Idle\` / \`Loading\` / \`Loaded\` / \`Error\`) with append-on-load-more, local filtering, and cursor clamping. Unit tested in isolation; the UI consumes a projected \`PrTabView\`.
- Plain \`tuicr\` still opens immediately and makes no network calls on startup. The PR fetch is triggered the first time the user enters the \`Pull Requests\` tab.
- GitHub remote detection uses git2 to read the \`origin\` URL and falls back to scanning other remotes, then parses through the URL parser added in PR 1.
- The PR filter is implemented as a sub-state of \`InputMode::CommitSelect\` driven by a new \`map_target_filter_mode\` keymap. Per the spec the internal name \`CommitSelect\` is kept for this PR; only the user-facing concept becomes \"targets\".
- Background fetches are spawned through \`std::thread::spawn\` and posted back over \`mpsc::Receiver<PrLoadEvent>\`. The main loop drains the channel each tick via \`App::poll_pr_load_events\`.

## Test plan

- [x] \`cargo fmt\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test\` (450 tests, 0 failed)
- New unit tests cover: PR state machine transitions (idle → loading → loaded/error), filter matching across all fields, load-more append + busy-flag, cursor clamping when filter narrows the list, stub PR open path, and the \`:targets\`/\`:prs\`/\`:commits\` command parsing.
- [x] Manual smoke test on a real GitHub checkout with PRs (reviewer)
- [x] Manual smoke test on a repo without a GitHub remote (reviewer; should show the disabled banner)

## Reviewer attention

- The progress bar redraws using wall-clock-derived position so it animates between frames without per-frame state on \`App\`. Look at \`render_pr_progress\` if that's not the pattern you want — easy to swap for a frame-counter on App if preferred.
- I chose to spawn a fresh \`GitHubGhBackend\` inside each fetch thread rather than carry a \`Box<dyn ForgeBackend + Send + Sync>\` on \`App\`. It keeps the trait Send-bound free and the App struct unchanged in the \"no forge\" case, but it means each fetch reconstructs the runner. If you want a shared backend on \`App\`, it's a small refactor.
- The filter is local-only (per spec). \`...load more\` is hidden while a filter is active so the user does not have to scroll past it to see filtered rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)