### PR TITLE
forge: PR diff mode + remote context expansion (PR 3 of forge v1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,8 +7,9 @@ use ratatui::style::Color;
 
 use crate::config::CommentTypeConfig;
 use crate::error::{Result, TuicrError};
+use crate::forge::context::{ContextProvider, ForgeContextProvider, VcsContextProvider};
 use crate::forge::selector::PullRequestsTab;
-use crate::forge::traits::ForgeRepository;
+use crate::forge::traits::{ForgeBackend, ForgeRepository};
 use crate::model::{
     ClearScope, Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin,
     LineRange, LineSide, ReviewSession, SessionDiffSource,
@@ -18,8 +19,10 @@ use crate::syntax::SyntaxHighlighter;
 use crate::theme::Theme;
 use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
+use crate::vcs::traits::VcsType;
 use crate::vcs::{
-    CommitInfo, FileBackend, GitBackendPreference, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
+    CommitInfo, FileBackend, GitBackendPreference, PrNoopVcs, VcsBackend, VcsChangeStatus, VcsInfo,
+    detect_vcs,
 };
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
@@ -353,6 +356,61 @@ pub enum DiffSource {
     StagedAndUnstaged,
     CommitRange(Vec<String>),
     StagedUnstagedAndCommits(Vec<String>),
+    /// Remote PR review. Carries identity + base/head SHAs needed for
+    /// context expansion and status bar labels.
+    ///
+    /// Boxed because `PullRequestDiffSource` is much larger than the other
+    /// variants; keeping it inline would balloon `DiffSource` for every
+    /// local-review caller.
+    PullRequest(Box<PullRequestDiffSource>),
+}
+
+/// Runtime PR identity for `DiffSource::PullRequest`.
+///
+/// The `PrSessionKey` portion is what scopes persistence; the additional
+/// fields are display state derived once at open time so the status bar and
+/// context expansion don't have to call back into the forge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullRequestDiffSource {
+    pub key: crate::forge::traits::PrSessionKey,
+    pub base_sha: String,
+    pub title: String,
+    pub url: String,
+    pub head_ref_name: String,
+    pub base_ref_name: String,
+    pub state: String,
+    pub closed: bool,
+    pub merged: bool,
+}
+
+impl PullRequestDiffSource {
+    pub fn from_details(details: &crate::forge::traits::PullRequestDetails) -> Self {
+        Self {
+            key: crate::forge::traits::PrSessionKey::from_details(details),
+            base_sha: details.base_sha.clone(),
+            title: details.title.clone(),
+            url: details.url.clone(),
+            head_ref_name: details.head_ref_name.clone(),
+            base_ref_name: details.base_ref_name.clone(),
+            state: details.state.clone(),
+            closed: details.closed,
+            merged: details.merged_at.is_some(),
+        }
+    }
+
+    pub fn read_only_reason(&self) -> Option<&'static str> {
+        if self.merged {
+            Some("merged")
+        } else if self.closed {
+            Some("closed")
+        } else {
+            None
+        }
+    }
+
+    pub fn is_read_only(&self) -> bool {
+        self.read_only_reason().is_some()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -474,6 +532,10 @@ pub struct App {
     /// Background-thread channel that delivers PR list fetch results.
     /// `Receiver` is only present while a fetch is in flight.
     pub pr_load_rx: Option<std::sync::mpsc::Receiver<PrLoadEvent>>,
+    /// Forge backend instance live while in PR diff mode. Used by the
+    /// context provider for gap expansion against base/head SHAs and (in a
+    /// future PR) for remote comment fetch/submit.
+    pub forge_backend: Option<Box<dyn ForgeBackend>>,
 
     pub should_quit: bool,
     pub dirty: bool,
@@ -656,6 +718,9 @@ pub struct AppStartupOptions<'a> {
     pub path_filter: Option<&'a str>,
     pub file_path: Option<&'a str>,
     pub git_backend_preference: GitBackendPreference,
+    /// Direct PR target (`tuicr pr <target>`). Mutually exclusive with the
+    /// other selectors above; the binary validates that before reaching here.
+    pub pr_target: Option<&'a str>,
 }
 
 impl App {
@@ -665,6 +730,13 @@ impl App {
         output_to_stdout: bool,
         options: AppStartupOptions<'_>,
     ) -> Result<Self> {
+        // `tuicr pr <target>` mode: enter PR review directly, skipping the
+        // selector. Errors here surface before TUI startup like other
+        // startup failures.
+        if let Some(target) = options.pr_target {
+            return Self::new_from_pr_target(theme, comment_type_configs, output_to_stdout, target);
+        }
+
         // --file mode: open a single file for annotation without VCS
         if let Some(file_path) = options.file_path {
             let vcs = Box::new(FileBackend::new(file_path)?);
@@ -1027,6 +1099,7 @@ impl App {
             pr_list_inner_area: None,
             pr_filter_draft: None,
             pr_load_rx: None,
+            forge_backend: None,
             should_quit: false,
             dirty: false,
             quit_warned: false,
@@ -1323,6 +1396,254 @@ impl App {
         }
 
         session
+    }
+
+    /// Materialize a PR session from an already-opened PR. Reattaches the
+    /// most recent persisted session for the same head SHA when present so
+    /// reviewed markers and local comments survive a reopen.
+    fn load_or_apply_pr_session(opened: &mut crate::forge::pr_open::OpenedPullRequest) {
+        let key = opened.key.clone();
+        let Ok(Some((_path, mut persisted))) = crate::persistence::load_pr_session(&key) else {
+            return;
+        };
+
+        // Re-register diff files against the loaded session so any new files
+        // in the PR appear with content_hash tracking, and any deleted files
+        // simply stop appearing in the file list.
+        for file in &opened.diff_files {
+            let path = file.display_path().clone();
+            persisted.add_file(path, file.status, file.content_hash);
+        }
+        persisted.pr_session_key = Some(key);
+        persisted.diff_source = SessionDiffSource::PullRequest;
+        persisted.updated_at = chrono::Utc::now();
+        opened.session = persisted;
+    }
+
+    /// Direct-entry PR open: `tuicr pr <target>`.
+    pub fn new_from_pr_target(
+        theme: Theme,
+        comment_type_configs: Option<Vec<CommentTypeConfig>>,
+        output_to_stdout: bool,
+        target: &str,
+    ) -> Result<Self> {
+        use crate::forge::github::gh::{GitHubGhBackend, parse_pull_request_target};
+        use crate::forge::pr_open::open_pull_request;
+
+        let parsed = parse_pull_request_target(target)?;
+        // Detect a default repo when the target is bare (`tuicr pr 125`).
+        // For URL/owner-repo targets, this is just an optional optimization
+        // since `parsed.repository` is already populated.
+        let local_repo_root = std::env::current_dir().ok();
+        let default_repo = local_repo_root
+            .as_deref()
+            .and_then(crate::forge::detect_github_repository);
+        let target_repo = parsed
+            .repository
+            .clone()
+            .or_else(|| default_repo.clone())
+            .ok_or_else(|| {
+                TuicrError::Forge(
+                    "tuicr pr <number> requires a local GitHub remote. \
+                     Use owner/repo#N or a full PR URL outside a checkout."
+                        .to_string(),
+                )
+            })?;
+
+        // Use the local checkout for `.tuicrignore` only when it matches the
+        // PR's target repository — using a foreign repo's checkout would
+        // mis-filter the PR diff.
+        let local_checkout_for_target = local_repo_root.as_deref().and_then(|root| {
+            let detected = crate::forge::detect_github_repository(root)?;
+            if detected == target_repo {
+                Some(root.to_path_buf())
+            } else {
+                None
+            }
+        });
+
+        let backend = GitHubGhBackend::new(Some(target_repo.clone()))
+            .with_local_checkout(local_checkout_for_target.clone());
+        let highlighter = theme.syntax_highlighter();
+        let mut opened = open_pull_request(
+            &backend,
+            parsed,
+            local_checkout_for_target.as_deref(),
+            highlighter,
+        )?;
+
+        Self::load_or_apply_pr_session(&mut opened);
+
+        let pr_source = PullRequestDiffSource::from_details(&opened.details);
+        let diff_source = DiffSource::PullRequest(Box::new(pr_source));
+        let vcs_info = VcsInfo {
+            root_path: opened.session.repo_path.clone(),
+            head_commit: opened.details.head_sha.clone(),
+            branch_name: Some(opened.details.head_ref_name.clone()),
+            vcs_type: VcsType::File,
+        };
+        // FileBackend acts as a no-op VCS placeholder; PR context expansion
+        // routes through the forge backend, not the VCS box.
+        let vcs: Box<dyn VcsBackend> = Box::new(PrNoopVcs::new(vcs_info.clone()));
+
+        let mut app = Self::build(
+            vcs,
+            vcs_info,
+            theme,
+            comment_type_configs,
+            output_to_stdout,
+            opened.diff_files,
+            opened.session,
+            diff_source,
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )?;
+
+        // Wire the forge backend so context expansion routes through it.
+        app.forge_backend = Some(Box::new(backend));
+        app.forge_repository = Some(target_repo);
+        if let DiffSource::PullRequest(pr) = &app.diff_source.clone()
+            && pr.is_read_only()
+        {
+            let reason = pr.read_only_reason().unwrap_or("read only");
+            app.set_warning(format!("This PR is {reason} — review is read-only"));
+        }
+        Ok(app)
+    }
+
+    /// Re-enter PR mode after we've already opened a PR via the selector.
+    /// Used by the selector → PR open path and by `:reload` in PR mode.
+    pub fn enter_pr_diff_mode(
+        &mut self,
+        backend: Box<dyn ForgeBackend>,
+        opened: crate::forge::pr_open::OpenedPullRequest,
+    ) -> Result<()> {
+        let crate::forge::pr_open::OpenedPullRequest {
+            details,
+            diff_files,
+            session,
+            key,
+        } = opened;
+
+        // Save the current session before transitioning so local-mode work
+        // isn't lost.
+        let _ = crate::persistence::save_session(&self.session);
+
+        let pr_source = PullRequestDiffSource::from_details(&details);
+        let read_only_reason = pr_source.read_only_reason();
+        let virtual_root = session.repo_path.clone();
+
+        self.vcs_info = VcsInfo {
+            root_path: virtual_root.clone(),
+            head_commit: details.head_sha.clone(),
+            branch_name: Some(details.head_ref_name.clone()),
+            vcs_type: VcsType::File,
+        };
+        self.vcs = Box::new(PrNoopVcs::new(self.vcs_info.clone()));
+        self.session = session;
+        self.diff_files = diff_files;
+        self.diff_source = DiffSource::PullRequest(Box::new(pr_source));
+        self.forge_backend = Some(backend);
+        self.forge_repository = Some(key.repository.clone());
+        self.input_mode = InputMode::Normal;
+        self.focused_panel = FocusedPanel::Diff;
+        self.clear_expanded_gaps();
+        self.commit_list.clear();
+        self.commit_selection_range = None;
+        self.review_commits.clear();
+        self.show_commit_selector = false;
+        self.range_diff_files = None;
+        self.saved_inline_selection = None;
+        self.diff_state = DiffState::default();
+
+        // Ensure session has all files registered after the swap.
+        for file in &self.diff_files {
+            let path = file.display_path().clone();
+            self.session.add_file(path, file.status, file.content_hash);
+        }
+
+        self.sort_files_by_directory(true);
+        self.expand_all_dirs();
+        self.rebuild_annotations();
+
+        if let Some(reason) = read_only_reason {
+            self.set_warning(format!("This PR is {reason} — review is read-only"));
+        }
+
+        Ok(())
+    }
+
+    /// Reload the PR's head from the forge. If the head SHA changed, this
+    /// switches sessions so old-head draft comments stay with the old
+    /// session and the new session starts clean.
+    pub fn reload_pull_request(&mut self) -> Result<bool> {
+        use crate::forge::github::gh::GitHubGhBackend;
+
+        let DiffSource::PullRequest(current) = self.diff_source.clone() else {
+            return Err(TuicrError::UnsupportedOperation(
+                "Not in PR mode".to_string(),
+            ));
+        };
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+        let backend = GitHubGhBackend::new(Some(current.key.repository.clone()))
+            .with_local_checkout(local_checkout.clone());
+        self.reload_pull_request_with_backend(Box::new(backend), local_checkout)
+    }
+
+    /// Inner reload path. Takes the forge backend as a parameter so tests
+    /// can inject a fake without going through `gh`.
+    pub fn reload_pull_request_with_backend(
+        &mut self,
+        backend: Box<dyn ForgeBackend>,
+        local_checkout: Option<std::path::PathBuf>,
+    ) -> Result<bool> {
+        use crate::forge::pr_open::open_pull_request;
+
+        let DiffSource::PullRequest(current) = self.diff_source.clone() else {
+            return Err(TuicrError::UnsupportedOperation(
+                "Not in PR mode".to_string(),
+            ));
+        };
+
+        let target = crate::forge::traits::PullRequestTarget::with_repository(
+            current.key.repository.clone(),
+            current.key.number,
+            current.key.number.to_string(),
+        );
+        let highlighter = self.theme.syntax_highlighter();
+        let mut opened = open_pull_request(
+            backend.as_ref(),
+            target,
+            local_checkout.as_deref(),
+            highlighter,
+        )?;
+
+        let head_changed = opened.details.head_sha != current.key.head_sha;
+        if head_changed {
+            // Save the old-head session before switching so drafts persist.
+            let _ = crate::persistence::save_session(&self.session);
+            Self::load_or_apply_pr_session(&mut opened);
+            self.enter_pr_diff_mode(backend, opened)?;
+        } else {
+            // Same head: re-parse the diff to pick up any side-channel
+            // changes (rare), but keep the session intact.
+            self.diff_files = opened.diff_files;
+            self.clear_expanded_gaps();
+            for file in &self.diff_files {
+                let path = file.display_path().clone();
+                self.session.add_file(path, file.status, file.content_hash);
+            }
+            self.sort_files_by_directory(true);
+            self.expand_all_dirs();
+            self.rebuild_annotations();
+        }
+
+        Ok(head_changed)
     }
 
     fn staged_commit_entry() -> CommitInfo {
@@ -1793,6 +2114,15 @@ impl App {
                     highlighter,
                     self.path_filter.as_deref(),
                 )?
+            }
+            DiffSource::PullRequest(_) => {
+                // PR reload is a separate code path that may switch sessions
+                // when the head SHA advances; callers dispatch via
+                // `reload_pull_request` instead of going through this
+                // local-reload helper.
+                return Err(TuicrError::UnsupportedOperation(
+                    "Use :reload from the command line in PR mode".to_string(),
+                ));
             }
         };
 
@@ -3906,7 +4236,7 @@ impl App {
     }
 
     /// Handle Enter on the PR tab. Returns true when the action was handled
-    /// (load more triggered, stub PR open message shown, etc).
+    /// (load more triggered, PR opened, error surfaced, etc).
     pub fn pr_tab_select(&mut self) -> bool {
         if self.pr_tab.cursor_on_load_more() {
             if let Some((repo, already)) = self.pr_tab.start_load_more() {
@@ -3914,16 +4244,70 @@ impl App {
             }
             return true;
         }
-        if let Some(pr) = self.pr_tab.cursor_pr() {
-            // PR diff mode lands in PR 3. For now, surface a clean info
-            // message and leave the selector intact.
-            let number = pr.number;
-            self.set_message(format!(
-                "Opening PR #{number} not yet implemented — coming in PR 3"
-            ));
-            return true;
+        // Clone the summary so we drop the immutable borrow before mutating
+        // the app to enter PR mode.
+        let Some(summary) = self.pr_tab.cursor_pr().cloned() else {
+            return false;
+        };
+        match self.open_pr_from_selector(&summary) {
+            Ok(()) => {
+                self.set_message(format!(
+                    "Opened PR {}#{}",
+                    summary.repository.display_name(),
+                    summary.number,
+                ));
+            }
+            Err(e) => {
+                // Errors surface inline in the selector (which the user
+                // can still navigate). The selector state machine moves to
+                // an Error variant; UI renders the message in the PR tab.
+                self.pr_tab
+                    .apply_initial_load(Err(format!("Failed to open PR: {e}")));
+            }
         }
-        false
+        true
+    }
+
+    fn open_pr_from_selector(
+        &mut self,
+        summary: &crate::forge::traits::PullRequestSummary,
+    ) -> Result<()> {
+        use crate::forge::github::gh::GitHubGhBackend;
+
+        let local_checkout = Some(self.vcs_info.root_path.clone());
+        let target_repo = summary.repository.clone();
+        let backend = GitHubGhBackend::new(Some(target_repo.clone()))
+            .with_local_checkout(local_checkout.clone());
+        self.open_pr_with_backend(summary, Box::new(backend), local_checkout)
+    }
+
+    /// Open a PR using the provided forge backend. Exists as a seam for
+    /// tests; production paths go through `open_pr_from_selector` or
+    /// `new_from_pr_target` which construct the real backend.
+    pub fn open_pr_with_backend(
+        &mut self,
+        summary: &crate::forge::traits::PullRequestSummary,
+        backend: Box<dyn ForgeBackend>,
+        local_checkout: Option<std::path::PathBuf>,
+    ) -> Result<()> {
+        use crate::forge::pr_open::open_pull_request;
+        use crate::forge::traits::PullRequestTarget;
+
+        let target = PullRequestTarget::with_repository(
+            summary.repository.clone(),
+            summary.number,
+            summary.number.to_string(),
+        );
+        let highlighter = self.theme.syntax_highlighter();
+        let mut opened = open_pull_request(
+            backend.as_ref(),
+            target,
+            local_checkout.as_deref(),
+            highlighter,
+        )?;
+        Self::load_or_apply_pr_session(&mut opened);
+        self.enter_pr_diff_mode(backend, opened)?;
+        Ok(())
     }
 
     pub fn begin_pr_filter(&mut self) {
@@ -4698,8 +5082,10 @@ impl App {
             .gap_boundaries(&gap_id)
             .ok_or_else(|| TuicrError::CorruptedSession(format!("Invalid gap: {:?}", gap_id)))?;
 
-        let file_path = self.diff_files[gap_id.file_idx].display_path().clone();
-        let file_status = self.diff_files[gap_id.file_idx].status;
+        let file = &self.diff_files[gap_id.file_idx];
+        let old_path = file.old_path.clone();
+        let new_path = file.new_path.clone();
+        let file_status = file.status;
 
         let top_len = self.expanded_top.get(&gap_id).map_or(0, |v| v.len()) as u32;
         let bot_len = self.expanded_bottom.get(&gap_id).map_or(0, |v| v.len()) as u32;
@@ -4712,16 +5098,21 @@ impl App {
             return Ok(()); // Fully expanded
         }
 
+        let fetch = |start: u32, end: u32| -> Result<Vec<DiffLine>> {
+            self.context_provider().fetch_context_lines(
+                old_path.as_ref(),
+                new_path.as_ref(),
+                file_status,
+                start,
+                end,
+            )
+        };
+
         match direction {
             ExpandDirection::Down => {
                 let n = limit.unwrap_or(usize::MAX) as u32;
                 let fetch_end = inner_start.saturating_add(n - 1).min(inner_end);
-                let new_lines = self.vcs.fetch_context_lines(
-                    &file_path,
-                    file_status,
-                    inner_start,
-                    fetch_end,
-                )?;
+                let new_lines = fetch(inner_start, fetch_end)?;
                 self.expanded_top
                     .entry(gap_id.clone())
                     .or_default()
@@ -4730,12 +5121,7 @@ impl App {
             ExpandDirection::Up => {
                 let n = limit.unwrap_or(usize::MAX) as u32;
                 let fetch_start = inner_end.saturating_sub(n - 1).max(inner_start);
-                let new_lines = self.vcs.fetch_context_lines(
-                    &file_path,
-                    file_status,
-                    fetch_start,
-                    inner_end,
-                )?;
+                let new_lines = fetch(fetch_start, inner_end)?;
                 // Prepend: new lines go before existing bottom lines
                 let existing = self.expanded_bottom.remove(&gap_id).unwrap_or_default();
                 let mut combined = new_lines;
@@ -4744,12 +5130,7 @@ impl App {
             }
             ExpandDirection::Both => {
                 // Fetch everything remaining
-                let new_lines = self.vcs.fetch_context_lines(
-                    &file_path,
-                    file_status,
-                    inner_start,
-                    inner_end,
-                )?;
+                let new_lines = fetch(inner_start, inner_end)?;
                 self.expanded_top
                     .entry(gap_id.clone())
                     .or_default()
@@ -4759,6 +5140,26 @@ impl App {
 
         self.rebuild_annotations();
         Ok(())
+    }
+
+    /// Resolve the right `ContextProvider` for the current diff source.
+    /// In PR mode (with a forge backend present), expansion goes through the
+    /// forge; otherwise it goes through the local VCS backend.
+    fn context_provider(&self) -> Box<dyn ContextProvider + '_> {
+        if let (DiffSource::PullRequest(pr), Some(backend)) =
+            (&self.diff_source, self.forge_backend.as_ref())
+        {
+            Box::new(ForgeContextProvider {
+                forge: backend.as_ref(),
+                repository: pr.key.repository.clone(),
+                base_sha: pr.base_sha.clone(),
+                head_sha: pr.key.head_sha.clone(),
+            })
+        } else {
+            Box::new(VcsContextProvider {
+                vcs: self.vcs.as_ref(),
+            })
+        }
     }
 
     /// Collapse an expanded gap
@@ -5637,6 +6038,67 @@ mod target_selector_tests {
         }
     }
 
+    fn test_pr_details(number: u64, title: &str) -> crate::forge::traits::PullRequestDetails {
+        crate::forge::traits::PullRequestDetails {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            number,
+            title: title.to_string(),
+            url: format!("https://github.com/agavra/tuicr/pull/{number}"),
+            state: "OPEN".to_string(),
+            is_draft: false,
+            author: Some("alice".to_string()),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            head_sha: "abcdef0123456789".to_string(),
+            base_sha: "1234567890abcdef".to_string(),
+            body: String::new(),
+            updated_at: None,
+            closed: false,
+            merged_at: None,
+        }
+    }
+
+    struct FakeForgeBackend {
+        details: crate::forge::traits::PullRequestDetails,
+        patch: String,
+    }
+
+    impl FakeForgeBackend {
+        fn open_pr_details(
+            details: crate::forge::traits::PullRequestDetails,
+            patch: String,
+        ) -> Self {
+            Self { details, patch }
+        }
+    }
+
+    impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
+        fn list_pull_requests(
+            &self,
+            _query: crate::forge::traits::PullRequestListQuery,
+        ) -> Result<crate::forge::traits::PagedPullRequests> {
+            unimplemented!("not used in this test")
+        }
+        fn get_pull_request(
+            &self,
+            _target: crate::forge::traits::PullRequestTarget,
+        ) -> Result<crate::forge::traits::PullRequestDetails> {
+            Ok(self.details.clone())
+        }
+        fn get_pull_request_diff(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<String> {
+            Ok(self.patch.clone())
+        }
+        fn fetch_file_lines(
+            &self,
+            _request: crate::forge::traits::ForgeFileLinesRequest,
+        ) -> Result<Vec<crate::model::DiffLine>> {
+            Ok(Vec::new())
+        }
+    }
+
     fn sample_pr(number: u64, title: &str) -> PullRequestSummary {
         PullRequestSummary {
             repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
@@ -5749,22 +6211,211 @@ mod target_selector_tests {
     }
 
     #[test]
-    fn should_show_stub_message_when_opening_pr_on_pr_tab() {
-        // given
+    fn should_enter_pr_mode_when_opening_pr_via_fake_backend() {
+        // given a selector with a single PR row and a fake forge backend
         let mut app = build_app();
         app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
         app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
         app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "answer");
         app.pr_tab
-            .apply_initial_load(Ok((vec![sample_pr(42, "answer")], false)));
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
         app.target_tab = TargetTab::PullRequests;
+        let backend = Box::new(FakeForgeBackend::open_pr_details(
+            test_pr_details(42, "answer"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
         // when
-        let handled = app.pr_tab_select();
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
         // then
-        assert!(handled);
-        let msg = app.message.as_ref().expect("expected info message");
-        assert!(msg.content.contains("#42"));
-        assert!(msg.content.contains("not yet implemented"));
+        assert!(matches!(app.diff_source, DiffSource::PullRequest(_)));
+        if let DiffSource::PullRequest(pr) = &app.diff_source {
+            assert_eq!(pr.key.number, 42);
+            assert_eq!(pr.title, "answer");
+            assert_eq!(pr.head_ref_name, "feat");
+            assert_eq!(pr.base_ref_name, "main");
+            assert_eq!(pr.key.head_sha, "abcdef0123456789");
+            assert_eq!(pr.base_sha, "1234567890abcdef");
+        }
+        // and the session is keyed by the PR
+        assert!(app.session.pr_session_key.is_some());
+        // and PR diff files were parsed
+        assert_eq!(app.diff_files.len(), 1);
+        // and the forge backend is wired for context expansion / submit
+        assert!(app.forge_backend.is_some());
+    }
+
+    #[test]
+    fn should_warn_when_opening_closed_pr() {
+        // given
+        let mut app = build_app();
+        let summary = sample_pr(42, "old");
+        let mut details = test_pr_details(42, "old");
+        details.state = "CLOSED".to_string();
+        details.closed = true;
+        let backend = Box::new(FakeForgeBackend::open_pr_details(
+            details,
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
+        // when
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        // then — warning message surfaces the read-only state
+        let msg = app.message.as_ref().expect("expected warning message");
+        assert!(msg.content.contains("closed"), "got: {:?}", msg.content);
+        assert!(msg.content.contains("read-only"), "got: {:?}", msg.content);
+        // and the diff source reflects the closed state
+        if let DiffSource::PullRequest(pr) = &app.diff_source {
+            assert!(pr.is_read_only());
+            assert_eq!(pr.read_only_reason(), Some("closed"));
+        } else {
+            panic!("expected PullRequest diff source");
+        }
+    }
+
+    #[test]
+    fn should_surface_pr_open_error_into_selector_state() {
+        // given a backend that fails at get_pull_request
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "boom");
+        app.pr_tab
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
+        app.target_tab = TargetTab::PullRequests;
+        let backend = Box::new(FailingForgeBackend);
+        // when
+        let result = app.open_pr_with_backend(&summary, backend, None);
+        // then
+        assert!(result.is_err());
+        // diff source did not switch
+        assert!(matches!(app.diff_source, DiffSource::WorkingTree));
+    }
+
+    #[test]
+    fn should_route_context_expansion_to_forge_provider_in_pr_mode() {
+        // given an app in PR mode with a counting fake backend
+        let mut app = build_app();
+        let summary = sample_pr(7, "ctx");
+        let backend = Box::new(FakeForgeBackend::open_pr_details(
+            test_pr_details(7, "ctx"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        // when we ask for a context provider
+        // (we can't easily trigger a real gap expansion without setting up
+        //  the full diff state, so instead we assert by construction)
+        let provider = app.context_provider();
+        // then — explicitly: the provider is the forge variant. We probe by
+        // calling fetch with a Modified file and asserting the forge backend
+        // recorded a head-side request via its trait method. The
+        // FakeForgeBackend just returns empty; we're verifying routing.
+        let res = provider
+            .fetch_context_lines(
+                None,
+                Some(&PathBuf::from("src/lib.rs")),
+                FileStatus::Modified,
+                1,
+                3,
+            )
+            .unwrap();
+        // The fake forge returns empty by default — the *call* succeeded
+        // (no error from a VCS backend would have meant VCS routing). The
+        // key signal: this didn't go through the VCS backend (DummyVcs
+        // doesn't implement fetch_context_lines and would have panicked).
+        assert!(res.is_empty());
+    }
+
+    #[test]
+    fn should_switch_session_when_pr_head_advances_on_reload() {
+        // given an app already in PR mode at head A
+        let mut app = build_app();
+        let summary = sample_pr(42, "head-a");
+        let mut details_a = test_pr_details(42, "head-a");
+        details_a.head_sha = "aaaaaaaaaaaaaaaa".to_string();
+        let backend_a = Box::new(FakeForgeBackend::open_pr_details(
+            details_a.clone(),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
+        app.open_pr_with_backend(&summary, backend_a, None).unwrap();
+        let old_session_id = app.session.id.clone();
+        // when reloading with a backend that reports head B
+        let mut details_b = details_a.clone();
+        details_b.head_sha = "bbbbbbbbbbbbbbbb".to_string();
+        details_b.title = "head-b".to_string();
+        let backend_b = Box::new(FakeForgeBackend::open_pr_details(
+            details_b.clone(),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
+        let head_changed = app
+            .reload_pull_request_with_backend(backend_b, None)
+            .unwrap();
+        // then — the session swap happened
+        assert!(head_changed);
+        if let DiffSource::PullRequest(pr) = &app.diff_source {
+            assert_eq!(pr.key.head_sha, "bbbbbbbbbbbbbbbb");
+            assert_eq!(pr.title, "head-b");
+        } else {
+            panic!("expected PullRequest diff source");
+        }
+        // and the session changed (new session, not the old one)
+        assert_ne!(app.session.id, old_session_id);
+    }
+
+    #[test]
+    fn should_keep_session_when_pr_head_unchanged_on_reload() {
+        // given an app in PR mode
+        let mut app = build_app();
+        let summary = sample_pr(42, "same");
+        let details = test_pr_details(42, "same");
+        let backend = Box::new(FakeForgeBackend::open_pr_details(
+            details.clone(),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        let session_id_before = app.session.id.clone();
+        // when reloading with the same head
+        let backend2 = Box::new(FakeForgeBackend::open_pr_details(
+            details,
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        ));
+        let changed = app
+            .reload_pull_request_with_backend(backend2, None)
+            .unwrap();
+        // then
+        assert!(!changed);
+        assert_eq!(app.session.id, session_id_before);
+    }
+
+    struct FailingForgeBackend;
+
+    impl crate::forge::traits::ForgeBackend for FailingForgeBackend {
+        fn list_pull_requests(
+            &self,
+            _q: crate::forge::traits::PullRequestListQuery,
+        ) -> Result<crate::forge::traits::PagedPullRequests> {
+            unimplemented!()
+        }
+        fn get_pull_request(
+            &self,
+            _target: crate::forge::traits::PullRequestTarget,
+        ) -> Result<crate::forge::traits::PullRequestDetails> {
+            Err(crate::error::TuicrError::Forge(
+                "simulated network failure".to_string(),
+            ))
+        }
+        fn get_pull_request_diff(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<String> {
+            unreachable!()
+        }
+        fn fetch_file_lines(
+            &self,
+            _req: crate::forge::traits::ForgeFileLinesRequest,
+        ) -> Result<Vec<crate::model::DiffLine>> {
+            Ok(Vec::new())
+        }
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -444,6 +444,37 @@ pub enum PrLoadEvent {
     LoadMore(std::result::Result<(Vec<crate::forge::traits::PullRequestSummary>, bool), String>),
 }
 
+/// In-flight PR open. Stored on `App::pr_open_state` so the selector
+/// renderer can paint a spinner glyph on the matching row and the
+/// handler can gate further input until the load resolves.
+#[derive(Debug, Clone)]
+pub struct PrOpenRequest {
+    pub repository: crate::forge::traits::ForgeRepository,
+    pub pr_number: u64,
+    /// Wall-clock origin for the spinner animation. Derived in the App
+    /// (not the renderer) so the spinner phase is stable across redraws.
+    pub started_at: Instant,
+}
+
+impl PrOpenRequest {
+    /// True when this in-flight open is for the given PR row.
+    pub fn matches(&self, repo: &crate::forge::traits::ForgeRepository, number: u64) -> bool {
+        self.pr_number == number && &self.repository == repo
+    }
+}
+
+/// Result delivered from the PR-open background thread.
+#[derive(Debug)]
+pub enum PrOpenEvent {
+    Done {
+        request: PrOpenRequest,
+        /// Network-only outcome. Parsing + session build runs on the main
+        /// thread after this lands so `SyntaxHighlighter` does not need to
+        /// cross thread boundaries.
+        result: std::result::Result<(crate::forge::traits::PullRequestDetails, String), String>,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffViewMode {
     Unified,
@@ -532,6 +563,12 @@ pub struct App {
     /// Background-thread channel that delivers PR list fetch results.
     /// `Receiver` is only present while a fetch is in flight.
     pub pr_load_rx: Option<std::sync::mpsc::Receiver<PrLoadEvent>>,
+    /// In-flight PR open. Drives the inline row spinner and gates further
+    /// Enter presses while the network calls run on a background thread.
+    pub pr_open_state: Option<PrOpenRequest>,
+    /// Background-thread channel that delivers the result of a PR open.
+    /// `Receiver` is only present while an open is in flight.
+    pub pr_open_rx: Option<std::sync::mpsc::Receiver<PrOpenEvent>>,
     /// Forge backend instance live while in PR diff mode. Used by the
     /// context provider for gap expansion against base/head SHAs and (in a
     /// future PR) for remote comment fetch/submit.
@@ -1099,6 +1136,8 @@ impl App {
             pr_list_inner_area: None,
             pr_filter_draft: None,
             pr_load_rx: None,
+            pr_open_state: None,
+            pr_open_rx: None,
             forge_backend: None,
             should_quit: false,
             dirty: false,
@@ -4236,8 +4275,14 @@ impl App {
     }
 
     /// Handle Enter on the PR tab. Returns true when the action was handled
-    /// (load more triggered, PR opened, error surfaced, etc).
+    /// (load more triggered, PR open kicked off, error surfaced, etc).
     pub fn pr_tab_select(&mut self) -> bool {
+        // Block re-entry while a previous open is still resolving — the
+        // spinner glyph on the row already tells the user something is in
+        // flight.
+        if self.pr_open_state.is_some() {
+            return true;
+        }
         if self.pr_tab.cursor_on_load_more() {
             if let Some((repo, already)) = self.pr_tab.start_load_more() {
                 self.spawn_pr_load_more(repo, already);
@@ -4249,41 +4294,137 @@ impl App {
         let Some(summary) = self.pr_tab.cursor_pr().cloned() else {
             return false;
         };
-        match self.open_pr_from_selector(&summary) {
-            Ok(()) => {
-                self.set_message(format!(
-                    "Opened PR {}#{}",
-                    summary.repository.display_name(),
-                    summary.number,
-                ));
-            }
-            Err(e) => {
-                // Errors surface inline in the selector (which the user
-                // can still navigate). The selector state machine moves to
-                // an Error variant; UI renders the message in the PR tab.
-                self.pr_tab
-                    .apply_initial_load(Err(format!("Failed to open PR: {e}")));
-            }
-        }
+        self.spawn_pr_open(&summary);
         true
     }
 
-    fn open_pr_from_selector(
-        &mut self,
-        summary: &crate::forge::traits::PullRequestSummary,
-    ) -> Result<()> {
+    /// Kick off the background fetch for a PR open. The main thread keeps
+    /// rendering and pumping events; the resulting `PrOpenEvent::Done` is
+    /// drained in `poll_pr_open_events` where parsing happens and PR mode
+    /// is entered.
+    fn spawn_pr_open(&mut self, summary: &crate::forge::traits::PullRequestSummary) {
         use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::pr_open::fetch_pr_data;
+        use crate::forge::traits::PullRequestTarget;
 
         let local_checkout = Some(self.vcs_info.root_path.clone());
-        let target_repo = summary.repository.clone();
-        let backend = GitHubGhBackend::new(Some(target_repo.clone()))
-            .with_local_checkout(local_checkout.clone());
-        self.open_pr_with_backend(summary, Box::new(backend), local_checkout)
+        let request = PrOpenRequest {
+            repository: summary.repository.clone(),
+            pr_number: summary.number,
+            started_at: Instant::now(),
+        };
+        self.pr_open_state = Some(request.clone());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_open_rx = Some(rx);
+
+        let summary_repo = summary.repository.clone();
+        let pr_number = summary.number;
+        let thread_local_checkout = local_checkout.clone();
+        std::thread::spawn(move || {
+            let backend = GitHubGhBackend::new(Some(summary_repo.clone()))
+                .with_local_checkout(thread_local_checkout);
+            let target =
+                PullRequestTarget::with_repository(summary_repo, pr_number, pr_number.to_string());
+            let outcome = fetch_pr_data(&backend, target).map_err(|e| e.to_string());
+            let _ = tx.send(PrOpenEvent::Done {
+                request,
+                result: outcome,
+            });
+        });
     }
 
-    /// Open a PR using the provided forge backend. Exists as a seam for
-    /// tests; production paths go through `open_pr_from_selector` or
-    /// `new_from_pr_target` which construct the real backend.
+    /// Drain any pending PR-open result and apply it. On success, parses
+    /// the diff and enters PR diff mode; on failure, routes the error
+    /// into the selector banner. Either way, clears `pr_open_state` and
+    /// the receiver so the spinner stops animating.
+    pub fn poll_pr_open_events(&mut self) {
+        let Some(rx) = self.pr_open_rx.as_ref() else {
+            return;
+        };
+        let event = match rx.try_recv() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        self.pr_open_rx = None;
+        let in_flight = self.pr_open_state.clone();
+        self.pr_open_state = None;
+        match event {
+            PrOpenEvent::Done { request, result } => {
+                // If the user cancelled (cleared pr_open_state) but the
+                // background thread sent a result before being torn down,
+                // ignore the result rather than entering PR mode.
+                if !in_flight
+                    .as_ref()
+                    .map(|s| s.matches(&request.repository, request.pr_number))
+                    .unwrap_or(false)
+                {
+                    return;
+                }
+                match result {
+                    Ok((details, patch)) => {
+                        if let Err(e) = self.finish_pr_open(details, patch, &request) {
+                            self.set_error(format!(
+                                "Failed to open PR #{}: {}",
+                                request.pr_number, e
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        self.set_error(format!("Failed to open PR #{}: {}", request.pr_number, e));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Main-thread half of the PR open: parse the patch, build the
+    /// session, and enter PR diff mode. Mirrors what the previous synchronous
+    /// `open_pr_with_backend` did, but the network fetch has already
+    /// happened on the background thread.
+    fn finish_pr_open(
+        &mut self,
+        details: crate::forge::traits::PullRequestDetails,
+        patch: String,
+        request: &PrOpenRequest,
+    ) -> Result<()> {
+        use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::pr_open::prepare_open_pr;
+
+        let local_checkout = Some(self.vcs_info.root_path.clone());
+        let highlighter = self.theme.syntax_highlighter();
+        let mut opened = prepare_open_pr(details, &patch, local_checkout.as_deref(), highlighter)?;
+        Self::load_or_apply_pr_session(&mut opened);
+        let backend = Box::new(
+            GitHubGhBackend::new(Some(request.repository.clone()))
+                .with_local_checkout(local_checkout),
+        );
+        self.enter_pr_diff_mode(backend, opened)?;
+        self.set_message(format!(
+            "Opened PR {}#{}",
+            request.repository.display_name(),
+            request.pr_number,
+        ));
+        Ok(())
+    }
+
+    /// Abort an in-flight PR open. Drops the receiver so the eventual
+    /// thread send becomes a no-op; clears the spinner state.
+    pub fn cancel_pr_open(&mut self) -> bool {
+        if self.pr_open_state.is_none() {
+            return false;
+        }
+        self.pr_open_state = None;
+        self.pr_open_rx = None;
+        self.set_message("PR open cancelled".to_string());
+        true
+    }
+
+    /// Open a PR using the provided forge backend, synchronously. Exists
+    /// as a seam for tests that want to drive the open without spinning
+    /// up a background thread + mpsc round-trip. Production paths go
+    /// through `spawn_pr_open` (selector) or `new_from_pr_target` (CLI).
+    #[allow(dead_code)]
     pub fn open_pr_with_backend(
         &mut self,
         summary: &crate::forge::traits::PullRequestSummary,
@@ -6479,6 +6620,179 @@ mod target_selector_tests {
         // then
         assert_eq!(app.target_tab, TargetTab::Local);
         assert_eq!(app.input_mode, InputMode::CommitSelect);
+    }
+
+    // -- async PR open spinner tests -----------------------------------------
+
+    fn loaded_pr_tab(pr_list: Vec<PullRequestSummary>) -> PullRequestsTab {
+        let mut tab = PullRequestsTab::new(Some(ForgeRepository::github(
+            "github.com",
+            "agavra",
+            "tuicr",
+        )));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((pr_list, false)));
+        tab
+    }
+
+    #[test]
+    fn should_set_pr_open_state_and_spawn_when_pressing_enter_on_a_pr_row() {
+        // given a loaded PR tab and no in-flight open
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = loaded_pr_tab(vec![sample_pr(42, "boom")]);
+        app.target_tab = TargetTab::PullRequests;
+        // when
+        let handled = app.pr_tab_select();
+        // then
+        assert!(handled);
+        assert!(app.pr_open_state.is_some());
+        let state = app.pr_open_state.as_ref().unwrap();
+        assert_eq!(state.pr_number, 42);
+        // Drop the receiver so the spawned thread's tx send is a no-op
+        // when it completes (the real `gh` call would block; this test
+        // does not wait for it).
+        app.pr_open_rx = None;
+        app.pr_open_state = None;
+    }
+
+    #[test]
+    fn should_be_a_noop_when_pressing_enter_during_an_in_flight_open() {
+        // given an in-flight open marker
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = loaded_pr_tab(vec![sample_pr(7, "ctx"), sample_pr(8, "next")]);
+        app.target_tab = TargetTab::PullRequests;
+        app.pr_open_state = Some(crate::app::PrOpenRequest {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 7,
+            started_at: std::time::Instant::now(),
+        });
+        // (no pr_open_rx is fine — the function never touches it on this path)
+        // when — Enter on a different row
+        if let crate::forge::selector::PullRequestsTab::Loaded { cursor, .. } = &mut app.pr_tab {
+            *cursor = 1;
+        }
+        let handled = app.pr_tab_select();
+        // then — handled but state unchanged (no new spawn for #8)
+        assert!(handled);
+        let state = app.pr_open_state.as_ref().unwrap();
+        assert_eq!(state.pr_number, 7);
+    }
+
+    #[test]
+    fn should_clear_pr_open_state_on_cancel() {
+        // given
+        let mut app = build_app();
+        app.pr_open_state = Some(crate::app::PrOpenRequest {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 11,
+            started_at: std::time::Instant::now(),
+        });
+        // when
+        let cancelled = app.cancel_pr_open();
+        // then
+        assert!(cancelled);
+        assert!(app.pr_open_state.is_none());
+        assert!(app.pr_open_rx.is_none());
+    }
+
+    #[test]
+    fn should_return_false_when_cancelling_with_no_in_flight_open() {
+        // given
+        let mut app = build_app();
+        // when
+        let cancelled = app.cancel_pr_open();
+        // then
+        assert!(!cancelled);
+    }
+
+    #[test]
+    fn should_surface_pr_open_error_to_message_bar_when_done_event_carries_error() {
+        // given an app waiting on a synthetic open
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = loaded_pr_tab(vec![sample_pr(42, "boom")]);
+        app.target_tab = TargetTab::PullRequests;
+        let request = crate::app::PrOpenRequest {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 42,
+            started_at: std::time::Instant::now(),
+        };
+        app.pr_open_state = Some(request.clone());
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_open_rx = Some(rx);
+        tx.send(crate::app::PrOpenEvent::Done {
+            request,
+            result: Err("auth failed".to_string()),
+        })
+        .unwrap();
+        // when
+        app.poll_pr_open_events();
+        // then — open state cleared, error surfaced to message bar, PR
+        // list is intact so the user can retry / pick a different PR
+        assert!(app.pr_open_state.is_none());
+        assert!(app.pr_open_rx.is_none());
+        assert!(matches!(app.pr_tab, PullRequestsTab::Loaded { .. }));
+        let msg = app
+            .message
+            .as_ref()
+            .expect("expected an error message on the bar");
+        assert!(matches!(msg.message_type, MessageType::Error));
+        assert!(msg.content.contains("auth failed"), "got {msg:?}");
+    }
+
+    #[test]
+    fn should_ignore_stale_done_event_after_cancel() {
+        // given an open was cancelled but the thread's send arrived anyway
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = loaded_pr_tab(vec![sample_pr(42, "boom")]);
+        app.target_tab = TargetTab::PullRequests;
+        let stale_request = crate::app::PrOpenRequest {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 42,
+            started_at: std::time::Instant::now(),
+        };
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_open_rx = Some(rx);
+        // pr_open_state is None — the user already cancelled.
+        tx.send(crate::app::PrOpenEvent::Done {
+            request: stale_request,
+            result: Err("would-have-failed".to_string()),
+        })
+        .unwrap();
+        // when
+        app.poll_pr_open_events();
+        // then — the stale error does not produce a user-visible message
+        assert!(matches!(app.pr_tab, PullRequestsTab::Loaded { .. }));
+        assert!(
+            app.message.is_none()
+                || !app
+                    .message
+                    .as_ref()
+                    .unwrap()
+                    .content
+                    .contains("would-have-failed")
+        );
+    }
+
+    #[test]
+    fn should_cancel_in_flight_open_when_pressing_esc_in_selector() {
+        // given
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = loaded_pr_tab(vec![sample_pr(99, "x")]);
+        app.target_tab = TargetTab::PullRequests;
+        app.pr_open_state = Some(crate::app::PrOpenRequest {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 99,
+            started_at: std::time::Instant::now(),
+        });
+        // when
+        crate::handler::handle_commit_select_action(&mut app, crate::input::Action::ExitMode);
+        // then
+        assert!(app.pr_open_state.is_none());
     }
 }
 

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -1,0 +1,241 @@
+//! Context provider abstraction for gap expansion.
+//!
+//! Gap expansion needs file content at an exact revision: working tree for
+//! local review, base/head SHAs for PR review. `ContextProvider` factors
+//! that lookup so the App can route expansion through the right source
+//! without knowing whether the diff is local or remote.
+//!
+//! Implementations:
+//! - `VcsContextProvider`: delegates to `VcsBackend::fetch_context_lines`.
+//! - `ForgeContextProvider`: builds a `ForgeFileLinesRequest` for the given
+//!   file/status and delegates to `ForgeBackend::fetch_file_lines`.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::Result;
+use crate::forge::traits::{ForgeBackend, ForgeFileLinesRequest, ForgeRepository, PrSessionKey};
+use crate::model::{DiffLine, FileStatus};
+use crate::vcs::VcsBackend;
+
+/// Source of context lines for gap expansion. Implementations either read
+/// from a local VCS working tree / blob, or fetch the exact base/head SHA
+/// from a remote forge.
+pub trait ContextProvider {
+    /// Fetch context lines for a file in `[start_line, end_line]` inclusive.
+    /// `old_path` and `new_path` come straight from the parsed diff and are
+    /// used to map rename/copy sides correctly.
+    fn fetch_context_lines(
+        &self,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+        file_status: FileStatus,
+        start_line: u32,
+        end_line: u32,
+    ) -> Result<Vec<DiffLine>>;
+}
+
+/// Adapter over a `VcsBackend`. Picks the appropriate display path (new on
+/// the head side, old on the base side) and forwards to the backend.
+pub struct VcsContextProvider<'a> {
+    pub vcs: &'a dyn VcsBackend,
+}
+
+impl ContextProvider for VcsContextProvider<'_> {
+    fn fetch_context_lines(
+        &self,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+        file_status: FileStatus,
+        start_line: u32,
+        end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        // Mirror the existing display_path rule: prefer new_path, fall back
+        // to old_path. Local VCS backends pick the side internally based on
+        // file status.
+        let path: &Path = match new_path.or(old_path) {
+            Some(p) => p.as_path(),
+            None => return Ok(Vec::new()),
+        };
+        self.vcs
+            .fetch_context_lines(path, file_status, start_line, end_line)
+    }
+}
+
+/// Adapter over a `ForgeBackend` for PR review mode.
+///
+/// Built from the PR's `PrSessionKey` (carries head SHA and repository) and
+/// the captured `base_sha`. Each `fetch_context_lines` call constructs the
+/// appropriate `ForgeFileLinesRequest` and delegates to the backend.
+pub struct ForgeContextProvider<'a> {
+    pub forge: &'a dyn ForgeBackend,
+    pub repository: ForgeRepository,
+    pub base_sha: String,
+    pub head_sha: String,
+}
+
+impl<'a> ForgeContextProvider<'a> {
+    pub fn for_pr(
+        forge: &'a dyn ForgeBackend,
+        key: &PrSessionKey,
+        base_sha: impl Into<String>,
+    ) -> Self {
+        Self {
+            forge,
+            repository: key.repository.clone(),
+            base_sha: base_sha.into(),
+            head_sha: key.head_sha.clone(),
+        }
+    }
+}
+
+impl ContextProvider for ForgeContextProvider<'_> {
+    fn fetch_context_lines(
+        &self,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+        file_status: FileStatus,
+        start_line: u32,
+        end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        let side = ForgeFileLinesRequest::side_for_status(file_status);
+        let Some(path) = ForgeFileLinesRequest::path_for_side(side, old_path, new_path) else {
+            return Ok(Vec::new());
+        };
+        let request = ForgeFileLinesRequest {
+            repository: self.repository.clone(),
+            base_sha: self.base_sha.clone(),
+            head_sha: self.head_sha.clone(),
+            path,
+            status: file_status,
+            side,
+            start_line,
+            end_line,
+        };
+        self.forge.fetch_file_lines(request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::traits::{
+        ForgeFileSide, PagedPullRequests, PullRequestDetails, PullRequestListQuery,
+        PullRequestTarget,
+    };
+    use crate::model::LineOrigin;
+    use std::cell::RefCell;
+
+    struct CapturingForge {
+        seen: RefCell<Vec<ForgeFileLinesRequest>>,
+        response: Vec<DiffLine>,
+    }
+
+    impl ForgeBackend for CapturingForge {
+        fn list_pull_requests(&self, _query: PullRequestListQuery) -> Result<PagedPullRequests> {
+            unimplemented!()
+        }
+        fn get_pull_request(&self, _target: PullRequestTarget) -> Result<PullRequestDetails> {
+            unimplemented!()
+        }
+        fn get_pull_request_diff(&self, _pr: &PullRequestDetails) -> Result<String> {
+            unimplemented!()
+        }
+        fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
+            self.seen.borrow_mut().push(request);
+            Ok(self.response.clone())
+        }
+    }
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    fn key() -> PrSessionKey {
+        PrSessionKey::new(repo(), 125, "headsha".to_string())
+    }
+
+    fn make_line(text: &str) -> DiffLine {
+        DiffLine {
+            origin: LineOrigin::Context,
+            content: text.to_string(),
+            old_lineno: Some(1),
+            new_lineno: Some(1),
+            highlighted_spans: None,
+        }
+    }
+
+    #[test]
+    fn should_use_head_side_for_modified_file() {
+        // given
+        let forge = CapturingForge {
+            seen: RefCell::new(Vec::new()),
+            response: vec![make_line("a")],
+        };
+        let provider = ForgeContextProvider::for_pr(&forge, &key(), "basesha");
+        let new_path = PathBuf::from("src/lib.rs");
+        // when
+        let _ = provider
+            .fetch_context_lines(None, Some(&new_path), FileStatus::Modified, 1, 1)
+            .unwrap();
+        // then
+        let seen = forge.seen.borrow();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].side, ForgeFileSide::Head);
+        assert_eq!(seen[0].sha(), "headsha");
+        assert_eq!(seen[0].path, PathBuf::from("src/lib.rs"));
+    }
+
+    #[test]
+    fn should_use_base_side_for_deleted_file() {
+        // given
+        let forge = CapturingForge {
+            seen: RefCell::new(Vec::new()),
+            response: vec![],
+        };
+        let provider = ForgeContextProvider::for_pr(&forge, &key(), "basesha");
+        let old_path = PathBuf::from("src/gone.rs");
+        // when
+        let _ = provider
+            .fetch_context_lines(Some(&old_path), None, FileStatus::Deleted, 1, 1)
+            .unwrap();
+        // then
+        let seen = forge.seen.borrow();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].side, ForgeFileSide::Base);
+        assert_eq!(seen[0].sha(), "basesha");
+        assert_eq!(seen[0].path, PathBuf::from("src/gone.rs"));
+    }
+
+    #[test]
+    fn should_pick_old_path_for_rename_base_side() {
+        // when called for a renamed file's base side (we'd never call that in
+        // expansion today, but the helper must do it), the old path wins.
+        let old = PathBuf::from("old.rs");
+        let new = PathBuf::from("new.rs");
+        assert_eq!(
+            ForgeFileLinesRequest::path_for_side(ForgeFileSide::Base, Some(&old), Some(&new),),
+            Some(old.clone()),
+        );
+        assert_eq!(
+            ForgeFileLinesRequest::path_for_side(ForgeFileSide::Head, Some(&old), Some(&new),),
+            Some(new),
+        );
+    }
+
+    #[test]
+    fn should_short_circuit_when_path_missing() {
+        // given a file with no paths at all (degenerate case)
+        let forge = CapturingForge {
+            seen: RefCell::new(Vec::new()),
+            response: vec![make_line("x")],
+        };
+        let provider = ForgeContextProvider::for_pr(&forge, &key(), "basesha");
+        // when
+        let result = provider
+            .fetch_context_lines(None, None, FileStatus::Modified, 1, 5)
+            .unwrap();
+        // then — empty result, no backend call
+        assert!(result.is_empty());
+        assert!(forge.seen.borrow().is_empty());
+    }
+}

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -1,10 +1,12 @@
 use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::forge::traits::{
-    ForgeBackend, ForgeRepository, PagedPullRequests, PullRequestDetails, PullRequestListQuery,
-    PullRequestTarget,
+    ForgeBackend, ForgeFileLinesRequest, ForgeRepository, PagedPullRequests, PullRequestDetails,
+    PullRequestListQuery, PullRequestTarget,
 };
+use crate::model::{DiffLine, LineOrigin};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 
 use super::models::{GhPullRequestDetails, GhPullRequestSummary};
@@ -53,10 +55,37 @@ impl From<CommandOutputError> for GhCommandError {
     }
 }
 
+/// Read a git blob from a checkout at `repo_root` using `git show <sha>:<path>`.
+/// Returns `None` if the object is missing or the command fails for any reason.
+fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
+    let spec = format!("{}:{}", sha, path.to_string_lossy());
+    let exists = run_command_output(
+        "git",
+        Some(repo_root),
+        ["cat-file", "-e", spec.as_str()]
+            .iter()
+            .map(|s| OsStr::new(*s)),
+    );
+    if exists.is_err() {
+        return None;
+    }
+    run_command_output(
+        "git",
+        Some(repo_root),
+        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
+    )
+    .ok()
+}
+
 #[derive(Debug, Clone)]
 pub struct GitHubGhBackend<R = SystemGhRunner> {
     default_repository: Option<ForgeRepository>,
     runner: R,
+    /// Optional path to a local checkout. When present, the backend may
+    /// satisfy `fetch_file_lines` from local git objects before falling back
+    /// to `gh api`. It is **never** used as the source of truth for PR
+    /// contents; the source of truth is always GitHub.
+    local_checkout: Option<PathBuf>,
 }
 
 impl GitHubGhBackend<SystemGhRunner> {
@@ -64,7 +93,13 @@ impl GitHubGhBackend<SystemGhRunner> {
         Self {
             default_repository,
             runner: SystemGhRunner,
+            local_checkout: None,
         }
+    }
+
+    pub fn with_local_checkout(mut self, checkout: Option<PathBuf>) -> Self {
+        self.local_checkout = checkout;
+        self
     }
 }
 
@@ -76,7 +111,16 @@ where
         Self {
             default_repository,
             runner,
+            local_checkout: None,
         }
+    }
+
+    pub fn set_local_checkout(&mut self, checkout: Option<PathBuf>) {
+        self.local_checkout = checkout;
+    }
+
+    pub fn local_checkout(&self) -> Option<&Path> {
+        self.local_checkout.as_deref()
     }
 
     fn resolve_repository(&self, target: &PullRequestTarget) -> Result<ForgeRepository> {
@@ -171,6 +215,86 @@ where
             &pr.repository.host,
         )
     }
+
+    fn local_checkout_path(&self) -> Option<PathBuf> {
+        self.local_checkout.clone()
+    }
+
+    fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
+        if request.start_line == 0 || request.start_line > request.end_line {
+            return Ok(Vec::new());
+        }
+
+        // Local optimization: read the blob from a configured checkout when
+        // we have it. The PR's exact SHAs may or may not be present locally;
+        // we silently fall back if they aren't.
+        let local_content = self
+            .local_checkout
+            .as_deref()
+            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
+
+        let content = if let Some(content) = local_content {
+            content
+        } else {
+            self.fetch_file_via_api(&request)?
+        };
+
+        Ok(slice_to_diff_lines(
+            &content,
+            request.start_line,
+            request.end_line,
+        ))
+    }
+}
+
+impl<R> GitHubGhBackend<R>
+where
+    R: GhCommandRunner,
+{
+    fn fetch_file_via_api(&self, request: &ForgeFileLinesRequest) -> Result<String> {
+        // `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>` returns a
+        // JSON object with base64-encoded `content` for text files. The
+        // `Accept: application/vnd.github.raw` header skips JSON wrapping
+        // and returns raw bytes, which we use here to keep parsing simple
+        // and binary-safe (callers already gate binary files out).
+        let path_str = request.path.to_string_lossy().replace('\\', "/");
+        let endpoint = format!(
+            "repos/{}/{}/contents/{}?ref={}",
+            request.repository.owner,
+            request.repository.name,
+            path_str,
+            request.sha(),
+        );
+        let mut args = vec![
+            "api".to_string(),
+            "-H".to_string(),
+            "Accept: application/vnd.github.raw".to_string(),
+        ];
+        if request.repository.host != "github.com" {
+            args.push("--hostname".to_string());
+            args.push(request.repository.host.clone());
+        }
+        args.push(endpoint);
+        self.run_gh(args, &request.repository.host)
+    }
+}
+
+fn slice_to_diff_lines(content: &str, start_line: u32, end_line: u32) -> Vec<DiffLine> {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut result = Vec::new();
+    for line_num in start_line..=end_line {
+        let idx = (line_num - 1) as usize;
+        if idx < lines.len() {
+            result.push(DiffLine {
+                origin: LineOrigin::Context,
+                content: lines[idx].to_string(),
+                old_lineno: Some(line_num),
+                new_lineno: Some(line_num),
+                highlighted_spans: None,
+            });
+        }
+    }
+    result
 }
 
 pub fn parse_pull_request_target(input: &str) -> Result<PullRequestTarget> {
@@ -358,6 +482,20 @@ fn malformed_target<T>(input: &str) -> Result<T> {
     Err(TuicrError::Forge(format!(
         "Malformed GitHub pull request target: `{input}`"
     )))
+}
+
+#[cfg(test)]
+pub(crate) mod tests_fixture {
+    pub const SIMPLE_PATCH: &str = r##"diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ pub fn answer() -> u32 {
+-    41
++    42
+ }
+"##;
 }
 
 #[cfg(test)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -5,7 +5,9 @@
 //! instead of shelling out to forge-specific tools directly.
 #![allow(dead_code)]
 
+pub mod context;
 pub mod github;
+pub mod pr_open;
 pub mod selector;
 pub mod traits;
 

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -41,13 +41,32 @@ pub fn open_pull_request(
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
+    let (details, patch) = fetch_pr_data(backend, target)?;
+    prepare_open_pr(details, &patch, local_checkout, highlighter)
+}
+
+/// Network-only half of the PR open path: fetch PR metadata and the raw
+/// patch text. Safe to run on a background thread because it does no
+/// syntax parsing and holds nothing that isn't `Send`.
+pub fn fetch_pr_data(
+    backend: &dyn ForgeBackend,
+    target: PullRequestTarget,
+) -> Result<(PullRequestDetails, String)> {
     let details = backend.get_pull_request(target)?;
     let patch = backend.get_pull_request_diff(&details)?;
+    Ok((details, patch))
+}
 
-    // Parse the patch through the existing Git-style diff parser. An empty
-    // PR (no file changes) returns NoChanges — surface that with a clearer
-    // message so the CLI doesn't print "No staged or unstaged changes".
-    let parsed = match parse_unified_diff(&patch, DiffFormat::GitStyle, highlighter) {
+/// CPU-only half of the PR open path: parse the patch, apply
+/// `.tuicrignore`, and build the session. Runs on the main thread because
+/// `SyntaxHighlighter` is not trivially `Send`-cloneable.
+pub fn prepare_open_pr(
+    details: PullRequestDetails,
+    patch: &str,
+    local_checkout: Option<&Path>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<OpenedPullRequest> {
+    let parsed = match parse_unified_diff(patch, DiffFormat::GitStyle, highlighter) {
         Ok(files) => files,
         Err(TuicrError::NoChanges) => {
             return Err(TuicrError::Forge(format!(

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -1,0 +1,307 @@
+//! PR open path.
+//!
+//! Given a `ForgeBackend` and a `PullRequestTarget`, produce the materials
+//! the App needs to enter PR review mode: parsed diff files, a session, and
+//! a `PrSessionKey` that scopes persistence and remote context fetches.
+//!
+//! Key invariants enforced here:
+//! - The current local checkout is never treated as the source of truth.
+//!   Diffs are parsed from `gh pr diff`; SHAs are captured from PR metadata.
+//! - `.tuicrignore` is applied only when the caller supplies a local
+//!   checkout path. Outside a checkout, the unfiltered diff is shown.
+//! - No checkout mutation. We never spawn `git checkout/fetch/reset/stash`
+//!   or branch-creation commands here.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Result, TuicrError};
+use crate::forge::traits::{ForgeBackend, PrSessionKey, PullRequestDetails, PullRequestTarget};
+use crate::model::{DiffFile, FileStatus, ReviewSession, SessionDiffSource};
+use crate::syntax::SyntaxHighlighter;
+use crate::tuicrignore;
+use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
+
+/// Everything the App needs to enter PR review mode.
+#[derive(Debug)]
+pub struct OpenedPullRequest {
+    pub details: PullRequestDetails,
+    pub diff_files: Vec<DiffFile>,
+    pub session: ReviewSession,
+    pub key: PrSessionKey,
+}
+
+/// Open a PR target through a forge backend and prepare review state.
+///
+/// `local_checkout` is optional: when provided, `.tuicrignore` rules at the
+/// root are applied. When absent (PR opened via URL outside a checkout, or
+/// for a different repo), no filtering happens.
+pub fn open_pull_request(
+    backend: &dyn ForgeBackend,
+    target: PullRequestTarget,
+    local_checkout: Option<&Path>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<OpenedPullRequest> {
+    let details = backend.get_pull_request(target)?;
+    let patch = backend.get_pull_request_diff(&details)?;
+
+    // Parse the patch through the existing Git-style diff parser. An empty
+    // PR (no file changes) returns NoChanges — surface that with a clearer
+    // message so the CLI doesn't print "No staged or unstaged changes".
+    let parsed = match parse_unified_diff(&patch, DiffFormat::GitStyle, highlighter) {
+        Ok(files) => files,
+        Err(TuicrError::NoChanges) => {
+            return Err(TuicrError::Forge(format!(
+                "Pull request #{} has no file changes",
+                details.number
+            )));
+        }
+        Err(e) => return Err(e),
+    };
+
+    let diff_files = match local_checkout {
+        Some(root) => tuicrignore::filter_diff_files(root, parsed),
+        None => parsed,
+    };
+
+    let key = PrSessionKey::from_details(&details);
+    let session = build_session(&details, &key, &diff_files);
+
+    Ok(OpenedPullRequest {
+        details,
+        diff_files,
+        session,
+        key,
+    })
+}
+
+fn build_session(
+    details: &PullRequestDetails,
+    key: &PrSessionKey,
+    diff_files: &[DiffFile],
+) -> ReviewSession {
+    // The session's repo_path is purely a presentation/identity slot for PR
+    // sessions. We use a virtual path so PR sessions don't collide with
+    // local sessions stored under the same on-disk repo root.
+    let repo_path = pr_session_repo_path(key);
+    let branch_name = Some(details.head_ref_name.clone());
+    let mut session = ReviewSession::new(
+        repo_path,
+        details.head_sha.clone(),
+        branch_name,
+        SessionDiffSource::PullRequest,
+    );
+    session.pr_session_key = Some(key.clone());
+    for file in diff_files {
+        let path: PathBuf = file.display_path().clone();
+        let status: FileStatus = file.status;
+        session.add_file(path, status, file.content_hash);
+    }
+    session
+}
+
+/// Synthetic path used as `ReviewSession::repo_path` for PR sessions.
+/// Keeps PR session filenames distinct from local sessions and conveys
+/// enough identity (`forge:host/owner/repo`) for humans inspecting the
+/// reviews directory.
+pub fn pr_session_repo_path(key: &PrSessionKey) -> PathBuf {
+    PathBuf::from(format!(
+        "forge:{}/{}/{}",
+        key.repository.host, key.repository.owner, key.repository.name,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::traits::{
+        ForgeFileLinesRequest, ForgeRepository, PagedPullRequests, PullRequestDetails,
+        PullRequestListQuery,
+    };
+    use crate::model::DiffLine;
+    use chrono::Utc;
+    use std::cell::RefCell;
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    fn details() -> PullRequestDetails {
+        PullRequestDetails {
+            repository: repo(),
+            number: 125,
+            title: "Review workflow".to_string(),
+            url: "https://github.com/agavra/tuicr/pull/125".to_string(),
+            state: "OPEN".to_string(),
+            is_draft: false,
+            author: Some("alice".to_string()),
+            head_ref_name: "reviews".to_string(),
+            base_ref_name: "main".to_string(),
+            head_sha: "abcdef0123456789".to_string(),
+            base_sha: "1234567890abcdef".to_string(),
+            body: "body".to_string(),
+            updated_at: Some(Utc::now()),
+            closed: false,
+            merged_at: None,
+        }
+    }
+
+    struct StaticBackend {
+        details: PullRequestDetails,
+        patch: String,
+        calls: RefCell<Vec<&'static str>>,
+    }
+
+    impl ForgeBackend for StaticBackend {
+        fn list_pull_requests(&self, _query: PullRequestListQuery) -> Result<PagedPullRequests> {
+            unimplemented!()
+        }
+        fn get_pull_request(&self, _target: PullRequestTarget) -> Result<PullRequestDetails> {
+            self.calls.borrow_mut().push("get_pull_request");
+            Ok(self.details.clone())
+        }
+        fn get_pull_request_diff(&self, _pr: &PullRequestDetails) -> Result<String> {
+            self.calls.borrow_mut().push("get_pull_request_diff");
+            Ok(self.patch.clone())
+        }
+        fn fetch_file_lines(&self, _req: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
+            unimplemented!()
+        }
+    }
+
+    const SIMPLE_PATCH: &str = r##"diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ pub fn answer() -> u32 {
+-    41
++    42
+ }
+"##;
+
+    #[test]
+    fn should_parse_pr_diff_and_build_session_keyed_by_head_sha() {
+        // given
+        let backend = StaticBackend {
+            details: details(),
+            patch: SIMPLE_PATCH.to_string(),
+            calls: RefCell::new(Vec::new()),
+        };
+        let target = PullRequestTarget::with_repository(repo(), 125, "125");
+        let highlighter = SyntaxHighlighter::default();
+        // when
+        let opened = open_pull_request(&backend, target, None, &highlighter).unwrap();
+        // then
+        assert_eq!(opened.diff_files.len(), 1);
+        assert_eq!(opened.key.head_sha, "abcdef0123456789");
+        assert_eq!(opened.key.number, 125);
+        assert_eq!(opened.session.diff_source, SessionDiffSource::PullRequest);
+        assert_eq!(
+            opened.session.pr_session_key.as_ref().map(|k| k.number),
+            Some(125),
+        );
+        assert_eq!(
+            opened.session.repo_path,
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+        );
+        // and — both forge calls were made, in order
+        assert_eq!(
+            backend.calls.borrow().as_slice(),
+            &["get_pull_request", "get_pull_request_diff"],
+        );
+    }
+
+    /// Patch fixture covering add/modify/delete/rename in a single PR
+    /// diff, mirroring what `gh pr diff --patch --color never` would
+    /// emit. Acts as a regression guard against future changes to the
+    /// shared diff parser.
+    const MULTI_STATUS_PATCH: &str = r##"diff --git a/added.rs b/added.rs
+new file mode 100644
+index 0000000..abc1234
+--- /dev/null
++++ b/added.rs
+@@ -0,0 +1,2 @@
++pub fn new_thing() {}
++
+diff --git a/modified.rs b/modified.rs
+index 1111111..2222222 100644
+--- a/modified.rs
++++ b/modified.rs
+@@ -1,3 +1,3 @@
+ pub fn answer() -> u32 {
+-    41
++    42
+ }
+diff --git a/deleted.rs b/deleted.rs
+deleted file mode 100644
+index 3333333..0000000
+--- a/deleted.rs
++++ /dev/null
+@@ -1,2 +0,0 @@
+-pub fn gone() {}
+-
+diff --git a/old_name.rs b/new_name.rs
+similarity index 100%
+rename from old_name.rs
+rename to new_name.rs
+"##;
+
+    #[test]
+    fn should_parse_multi_status_pr_patch_into_correct_diff_files() {
+        // given a backend serving a patch with add/modify/delete/rename
+        let backend = StaticBackend {
+            details: details(),
+            patch: MULTI_STATUS_PATCH.to_string(),
+            calls: RefCell::new(Vec::new()),
+        };
+        let target = PullRequestTarget::with_repository(repo(), 125, "125");
+        let highlighter = SyntaxHighlighter::default();
+        // when
+        let opened = open_pull_request(&backend, target, None, &highlighter).unwrap();
+        // then — all four files are recognized with correct statuses
+        assert_eq!(opened.diff_files.len(), 4);
+        let statuses: Vec<(String, crate::model::FileStatus)> = opened
+            .diff_files
+            .iter()
+            .map(|f| (f.display_path().to_string_lossy().into_owned(), f.status))
+            .collect();
+        // Order is not guaranteed by the parser, so look up by name.
+        let by_name: std::collections::HashMap<_, _> = statuses.into_iter().collect();
+        assert_eq!(
+            by_name.get("added.rs"),
+            Some(&crate::model::FileStatus::Added)
+        );
+        assert_eq!(
+            by_name.get("modified.rs"),
+            Some(&crate::model::FileStatus::Modified)
+        );
+        assert_eq!(
+            by_name.get("deleted.rs"),
+            Some(&crate::model::FileStatus::Deleted)
+        );
+        assert_eq!(
+            by_name.get("new_name.rs"),
+            Some(&crate::model::FileStatus::Renamed)
+        );
+    }
+
+    #[test]
+    fn should_surface_empty_pr_as_forge_error() {
+        // given a PR with no file changes (empty patch)
+        let backend = StaticBackend {
+            details: details(),
+            patch: String::new(),
+            calls: RefCell::new(Vec::new()),
+        };
+        let target = PullRequestTarget::with_repository(repo(), 125, "125");
+        let highlighter = SyntaxHighlighter::default();
+        // when
+        let err = open_pull_request(&backend, target, None, &highlighter).unwrap_err();
+        // then
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Pull request #125 has no file changes"),
+            "unexpected error message: {msg}"
+        );
+    }
+}

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -1,7 +1,9 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 use crate::error::Result;
+use crate::model::{DiffLine, FileStatus};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -134,10 +136,205 @@ impl PullRequestDetails {
     pub fn is_read_only(&self) -> bool {
         self.closed || self.merged_at.is_some()
     }
+
+    pub fn read_only_reason(&self) -> Option<&'static str> {
+        if self.merged_at.is_some() {
+            Some("merged")
+        } else if self.closed {
+            Some("closed")
+        } else {
+            None
+        }
+    }
+}
+
+/// Stable identity for a PR review session.
+///
+/// Sessions are keyed by forge kind + host + owner/repo + PR number + head
+/// SHA per the spec. Two opens of the same PR at the same head SHA must
+/// produce equal keys so persistence reattaches local comments and reviewed
+/// markers; a PR that advances to a new head opens a new session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrSessionKey {
+    pub repository: ForgeRepository,
+    pub number: u64,
+    pub head_sha: String,
+}
+
+impl PrSessionKey {
+    pub fn new(repository: ForgeRepository, number: u64, head_sha: impl Into<String>) -> Self {
+        Self {
+            repository,
+            number,
+            head_sha: head_sha.into(),
+        }
+    }
+
+    pub fn from_details(details: &PullRequestDetails) -> Self {
+        Self::new(
+            details.repository.clone(),
+            details.number,
+            details.head_sha.clone(),
+        )
+    }
+
+    /// Short, human-recognizable head SHA prefix used in filenames and UI.
+    pub fn short_head(&self) -> String {
+        self.head_sha
+            .chars()
+            .take(8.min(self.head_sha.len()))
+            .collect()
+    }
+}
+
+/// Which side of a pull request diff the caller wants to read from.
+///
+/// Maps to a concrete SHA + path: for added/modified/copied/renamed files
+/// the caller wants the head side; for deleted files the base side. Renames
+/// pick the old path on the base side and the new path on the head side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ForgeFileSide {
+    Base,
+    Head,
+}
+
+/// A single request to read file lines from a forge for context expansion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgeFileLinesRequest {
+    pub repository: ForgeRepository,
+    /// Base SHA captured when the PR was opened.
+    pub base_sha: String,
+    /// Head SHA captured when the PR was opened.
+    pub head_sha: String,
+    /// File path relative to the repository root.
+    pub path: PathBuf,
+    /// File status, used to choose the appropriate side without forcing the
+    /// caller to also compute it. Renames use `Renamed`; `path` should already
+    /// reflect the chosen side.
+    pub status: FileStatus,
+    /// Which side to read from. The caller is responsible for picking the
+    /// right side per the spec mapping rules.
+    pub side: ForgeFileSide,
+    /// Inclusive 1-based line range. Caller is responsible for clamping.
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+impl ForgeFileLinesRequest {
+    /// Resolve the side and path for a given file based on its status.
+    /// Helper for callers that have a `DiffFile` and want to fetch context.
+    pub fn side_for_status(status: FileStatus) -> ForgeFileSide {
+        match status {
+            FileStatus::Deleted => ForgeFileSide::Base,
+            FileStatus::Added | FileStatus::Modified | FileStatus::Renamed | FileStatus::Copied => {
+                ForgeFileSide::Head
+            }
+        }
+    }
+
+    /// Pick the right path for a forge fetch given old/new paths and the
+    /// side. Renamed files use `old_path` on the base side, `new_path` on
+    /// the head side.
+    pub fn path_for_side(
+        side: ForgeFileSide,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+    ) -> Option<PathBuf> {
+        match side {
+            ForgeFileSide::Base => old_path.or(new_path).cloned(),
+            ForgeFileSide::Head => new_path.or(old_path).cloned(),
+        }
+    }
+
+    /// Return the SHA matching `side`.
+    pub fn sha(&self) -> &str {
+        match self.side {
+            ForgeFileSide::Base => &self.base_sha,
+            ForgeFileSide::Head => &self.head_sha,
+        }
+    }
 }
 
 pub trait ForgeBackend {
     fn list_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests>;
     fn get_pull_request(&self, target: PullRequestTarget) -> Result<PullRequestDetails>;
     fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String>;
+    /// Fetch the requested file lines from the forge for context expansion.
+    /// Implementations may optimize by reading from a local checkout when
+    /// available; the trait does not require that path.
+    fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>>;
+    /// Optional path to a local checkout the backend may consult as an
+    /// optimization. The default returns `None`; callers must never treat
+    /// this path as the source of truth for PR contents.
+    fn local_checkout_path(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_round_trip_pr_session_key_via_serde() {
+        // given
+        let key = PrSessionKey::new(
+            ForgeRepository::github("github.com", "agavra", "tuicr"),
+            125,
+            "abcdef0123456789".to_string(),
+        );
+        // when
+        let serialized = serde_json::to_string(&key).unwrap();
+        let restored: PrSessionKey = serde_json::from_str(&serialized).unwrap();
+        // then
+        assert_eq!(key, restored);
+    }
+
+    #[test]
+    fn should_truncate_long_head_sha_for_short_head() {
+        // given
+        let key = PrSessionKey::new(
+            ForgeRepository::github("github.com", "a", "b"),
+            1,
+            "1234567890abcdef1234567890abcdef".to_string(),
+        );
+        // when/then
+        assert_eq!(key.short_head(), "12345678");
+    }
+
+    #[test]
+    fn should_handle_short_head_sha_gracefully() {
+        // given
+        let key = PrSessionKey::new(
+            ForgeRepository::github("github.com", "a", "b"),
+            1,
+            "abc".to_string(),
+        );
+        // when/then
+        assert_eq!(key.short_head(), "abc");
+    }
+
+    #[test]
+    fn should_pick_head_side_for_added_modified_renamed_copied() {
+        for status in [
+            FileStatus::Added,
+            FileStatus::Modified,
+            FileStatus::Renamed,
+            FileStatus::Copied,
+        ] {
+            assert_eq!(
+                ForgeFileLinesRequest::side_for_status(status),
+                ForgeFileSide::Head,
+                "{status:?} should pick head"
+            );
+        }
+    }
+
+    #[test]
+    fn should_pick_base_side_for_deleted_files() {
+        assert_eq!(
+            ForgeFileLinesRequest::side_for_status(FileStatus::Deleted),
+            ForgeFileSide::Base,
+        );
+    }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -359,18 +359,33 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                     }
                     Err(e) => app.set_error(format!("Save failed: {e}")),
                 },
-                "e" | "reload" => match app.reload_diff_files() {
-                    Ok((count, invalidated)) => {
-                        if invalidated > 0 {
-                            app.set_message(format!(
-                                "Reloaded {count} files, {invalidated} changed since last review"
-                            ));
-                        } else {
-                            app.set_message(format!("Reloaded {count} files"));
+                "e" | "reload" => {
+                    if matches!(app.diff_source, app::DiffSource::PullRequest(_)) {
+                        match app.reload_pull_request() {
+                            Ok(true) => {
+                                app.set_message(
+                                    "Reloaded PR at new head — switched to fresh session"
+                                        .to_string(),
+                                );
+                            }
+                            Ok(false) => app.set_message("PR is already at the latest head"),
+                            Err(e) => app.set_error(format!("Reload failed: {e}")),
+                        }
+                    } else {
+                        match app.reload_diff_files() {
+                            Ok((count, invalidated)) => {
+                                if invalidated > 0 {
+                                    app.set_message(format!(
+                                        "Reloaded {count} files, {invalidated} changed since last review"
+                                    ));
+                                } else {
+                                    app.set_message(format!("Reloaded {count} files"));
+                                }
+                            }
+                            Err(e) => app.set_error(format!("Reload failed: {e}")),
                         }
                     }
-                    Err(e) => app.set_error(format!("Reload failed: {e}")),
-                },
+                }
                 "clip" | "export" => handle_export(app),
                 "clear" => app.clear_comments(ClearScope::CommentsAndReviewed),
                 "clearc" => app.clear_comments(ClearScope::CommentsOnly),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -606,6 +606,13 @@ pub fn handle_commit_select_action(app: &mut App, action: Action) {
         Action::TargetSelectorTabPrev => app.cycle_target_tab(false),
         Action::Quit => app.should_quit = true,
         Action::ExitMode => {
+            // Esc during an in-flight PR open aborts the load and stays
+            // in the selector. Takes precedence over the
+            // commit-selection-range exit so the user isn't stuck staring
+            // at a spinner.
+            if app.cancel_pr_open() {
+                return;
+            }
             if app.commit_selection_range.is_none() {
                 return;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,7 @@ fn main() -> anyhow::Result<()> {
 
         app.clear_expired_message();
         app.poll_pr_load_events();
+        app.poll_pr_open_events();
 
         // Render
         terminal.draw(|frame| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,9 +185,15 @@ fn main() -> anyhow::Result<()> {
         }
         Err(e) => {
             eprintln!("Error: {e}");
-            eprintln!(
-                "\nMake sure you're in a git, jujutsu, or mercurial repository with commits or staged/unstaged changes."
-            );
+            // The "you need to be in a git repo" hint is only meaningful
+            // when the failure was the absence of a repo. For other
+            // startup errors — `tuicr pr <bad-url>`, forge auth issues,
+            // missing PR, `--file <missing-path>` — the hint is wrong.
+            if matches!(e, crate::error::TuicrError::NotARepository) {
+                eprintln!(
+                    "\nMake sure you're in a git, jujutsu, or mercurial repository with commits or staged/unstaged changes."
+                );
+            }
             std::process::exit(1);
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,6 +174,7 @@ fn main() -> anyhow::Result<()> {
                 path_filter: cli_args.path_filter.as_deref(),
                 file_path: cli_args.file_path.as_deref(),
                 git_backend_preference,
+                pr_target: cli_args.pr_target.as_deref(),
             },
         )
     }) {

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use super::comment::Comment;
 use super::diff_types::FileStatus;
+use crate::forge::traits::PrSessionKey;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClearScope {
@@ -60,6 +61,10 @@ pub enum SessionDiffSource {
     CommitRange,
     WorkingTreeAndCommits,
     StagedUnstagedAndCommits,
+    /// Remote pull request review. Per-PR identity lives in
+    /// `ReviewSession::pr_session_key`; this variant is a discriminator so
+    /// the persistence layer can route to PR-specific filename construction.
+    PullRequest,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -74,6 +79,10 @@ pub struct ReviewSession {
     pub diff_source: SessionDiffSource,
     #[serde(default)]
     pub commit_range: Option<Vec<String>>,
+    /// Identity for PR-mode sessions. `None` for local sessions. Default is
+    /// `None` so existing local session JSON deserializes unchanged.
+    #[serde(default)]
+    pub pr_session_key: Option<PrSessionKey>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     #[serde(default)]
@@ -98,6 +107,7 @@ impl ReviewSession {
             base_commit,
             diff_source,
             commit_range: None,
+            pr_session_key: None,
             created_at: now,
             updated_at: now,
             review_comments: Vec::new(),
@@ -342,6 +352,60 @@ mod tests {
 
         let file = session.files.get(&path).unwrap();
         assert_eq!(file.content_hash, Some(200));
+    }
+
+    /// Snapshot of a session JSON produced before PR 3 landed. New fields
+    /// must deserialize with defaults; this guards against accidental
+    /// breaking changes to the on-disk format.
+    const LEGACY_SESSION_JSON: &str = r##"{
+        "id": "abc-uuid",
+        "version": "1.2",
+        "repo_path": "/tmp/test-repo",
+        "branch_name": "main",
+        "base_commit": "deadbeef",
+        "diff_source": "working_tree",
+        "created_at": "2026-05-01T12:00:00Z",
+        "updated_at": "2026-05-01T12:00:00Z",
+        "review_comments": [],
+        "files": {},
+        "session_notes": null
+    }"##;
+
+    #[test]
+    fn should_deserialize_pre_pr3_session_without_breakage() {
+        // given a session JSON from before PR 3 landed
+        // when
+        let session: ReviewSession =
+            serde_json::from_str(LEGACY_SESSION_JSON).expect("legacy session should parse");
+        // then — new fields default to None / their default and identity is preserved
+        assert_eq!(session.id, "abc-uuid");
+        assert_eq!(session.base_commit, "deadbeef");
+        assert_eq!(session.diff_source, SessionDiffSource::WorkingTree);
+        assert!(session.pr_session_key.is_none());
+        assert!(session.commit_range.is_none());
+    }
+
+    #[test]
+    fn should_round_trip_pr_session_via_serde() {
+        // given
+        let mut session = ReviewSession::new(
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+            "abcdef0123456789".to_string(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        let key = PrSessionKey::new(
+            crate::forge::traits::ForgeRepository::github("github.com", "agavra", "tuicr"),
+            125,
+            "abcdef0123456789".to_string(),
+        );
+        session.pr_session_key = Some(key.clone());
+        // when
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: ReviewSession = serde_json::from_str(&json).unwrap();
+        // then
+        assert_eq!(restored.pr_session_key, Some(key));
+        assert_eq!(restored.diff_source, SessionDiffSource::PullRequest);
     }
 
     #[test]

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -139,6 +139,11 @@ fn review_scope_label(diff_source: &DiffSource) -> String {
         DiffSource::StagedUnstagedAndCommits(_) => {
             "selected commit range + staged/unstaged changes".to_string()
         }
+        DiffSource::PullRequest(pr) => format!(
+            "pull request {}#{}",
+            pr.key.repository.display_name(),
+            pr.key.number
+        ),
     };
 
     format!("Review Comment (scope: {scope})")
@@ -194,6 +199,19 @@ fn generate_markdown(
                 "Reviewing staged + unstaged + commits: {}",
                 short_ids.join(", ")
             );
+            let _ = writeln!(md);
+        }
+        DiffSource::PullRequest(pr) => {
+            let short = pr.key.short_head();
+            let _ = writeln!(
+                md,
+                "Reviewing pull request {}#{}: {}",
+                pr.key.repository.display_name(),
+                pr.key.number,
+                pr.title
+            );
+            let _ = writeln!(md, "URL: {}", pr.url);
+            let _ = writeln!(md, "Head: {short}");
             let _ = writeln!(md);
         }
     }

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,3 +1,3 @@
 pub mod storage;
 
-pub use storage::{load_latest_session_for_context, save_session};
+pub use storage::{load_latest_session_for_context, load_pr_session, save_session};

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::error::{Result, TuicrError};
+use crate::forge::traits::PrSessionKey;
 use crate::hash::fnv1a_64;
 use crate::model::ReviewSession;
 use crate::model::review::SessionDiffSource;
@@ -21,6 +22,11 @@ struct SessionFilenameParts {
 }
 
 fn parse_session_filename(filename: &str) -> Option<SessionFilenameParts> {
+    // PR sessions use a different layout; never treat them as local session
+    // candidates here.
+    if filename.starts_with("pr_github_") {
+        return None;
+    }
     let stem = filename.strip_suffix(".json")?;
     let parts: Vec<&str> = stem.split('_').collect();
 
@@ -129,6 +135,21 @@ fn normalize_repo_path(repo_path: &Path) -> String {
 }
 
 fn session_filename(session: &ReviewSession) -> String {
+    // PR sessions key by forge identity + PR number + head SHA so multiple
+    // PR opens of the same repo land in distinct files, and reopening the
+    // same PR at the same head reuses the same session.
+    if let Some(key) = session.pr_session_key.as_ref() {
+        let host = sanitize_filename_component(&key.repository.host);
+        let owner = sanitize_filename_component(&key.repository.owner);
+        let repo = sanitize_filename_component(&key.repository.name);
+        let short = sanitize_filename_component(&key.short_head());
+        let id_fragment = session.id.split('-').next().unwrap_or(&session.id);
+        return format!(
+            "pr_github_{}_{}_{}_{}_{}_{}.json",
+            host, owner, repo, key.number, short, id_fragment,
+        );
+    }
+
     let repo_name = session
         .repo_path
         .file_name()
@@ -149,6 +170,7 @@ fn session_filename(session: &ReviewSession) -> String {
         SessionDiffSource::CommitRange => "commits",
         SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
         SessionDiffSource::StagedUnstagedAndCommits => "staged_unstaged_and_commits",
+        SessionDiffSource::PullRequest => "pr",
     };
 
     let timestamp = session.created_at.format("%Y%m%d_%H%M%S");
@@ -178,6 +200,48 @@ pub fn load_session(path: &PathBuf) -> Result<ReviewSession> {
     Ok(session)
 }
 
+/// Look up the most recent persisted session for a PR keyed by forge identity,
+/// PR number, and head SHA. Returns `None` when no matching session exists.
+///
+/// PR sessions key only by identity; we deliberately do not consult mtime or
+/// other filename fields because reopening the same PR at the same head must
+/// restore the exact session that was last persisted for it.
+pub fn load_pr_session(key: &PrSessionKey) -> Result<Option<(PathBuf, ReviewSession)>> {
+    let reviews_dir = get_reviews_dir()?;
+    let entries = match fs::read_dir(&reviews_dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(TuicrError::Io(e)),
+    };
+
+    let mut best: Option<(PathBuf, ReviewSession)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(filename) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !filename.starts_with("pr_github_") || !filename.ends_with(".json") {
+            continue;
+        }
+        let Ok(session) = load_session(&path) else {
+            continue;
+        };
+        if session.pr_session_key.as_ref() == Some(key) {
+            // Keep the most recently updated entry when more than one exists
+            // (e.g. multiple draft saves in flight before cleanup).
+            let candidate_updated = session.updated_at;
+            let prefer_new = match best.as_ref() {
+                Some((_, current)) => candidate_updated > current.updated_at,
+                None => true,
+            };
+            if prefer_new {
+                best = Some((path, session));
+            }
+        }
+    }
+    Ok(best)
+}
+
 pub fn load_latest_session_for_context(
     repo_path: &Path,
     branch_name: Option<&str>,
@@ -195,6 +259,9 @@ pub fn load_latest_session_for_context(
         SessionDiffSource::CommitRange => "commits",
         SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
         SessionDiffSource::StagedUnstagedAndCommits => "staged_unstaged_and_commits",
+        // PR sessions are looked up via `load_pr_session`. If a caller asks
+        // for the local-session loader with this diff source, return nothing.
+        SessionDiffSource::PullRequest => return Ok(None),
     };
 
     let reviews_dir = get_reviews_dir()?;
@@ -918,5 +985,105 @@ mod tests {
             normalize_repo_path(&selected.repo_path),
             normalize_repo_path(&repo_a)
         );
+    }
+
+    fn pr_key(number: u64, head_sha: &str) -> PrSessionKey {
+        PrSessionKey::new(
+            crate::forge::traits::ForgeRepository::github("github.com", "agavra", "tuicr"),
+            number,
+            head_sha.to_string(),
+        )
+    }
+
+    fn pr_session(key: &PrSessionKey) -> ReviewSession {
+        let mut session = ReviewSession::new(
+            PathBuf::from(format!(
+                "forge:{}/{}/{}",
+                key.repository.host, key.repository.owner, key.repository.name
+            )),
+            key.head_sha.clone(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.pr_session_key = Some(key.clone());
+        session
+    }
+
+    #[test]
+    fn should_generate_pr_session_filename_keyed_by_identity_and_head() {
+        // given a PR session
+        let key = pr_key(125, "abcdef0123456789");
+        let session = pr_session(&key);
+        // when
+        let filename = session_filename(&session);
+        // then
+        assert!(filename.starts_with("pr_github_github.com_agavra_tuicr_125_abcdef01_"));
+        assert!(filename.ends_with(".json"));
+    }
+
+    #[test]
+    fn should_round_trip_pr_session_via_storage() {
+        let _guard = with_test_reviews_dir();
+        // given
+        let key = pr_key(125, "abcdef0123456789");
+        let session = pr_session(&key);
+        // when
+        let path = save_session(&session).unwrap();
+        let (loaded_path, loaded) = load_pr_session(&key).unwrap().unwrap();
+        // then
+        assert_eq!(loaded_path, path);
+        assert_eq!(loaded.pr_session_key.as_ref(), Some(&key));
+        assert_eq!(loaded.diff_source, SessionDiffSource::PullRequest);
+        let _ = delete_session(&path);
+    }
+
+    #[test]
+    fn should_return_none_when_no_session_matches_head_sha() {
+        let _guard = with_test_reviews_dir();
+        // given a session at old head
+        let old_key = pr_key(125, "abcdef0123456789");
+        let _ = save_session(&pr_session(&old_key)).unwrap();
+        // when looking up a new head
+        let new_key = pr_key(125, "9999999999999999");
+        let loaded = load_pr_session(&new_key).unwrap();
+        // then
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn should_skip_pr_files_when_loading_local_session() {
+        let _guard = with_test_reviews_dir();
+        // given a saved PR session and no local sessions
+        let key = pr_key(125, "abcdef0123456789");
+        let _ = save_session(&pr_session(&key)).unwrap();
+        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&repo_path).unwrap();
+        // when asking for a local working-tree session
+        let loaded = load_latest_session_for_context(
+            &repo_path,
+            Some("main"),
+            "head",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap();
+        // then PR sessions are not surfaced to the local loader
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn should_keep_pr_sessions_separate_per_pr_number() {
+        let _guard = with_test_reviews_dir();
+        // given two PR sessions for different numbers
+        let key_a = pr_key(125, "abcdef0123456789");
+        let key_b = pr_key(148, "abcdef0123456789");
+        let _ = save_session(&pr_session(&key_a)).unwrap();
+        let _ = save_session(&pr_session(&key_b)).unwrap();
+        // when
+        let loaded_a = load_pr_session(&key_a).unwrap().unwrap();
+        let loaded_b = load_pr_session(&key_b).unwrap().unwrap();
+        // then each load returns its matching PR
+        assert_eq!(loaded_a.1.pr_session_key.as_ref(), Some(&key_a));
+        assert_eq!(loaded_b.1.pr_session_key.as_ref(), Some(&key_b));
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1369,6 +1369,8 @@ pub struct CliArgs {
     pub path_filter: Option<String>,
     /// Open a single file for annotation (no VCS required)
     pub file_path: Option<String>,
+    /// Direct pull request target from `tuicr pr <target>`.
+    pub pr_target: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1753,6 +1755,22 @@ pub fn parse_cli_args() -> CliArgs {
 
 fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
     let mut cli_args = CliArgs::default();
+
+    // Subcommand form: `tuicr pr <target>`. We special-case it before the
+    // flag loop because `pr` is a positional token, not a flag. Only the
+    // first positional position counts; subsequent arguments after the
+    // target are treated as ordinary flags (theme, appearance, etc).
+    if args.len() >= 2 && args[1] == "pr" {
+        let target = args.get(2).ok_or_else(|| {
+            "tuicr pr requires a target: <number>, <owner/repo#N>, or a PR URL".to_string()
+        })?;
+        if target.starts_with('-') {
+            return Err(
+                "tuicr pr requires a target: <number>, <owner/repo#N>, or a PR URL".to_string(),
+            );
+        }
+        cli_args.pr_target = Some(target.clone());
+    }
 
     for i in 0..args.len() {
         // Handle --version / -V
@@ -2285,5 +2303,68 @@ mod tests {
             .expect("parse should succeed");
         assert_eq!(parsed.path_filter, Some("src/".to_string()));
         assert_eq!(parsed.revisions, Some("HEAD~3..".to_string()));
+    }
+
+    #[test]
+    fn should_parse_pr_target_as_bare_number() {
+        // given/when
+        let parsed = parse_for_test(&["tuicr", "pr", "125"]).expect("parse should succeed");
+        // then
+        assert_eq!(parsed.pr_target, Some("125".to_string()));
+    }
+
+    #[test]
+    fn should_parse_pr_target_as_owner_repo_hash() {
+        // given/when
+        let parsed =
+            parse_for_test(&["tuicr", "pr", "agavra/tuicr#125"]).expect("parse should succeed");
+        // then
+        assert_eq!(parsed.pr_target, Some("agavra/tuicr#125".to_string()));
+    }
+
+    #[test]
+    fn should_parse_pr_target_as_full_url() {
+        // given/when
+        let parsed = parse_for_test(&["tuicr", "pr", "https://github.com/agavra/tuicr/pull/125"])
+            .expect("parse should succeed");
+        // then
+        assert_eq!(
+            parsed.pr_target,
+            Some("https://github.com/agavra/tuicr/pull/125".to_string()),
+        );
+    }
+
+    #[test]
+    fn should_error_when_pr_target_is_missing() {
+        // given/when
+        let err = parse_for_test(&["tuicr", "pr"]).expect_err("parse should fail");
+        // then
+        assert!(err.contains("tuicr pr requires a target"));
+    }
+
+    #[test]
+    fn should_error_when_pr_target_looks_like_flag() {
+        // given/when
+        let err = parse_for_test(&["tuicr", "pr", "--theme"]).expect_err("parse should fail");
+        // then
+        assert!(err.contains("tuicr pr requires a target"));
+    }
+
+    #[test]
+    fn should_combine_pr_target_with_theme_flag() {
+        // given/when — flag arguments still apply after the PR target.
+        let parsed = parse_for_test(&["tuicr", "pr", "125", "--theme", "dark"])
+            .expect("parse should succeed");
+        // then
+        assert_eq!(parsed.pr_target, Some("125".to_string()));
+        assert_eq!(parsed.theme, Some(ThemeArg::Dark));
+    }
+
+    #[test]
+    fn should_leave_pr_target_none_when_no_pr_subcommand() {
+        // given/when
+        let parsed = parse_for_test(&["tuicr"]).expect("parse should succeed");
+        // then
+        assert_eq!(parsed.pr_target, None);
     }
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -428,7 +428,9 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  :e        ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Reload diff files"),
+            Span::raw(
+                "Reload diff files (in PR mode: refetch PR; switches session if head SHA advanced)",
+            ),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -363,11 +363,32 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
         return;
     }
 
+    // Pre-compute the spinner glyph once per draw so it animates without
+    // per-row recalculation. Held outside the loop because Rust's borrow
+    // rules around `app` are simpler that way.
+    let spinner = app
+        .pr_open_state
+        .as_ref()
+        .map(|s| pr_open_spinner_glyph(s.started_at.elapsed()));
+
     let mut lines: Vec<Line> = Vec::new();
     for (i, row) in view.rows.iter().enumerate() {
         let is_cursor = i == view.cursor;
-        let pointer = if is_cursor { "> " } else { "  " };
-        let pointer_style = if is_cursor {
+        let is_loading = matches!(
+            (spinner, app.pr_open_state.as_ref()),
+            (Some(_), Some(s)) if s.matches(&row.summary.repository, row.summary.number)
+        );
+        // Spinner glyph replaces the cursor pointer (per design A): the
+        // row's leading character means "this is the active thing" in
+        // both the navigation and loading states.
+        let pointer_str = if is_loading {
+            format!("{} ", spinner.unwrap_or("⠋"))
+        } else if is_cursor {
+            "> ".to_string()
+        } else {
+            "  ".to_string()
+        };
+        let pointer_style = if is_loading || is_cursor {
             styles::selected_style(theme)
         } else {
             Style::default().fg(theme.fg_secondary)
@@ -383,7 +404,7 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
         let draft = if row.summary.is_draft { " [draft]" } else { "" };
 
         let line = Line::from(vec![
-            Span::styled(pointer, pointer_style),
+            Span::styled(pointer_str, pointer_style),
             Span::styled(number, styles::hash_style(theme)),
             Span::styled(" ", Style::default()),
             Span::styled(title, Style::default().fg(theme.fg_primary)),
@@ -437,6 +458,15 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
         .collect();
     let paragraph = Paragraph::new(visible).style(styles::panel_style(theme));
     frame.render_widget(paragraph, area);
+}
+
+/// Braille spinner frames advanced every ~100ms based on elapsed time.
+/// Stable across redraws because the start instant lives on `App`.
+pub(crate) fn pr_open_spinner_glyph(elapsed: std::time::Duration) -> &'static str {
+    const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    const FRAME_MS: u128 = 100;
+    let idx = (elapsed.as_millis() / FRAME_MS) as usize % FRAMES.len();
+    FRAMES[idx]
 }
 
 fn format_relative_time(time: chrono::DateTime<chrono::Utc>) -> String {
@@ -892,5 +922,115 @@ mod selector_render_snapshot_tests {
             body.contains("Fetching pull requests"),
             "expected loading banner, got:\n{body}"
         );
+    }
+
+    #[test]
+    fn should_render_spinner_glyph_in_place_of_cursor_for_loading_pr_row() {
+        // given — two PRs loaded, an open in-flight for #148
+        use crate::app::PrOpenRequest;
+        use std::time::Instant;
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((
+            vec![
+                pr(148, "Add forge-backed PR review", "alice"),
+                pr(125, "Support fetching/pushing reviews", "ypares"),
+            ],
+            false,
+        )));
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        app.pr_open_state = Some(PrOpenRequest {
+            repository: repo(),
+            pr_number: 148,
+            started_at: Instant::now(),
+        });
+        // when
+        let buffer = draw(&mut app);
+        // then — the loading row leads with one of the braille spinner glyphs
+        let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+        let lines: Vec<String> = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect();
+        let loading_row = lines
+            .iter()
+            .find(|l| l.contains("#148"))
+            .expect("#148 row missing");
+        let non_loading_row = lines
+            .iter()
+            .find(|l| l.contains("#125"))
+            .expect("#125 row missing");
+        assert!(
+            frames
+                .iter()
+                .any(|g| loading_row.starts_with(&format!(" {g}")) || loading_row.contains(g)),
+            "loading row should contain a spinner glyph: {loading_row:?}"
+        );
+        // The non-loading row should not have any spinner glyph at the front.
+        assert!(
+            !frames.iter().any(|g| non_loading_row.contains(g)),
+            "non-loading row should not contain a spinner glyph: {non_loading_row:?}"
+        );
+    }
+
+    #[test]
+    fn should_keep_cursor_pointer_on_other_rows_during_loading() {
+        // given — loading #148, cursor on #125
+        use crate::app::PrOpenRequest;
+        use std::time::Instant;
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((
+            vec![
+                pr(148, "Add forge-backed PR review", "alice"),
+                pr(125, "Support fetching/pushing reviews", "ypares"),
+            ],
+            false,
+        )));
+        if let PullRequestsTab::Loaded { cursor, .. } = &mut tab {
+            *cursor = 1; // cursor on #125
+        }
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        app.pr_open_state = Some(PrOpenRequest {
+            repository: repo(),
+            pr_number: 148,
+            started_at: Instant::now(),
+        });
+        // when
+        let buffer = draw(&mut app);
+        // then — #125 row keeps the `> ` cursor pointer (after the panel border)
+        let lines: Vec<String> = (3..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect();
+        let cursor_row = lines
+            .iter()
+            .find(|l| l.contains("#125"))
+            .expect("#125 row missing");
+        assert!(
+            cursor_row.contains("> #125"),
+            "cursor row should contain `> #125`: {cursor_row:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod pr_open_spinner_tests {
+    use super::pr_open_spinner_glyph;
+    use std::time::Duration;
+
+    #[test]
+    fn should_advance_braille_frame_every_100ms() {
+        // given / when / then
+        assert_eq!(pr_open_spinner_glyph(Duration::from_millis(0)), "⠋");
+        assert_eq!(pr_open_spinner_glyph(Duration::from_millis(99)), "⠋");
+        assert_eq!(pr_open_spinner_glyph(Duration::from_millis(100)), "⠙");
+        assert_eq!(pr_open_spinner_glyph(Duration::from_millis(900)), "⠏");
+        // Wraps after the 10th frame.
+        assert_eq!(pr_open_spinner_glyph(Duration::from_millis(1000)), "⠋");
     }
 }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -53,8 +53,19 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     let vcs_type = &app.vcs_info.vcs_type;
     let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
 
-    let title = " tuicr - Code Review ".to_string();
-    let vcs_info = format!("[{vcs_type}:{branch}] ");
+    let in_pr_mode = matches!(app.diff_source, DiffSource::PullRequest(_));
+
+    let title = if in_pr_mode {
+        " tuicr - PR Review ".to_string()
+    } else {
+        " tuicr - Code Review ".to_string()
+    };
+    let vcs_info = if in_pr_mode {
+        // PR mode header is anchored on the PR identity, not the local VCS.
+        String::new()
+    } else {
+        format!("[{vcs_type}:{branch}] ")
+    };
 
     // Show diff source info
     let source_info = match &app.diff_source {
@@ -87,6 +98,22 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 format!("[staged + unstaged + {} commits] ", commits.len())
             }
+        }
+        DiffSource::PullRequest(pr) => {
+            let slug = pr.key.repository.display_name();
+            let trimmed_title = if pr.title.len() > 60 {
+                format!("{}…", &pr.title[..59])
+            } else {
+                pr.title.clone()
+            };
+            let mut info = format!(
+                "[PR mode · {slug}#{number} · {trimmed_title}] ",
+                number = pr.key.number,
+            );
+            if let Some(state) = pr.read_only_reason() {
+                info.push_str(&format!("[{state} — read only] "));
+            }
+            info
         }
     };
 
@@ -294,5 +321,164 @@ mod tests {
         let (span, _) = build_message_span(Some(&test_message(MessageType::Error)), &theme);
         assert_eq!(span.style.fg, Some(theme.message_error_fg));
         assert_eq!(span.style.bg, Some(theme.message_error_bg));
+    }
+}
+
+#[cfg(test)]
+mod pr_header_snapshot_tests {
+    //! Render-snapshot coverage for the status bar header in PR mode.
+    //! Drives the full `render_header` against ratatui's `TestBackend`
+    //! and asserts on the produced character grid.
+
+    use crate::app::{App, DiffSource, InputMode, PullRequestDiffSource};
+    use crate::error::Result as TuicrResult;
+    use crate::error::TuicrError;
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
+    use crate::model::{DiffFile, DiffLine, FileStatus, ReviewSession, SessionDiffSource};
+    use crate::syntax::SyntaxHighlighter;
+    use crate::theme::Theme;
+    use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use std::path::{Path, PathBuf};
+
+    struct NoopVcs {
+        info: VcsInfo,
+    }
+    impl VcsBackend for NoopVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+        fn get_working_tree_diff(
+            &self,
+            _highlighter: &SyntaxHighlighter,
+        ) -> TuicrResult<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _start_line: u32,
+            _end_line: u32,
+        ) -> TuicrResult<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+    }
+
+    fn pr_source(closed: bool, merged: bool) -> PullRequestDiffSource {
+        PullRequestDiffSource {
+            key: PrSessionKey::new(
+                ForgeRepository::github("github.com", "agavra", "tuicr"),
+                125,
+                "abcdef0123456789".to_string(),
+            ),
+            base_sha: "1234567890abcdef".to_string(),
+            title: "Add forge-backed PR review".to_string(),
+            url: "https://github.com/agavra/tuicr/pull/125".to_string(),
+            head_ref_name: "reviews".to_string(),
+            base_ref_name: "main".to_string(),
+            state: if closed { "CLOSED" } else { "OPEN" }.to_string(),
+            closed,
+            merged,
+        }
+    }
+
+    fn build_pr_app(pr: PullRequestDiffSource) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("forge:github.com/agavra/tuicr"),
+            head_commit: pr.key.head_sha.clone(),
+            branch_name: Some(pr.head_ref_name.clone()),
+            vcs_type: VcsType::File,
+        };
+        let mut session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            pr.key.head_sha.clone(),
+            Some(pr.head_ref_name.clone()),
+            SessionDiffSource::PullRequest,
+        );
+        session.pr_session_key = Some(pr.key.clone());
+        App::build(
+            Box::new(NoopVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            Vec::new(),
+            session,
+            DiffSource::PullRequest(Box::new(pr)),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build pr app")
+    }
+
+    fn draw_header(app: &App) -> Buffer {
+        let backend = TestBackend::new(140, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                super::render_header(frame, app, area);
+            })
+            .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn row_text(buffer: &Buffer, y: u16) -> String {
+        (0..buffer.area.width)
+            .map(|x| buffer[(x, y)].symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn should_render_pr_mode_header_with_slug_number_and_title() {
+        // given a PR-mode app for agavra/tuicr#125
+        let app = build_pr_app(pr_source(false, false));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(line.contains("tuicr - PR Review"), "got: {line:?}");
+        assert!(line.contains("PR mode"), "got: {line:?}");
+        assert!(line.contains("agavra/tuicr#125"), "got: {line:?}");
+        assert!(line.contains("Add forge-backed PR review"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_render_read_only_badge_for_closed_pr() {
+        // given a closed PR
+        let app = build_pr_app(pr_source(true, false));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(line.contains("closed — read only"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_render_read_only_badge_for_merged_pr() {
+        // given a merged PR
+        let app = build_pr_app(pr_source(false, true));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(line.contains("merged — read only"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_omit_read_only_badge_for_open_pr() {
+        // given
+        let app = build_pr_app(pr_source(false, false));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(!line.contains("read only"), "got: {line:?}");
     }
 }

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -11,17 +11,19 @@
 //! are Git-backed and contain a `.git` directory. If jj detection fails, Git
 //! is tried next, then Mercurial.
 
-mod diff_parser;
+pub(crate) mod diff_parser;
 pub mod file;
 pub mod git;
 mod hg;
 mod jj;
+pub mod pr_noop;
 pub(crate) mod traits;
 
 pub use file::FileBackend;
 pub use git::{GitBackend, GitBackendPreference};
 pub use hg::HgBackend;
 pub use jj::JjBackend;
+pub use pr_noop::PrNoopVcs;
 pub use traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 
 use std::collections::HashMap;

--- a/src/vcs/pr_noop.rs
+++ b/src/vcs/pr_noop.rs
@@ -1,0 +1,97 @@
+//! Placeholder VCS backend used in PR diff mode.
+//!
+//! When the App enters PR mode, the diff comes from the forge (`gh pr diff`),
+//! not from a local working tree. The `VcsBackend` slot still needs to be
+//! filled because the App and a number of other call sites assume one is
+//! always present. `PrNoopVcs` satisfies that requirement without doing any
+//! real work — every method either succeeds with an empty result or returns
+//! `UnsupportedOperation`. PR-mode code paths route through
+//! `ForgeContextProvider` for the operations that matter (context
+//! expansion); they never call into the VCS backend.
+
+use std::path::Path;
+
+use crate::error::{Result, TuicrError};
+use crate::model::{DiffFile, DiffLine, FileStatus};
+use crate::syntax::SyntaxHighlighter;
+
+use super::traits::{VcsBackend, VcsInfo};
+
+pub struct PrNoopVcs {
+    info: VcsInfo,
+}
+
+impl PrNoopVcs {
+    pub fn new(info: VcsInfo) -> Self {
+        Self { info }
+    }
+}
+
+impl VcsBackend for PrNoopVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.info
+    }
+
+    fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        Err(TuicrError::UnsupportedOperation(
+            "PR mode does not read from the local working tree".to_string(),
+        ))
+    }
+
+    fn fetch_context_lines(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _start_line: u32,
+        _end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        // PR-mode context expansion routes through `ForgeContextProvider`.
+        // If anything reaches this backend, it's a routing bug — return an
+        // empty result rather than panicking so the UI degrades gracefully.
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vcs::traits::VcsType;
+    use std::path::PathBuf;
+
+    fn info() -> VcsInfo {
+        VcsInfo {
+            root_path: PathBuf::from("forge:github.com/a/b"),
+            head_commit: "abc".to_string(),
+            branch_name: Some("main".to_string()),
+            vcs_type: VcsType::File,
+        }
+    }
+
+    #[test]
+    fn should_return_empty_context_lines_from_noop_backend() {
+        // given
+        let vcs = PrNoopVcs::new(info());
+        // when
+        let lines = vcs
+            .fetch_context_lines(&PathBuf::from("x"), FileStatus::Modified, 1, 5)
+            .unwrap();
+        // then
+        assert!(lines.is_empty());
+    }
+
+    #[test]
+    fn should_reject_working_tree_diff_on_noop_backend() {
+        // given
+        let vcs = PrNoopVcs::new(info());
+        // when
+        let err = vcs
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .unwrap_err();
+        // then
+        assert!(
+            err.to_string()
+                .contains("PR mode does not read from the local working tree"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of the forge v1 integration: lets users review GitHub pull requests
inside `tuicr` without mutating the local checkout. Adds:

- `tuicr pr <target>` CLI subcommand (bare number, `owner/repo#N`, or
  full URL).
- A real selector → PR open path (replaces the PR 2 stub).
- A PR diff source that parses `gh pr diff` through the existing diff
  parser.
- A forge-aware context provider so gap expansion fetches base/head SHA
  content (with a local-blob optimization when the checkout matches).
- PR sessions keyed by forge identity + PR number + head SHA so
  reopening the same PR at the same head restores reviewed markers and
  local drafts; advancing the head opens a new session.
- `:reload` / `:e` in PR mode that re-fetches and switches sessions on
  head advance.
- Header badge for read-only (closed/merged) PRs.

## Scope (in)

- `tuicr pr <target>` direct entry, parsed in `theme::parse_cli_args`.
- `DiffSource::PullRequest(Box<...>)` + `SessionDiffSource::PullRequest`
  variant with `pr_session_key` field. Existing local-session JSON
  deserializes unchanged (regression test).
- `ContextProvider` trait with VCS and forge adapters. App picks via
  `DiffSource`.
- `ForgeBackend::fetch_file_lines` + `local_checkout_path()`.
- `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>` (with
  `Accept: application/vnd.github.raw`) for forge content lookup.
- Local optimization via `git cat-file -e` + `git show` when a matching
  checkout is present. Never the source of truth.
- `.tuicrignore` applied **only** when a matching local checkout is
  available.
- Status bar / help / markdown export labels for PR mode.
- Read-only badge in header when PR is closed/merged; startup warning
  surfaces the state. Comment editing is **not** disabled (that's PR
  5/6).

## Scope (out — explicitly punted)

- Remote comments / `:comments unresolved|all|hide` (PR 4).
- `:submit*` commands, resolver modal, payload builder, locked comment
  lifecycle (PR 5/6).
- README repositioning (PR 7) — help popup updated where commands
  changed.

## Key design choices to look at first

1. **`ContextProvider` trait shape.** Methods take both `old_path` and
   `new_path` plus `FileStatus` so the forge provider can route
   rename/copy correctly without callers needing to know the
   base-vs-head rule. The trait lives at `src/forge/context.rs`. The
   App calls `context_provider()` per expansion; the cost is one
   `Box::new` per call, which is well below the gap-expansion budget.
2. **`PullRequestDiffSource` is boxed** inside `DiffSource::PullRequest`.
   Clippy flagged the unboxed variant as a 256B inline payload that
   would bloat the enum for all local-review callers; boxing pays a
   single allocation per PR open in exchange.
3. **PR session filename layout** is `pr_github_<host>_<owner>_<repo>_<num>_<short_head>_<id>.json`.
   The local-session filename parser explicitly skips `pr_github_`
   files and the local loader returns `None` for
   `SessionDiffSource::PullRequest`, so the two namespaces don't
   collide.
4. **`PrNoopVcs`** fills the `VcsBackend` slot in PR mode. Its
   `fetch_context_lines` returns empty rather than panicking — a
   routing bug there should degrade gracefully, not crash.
5. **`App::open_pr_with_backend` and `App::reload_pull_request_with_backend`**
   exist as seams for tests with a fake `ForgeBackend`; production
   paths (`pr_tab_select`, `:reload`) construct a real `GitHubGhBackend`
   and call into these.
6. **Read-only state is surfaced visually only.** Closed/merged PRs
   open and render normally; the header gets a badge and a startup
   warning fires. Disabling comment authoring waits for PR 5/6.

## No checkout mutation

Verified by grep: zero `git checkout`/`fetch`/`reset`/`stash`/branch
or ref creation anywhere in the PR open or reload paths. The only Git
invocations are read-only `git cat-file -e` and `git show` for the
local-blob optimization.

## Test coverage summary

37 new tests, total 459 → 496. Coverage spans:

- CLI parsing for `tuicr pr <target>` in all three forms + error cases.
- `PrSessionKey` round-trip serde, short-head truncation.
- Side selection (head vs base) for every `FileStatus`.
- Forge context provider routes head/base correctly per status.
- Pre-PR3 local session JSON deserializes unchanged.
- Persistence: PR filename, round-trip, head-SHA-not-found, local
  loader skips PR files, distinct PR numbers stay separate.
- Multi-status PR patch (add/modify/delete/rename) parses correctly.
- App PR open from fake backend wires `forge_backend`, sets correct
  `DiffSource`, and registers files in the session.
- Closed PR surfaces a read-only warning.
- PR open errors surface in the selector instead of leaving the App in
  a half-state.
- Reload with head-SHA change swaps sessions; reload with same head
  keeps the session.
- Render snapshots for the PR header label + read-only badge.

## Quality gates

- `cargo fmt`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test`: 496 passed, 0 failed, 1 ignored

## Test plan

- [ ] Open a public GitHub PR via `tuicr pr <number>` inside a local
  checkout.
- [ ] Open a public GitHub PR via `tuicr pr owner/repo#N` outside a
  checkout.
- [ ] Open a public GitHub PR via full URL outside a checkout.
- [ ] Open a fork PR (verify `gh api` content path works without local
  objects).
- [ ] Open a closed PR — verify the read-only badge appears.
- [ ] Inside an opened PR, expand context around a hunk — verify the
  expansion fetches via `gh api` (or local blob when present).
- [ ] Open a PR, push a new commit upstream, run `:reload` — verify the
  session switches.
- [ ] Verify no `git checkout`/`fetch`/`reset` runs during any of the
  above (check via `git reflog` and working tree state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)