### PR TITLE
forge: existing remote GitHub comments, read-only (PR 4 of forge v1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -238,10 +238,39 @@ pub enum AnnotatedLine {
         side: LineSide,
         comment_idx: usize,
     },
+    /// A read-only line of a rendered remote review thread. Cursor cannot
+    /// edit or reply to these in v1; the annotation is informational so
+    /// hit-testing and scroll math stay correct.
+    RemoteThreadLine { thread_idx: usize },
     /// Binary or empty file indicator
     BinaryOrEmpty { file_idx: usize },
     /// Spacing between files
     Spacing,
+}
+
+/// Per-file index of remote threads keyed by `(line, side)` so the
+/// renderer / annotation builder can place threads inline at the right
+/// anchor without scanning all threads on every diff line.
+#[derive(Debug, Default, Clone)]
+pub struct RemoteThreadIndex {
+    /// Outer key = file path (display form). Inner key =
+    /// `(line, side)` where `side` is the *local* `LineSide` mapping.
+    pub by_file:
+        std::collections::HashMap<String, std::collections::HashMap<(u32, LineSide), Vec<usize>>>,
+}
+
+impl RemoteThreadIndex {
+    #[allow(dead_code)]
+    pub fn threads_at(
+        &self,
+        path: &std::path::Path,
+        line: u32,
+        side: LineSide,
+    ) -> Option<&Vec<usize>> {
+        self.by_file
+            .get(path.to_string_lossy().as_ref())
+            .and_then(|m| m.get(&(line, side)))
+    }
 }
 
 /// Result of searching for a source line number in annotations.
@@ -289,6 +318,7 @@ pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
         | AnnotatedLine::Expander { .. }
         | AnnotatedLine::HiddenLines { .. }
         | AnnotatedLine::ExpandedContext { .. }
+        | AnnotatedLine::RemoteThreadLine { .. }
         | AnnotatedLine::Spacing => None,
     }
 }
@@ -475,6 +505,21 @@ pub enum PrOpenEvent {
     },
 }
 
+/// Result delivered from the remote-thread fetch background thread. The PR
+/// diff is rendered as soon as it parses; threads land asynchronously and
+/// trigger a repaint via `poll_pr_threads_events`.
+#[derive(Debug)]
+pub enum PrThreadsEvent {
+    Done {
+        /// Forge identity for the request; used to discard stale results if
+        /// the user has since opened a different PR.
+        repository: crate::forge::traits::ForgeRepository,
+        pr_number: u64,
+        head_sha: String,
+        result: std::result::Result<Vec<crate::forge::remote_comments::RemoteReviewThread>, String>,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffViewMode {
     Unified,
@@ -573,6 +618,19 @@ pub struct App {
     /// context provider for gap expansion against base/head SHAs and (in a
     /// future PR) for remote comment fetch/submit.
     pub forge_backend: Option<Box<dyn ForgeBackend>>,
+    /// Remote review threads fetched from the forge for the active PR.
+    /// Populated asynchronously after the diff renders (see
+    /// `poll_pr_threads_events`). Empty in non-PR modes and during the
+    /// loading window.
+    pub forge_review_threads: Vec<crate::forge::remote_comments::RemoteReviewThread>,
+    /// True while a background remote-thread fetch is in flight for the
+    /// currently open PR. Drives the footer "Loading remote comments…"
+    /// hint and skips re-fetch if `:e` is hit again before the first
+    /// fetch lands.
+    pub forge_review_threads_loading: bool,
+    /// Background-thread channel that delivers remote-thread fetch results.
+    /// `Receiver` is only present while a fetch is in flight.
+    pub pr_threads_rx: Option<std::sync::mpsc::Receiver<PrThreadsEvent>>,
 
     pub should_quit: bool,
     pub dirty: bool,
@@ -1139,6 +1197,9 @@ impl App {
             pr_open_state: None,
             pr_open_rx: None,
             forge_backend: None,
+            forge_review_threads: Vec::new(),
+            forge_review_threads_loading: false,
+            pr_threads_rx: None,
             should_quit: false,
             dirty: false,
             quit_warned: false,
@@ -1525,6 +1586,9 @@ impl App {
         // routes through the forge backend, not the VCS box.
         let vcs: Box<dyn VcsBackend> = Box::new(PrNoopVcs::new(vcs_info.clone()));
 
+        // Snapshot the PR details before consuming `opened` so we can kick
+        // off the remote-thread fetch after `Self::build` returns.
+        let details_for_threads = opened.details.clone();
         let mut app = Self::build(
             vcs,
             vcs_info,
@@ -1548,6 +1612,9 @@ impl App {
             let reason = pr.read_only_reason().unwrap_or("read only");
             app.set_warning(format!("This PR is {reason} — review is read-only"));
         }
+        // Spawn thread-fetch on startup; the main event loop will drain
+        // the receiver via `poll_pr_threads_events` once it begins.
+        app.spawn_pr_threads_fetch(&details_for_threads, local_checkout_for_target);
         Ok(app)
     }
 
@@ -1585,6 +1652,11 @@ impl App {
         self.diff_source = DiffSource::PullRequest(Box::new(pr_source));
         self.forge_backend = Some(backend);
         self.forge_repository = Some(key.repository.clone());
+        // Reset remote-comment state on every PR mode entry; the new PR's
+        // threads will be fetched separately by spawn_pr_threads_fetch.
+        self.forge_review_threads = Vec::new();
+        self.forge_review_threads_loading = false;
+        self.pr_threads_rx = None;
         self.input_mode = InputMode::Normal;
         self.focused_panel = FocusedPanel::Diff;
         self.clear_expanded_gaps();
@@ -1666,8 +1738,12 @@ impl App {
         if head_changed {
             // Save the old-head session before switching so drafts persist.
             let _ = crate::persistence::save_session(&self.session);
+            let details_for_threads = opened.details.clone();
             Self::load_or_apply_pr_session(&mut opened);
             self.enter_pr_diff_mode(backend, opened)?;
+            // Fetch threads against the new head; old-head threads stay
+            // tied to the old session and are dropped here.
+            self.spawn_pr_threads_fetch(&details_for_threads, local_checkout.clone());
         } else {
             // Same head: re-parse the diff to pick up any side-channel
             // changes (rare), but keep the session intact.
@@ -2699,6 +2775,14 @@ impl App {
                     .map(|l| l.content.as_str())
                     .unwrap_or("");
                 Some(format!("{} {}", del_content, add_content))
+            }
+            AnnotatedLine::RemoteThreadLine { thread_idx } => {
+                let thread = self.forge_review_threads.get(*thread_idx)?;
+                // Search matches any text in the thread (including replies).
+                let mut bodies: Vec<String> =
+                    thread.comments.iter().map(|c| c.body.clone()).collect();
+                bodies.insert(0, format!("github {}", thread.path));
+                Some(bodies.join(" "))
             }
             AnnotatedLine::Spacing => None,
         }
@@ -4393,19 +4477,131 @@ impl App {
 
         let local_checkout = Some(self.vcs_info.root_path.clone());
         let highlighter = self.theme.syntax_highlighter();
-        let mut opened = prepare_open_pr(details, &patch, local_checkout.as_deref(), highlighter)?;
+        let mut opened = prepare_open_pr(
+            details.clone(),
+            &patch,
+            local_checkout.as_deref(),
+            highlighter,
+        )?;
         Self::load_or_apply_pr_session(&mut opened);
         let backend = Box::new(
             GitHubGhBackend::new(Some(request.repository.clone()))
-                .with_local_checkout(local_checkout),
+                .with_local_checkout(local_checkout.clone()),
         );
         self.enter_pr_diff_mode(backend, opened)?;
+        // Kick the remote-thread fetch off on a fresh background thread.
+        // The diff view is already up; threads fade in once they land.
+        self.spawn_pr_threads_fetch(&details, local_checkout);
         self.set_message(format!(
             "Opened PR {}#{}",
             request.repository.display_name(),
             request.pr_number,
         ));
         Ok(())
+    }
+
+    /// Kick off a background fetch of remote review threads for `details`.
+    /// Replaces any in-flight fetch — we don't try to merge results across
+    /// concurrent fetches because the head SHA scopes everything.
+    fn spawn_pr_threads_fetch(
+        &mut self,
+        details: &crate::forge::traits::PullRequestDetails,
+        local_checkout: Option<std::path::PathBuf>,
+    ) {
+        use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::traits::ForgeBackend;
+
+        self.forge_review_threads.clear();
+        self.forge_review_threads_loading = true;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_threads_rx = Some(rx);
+
+        let details_clone = details.clone();
+        let repository = details.repository.clone();
+        let pr_number = details.number;
+        let head_sha = details.head_sha.clone();
+
+        std::thread::spawn(move || {
+            let backend =
+                GitHubGhBackend::new(Some(repository.clone())).with_local_checkout(local_checkout);
+            let result = backend
+                .list_review_threads(&details_clone)
+                .map_err(|e| e.to_string());
+            let _ = tx.send(PrThreadsEvent::Done {
+                repository,
+                pr_number,
+                head_sha,
+                result,
+            });
+        });
+    }
+
+    /// Drain any pending remote-thread fetch result and apply it. Stale
+    /// results (a result that arrived after the user switched to a
+    /// different PR) are discarded.
+    pub fn poll_pr_threads_events(&mut self) {
+        let Some(rx) = self.pr_threads_rx.as_ref() else {
+            return;
+        };
+        let event = match rx.try_recv() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        self.pr_threads_rx = None;
+        self.forge_review_threads_loading = false;
+
+        match event {
+            PrThreadsEvent::Done {
+                repository,
+                pr_number,
+                head_sha,
+                result,
+            } => {
+                // Validate against the currently open PR. If the user has
+                // opened a different PR (or left PR mode) while the fetch
+                // was in flight, drop the result silently.
+                let current = match &self.diff_source {
+                    DiffSource::PullRequest(pr) => Some((
+                        pr.key.repository.clone(),
+                        pr.key.number,
+                        pr.key.head_sha.clone(),
+                    )),
+                    _ => None,
+                };
+                let still_relevant = current
+                    .as_ref()
+                    .map(|(r, n, sha)| *r == repository && *n == pr_number && *sha == head_sha)
+                    .unwrap_or(false);
+                if !still_relevant {
+                    return;
+                }
+                match result {
+                    Ok(threads) => {
+                        self.forge_review_threads = threads;
+                        self.rebuild_annotations();
+                    }
+                    Err(e) => {
+                        self.forge_review_threads = Vec::new();
+                        self.set_warning(format!("Failed to load remote comments: {e}"));
+                    }
+                }
+            }
+        }
+    }
+
+    /// Update the per-session remote comments visibility and repaint.
+    /// Returns `true` if the visibility actually changed.
+    pub fn set_remote_comments_visibility(
+        &mut self,
+        visibility: crate::forge::remote_comments::PrCommentsVisibility,
+    ) -> bool {
+        if self.session.remote_comments_visibility == visibility {
+            return false;
+        }
+        self.session.remote_comments_visibility = visibility;
+        self.rebuild_annotations();
+        true
     }
 
     /// Abort an in-flight PR open. Drops the receiver so the eventual
@@ -4420,10 +4616,46 @@ impl App {
         true
     }
 
+    /// Re-fetch remote review threads for the currently open PR. Called
+    /// from `:e` so users can pull the latest discussions without
+    /// reopening the PR. No-op outside PR mode.
+    pub fn refetch_pr_threads(&mut self) {
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|b| b.local_checkout_path());
+        let details = match &self.diff_source {
+            DiffSource::PullRequest(pr) => crate::forge::traits::PullRequestDetails {
+                repository: pr.key.repository.clone(),
+                number: pr.key.number,
+                title: pr.title.clone(),
+                url: pr.url.clone(),
+                state: pr.state.clone(),
+                is_draft: false,
+                author: None,
+                head_ref_name: pr.head_ref_name.clone(),
+                base_ref_name: pr.base_ref_name.clone(),
+                head_sha: pr.key.head_sha.clone(),
+                base_sha: pr.base_sha.clone(),
+                body: String::new(),
+                updated_at: None,
+                closed: pr.closed,
+                merged_at: None,
+            },
+            _ => return,
+        };
+        self.spawn_pr_threads_fetch(&details, local_checkout);
+    }
+
     /// Open a PR using the provided forge backend, synchronously. Exists
     /// as a seam for tests that want to drive the open without spinning
     /// up a background thread + mpsc round-trip. Production paths go
     /// through `spawn_pr_open` (selector) or `new_from_pr_target` (CLI).
+    ///
+    /// Synchronously fetches `list_review_threads` from the same backend
+    /// and applies it before returning. This is the convenient seam for
+    /// integration tests; the production async path uses
+    /// `spawn_pr_threads_fetch` instead.
     #[allow(dead_code)]
     pub fn open_pr_with_backend(
         &mut self,
@@ -4447,7 +4679,14 @@ impl App {
             highlighter,
         )?;
         Self::load_or_apply_pr_session(&mut opened);
+        // Sync thread fetch — tests assert on `app.forge_review_threads`
+        // immediately after this returns.
+        let threads = backend
+            .list_review_threads(&opened.details)
+            .unwrap_or_default();
         self.enter_pr_diff_mode(backend, opened)?;
+        self.forge_review_threads = threads;
+        self.rebuild_annotations();
         Ok(())
     }
 
@@ -5324,6 +5563,12 @@ impl App {
     pub fn rebuild_annotations(&mut self) {
         self.line_annotations.clear();
 
+        // Pre-index remote threads by (path, line, side) for quick lookup
+        // during the file/hunk walk. Threads whose visibility is
+        // suppressed don't appear in this map at all, so no annotations
+        // are emitted for them.
+        let remote_index = self.build_remote_thread_index();
+
         self.line_annotations
             .push(AnnotatedLine::ReviewCommentsHeader);
         for (comment_idx, comment) in self.session.review_comments.iter().enumerate() {
@@ -5464,6 +5709,9 @@ impl App {
                                 hunk_idx,
                                 &hunk.lines,
                                 &line_comments,
+                                path,
+                                &self.forge_review_threads,
+                                &remote_index,
                             );
                         }
                         DiffViewMode::SideBySide => {
@@ -5473,6 +5721,9 @@ impl App {
                                 hunk_idx,
                                 &hunk.lines,
                                 &line_comments,
+                                path,
+                                &self.forge_review_threads,
+                                &remote_index,
                             );
                         }
                     }
@@ -5519,13 +5770,74 @@ impl App {
         }
     }
 
+    /// Per-file map of `(line, side)` -> indices into `forge_review_threads`.
+    /// Sides use the `RemoteCommentSide` mapping: `Right` -> `LineSide::New`,
+    /// `Left` -> `LineSide::Old`.
+    fn build_remote_thread_index(&self) -> RemoteThreadIndex {
+        use crate::forge::remote_comments::RemoteCommentSide;
+        let mut by_file: std::collections::HashMap<
+            String,
+            std::collections::HashMap<(u32, LineSide), Vec<usize>>,
+        > = std::collections::HashMap::new();
+        let visibility = self.session.remote_comments_visibility;
+
+        for (thread_idx, thread) in self.forge_review_threads.iter().enumerate() {
+            if visibility.render_decision(thread).is_none() {
+                continue;
+            }
+            let Some(line) = thread.line else { continue };
+            let side = match thread.side {
+                RemoteCommentSide::Right => LineSide::New,
+                RemoteCommentSide::Left => LineSide::Old,
+            };
+            by_file
+                .entry(thread.path.clone())
+                .or_default()
+                .entry((line, side))
+                .or_default()
+                .push(thread_idx);
+        }
+
+        RemoteThreadIndex { by_file }
+    }
+
+    fn push_remote_threads(
+        annotations: &mut Vec<AnnotatedLine>,
+        threads: &[crate::forge::remote_comments::RemoteReviewThread],
+        index: &RemoteThreadIndex,
+        path: &std::path::Path,
+        line: u32,
+        side: LineSide,
+    ) {
+        let Some(file_index) = index.by_file.get(path.to_string_lossy().as_ref()) else {
+            return;
+        };
+        let Some(thread_indices) = file_index.get(&(line, side)) else {
+            return;
+        };
+        for thread_idx in thread_indices {
+            if let Some(thread) = threads.get(*thread_idx) {
+                let n = crate::forge::remote_comments::thread_display_lines(thread);
+                for _ in 0..n {
+                    annotations.push(AnnotatedLine::RemoteThreadLine {
+                        thread_idx: *thread_idx,
+                    });
+                }
+            }
+        }
+    }
+
     /// Build annotations for unified diff mode (one annotation per diff line)
+    #[allow(clippy::too_many_arguments)]
     fn build_unified_diff_annotations(
         annotations: &mut Vec<AnnotatedLine>,
         file_idx: usize,
         hunk_idx: usize,
         lines: &[crate::model::DiffLine],
         line_comments: &std::collections::HashMap<u32, Vec<crate::model::Comment>>,
+        path: &std::path::Path,
+        remote_threads: &[crate::forge::remote_comments::RemoteReviewThread],
+        remote_index: &RemoteThreadIndex,
     ) {
         for (line_idx, diff_line) in lines.iter().enumerate() {
             annotations.push(AnnotatedLine::DiffLine {
@@ -5545,6 +5857,14 @@ impl App {
                     line_comments,
                     LineSide::Old,
                 );
+                Self::push_remote_threads(
+                    annotations,
+                    remote_threads,
+                    remote_index,
+                    path,
+                    old_ln,
+                    LineSide::Old,
+                );
             }
 
             // Line comments on new side (added/context lines)
@@ -5556,17 +5876,29 @@ impl App {
                     line_comments,
                     LineSide::New,
                 );
+                Self::push_remote_threads(
+                    annotations,
+                    remote_threads,
+                    remote_index,
+                    path,
+                    new_ln,
+                    LineSide::New,
+                );
             }
         }
     }
 
     /// Build annotations for side-by-side diff mode, pairing deletions and additions into aligned rows.
+    #[allow(clippy::too_many_arguments)]
     fn build_side_by_side_annotations(
         annotations: &mut Vec<AnnotatedLine>,
         file_idx: usize,
         hunk_idx: usize,
         lines: &[crate::model::DiffLine],
         line_comments: &std::collections::HashMap<u32, Vec<crate::model::Comment>>,
+        path: &std::path::Path,
+        remote_threads: &[crate::forge::remote_comments::RemoteReviewThread],
+        remote_index: &RemoteThreadIndex,
     ) {
         let mut i = 0;
         while i < lines.len() {
@@ -5590,6 +5922,16 @@ impl App {
                         line_comments,
                         LineSide::New,
                     );
+                    if let Some(new_ln) = diff_line.new_lineno {
+                        Self::push_remote_threads(
+                            annotations,
+                            remote_threads,
+                            remote_index,
+                            path,
+                            new_ln,
+                            LineSide::New,
+                        );
+                    }
 
                     i += 1
                 }
@@ -5644,6 +5986,16 @@ impl App {
                             line_comments,
                             LineSide::Old,
                         );
+                        if let Some(old_ln) = old_lineno {
+                            Self::push_remote_threads(
+                                annotations,
+                                remote_threads,
+                                remote_index,
+                                path,
+                                old_ln,
+                                LineSide::Old,
+                            );
+                        }
                         Self::push_comments(
                             annotations,
                             file_idx,
@@ -5651,6 +6003,16 @@ impl App {
                             line_comments,
                             LineSide::New,
                         );
+                        if let Some(new_ln) = new_lineno {
+                            Self::push_remote_threads(
+                                annotations,
+                                remote_threads,
+                                remote_index,
+                                path,
+                                new_ln,
+                                LineSide::New,
+                            );
+                        }
                     }
 
                     i = add_end;
@@ -5672,6 +6034,16 @@ impl App {
                         line_comments,
                         LineSide::New,
                     );
+                    if let Some(new_ln) = diff_line.new_lineno {
+                        Self::push_remote_threads(
+                            annotations,
+                            remote_threads,
+                            remote_index,
+                            path,
+                            new_ln,
+                            LineSide::New,
+                        );
+                    }
 
                     i += 1;
                 }
@@ -6238,6 +6610,12 @@ mod target_selector_tests {
         ) -> Result<Vec<crate::model::DiffLine>> {
             Ok(Vec::new())
         }
+        fn list_review_threads(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
+            Ok(Vec::new())
+        }
     }
 
     fn sample_pr(number: u64, title: &str) -> PullRequestSummary {
@@ -6557,6 +6935,12 @@ mod target_selector_tests {
         ) -> Result<Vec<crate::model::DiffLine>> {
             Ok(Vec::new())
         }
+        fn list_review_threads(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
+            Ok(Vec::new())
+        }
     }
 
     #[test]
@@ -6793,6 +7177,254 @@ mod target_selector_tests {
         crate::handler::handle_commit_select_action(&mut app, crate::input::Action::ExitMode);
         // then
         assert!(app.pr_open_state.is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // Remote review threads (PR 4)
+    // -----------------------------------------------------------------
+
+    use crate::forge::remote_comments::{
+        PrCommentsVisibility, RemoteCommentSide, RemoteReviewComment, RemoteReviewThread,
+    };
+
+    struct ThreadAwareForgeBackend {
+        details: crate::forge::traits::PullRequestDetails,
+        patch: String,
+        threads: Vec<RemoteReviewThread>,
+        calls: std::cell::Cell<u32>,
+    }
+
+    impl ThreadAwareForgeBackend {
+        fn new(
+            details: crate::forge::traits::PullRequestDetails,
+            patch: String,
+            threads: Vec<RemoteReviewThread>,
+        ) -> Self {
+            Self {
+                details,
+                patch,
+                threads,
+                calls: std::cell::Cell::new(0),
+            }
+        }
+    }
+
+    impl crate::forge::traits::ForgeBackend for ThreadAwareForgeBackend {
+        fn list_pull_requests(
+            &self,
+            _q: crate::forge::traits::PullRequestListQuery,
+        ) -> Result<crate::forge::traits::PagedPullRequests> {
+            unimplemented!()
+        }
+        fn get_pull_request(
+            &self,
+            _t: crate::forge::traits::PullRequestTarget,
+        ) -> Result<crate::forge::traits::PullRequestDetails> {
+            Ok(self.details.clone())
+        }
+        fn get_pull_request_diff(
+            &self,
+            _p: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<String> {
+            Ok(self.patch.clone())
+        }
+        fn fetch_file_lines(
+            &self,
+            _r: crate::forge::traits::ForgeFileLinesRequest,
+        ) -> Result<Vec<crate::model::DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn list_review_threads(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<Vec<RemoteReviewThread>> {
+            self.calls.set(self.calls.get() + 1);
+            Ok(self.threads.clone())
+        }
+    }
+
+    fn sample_thread(line: u32, body: &str, resolved: bool, outdated: bool) -> RemoteReviewThread {
+        RemoteReviewThread {
+            id: "T".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(line),
+            side: RemoteCommentSide::Right,
+            is_resolved: resolved,
+            is_outdated: outdated,
+            comments: vec![RemoteReviewComment {
+                id: "C".to_string(),
+                author: Some("alice".to_string()),
+                body: body.to_string(),
+                created_at: None,
+                path: "src/lib.rs".to_string(),
+                line: Some(line),
+                side: RemoteCommentSide::Right,
+                in_reply_to: None,
+                url: "https://example.com/c".to_string(),
+            }],
+        }
+    }
+
+    #[test]
+    fn should_populate_remote_threads_when_opening_pr_through_test_seam() {
+        // given
+        let mut app = build_app();
+        let summary = sample_pr(42, "answer");
+        let backend = Box::new(ThreadAwareForgeBackend::new(
+            test_pr_details(42, "answer"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+            vec![sample_thread(2, "remote body", false, false)],
+        ));
+        // when
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        // then
+        assert_eq!(app.forge_review_threads.len(), 1);
+        assert_eq!(app.forge_review_threads[0].comments[0].body, "remote body");
+        // default visibility is Unresolved on a fresh PR session
+        assert_eq!(
+            app.session.remote_comments_visibility,
+            PrCommentsVisibility::Unresolved
+        );
+    }
+
+    #[test]
+    fn should_clear_remote_threads_without_refetch_when_setting_visibility_hide() {
+        // given a PR open with one fetched thread
+        let mut app = build_app();
+        let summary = sample_pr(42, "answer");
+        let backend = Box::new(ThreadAwareForgeBackend::new(
+            test_pr_details(42, "answer"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+            vec![sample_thread(2, "remote", false, false)],
+        ));
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        assert_eq!(app.forge_review_threads.len(), 1);
+        // when — switch to hide
+        let changed = app.set_remote_comments_visibility(PrCommentsVisibility::Hide);
+        // then
+        assert!(changed);
+        assert_eq!(
+            app.session.remote_comments_visibility,
+            PrCommentsVisibility::Hide
+        );
+        // We don't drop the cache on visibility change — only filtering changes.
+        // Switching back to Unresolved should restore the rendered comments
+        // without making a new network call.
+        assert_eq!(app.forge_review_threads.len(), 1);
+    }
+
+    #[test]
+    fn should_route_comments_unresolved_command_through_command_handler() {
+        use crate::handler::handle_command_action;
+        use crate::input::Action;
+        // given
+        let mut app = build_app();
+        let summary = sample_pr(42, "answer");
+        let backend = Box::new(ThreadAwareForgeBackend::new(
+            test_pr_details(42, "answer"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+            vec![sample_thread(2, "remote", false, false)],
+        ));
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        // when — enter command mode then submit `:comments all`
+        app.input_mode = crate::app::InputMode::Command;
+        app.command_buffer = "comments all".to_string();
+        handle_command_action(&mut app, Action::SubmitInput);
+        // then
+        assert_eq!(
+            app.session.remote_comments_visibility,
+            PrCommentsVisibility::All
+        );
+    }
+
+    #[test]
+    fn should_warn_when_comments_command_used_outside_pr_mode() {
+        use crate::handler::handle_command_action;
+        use crate::input::Action;
+        // given — plain local working-tree session
+        let mut app = build_app();
+        app.input_mode = crate::app::InputMode::Command;
+        app.command_buffer = "comments all".to_string();
+        // when
+        handle_command_action(&mut app, Action::SubmitInput);
+        // then — visibility unchanged, a warning surfaced on the message bar
+        assert_eq!(
+            app.session.remote_comments_visibility,
+            PrCommentsVisibility::Unresolved
+        );
+        let msg = app
+            .message
+            .as_ref()
+            .expect("expected warning on message bar");
+        assert!(matches!(msg.message_type, MessageType::Warning));
+        assert!(
+            msg.content.contains("PR mode"),
+            "got message: {}",
+            msg.content
+        );
+    }
+
+    #[test]
+    fn should_apply_remote_threads_event_when_relevant() {
+        // given a PR session is open at head=`headsha`
+        let mut app = build_app();
+        let summary = sample_pr(42, "answer");
+        let backend = Box::new(ThreadAwareForgeBackend::new(
+            test_pr_details(42, "answer"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+            // open with empty threads — we'll deliver via the channel
+            Vec::new(),
+        ));
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        // simulate a background fetch that finished after open
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_threads_rx = Some(rx);
+        app.forge_review_threads_loading = true;
+        let pr_key = match &app.diff_source {
+            DiffSource::PullRequest(pr) => pr.key.clone(),
+            _ => panic!("expected PR mode"),
+        };
+        tx.send(crate::app::PrThreadsEvent::Done {
+            repository: pr_key.repository.clone(),
+            pr_number: pr_key.number,
+            head_sha: pr_key.head_sha.clone(),
+            result: Ok(vec![sample_thread(2, "delayed", false, false)]),
+        })
+        .unwrap();
+        // when
+        app.poll_pr_threads_events();
+        // then
+        assert!(!app.forge_review_threads_loading);
+        assert_eq!(app.forge_review_threads.len(), 1);
+        assert_eq!(app.forge_review_threads[0].comments[0].body, "delayed");
+    }
+
+    #[test]
+    fn should_discard_stale_remote_threads_event_after_switching_pr() {
+        // given a PR open, then user switches to a different PR while a
+        // fetch is in flight
+        let mut app = build_app();
+        let summary = sample_pr(42, "answer");
+        let backend = Box::new(ThreadAwareForgeBackend::new(
+            test_pr_details(42, "answer"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+            Vec::new(),
+        ));
+        app.open_pr_with_backend(&summary, backend, None).unwrap();
+        // simulate a stale event from a different PR head
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_threads_rx = Some(rx);
+        tx.send(crate::app::PrThreadsEvent::Done {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 999,                         // wrong number
+            head_sha: "definitely-not-this".into(), // wrong head
+            result: Ok(vec![sample_thread(2, "stale", false, false)]),
+        })
+        .unwrap();
+        // when
+        app.poll_pr_threads_events();
+        // then — stale result was dropped
+        assert!(app.forge_review_threads.is_empty());
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1810,14 +1810,11 @@ impl App {
             }
         }
         let target = best.or(file_first).unwrap_or(0);
-        self.diff_state.cursor_line = target;
-        // Anchor the current_file_idx to whatever annotation we landed on
-        // so the file list highlight stays in sync.
-        if let Some(ann) = self.line_annotations.get(target)
-            && let Some(file_idx) = annotation_file_idx(ann)
-        {
-            self.diff_state.current_file_idx = file_idx;
-        }
+        // `move_cursor_to_annotation` updates cursor_line AND adjusts
+        // `scroll_offset` so the cursor stays in the viewport. Without
+        // it the viewport snaps back to the top of the diff after the
+        // reload.
+        self.move_cursor_to_annotation(target);
     }
 
     /// Kick off `:e` asynchronously. Captures the cursor anchor, sets

--- a/src/app.rs
+++ b/src/app.rs
@@ -505,6 +505,38 @@ pub enum PrOpenEvent {
     },
 }
 
+/// A semantic anchor for the cursor — what we captured before kicking
+/// off `:e`, and what we try to re-locate after the new diff lands.
+/// Identifies the cursor's last-known position in terms of file path
+/// and line numbers rather than the volatile annotation index.
+#[derive(Debug, Clone)]
+pub struct PrCursorAnchor {
+    pub path: std::path::PathBuf,
+    pub new_lineno: Option<u32>,
+    pub old_lineno: Option<u32>,
+}
+
+/// In-flight `:e` reload of the current PR. Drives the status-bar
+/// spinner and carries the cursor anchor we want to restore after the
+/// reload lands.
+#[derive(Debug, Clone)]
+pub struct PrReloadRequest {
+    pub repository: crate::forge::traits::ForgeRepository,
+    pub pr_number: u64,
+    pub head_sha: String,
+    pub started_at: Instant,
+    pub anchor: Option<PrCursorAnchor>,
+}
+
+/// Result delivered from the PR-reload background thread.
+#[derive(Debug)]
+pub enum PrReloadEvent {
+    Done {
+        request: PrReloadRequest,
+        result: std::result::Result<(crate::forge::traits::PullRequestDetails, String), String>,
+    },
+}
+
 /// Result delivered from the remote-thread fetch background thread. The PR
 /// diff is rendered as soon as it parses; threads land asynchronously and
 /// trigger a repaint via `poll_pr_threads_events`.
@@ -614,6 +646,11 @@ pub struct App {
     /// Background-thread channel that delivers the result of a PR open.
     /// `Receiver` is only present while an open is in flight.
     pub pr_open_rx: Option<std::sync::mpsc::Receiver<PrOpenEvent>>,
+    /// In-flight `:e` reload. Drives the status-bar spinner and stores
+    /// the cursor anchor we want to restore after the new diff lands.
+    pub pr_reload_state: Option<PrReloadRequest>,
+    /// Background-thread channel that delivers the result of a PR reload.
+    pub pr_reload_rx: Option<std::sync::mpsc::Receiver<PrReloadEvent>>,
     /// Forge backend instance live while in PR diff mode. Used by the
     /// context provider for gap expansion against base/head SHAs and (in a
     /// future PR) for remote comment fetch/submit.
@@ -1196,6 +1233,8 @@ impl App {
             pr_load_rx: None,
             pr_open_state: None,
             pr_open_rx: None,
+            pr_reload_state: None,
+            pr_reload_rx: None,
             forge_backend: None,
             forge_review_threads: Vec::new(),
             forge_review_threads_loading: false,
@@ -1688,6 +1727,235 @@ impl App {
     /// Reload the PR's head from the forge. If the head SHA changed, this
     /// switches sessions so old-head draft comments stay with the old
     /// session and the new session starts clean.
+    /// Capture the cursor's current file + line numbers so we can try to
+    /// land back here after `:e` rebuilds the diff. Returns `None` when
+    /// the cursor isn't on a diff line (e.g., it's on a header / comment
+    /// / hunk header / expander).
+    fn capture_pr_cursor_anchor(&self) -> Option<PrCursorAnchor> {
+        let annotation = self.line_annotations.get(self.diff_state.cursor_line)?;
+        let (file_idx, old_lineno, new_lineno) = match annotation {
+            AnnotatedLine::DiffLine {
+                file_idx,
+                old_lineno,
+                new_lineno,
+                ..
+            } => (*file_idx, *old_lineno, *new_lineno),
+            AnnotatedLine::SideBySideLine {
+                file_idx,
+                old_lineno,
+                new_lineno,
+                ..
+            } => (*file_idx, *old_lineno, *new_lineno),
+            AnnotatedLine::ExpandedContext { gap_id, .. } => {
+                // Approximate: drop back to the file index from the gap.
+                let file_idx = gap_id.file_idx;
+                (file_idx, None, None)
+            }
+            _ => {
+                let file_idx = annotation_file_idx(annotation)?;
+                (file_idx, None, None)
+            }
+        };
+        let path = self.diff_files.get(file_idx)?.display_path().clone();
+        Some(PrCursorAnchor {
+            path,
+            new_lineno,
+            old_lineno,
+        })
+    }
+
+    /// Move the cursor to a sensible spot after a reload that may have
+    /// shifted file ordering / hunk boundaries. Best-effort: match the
+    /// exact `(path, new_lineno)` if it still exists, else the same
+    /// `(path, old_lineno)` on the LEFT side, else the file's first
+    /// annotation, else stay at line 0.
+    fn restore_pr_cursor_to_anchor(&mut self, anchor: &PrCursorAnchor) {
+        let mut best: Option<usize> = None;
+        let mut file_first: Option<usize> = None;
+        for (idx, ann) in self.line_annotations.iter().enumerate() {
+            let file_idx = match ann {
+                AnnotatedLine::DiffLine { file_idx, .. }
+                | AnnotatedLine::SideBySideLine { file_idx, .. }
+                | AnnotatedLine::HunkHeader { file_idx, .. }
+                | AnnotatedLine::FileHeader { file_idx, .. } => *file_idx,
+                _ => continue,
+            };
+            let Some(file) = self.diff_files.get(file_idx) else {
+                continue;
+            };
+            if file.display_path() != &anchor.path {
+                continue;
+            }
+            file_first.get_or_insert(idx);
+            let (line_new, line_old) = match ann {
+                AnnotatedLine::DiffLine {
+                    old_lineno,
+                    new_lineno,
+                    ..
+                }
+                | AnnotatedLine::SideBySideLine {
+                    old_lineno,
+                    new_lineno,
+                    ..
+                } => (*new_lineno, *old_lineno),
+                _ => (None, None),
+            };
+            if anchor.new_lineno.is_some() && line_new == anchor.new_lineno {
+                best = Some(idx);
+                break;
+            }
+            if anchor.old_lineno.is_some() && line_old == anchor.old_lineno {
+                best = Some(idx);
+                // Don't break — a later RIGHT-side match may still be better.
+            }
+        }
+        let target = best.or(file_first).unwrap_or(0);
+        self.diff_state.cursor_line = target;
+        // Anchor the current_file_idx to whatever annotation we landed on
+        // so the file list highlight stays in sync.
+        if let Some(ann) = self.line_annotations.get(target)
+            && let Some(file_idx) = annotation_file_idx(ann)
+        {
+            self.diff_state.current_file_idx = file_idx;
+        }
+    }
+
+    /// Kick off `:e` asynchronously. Captures the cursor anchor, sets
+    /// the reload state for the spinner, and spawns the network fetch
+    /// on a background thread. Returns immediately. The result is
+    /// applied later in `poll_pr_reload_events`.
+    pub fn spawn_pr_reload(&mut self) -> Result<()> {
+        use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::pr_open::fetch_pr_data;
+        use crate::forge::traits::PullRequestTarget;
+
+        let DiffSource::PullRequest(current) = self.diff_source.clone() else {
+            return Err(TuicrError::UnsupportedOperation(
+                "Not in PR mode".to_string(),
+            ));
+        };
+        if self.pr_reload_state.is_some() {
+            return Ok(()); // already in flight; the existing spinner is enough
+        }
+
+        let anchor = self.capture_pr_cursor_anchor();
+        let request = PrReloadRequest {
+            repository: current.key.repository.clone(),
+            pr_number: current.key.number,
+            head_sha: current.key.head_sha.clone(),
+            started_at: Instant::now(),
+            anchor,
+        };
+        self.pr_reload_state = Some(request.clone());
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_reload_rx = Some(rx);
+
+        let repository = current.key.repository.clone();
+        let pr_number = current.key.number;
+        std::thread::spawn(move || {
+            let backend =
+                GitHubGhBackend::new(Some(repository.clone())).with_local_checkout(local_checkout);
+            let target =
+                PullRequestTarget::with_repository(repository, pr_number, pr_number.to_string());
+            let outcome = fetch_pr_data(&backend, target).map_err(|e| e.to_string());
+            let _ = tx.send(PrReloadEvent::Done {
+                request,
+                result: outcome,
+            });
+        });
+        Ok(())
+    }
+
+    /// Pump a pending reload result. Parses + applies on the main thread,
+    /// then restores the cursor to the remembered anchor.
+    pub fn poll_pr_reload_events(&mut self) {
+        let Some(rx) = self.pr_reload_rx.as_ref() else {
+            return;
+        };
+        let event = match rx.try_recv() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        self.pr_reload_rx = None;
+        let in_flight = self.pr_reload_state.clone();
+        self.pr_reload_state = None;
+        let PrReloadEvent::Done { request, result } = event;
+        if !in_flight
+            .as_ref()
+            .is_some_and(|s| s.pr_number == request.pr_number && s.repository == request.repository)
+        {
+            return;
+        }
+        match result {
+            Ok((details, patch)) => {
+                if let Err(e) = self.finish_pr_reload(details, patch, &request) {
+                    self.set_error(format!("Reload failed: {e}"));
+                }
+            }
+            Err(e) => {
+                self.set_error(format!("Reload failed: {e}"));
+            }
+        }
+    }
+
+    fn finish_pr_reload(
+        &mut self,
+        details: crate::forge::traits::PullRequestDetails,
+        patch: String,
+        request: &PrReloadRequest,
+    ) -> Result<()> {
+        use crate::forge::github::gh::GitHubGhBackend;
+        use crate::forge::pr_open::prepare_open_pr;
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+        let highlighter = self.theme.syntax_highlighter();
+        let mut opened = prepare_open_pr(details, &patch, local_checkout.as_deref(), highlighter)?;
+
+        let head_changed = opened.details.head_sha != request.head_sha;
+        if head_changed {
+            let _ = crate::persistence::save_session(&self.session);
+            let details_for_threads = opened.details.clone();
+            Self::load_or_apply_pr_session(&mut opened);
+            let backend = Box::new(
+                GitHubGhBackend::new(Some(request.repository.clone()))
+                    .with_local_checkout(local_checkout.clone()),
+            );
+            self.enter_pr_diff_mode(backend, opened)?;
+            self.spawn_pr_threads_fetch(&details_for_threads, local_checkout);
+            self.set_message("Reloaded PR at new head — switched to fresh session".to_string());
+        } else {
+            self.diff_files = opened.diff_files;
+            self.clear_expanded_gaps();
+            for file in &self.diff_files {
+                let path = file.display_path().clone();
+                self.session.add_file(path, file.status, file.content_hash);
+            }
+            self.sort_files_by_directory(true);
+            self.expand_all_dirs();
+            self.rebuild_annotations();
+            self.refetch_pr_threads();
+            self.set_message("Reloaded PR (no new commits)".to_string());
+        }
+
+        if let Some(anchor) = &request.anchor {
+            self.restore_pr_cursor_to_anchor(anchor);
+        }
+        Ok(())
+    }
+
+    /// Synchronous reload. Production code uses `spawn_pr_reload` for the
+    /// async path; kept as a seam for tests that need to drive a reload
+    /// in one call without an mpsc round-trip.
+    #[allow(dead_code)]
     pub fn reload_pull_request(&mut self) -> Result<bool> {
         use crate::forge::github::gh::GitHubGhBackend;
 
@@ -1708,6 +1976,7 @@ impl App {
 
     /// Inner reload path. Takes the forge backend as a parameter so tests
     /// can inject a fake without going through `gh`.
+    #[allow(dead_code)]
     pub fn reload_pull_request_with_backend(
         &mut self,
         backend: Box<dyn ForgeBackend>,

--- a/src/app.rs
+++ b/src/app.rs
@@ -3611,6 +3611,17 @@ impl App {
     }
 
     /// Find the comment at the current cursor position
+    /// True when the cursor is on a row that belongs to a fetched-from-GitHub
+    /// review thread. Remote threads are read-only in v1; surfaced as a
+    /// distinct condition so the handler can produce a clearer message than
+    /// the generic "no comment at cursor".
+    pub fn cursor_on_remote_thread(&self) -> bool {
+        matches!(
+            self.line_annotations.get(self.diff_state.cursor_line),
+            Some(AnnotatedLine::RemoteThreadLine { .. })
+        )
+    }
+
     fn find_comment_at_cursor(&self) -> Option<CommentLocation> {
         let target = self.diff_state.cursor_line;
         match self.line_annotations.get(target) {
@@ -7256,9 +7267,6 @@ mod target_selector_tests {
                 author: Some("alice".to_string()),
                 body: body.to_string(),
                 created_at: None,
-                path: "src/lib.rs".to_string(),
-                line: Some(line),
-                side: RemoteCommentSide::Right,
                 in_reply_to: None,
                 url: "https://example.com/c".to_string(),
             }],

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -144,6 +144,12 @@ mod tests {
             self.seen.borrow_mut().push(request);
             Ok(self.response.clone())
         }
+        fn list_review_threads(
+            &self,
+            _pr: &PullRequestDetails,
+        ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
+            Ok(Vec::new())
+        }
     }
 
     fn repo() -> ForgeRepository {

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -203,6 +203,13 @@ where
     }
 
     fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String> {
+        // We want the *cumulative* diff between base and head for the PR.
+        // `gh pr diff --patch` returns mbox-style `git format-patch` output
+        // — one patch per commit — so a 7-commit PR yields 7 separate
+        // `diff --git` blocks per file, which our parser dutifully turns
+        // into duplicate `DiffFile`s. Plain `gh pr diff` (no `--patch`)
+        // returns the single cumulative diff. Hard-won lesson; see the
+        // duplicate-files-in-list bug.
         self.run_gh(
             vec![
                 "pr".to_string(),
@@ -210,7 +217,6 @@ where
                 pr.number.to_string(),
                 "--repo".to_string(),
                 gh_repo_arg(&pr.repository),
-                "--patch".to_string(),
                 "--color".to_string(),
                 "never".to_string(),
             ],
@@ -872,6 +878,34 @@ index 1111111..2222222 100644
         let patch = backend.get_pull_request_diff(&details).unwrap();
 
         assert_eq!(patch, PR_PATCH);
+    }
+
+    #[test]
+    fn should_not_pass_patch_flag_to_gh_pr_diff() {
+        // Regression: `gh pr diff --patch` returns mbox-style per-commit
+        // patches concatenated, which the diff parser turns into duplicate
+        // DiffFile entries (one per commit-touching-the-same-file). We
+        // want the cumulative diff. Lock the argv so this can't silently
+        // regress.
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        let _ = backend.get_pull_request_diff(&details).unwrap();
+
+        let calls = backend.runner.calls.borrow();
+        let diff_call = calls
+            .iter()
+            .find(|args| {
+                args.first().map(String::as_str) == Some("pr")
+                    && args.get(1).map(String::as_str) == Some("diff")
+            })
+            .expect("expected a `gh pr diff` call");
+        assert!(
+            !diff_call.iter().any(|a| a == "--patch"),
+            "`gh pr diff` must NOT pass --patch (mbox output duplicates files); got {diff_call:?}"
+        );
     }
 
     #[test]

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
+use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, PagedPullRequests, PullRequestDetails,
     PullRequestListQuery, PullRequestTarget,
@@ -10,6 +11,7 @@ use crate::model::{DiffLine, LineOrigin};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 
 use super::models::{GhPullRequestDetails, GhPullRequestSummary};
+use super::review_threads::{build_query, parse_graphql_page};
 
 const DEFAULT_GITHUB_HOST: &str = "github.com";
 const PR_LIST_JSON_FIELDS: &str =
@@ -220,6 +222,30 @@ where
         self.local_checkout.clone()
     }
 
+    fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>> {
+        let mut all: Vec<RemoteReviewThread> = Vec::new();
+        let mut cursor: Option<String> = None;
+        // Bound the pagination loop so a buggy/cyclic server can't hang us.
+        // 100 threads * 100 pages = 10k threads; well beyond realistic PRs.
+        for _ in 0..100 {
+            let args = self.build_review_threads_args(pr, cursor.as_deref());
+            let output = self.run_gh(args, &pr.repository.host)?;
+            let parsed = parse_graphql_page(&output)?;
+            all.extend(parsed.threads);
+            let Some(page_info) = parsed.page_info else {
+                break;
+            };
+            if !page_info.has_next_page {
+                break;
+            }
+            let Some(end_cursor) = page_info.end_cursor else {
+                break;
+            };
+            cursor = Some(end_cursor);
+        }
+        Ok(all)
+    }
+
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
@@ -251,6 +277,37 @@ impl<R> GitHubGhBackend<R>
 where
     R: GhCommandRunner,
 {
+    fn build_review_threads_args(
+        &self,
+        pr: &PullRequestDetails,
+        cursor: Option<&str>,
+    ) -> Vec<String> {
+        let query = build_query(cursor);
+        let mut args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={query}"),
+            "-F".to_string(),
+            format!("owner={}", pr.repository.owner),
+            "-F".to_string(),
+            format!("name={}", pr.repository.name),
+            "-F".to_string(),
+            format!("number={}", pr.number),
+        ];
+        if let Some(c) = cursor {
+            args.push("-F".to_string());
+            args.push(format!("after={c}"));
+        }
+        // Enterprise host routing — `gh api graphql --hostname` picks the
+        // correct endpoint when the repo lives on a non-default host.
+        if pr.repository.host != "github.com" {
+            args.push("--hostname".to_string());
+            args.push(pr.repository.host.clone());
+        }
+        args
+    }
+
     fn fetch_file_via_api(&self, request: &ForgeFileLinesRequest) -> Result<String> {
         // `gh api repos/<owner>/<repo>/contents/<path>?ref=<sha>` returns a
         // JSON object with base64-encoded `content` for text files. The
@@ -571,10 +628,21 @@ index 1111111..2222222 100644
     impl GhCommandRunner for FakeGhRunner {
         fn run(&self, args: &[String]) -> GhCommandResult<String> {
             self.calls.borrow_mut().push(args.to_vec());
-            match args.get(1).map(String::as_str) {
-                Some("list") => Ok(PR_LIST_JSON.to_string()),
-                Some("view") => Ok(PR_VIEW_JSON.to_string()),
-                Some("diff") => Ok(PR_PATCH.to_string()),
+            match args.first().map(String::as_str) {
+                // gh pr list/view/diff — second arg is the subcommand.
+                Some("pr") => match args.get(1).map(String::as_str) {
+                    Some("list") => Ok(PR_LIST_JSON.to_string()),
+                    Some("view") => Ok(PR_VIEW_JSON.to_string()),
+                    Some("diff") => Ok(PR_PATCH.to_string()),
+                    _ => Err(GhCommandError::Failed {
+                        status: Some(1),
+                        stderr: "unexpected pr command".to_string(),
+                    }),
+                },
+                // gh api graphql for review threads.
+                Some("api") if args.get(1).map(String::as_str) == Some("graphql") => {
+                    Ok(REVIEW_THREADS_JSON.to_string())
+                }
                 _ => Err(GhCommandError::Failed {
                     status: Some(1),
                     stderr: "unexpected command".to_string(),
@@ -582,6 +650,38 @@ index 1111111..2222222 100644
             }
         }
     }
+
+    const REVIEW_THREADS_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [
+                            {
+                                "id": "PRRT_1",
+                                "isResolved": false,
+                                "isOutdated": false,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_1",
+                                            "body": "remote one",
+                                            "author": { "login": "alice" },
+                                            "path": "src/lib.rs",
+                                            "line": 42,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
 
     fn repo() -> ForgeRepository {
         ForgeRepository::github("github.com", "agavra", "tuicr")
@@ -772,6 +872,33 @@ index 1111111..2222222 100644
         let patch = backend.get_pull_request_diff(&details).unwrap();
 
         assert_eq!(patch, PR_PATCH);
+    }
+
+    #[test]
+    fn should_list_review_threads_via_graphql_api_call() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let threads = backend.list_review_threads(&details).unwrap();
+        // then
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0].id, "PRRT_1");
+        assert_eq!(threads[0].path, "src/lib.rs");
+        // and — the API call was placed against `gh api graphql` with the
+        // owner/name/number parameters.
+        let calls = backend.runner.calls.borrow();
+        let graphql_call = calls
+            .iter()
+            .find(|args| args.first().map(String::as_str) == Some("api"))
+            .expect("expected a gh api call");
+        assert_eq!(graphql_call[1], "graphql");
+        assert!(graphql_call.iter().any(|a| a == "owner=agavra"));
+        assert!(graphql_call.iter().any(|a| a == "name=tuicr"));
+        assert!(graphql_call.iter().any(|a| a == "number=125"));
     }
 
     #[test]

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -662,15 +662,15 @@ index 1111111..2222222 100644
                                 "id": "PRRT_1",
                                 "isResolved": false,
                                 "isOutdated": false,
+                                "path": "src/lib.rs",
+                                "line": 42,
+                                "diffSide": "RIGHT",
                                 "comments": {
                                     "nodes": [
                                         {
                                             "id": "PRRC_1",
                                             "body": "remote one",
                                             "author": { "login": "alice" },
-                                            "path": "src/lib.rs",
-                                            "line": 42,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/1"
                                         }
                                     ]

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -1,2 +1,3 @@
 pub mod gh;
 pub mod models;
+pub mod review_threads;

--- a/src/forge/github/review_threads.rs
+++ b/src/forge/github/review_threads.rs
@@ -1,0 +1,615 @@
+//! GraphQL parsing for GitHub review threads.
+//!
+//! REST exposes review comments but not the resolved/outdated thread state
+//! that v1 requires for `:comments unresolved`. The GitHub GraphQL API
+//! groups comments into `reviewThreads` with `isResolved` and `isOutdated`
+//! flags. We fetch via `gh api graphql` so authentication, host, and
+//! enterprise routing reuse what `gh` already knows.
+//!
+//! Payload shape (only the fields we read are documented here):
+//!
+//! ```json
+//! {
+//!   "data": {
+//!     "repository": {
+//!       "pullRequest": {
+//!         "reviewThreads": {
+//!           "pageInfo": { "hasNextPage": false, "endCursor": null },
+//!           "nodes": [
+//!             {
+//!               "id": "PRRT_kw...",
+//!               "isResolved": false,
+//!               "isOutdated": false,
+//!               "comments": {
+//!                 "nodes": [
+//!                   {
+//!                     "id": "PRRC_kw...",
+//!                     "body": "Can this be simplified?",
+//!                     "author": { "login": "alice" },
+//!                     "createdAt": "2026-05-12T18:30:00Z",
+//!                     "path": "src/lib.rs",
+//!                     "line": 42,
+//!                     "originalLine": 42,
+//!                     "side": "RIGHT",
+//!                     "url": "https://github.com/agavra/tuicr/pull/125#discussion_r1"
+//!                   }
+//!                 ]
+//!               }
+//!             }
+//!           ]
+//!         }
+//!       }
+//!     }
+//!   }
+//! }
+//! ```
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::{Result, TuicrError};
+use crate::forge::remote_comments::{RemoteCommentSide, RemoteReviewComment, RemoteReviewThread};
+
+#[derive(Debug, Deserialize)]
+struct GhAuthor {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReviewComment {
+    id: String,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    author: Option<GhAuthor>,
+    #[serde(default)]
+    created_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    line: Option<u32>,
+    #[serde(default)]
+    original_line: Option<u32>,
+    #[serde(default)]
+    side: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    reply_to: Option<GhReplyRef>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhReplyRef {
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCommentsConn {
+    #[serde(default)]
+    nodes: Vec<GhReviewComment>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReviewThread {
+    id: String,
+    #[serde(default)]
+    is_resolved: bool,
+    #[serde(default)]
+    is_outdated: bool,
+    #[serde(default)]
+    comments: Option<GhCommentsConn>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GhPageInfo {
+    #[serde(default)]
+    pub has_next_page: bool,
+    #[serde(default)]
+    pub end_cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReviewThreadsConn {
+    #[serde(default)]
+    page_info: Option<GhPageInfo>,
+    #[serde(default)]
+    nodes: Vec<GhReviewThread>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPullRequest {
+    #[serde(default)]
+    review_threads: Option<GhReviewThreadsConn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRepository {
+    #[serde(default, rename = "pullRequest")]
+    pull_request: Option<GhPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhData {
+    #[serde(default)]
+    repository: Option<GhRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhResponse {
+    #[serde(default)]
+    data: Option<GhData>,
+}
+
+/// Outcome of parsing a single GraphQL page.
+#[derive(Debug)]
+pub(crate) struct ParsedPage {
+    pub threads: Vec<RemoteReviewThread>,
+    pub page_info: Option<GhPageInfo>,
+}
+
+/// Parse one GraphQL response page into domain threads + pagination info.
+/// Errors only on malformed JSON; missing optional fields are tolerated.
+pub(crate) fn parse_graphql_page(json: &str) -> Result<ParsedPage> {
+    let response: GhResponse = serde_json::from_str(json).map_err(|e| {
+        TuicrError::Forge(format!(
+            "Failed to parse GitHub review threads response: {e}"
+        ))
+    })?;
+
+    let conn = response
+        .data
+        .and_then(|d| d.repository)
+        .and_then(|r| r.pull_request)
+        .and_then(|p| p.review_threads);
+
+    let Some(conn) = conn else {
+        return Ok(ParsedPage {
+            threads: Vec::new(),
+            page_info: None,
+        });
+    };
+
+    let page_info = conn.page_info;
+    let mut threads = Vec::with_capacity(conn.nodes.len());
+    for raw in conn.nodes {
+        threads.push(convert_thread(raw));
+    }
+    Ok(ParsedPage { threads, page_info })
+}
+
+fn convert_thread(raw: GhReviewThread) -> RemoteReviewThread {
+    let comments_conn = raw.comments.unwrap_or(GhCommentsConn { nodes: Vec::new() });
+    let comments: Vec<RemoteReviewComment> = comments_conn
+        .nodes
+        .into_iter()
+        .map(convert_comment)
+        .collect();
+
+    // Thread anchor: prefer the root comment's effective position. If the
+    // thread is outdated, GitHub returns line=null but originalLine is set,
+    // which we surface as `is_outdated` rather than synthesizing a line.
+    let root = comments.first();
+    let path = root.map(|c| c.path.clone()).unwrap_or_default();
+    let line = root.and_then(|c| c.line);
+    let side = root.map(|c| c.side).unwrap_or(RemoteCommentSide::Right);
+
+    RemoteReviewThread {
+        id: raw.id,
+        path,
+        line,
+        side,
+        is_resolved: raw.is_resolved,
+        is_outdated: raw.is_outdated,
+        comments,
+    }
+}
+
+fn convert_comment(raw: GhReviewComment) -> RemoteReviewComment {
+    let side = raw
+        .side
+        .as_deref()
+        .map(RemoteCommentSide::parse)
+        .unwrap_or(RemoteCommentSide::Right);
+    RemoteReviewComment {
+        id: raw.id,
+        author: raw.author.and_then(|a| a.login),
+        body: raw.body,
+        created_at: raw.created_at,
+        path: raw.path.unwrap_or_default(),
+        // If `line` is null on an outdated comment, fall back to
+        // `originalLine` so we still know roughly where it was anchored.
+        line: raw.line.or(raw.original_line),
+        side,
+        in_reply_to: raw.reply_to.map(|r| r.id),
+        url: raw.url.unwrap_or_default(),
+    }
+}
+
+/// Build the GraphQL query string parameterized by repository + PR number.
+pub(crate) fn build_query(after_cursor: Option<&str>) -> String {
+    let cursor_arg = match after_cursor {
+        Some(_) => ", after: $after",
+        None => "",
+    };
+    format!(
+        r#"query($owner: String!, $name: String!, $number: Int!{cursor_param}) {{
+  repository(owner: $owner, name: $name) {{
+    pullRequest(number: $number) {{
+      reviewThreads(first: 100{cursor_arg}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          id
+          isResolved
+          isOutdated
+          comments(first: 100) {{
+            nodes {{
+              id
+              body
+              author {{ login }}
+              createdAt
+              path
+              line
+              originalLine
+              side
+              url
+              replyTo {{ id }}
+            }}
+          }}
+        }}
+      }}
+    }}
+  }}
+}}"#,
+        cursor_param = if after_cursor.is_some() {
+            ", $after: String!"
+        } else {
+            ""
+        },
+        cursor_arg = cursor_arg,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SINGLE_THREAD_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [
+                            {
+                                "id": "PRRT_1",
+                                "isResolved": false,
+                                "isOutdated": false,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_1",
+                                            "body": "Can this be simplified?",
+                                            "author": { "login": "alice" },
+                                            "createdAt": "2026-05-12T18:30:00Z",
+                                            "path": "src/lib.rs",
+                                            "line": 42,
+                                            "originalLine": 42,
+                                            "side": "RIGHT",
+                                            "url": "https://github.com/agavra/tuicr/pull/125#discussion_r1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const MULTI_COMMENT_THREAD_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [
+                            {
+                                "id": "PRRT_1",
+                                "isResolved": false,
+                                "isOutdated": false,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_1",
+                                            "body": "Root",
+                                            "author": { "login": "alice" },
+                                            "path": "src/lib.rs",
+                                            "line": 42,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/1"
+                                        },
+                                        {
+                                            "id": "PRRC_2",
+                                            "body": "Reply 1",
+                                            "author": { "login": "bob" },
+                                            "path": "src/lib.rs",
+                                            "line": 42,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/2",
+                                            "replyTo": { "id": "PRRC_1" }
+                                        },
+                                        {
+                                            "id": "PRRC_3",
+                                            "body": "Reply 2",
+                                            "author": { "login": "alice" },
+                                            "path": "src/lib.rs",
+                                            "line": 42,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/3",
+                                            "replyTo": { "id": "PRRC_1" }
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const RESOLVED_THREAD_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "PRRT_resolved",
+                                "isResolved": true,
+                                "isOutdated": false,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_old",
+                                            "body": "Old resolved comment.",
+                                            "author": { "login": "bob" },
+                                            "path": "src/lib.rs",
+                                            "line": 7,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/r"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const OUTDATED_THREAD_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "PRRT_outdated",
+                                "isResolved": false,
+                                "isOutdated": true,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_old",
+                                            "body": "Comment on a line that has moved.",
+                                            "author": { "login": "alice" },
+                                            "path": "src/lib.rs",
+                                            "line": null,
+                                            "originalLine": 19,
+                                            "side": "LEFT",
+                                            "url": "https://example.com/o"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const CROSS_FILE_THREADS_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "nodes": [
+                            {
+                                "id": "PRRT_a",
+                                "isResolved": false,
+                                "isOutdated": false,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_a",
+                                            "body": "Comment in lib",
+                                            "author": { "login": "alice" },
+                                            "path": "src/lib.rs",
+                                            "line": 10,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/a"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "id": "PRRT_b",
+                                "isResolved": false,
+                                "isOutdated": false,
+                                "comments": {
+                                    "nodes": [
+                                        {
+                                            "id": "PRRC_b",
+                                            "body": "Comment in main",
+                                            "author": { "login": "bob" },
+                                            "path": "src/main.rs",
+                                            "line": 5,
+                                            "side": "RIGHT",
+                                            "url": "https://example.com/b"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const EMPTY_THREADS_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": []
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const NULL_REPO_JSON: &str = r##"{ "data": { "repository": null } }"##;
+
+    #[test]
+    fn should_parse_single_thread_with_one_comment() {
+        // given
+        let json = SINGLE_THREAD_JSON;
+        // when
+        let parsed = parse_graphql_page(json).unwrap();
+        // then
+        assert_eq!(parsed.threads.len(), 1);
+        let thread = &parsed.threads[0];
+        assert_eq!(thread.id, "PRRT_1");
+        assert_eq!(thread.path, "src/lib.rs");
+        assert_eq!(thread.line, Some(42));
+        assert_eq!(thread.side, RemoteCommentSide::Right);
+        assert!(!thread.is_resolved);
+        assert!(!thread.is_outdated);
+        assert_eq!(thread.comments.len(), 1);
+        assert_eq!(thread.comments[0].author.as_deref(), Some("alice"));
+        assert_eq!(thread.comments[0].body, "Can this be simplified?");
+    }
+
+    #[test]
+    fn should_parse_multi_comment_thread_with_replies() {
+        // given/when
+        let parsed = parse_graphql_page(MULTI_COMMENT_THREAD_JSON).unwrap();
+        // then
+        let thread = &parsed.threads[0];
+        assert_eq!(thread.comments.len(), 3);
+        assert_eq!(thread.comments[0].in_reply_to, None);
+        assert_eq!(thread.comments[1].in_reply_to.as_deref(), Some("PRRC_1"));
+        assert_eq!(thread.comments[2].in_reply_to.as_deref(), Some("PRRC_1"));
+        // root() returns the first; replies() returns the rest
+        assert_eq!(thread.root().unwrap().body, "Root");
+        let replies: Vec<&str> = thread.replies().map(|c| c.body.as_str()).collect();
+        assert_eq!(replies, vec!["Reply 1", "Reply 2"]);
+    }
+
+    #[test]
+    fn should_parse_resolved_thread_flag() {
+        // given/when
+        let parsed = parse_graphql_page(RESOLVED_THREAD_JSON).unwrap();
+        // then
+        let thread = &parsed.threads[0];
+        assert!(thread.is_resolved);
+        assert!(!thread.is_outdated);
+    }
+
+    #[test]
+    fn should_parse_outdated_thread_flag_and_fall_back_to_original_line() {
+        // given/when
+        let parsed = parse_graphql_page(OUTDATED_THREAD_JSON).unwrap();
+        // then
+        let thread = &parsed.threads[0];
+        assert!(thread.is_outdated);
+        // line is null but originalLine = 19 — we surface originalLine so
+        // the renderer can still place the comment at its last known anchor.
+        assert_eq!(thread.line, Some(19));
+        assert_eq!(thread.side, RemoteCommentSide::Left);
+    }
+
+    #[test]
+    fn should_parse_cross_file_threads_preserving_paths() {
+        // given/when
+        let parsed = parse_graphql_page(CROSS_FILE_THREADS_JSON).unwrap();
+        // then
+        assert_eq!(parsed.threads.len(), 2);
+        let paths: Vec<&str> = parsed.threads.iter().map(|t| t.path.as_str()).collect();
+        assert_eq!(paths, vec!["src/lib.rs", "src/main.rs"]);
+    }
+
+    #[test]
+    fn should_parse_empty_threads_array_without_error() {
+        // given/when
+        let parsed = parse_graphql_page(EMPTY_THREADS_JSON).unwrap();
+        // then
+        assert!(parsed.threads.is_empty());
+        assert!(parsed.page_info.is_some());
+        assert!(!parsed.page_info.as_ref().unwrap().has_next_page);
+    }
+
+    #[test]
+    fn should_tolerate_missing_repository_object() {
+        // given a PR with no review-thread payload reachable (rare)
+        // when
+        let parsed = parse_graphql_page(NULL_REPO_JSON).unwrap();
+        // then — no error, no threads
+        assert!(parsed.threads.is_empty());
+        assert!(parsed.page_info.is_none());
+    }
+
+    #[test]
+    fn should_error_on_malformed_json() {
+        // given
+        let bad = "not json";
+        // when
+        let err = parse_graphql_page(bad).unwrap_err();
+        // then
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Failed to parse GitHub review threads response"),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn should_build_query_without_cursor_for_first_page() {
+        // given/when
+        let q = build_query(None);
+        // then
+        assert!(q.contains("reviewThreads(first: 100)"));
+        assert!(!q.contains("after: $after"));
+    }
+
+    #[test]
+    fn should_build_query_with_cursor_for_subsequent_pages() {
+        // given/when
+        let q = build_query(Some("CURSOR"));
+        // then
+        assert!(q.contains("$after: String!"));
+        assert!(q.contains("after: $after"));
+    }
+}

--- a/src/forge/github/review_threads.rs
+++ b/src/forge/github/review_threads.rs
@@ -8,6 +8,12 @@
 //!
 //! Payload shape (only the fields we read are documented here):
 //!
+//! In GitHub's GraphQL schema, anchor fields (`path`, `line`, `originalLine`,
+//! `diffSide`) live on `PullRequestReviewThread`, NOT on each comment node.
+//! An earlier version of this code put them on the comment nodes; GraphQL
+//! rejected the query with "Field 'side' doesn't exist on type
+//! 'PullRequestReviewComment'". Hence this shape:
+//!
 //! ```json
 //! {
 //!   "data": {
@@ -20,6 +26,10 @@
 //!               "id": "PRRT_kw...",
 //!               "isResolved": false,
 //!               "isOutdated": false,
+//!               "path": "src/lib.rs",
+//!               "line": 42,
+//!               "originalLine": 42,
+//!               "diffSide": "RIGHT",
 //!               "comments": {
 //!                 "nodes": [
 //!                   {
@@ -27,10 +37,6 @@
 //!                     "body": "Can this be simplified?",
 //!                     "author": { "login": "alice" },
 //!                     "createdAt": "2026-05-12T18:30:00Z",
-//!                     "path": "src/lib.rs",
-//!                     "line": 42,
-//!                     "originalLine": 42,
-//!                     "side": "RIGHT",
 //!                     "url": "https://github.com/agavra/tuicr/pull/125#discussion_r1"
 //!                   }
 //!                 ]
@@ -67,14 +73,6 @@ struct GhReviewComment {
     #[serde(default)]
     created_at: Option<DateTime<Utc>>,
     #[serde(default)]
-    path: Option<String>,
-    #[serde(default)]
-    line: Option<u32>,
-    #[serde(default)]
-    original_line: Option<u32>,
-    #[serde(default)]
-    side: Option<String>,
-    #[serde(default)]
     url: Option<String>,
     #[serde(default)]
     reply_to: Option<GhReplyRef>,
@@ -99,6 +97,14 @@ struct GhReviewThread {
     is_resolved: bool,
     #[serde(default)]
     is_outdated: bool,
+    #[serde(default)]
+    path: Option<String>,
+    #[serde(default)]
+    line: Option<u32>,
+    #[serde(default)]
+    original_line: Option<u32>,
+    #[serde(default)]
+    diff_side: Option<String>,
     #[serde(default)]
     comments: Option<GhCommentsConn>,
 }
@@ -191,17 +197,21 @@ fn convert_thread(raw: GhReviewThread) -> RemoteReviewThread {
         .map(convert_comment)
         .collect();
 
-    // Thread anchor: prefer the root comment's effective position. If the
-    // thread is outdated, GitHub returns line=null but originalLine is set,
-    // which we surface as `is_outdated` rather than synthesizing a line.
-    let root = comments.first();
-    let path = root.map(|c| c.path.clone()).unwrap_or_default();
-    let line = root.and_then(|c| c.line);
-    let side = root.map(|c| c.side).unwrap_or(RemoteCommentSide::Right);
+    let side = raw
+        .diff_side
+        .as_deref()
+        .map(RemoteCommentSide::parse)
+        .unwrap_or(RemoteCommentSide::Right);
+
+    // If `line` is null on an outdated thread, fall back to `originalLine`
+    // so we still know roughly where the thread was anchored. The
+    // `is_outdated` flag drives muted styling + suppression from the
+    // default `:comments unresolved` view.
+    let line = raw.line.or(raw.original_line);
 
     RemoteReviewThread {
         id: raw.id,
-        path,
+        path: raw.path.unwrap_or_default(),
         line,
         side,
         is_resolved: raw.is_resolved,
@@ -211,21 +221,11 @@ fn convert_thread(raw: GhReviewThread) -> RemoteReviewThread {
 }
 
 fn convert_comment(raw: GhReviewComment) -> RemoteReviewComment {
-    let side = raw
-        .side
-        .as_deref()
-        .map(RemoteCommentSide::parse)
-        .unwrap_or(RemoteCommentSide::Right);
     RemoteReviewComment {
         id: raw.id,
         author: raw.author.and_then(|a| a.login),
         body: raw.body,
         created_at: raw.created_at,
-        path: raw.path.unwrap_or_default(),
-        // If `line` is null on an outdated comment, fall back to
-        // `originalLine` so we still know roughly where it was anchored.
-        line: raw.line.or(raw.original_line),
-        side,
         in_reply_to: raw.reply_to.map(|r| r.id),
         url: raw.url.unwrap_or_default(),
     }
@@ -247,16 +247,16 @@ pub(crate) fn build_query(after_cursor: Option<&str>) -> String {
           id
           isResolved
           isOutdated
+          path
+          line
+          originalLine
+          diffSide
           comments(first: 100) {{
             nodes {{
               id
               body
               author {{ login }}
               createdAt
-              path
-              line
-              originalLine
-              side
               url
               replyTo {{ id }}
             }}
@@ -290,6 +290,10 @@ mod tests {
                                 "id": "PRRT_1",
                                 "isResolved": false,
                                 "isOutdated": false,
+                                "path": "src/lib.rs",
+                                "line": 42,
+                                "originalLine": 42,
+                                "diffSide": "RIGHT",
                                 "comments": {
                                     "nodes": [
                                         {
@@ -297,10 +301,6 @@ mod tests {
                                             "body": "Can this be simplified?",
                                             "author": { "login": "alice" },
                                             "createdAt": "2026-05-12T18:30:00Z",
-                                            "path": "src/lib.rs",
-                                            "line": 42,
-                                            "originalLine": 42,
-                                            "side": "RIGHT",
                                             "url": "https://github.com/agavra/tuicr/pull/125#discussion_r1"
                                         }
                                     ]
@@ -324,24 +324,21 @@ mod tests {
                                 "id": "PRRT_1",
                                 "isResolved": false,
                                 "isOutdated": false,
+                                "path": "src/lib.rs",
+                                "line": 42,
+                                "diffSide": "RIGHT",
                                 "comments": {
                                     "nodes": [
                                         {
                                             "id": "PRRC_1",
                                             "body": "Root",
                                             "author": { "login": "alice" },
-                                            "path": "src/lib.rs",
-                                            "line": 42,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/1"
                                         },
                                         {
                                             "id": "PRRC_2",
                                             "body": "Reply 1",
                                             "author": { "login": "bob" },
-                                            "path": "src/lib.rs",
-                                            "line": 42,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/2",
                                             "replyTo": { "id": "PRRC_1" }
                                         },
@@ -349,9 +346,6 @@ mod tests {
                                             "id": "PRRC_3",
                                             "body": "Reply 2",
                                             "author": { "login": "alice" },
-                                            "path": "src/lib.rs",
-                                            "line": 42,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/3",
                                             "replyTo": { "id": "PRRC_1" }
                                         }
@@ -375,15 +369,15 @@ mod tests {
                                 "id": "PRRT_resolved",
                                 "isResolved": true,
                                 "isOutdated": false,
+                                "path": "src/lib.rs",
+                                "line": 7,
+                                "diffSide": "RIGHT",
                                 "comments": {
                                     "nodes": [
                                         {
                                             "id": "PRRC_old",
                                             "body": "Old resolved comment.",
                                             "author": { "login": "bob" },
-                                            "path": "src/lib.rs",
-                                            "line": 7,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/r"
                                         }
                                     ]
@@ -406,16 +400,16 @@ mod tests {
                                 "id": "PRRT_outdated",
                                 "isResolved": false,
                                 "isOutdated": true,
+                                "path": "src/lib.rs",
+                                "line": null,
+                                "originalLine": 19,
+                                "diffSide": "LEFT",
                                 "comments": {
                                     "nodes": [
                                         {
                                             "id": "PRRC_old",
                                             "body": "Comment on a line that has moved.",
                                             "author": { "login": "alice" },
-                                            "path": "src/lib.rs",
-                                            "line": null,
-                                            "originalLine": 19,
-                                            "side": "LEFT",
                                             "url": "https://example.com/o"
                                         }
                                     ]
@@ -438,15 +432,15 @@ mod tests {
                                 "id": "PRRT_a",
                                 "isResolved": false,
                                 "isOutdated": false,
+                                "path": "src/lib.rs",
+                                "line": 10,
+                                "diffSide": "RIGHT",
                                 "comments": {
                                     "nodes": [
                                         {
                                             "id": "PRRC_a",
                                             "body": "Comment in lib",
                                             "author": { "login": "alice" },
-                                            "path": "src/lib.rs",
-                                            "line": 10,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/a"
                                         }
                                     ]
@@ -456,15 +450,15 @@ mod tests {
                                 "id": "PRRT_b",
                                 "isResolved": false,
                                 "isOutdated": false,
+                                "path": "src/main.rs",
+                                "line": 5,
+                                "diffSide": "RIGHT",
                                 "comments": {
                                     "nodes": [
                                         {
                                             "id": "PRRC_b",
                                             "body": "Comment in main",
                                             "author": { "login": "bob" },
-                                            "path": "src/main.rs",
-                                            "line": 5,
-                                            "side": "RIGHT",
                                             "url": "https://example.com/b"
                                         }
                                     ]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -8,6 +8,7 @@
 pub mod context;
 pub mod github;
 pub mod pr_open;
+pub mod remote_comments;
 pub mod selector;
 pub mod traits;
 

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -185,6 +185,12 @@ mod tests {
         fn fetch_file_lines(&self, _req: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
             unimplemented!()
         }
+        fn list_review_threads(
+            &self,
+            _pr: &PullRequestDetails,
+        ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
+            Ok(Vec::new())
+        }
     }
 
     const SIMPLE_PATCH: &str = r##"diff --git a/src/lib.rs b/src/lib.rs

--- a/src/forge/remote_comments.rs
+++ b/src/forge/remote_comments.rs
@@ -1,0 +1,317 @@
+//! Remote review comment/thread models.
+//!
+//! These types carry existing GitHub review discussions into the App for
+//! read-only display, filtering, and export. They are deliberately
+//! source-of-truth-on-remote: we never mutate, reply to, or persist them
+//! locally past the in-memory cache.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Which side of the diff a remote comment anchors to.
+///
+/// Mirrors GitHub's submission model: `RIGHT` is the head side (added/context
+/// lines), `LEFT` is the base side (deleted lines).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RemoteCommentSide {
+    Right,
+    Left,
+}
+
+impl RemoteCommentSide {
+    pub fn parse(value: &str) -> Self {
+        match value.to_ascii_uppercase().as_str() {
+            "LEFT" => RemoteCommentSide::Left,
+            _ => RemoteCommentSide::Right,
+        }
+    }
+}
+
+/// A single remote review comment, fetched from a forge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteReviewComment {
+    /// Forge-assigned comment node ID (opaque string).
+    pub id: String,
+    /// Login/handle of the comment author, when available.
+    pub author: Option<String>,
+    /// Markdown body as written on the forge.
+    pub body: String,
+    pub created_at: Option<DateTime<Utc>>,
+    /// File path the comment anchors to.
+    pub path: String,
+    /// 1-based line on the chosen side, or `None` if the forge reports this
+    /// comment as outdated (line no longer maps to the current diff).
+    pub line: Option<u32>,
+    pub side: RemoteCommentSide,
+    /// For reply comments, the ID of the parent comment.
+    pub in_reply_to: Option<String>,
+    /// Permalink to the comment on the forge.
+    pub url: String,
+}
+
+/// A discussion thread on a forge — one root comment plus zero or more replies.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteReviewThread {
+    /// Forge-assigned thread node ID.
+    pub id: String,
+    /// File path the thread anchors to.
+    pub path: String,
+    /// Anchor line on the chosen side. `None` for fully-outdated threads.
+    pub line: Option<u32>,
+    pub side: RemoteCommentSide,
+    pub is_resolved: bool,
+    pub is_outdated: bool,
+    /// Root comment first, replies in posted order.
+    pub comments: Vec<RemoteReviewComment>,
+}
+
+impl RemoteReviewThread {
+    /// Per the spec, the default `:comments unresolved` view shows only
+    /// threads that are neither resolved nor outdated. `:comments all`
+    /// shows everything, and `:comments hide` shows nothing.
+    pub fn is_active(&self) -> bool {
+        !self.is_resolved && !self.is_outdated
+    }
+
+    /// The first comment is the thread root for display purposes.
+    pub fn root(&self) -> Option<&RemoteReviewComment> {
+        self.comments.first()
+    }
+
+    /// Iterator over reply comments (everything after the root).
+    pub fn replies(&self) -> impl Iterator<Item = &RemoteReviewComment> {
+        self.comments.iter().skip(1)
+    }
+}
+
+/// User-controlled visibility for remote review comments in PR mode.
+///
+/// Persisted per-session so visibility survives reopen. Default is
+/// `Unresolved` — see the spec section "Existing GitHub Comments".
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PrCommentsVisibility {
+    /// Show only unresolved (and not outdated) threads. Default.
+    #[default]
+    Unresolved,
+    /// Show all fetched threads, with muted styling for resolved/outdated.
+    All,
+    /// Show nothing.
+    Hide,
+}
+
+impl PrCommentsVisibility {
+    /// Decide whether a thread should appear under this visibility setting.
+    /// Returns:
+    /// - `Some(false)` — render with normal styling
+    /// - `Some(true)` — render with muted styling (resolved or outdated)
+    /// - `None`       — do not render
+    pub fn render_decision(&self, thread: &RemoteReviewThread) -> Option<bool> {
+        match self {
+            PrCommentsVisibility::Hide => None,
+            PrCommentsVisibility::Unresolved => {
+                if thread.is_active() {
+                    Some(false)
+                } else {
+                    None
+                }
+            }
+            PrCommentsVisibility::All => Some(!thread.is_active()),
+        }
+    }
+
+    /// Short label for use in status bar / footer hints.
+    pub fn label(&self) -> &'static str {
+        match self {
+            PrCommentsVisibility::Unresolved => "unresolved",
+            PrCommentsVisibility::All => "all",
+            PrCommentsVisibility::Hide => "hidden",
+        }
+    }
+}
+
+/// Filter a list of threads by the active visibility setting. Threads that
+/// should not render are dropped; remaining ones keep their flags so the
+/// renderer can decide on muted styling per-thread.
+pub fn filter_threads(
+    threads: &[RemoteReviewThread],
+    visibility: PrCommentsVisibility,
+) -> Vec<&RemoteReviewThread> {
+    threads
+        .iter()
+        .filter(|t| visibility.render_decision(t).is_some())
+        .collect()
+}
+
+/// Count the number of rendered lines a thread occupies in the diff view.
+/// Used by `App::rebuild_annotations` to push the matching number of
+/// annotations so cursor/hit-test math stays in sync with rendering.
+///
+/// Layout (must match `ui::comment_panel::format_remote_comment_lines`):
+/// - Root comment: 1 header + N body lines + 1 footer (so `2 + body_lines`).
+/// - Each reply: 1 header + N body lines (no extra footer; the root's
+///   footer closes the thread visually). So `1 + body_lines`.
+pub fn thread_display_lines(thread: &RemoteReviewThread) -> usize {
+    let mut total = 0;
+    for (idx, comment) in thread.comments.iter().enumerate() {
+        let body_lines = comment.body.split('\n').count();
+        if idx == 0 {
+            total += 2 + body_lines;
+        } else {
+            total += 1 + body_lines;
+        }
+    }
+    total
+}
+
+/// Group threads by file path for export grouping. Preserves the input
+/// order within each file.
+pub fn group_threads_by_path(
+    threads: &[RemoteReviewThread],
+) -> Vec<(&str, Vec<&RemoteReviewThread>)> {
+    let mut groups: Vec<(&str, Vec<&RemoteReviewThread>)> = Vec::new();
+    for thread in threads {
+        if let Some((_, bucket)) = groups.iter_mut().find(|(p, _)| *p == thread.path.as_str()) {
+            bucket.push(thread);
+        } else {
+            groups.push((thread.path.as_str(), vec![thread]));
+        }
+    }
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_thread(
+        id: &str,
+        path: &str,
+        line: Option<u32>,
+        is_resolved: bool,
+        is_outdated: bool,
+    ) -> RemoteReviewThread {
+        RemoteReviewThread {
+            id: id.to_string(),
+            path: path.to_string(),
+            line,
+            side: RemoteCommentSide::Right,
+            is_resolved,
+            is_outdated,
+            comments: vec![RemoteReviewComment {
+                id: format!("{id}-root"),
+                author: Some("alice".to_string()),
+                body: "Root body".to_string(),
+                created_at: None,
+                path: path.to_string(),
+                line,
+                side: RemoteCommentSide::Right,
+                in_reply_to: None,
+                url: format!("https://example.com/{id}"),
+            }],
+        }
+    }
+
+    #[test]
+    fn should_default_visibility_to_unresolved() {
+        // given/when
+        let v = PrCommentsVisibility::default();
+        // then
+        assert_eq!(v, PrCommentsVisibility::Unresolved);
+    }
+
+    #[test]
+    fn should_show_only_active_threads_when_unresolved() {
+        // given
+        let v = PrCommentsVisibility::Unresolved;
+        let active = make_thread("a", "src/lib.rs", Some(10), false, false);
+        let resolved = make_thread("b", "src/lib.rs", Some(20), true, false);
+        let outdated = make_thread("c", "src/lib.rs", Some(30), false, true);
+        // when/then
+        assert_eq!(v.render_decision(&active), Some(false));
+        assert_eq!(v.render_decision(&resolved), None);
+        assert_eq!(v.render_decision(&outdated), None);
+    }
+
+    #[test]
+    fn should_show_all_threads_with_muted_for_inactive_when_all() {
+        // given
+        let v = PrCommentsVisibility::All;
+        let active = make_thread("a", "src/lib.rs", Some(10), false, false);
+        let resolved = make_thread("b", "src/lib.rs", Some(20), true, false);
+        let outdated = make_thread("c", "src/lib.rs", Some(30), false, true);
+        // when/then
+        assert_eq!(v.render_decision(&active), Some(false));
+        assert_eq!(v.render_decision(&resolved), Some(true));
+        assert_eq!(v.render_decision(&outdated), Some(true));
+    }
+
+    #[test]
+    fn should_show_no_threads_when_hidden() {
+        // given
+        let v = PrCommentsVisibility::Hide;
+        let active = make_thread("a", "src/lib.rs", Some(10), false, false);
+        // when/then
+        assert_eq!(v.render_decision(&active), None);
+    }
+
+    #[test]
+    fn should_filter_threads_preserving_order() {
+        // given
+        let threads = vec![
+            make_thread("a", "src/lib.rs", Some(10), false, false),
+            make_thread("b", "src/lib.rs", Some(20), true, false),
+            make_thread("c", "src/main.rs", Some(30), false, false),
+        ];
+        // when
+        let unresolved = filter_threads(&threads, PrCommentsVisibility::Unresolved);
+        // then
+        assert_eq!(unresolved.len(), 2);
+        assert_eq!(unresolved[0].id, "a");
+        assert_eq!(unresolved[1].id, "c");
+    }
+
+    #[test]
+    fn should_round_trip_visibility_via_serde() {
+        // given
+        let cases = [
+            PrCommentsVisibility::Unresolved,
+            PrCommentsVisibility::All,
+            PrCommentsVisibility::Hide,
+        ];
+        // when/then
+        for c in cases {
+            let json = serde_json::to_string(&c).unwrap();
+            let back: PrCommentsVisibility = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, c);
+        }
+    }
+
+    #[test]
+    fn should_group_threads_by_file_preserving_order() {
+        // given
+        let threads = vec![
+            make_thread("a", "src/lib.rs", Some(10), false, false),
+            make_thread("b", "src/main.rs", Some(5), false, false),
+            make_thread("c", "src/lib.rs", Some(20), false, false),
+        ];
+        // when
+        let groups = group_threads_by_path(&threads);
+        // then
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].0, "src/lib.rs");
+        assert_eq!(groups[0].1.len(), 2);
+        assert_eq!(groups[1].0, "src/main.rs");
+        assert_eq!(groups[1].1.len(), 1);
+    }
+
+    #[test]
+    fn should_parse_remote_comment_side() {
+        // given/when/then
+        assert_eq!(RemoteCommentSide::parse("LEFT"), RemoteCommentSide::Left);
+        assert_eq!(RemoteCommentSide::parse("RIGHT"), RemoteCommentSide::Right);
+        assert_eq!(RemoteCommentSide::parse("left"), RemoteCommentSide::Left);
+        // unknown defaults to RIGHT (head side) — safer for display
+        assert_eq!(RemoteCommentSide::parse(""), RemoteCommentSide::Right);
+    }
+}

--- a/src/forge/remote_comments.rs
+++ b/src/forge/remote_comments.rs
@@ -28,6 +28,10 @@ impl RemoteCommentSide {
 }
 
 /// A single remote review comment, fetched from a forge.
+///
+/// Anchor fields (`path`, `line`, `side`) live on the parent
+/// `RemoteReviewThread`, not on each comment, mirroring GitHub's GraphQL
+/// schema where `PullRequestReviewComment` does not carry these directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteReviewComment {
     /// Forge-assigned comment node ID (opaque string).
@@ -37,12 +41,6 @@ pub struct RemoteReviewComment {
     /// Markdown body as written on the forge.
     pub body: String,
     pub created_at: Option<DateTime<Utc>>,
-    /// File path the comment anchors to.
-    pub path: String,
-    /// 1-based line on the chosen side, or `None` if the forge reports this
-    /// comment as outdated (line no longer maps to the current diff).
-    pub line: Option<u32>,
-    pub side: RemoteCommentSide,
     /// For reply comments, the ID of the parent comment.
     pub in_reply_to: Option<String>,
     /// Permalink to the comment on the forge.
@@ -147,20 +145,19 @@ pub fn filter_threads(
 /// Used by `App::rebuild_annotations` to push the matching number of
 /// annotations so cursor/hit-test math stays in sync with rendering.
 ///
-/// Layout (must match `ui::comment_panel::format_remote_comment_lines`):
-/// - Root comment: 1 header + N body lines + 1 footer (so `2 + body_lines`).
-/// - Each reply: 1 header + N body lines (no extra footer; the root's
-///   footer closes the thread visually). So `1 + body_lines`.
+/// Layout (must match `ui::comment_panel::format_remote_thread_lines`):
+/// - 1 header line for the root comment (`╭─ [github @author] L42 ──`)
+/// - 1 separator line per reply (`├─ ↳ @author ──`)
+/// - 1 body line per `\n`-split line in each comment's body
+/// - 1 footer line at the end of the thread (`╰────`)
 pub fn thread_display_lines(thread: &RemoteReviewThread) -> usize {
     let mut total = 0;
-    for (idx, comment) in thread.comments.iter().enumerate() {
-        let body_lines = comment.body.split('\n').count();
-        if idx == 0 {
-            total += 2 + body_lines;
-        } else {
-            total += 1 + body_lines;
-        }
+    for comment in &thread.comments {
+        // header (root) or separator (reply) + body lines
+        total += 1 + comment.body.split('\n').count();
     }
+    // single closing rule for the whole thread
+    total += 1;
     total
 }
 
@@ -203,9 +200,6 @@ mod tests {
                 author: Some("alice".to_string()),
                 body: "Root body".to_string(),
                 created_at: None,
-                path: path.to_string(),
-                line,
-                side: RemoteCommentSide::Right,
                 in_reply_to: None,
                 url: format!("https://example.com/{id}"),
             }],

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 use crate::error::Result;
+use crate::forge::remote_comments::RemoteReviewThread;
 use crate::model::{DiffLine, FileStatus};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -263,6 +264,10 @@ pub trait ForgeBackend {
     /// Implementations may optimize by reading from a local checkout when
     /// available; the trait does not require that path.
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>>;
+    /// Fetch existing review discussions for a PR, including their resolved
+    /// and outdated state. Implementations should return all threads in
+    /// posted order; filtering by visibility happens in the App.
+    fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>>;
     /// Optional path to a local checkout the backend may consult as an
     /// optimization. The default returns `None`; callers must never treat
     /// this path as the source of truth for PR contents.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -183,6 +183,7 @@ fn handle_export(app: &mut App) {
             &app.diff_source,
             &app.comment_types,
             app.export_legend,
+            &app.forge_review_threads,
         ) {
             Ok(content) => {
                 app.pending_stdout_output = Some(content);
@@ -196,6 +197,7 @@ fn handle_export(app: &mut App) {
             &app.diff_source,
             &app.comment_types,
             app.export_legend,
+            &app.forge_review_threads,
         ) {
             Ok(msg) => app.set_message(msg),
             Err(e) => app.set_warning(format!("{e}")),
@@ -368,7 +370,13 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                                         .to_string(),
                                 );
                             }
-                            Ok(false) => app.set_message("PR is already at the latest head"),
+                            Ok(false) => {
+                                // Same head: still re-fetch remote threads
+                                // since reviewers may have posted new
+                                // discussions while the user was in tuicr.
+                                app.refetch_pr_threads();
+                                app.set_message("PR is already at the latest head");
+                            }
                             Err(e) => app.set_error(format!("Reload failed: {e}")),
                         }
                     } else {
@@ -453,6 +461,26 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                         app.set_error(format!("Failed to open PR selector: {e}"));
                     } else {
                         return;
+                    }
+                }
+                "comments unresolved" | "comments all" | "comments hide" => {
+                    use crate::forge::remote_comments::PrCommentsVisibility;
+                    if !matches!(app.diff_source, app::DiffSource::PullRequest(_)) {
+                        app.set_warning(":comments only applies in PR mode");
+                    } else {
+                        let new_visibility = match cmd.as_str() {
+                            "comments unresolved" => PrCommentsVisibility::Unresolved,
+                            "comments all" => PrCommentsVisibility::All,
+                            "comments hide" => PrCommentsVisibility::Hide,
+                            _ => unreachable!(),
+                        };
+                        let changed = app.set_remote_comments_visibility(new_visibility);
+                        let label = new_visibility.label();
+                        if changed {
+                            app.set_message(format!("Remote comments: {label}"));
+                        } else {
+                            app.set_message(format!("Remote comments: already {label}"));
+                        }
                     }
                 }
                 _ => app.set_message(format!("Unknown command: {cmd}")),
@@ -559,6 +587,7 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
                         &app.diff_source,
                         &app.comment_types,
                         app.export_legend,
+                        &app.forge_review_threads,
                     ) {
                         Ok(content) => app.pending_stdout_output = Some(content),
                         Err(e) => app.set_warning(format!("{e}")),
@@ -569,6 +598,7 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
                         &app.diff_source,
                         &app.comment_types,
                         app.export_legend,
+                        &app.forge_review_threads,
                     ) {
                         Ok(msg) => app.set_message(msg),
                         Err(e) => app.set_warning(format!("{e}")),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -363,21 +363,11 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                 },
                 "e" | "reload" => {
                     if matches!(app.diff_source, app::DiffSource::PullRequest(_)) {
-                        match app.reload_pull_request() {
-                            Ok(true) => {
-                                app.set_message(
-                                    "Reloaded PR at new head — switched to fresh session"
-                                        .to_string(),
-                                );
-                            }
-                            Ok(false) => {
-                                // Same head: still re-fetch remote threads
-                                // since reviewers may have posted new
-                                // discussions while the user was in tuicr.
-                                app.refetch_pr_threads();
-                                app.set_message("PR is already at the latest head");
-                            }
-                            Err(e) => app.set_error(format!("Reload failed: {e}")),
+                        // Async: shows a spinner in the status bar; result
+                        // is applied in `poll_pr_reload_events` and the
+                        // cursor is restored to the captured anchor.
+                        if let Err(e) = app.spawn_pr_reload() {
+                            app.set_error(format!("Reload failed: {e}"));
                         }
                     } else {
                         match app.reload_diff_files() {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -928,7 +928,11 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         }
         Action::AddFileComment => app.enter_comment_mode(true, None),
         Action::EditComment if !app.enter_edit_mode() => {
-            app.set_message("No comment at cursor");
+            if app.cursor_on_remote_thread() {
+                app.set_message("GitHub comment — read only in tuicr");
+            } else {
+                app.set_message("No comment at cursor");
+            }
         }
         Action::ExportToClipboard => handle_export(app),
         Action::SearchNext => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,7 @@ fn main() -> anyhow::Result<()> {
         app.clear_expired_message();
         app.poll_pr_load_events();
         app.poll_pr_open_events();
+        app.poll_pr_reload_events();
         app.poll_pr_threads_events();
 
         // Render

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,7 +388,11 @@ fn main() -> anyhow::Result<()> {
                         pending_d = false;
                         if key.code == crossterm::event::KeyCode::Char('d') {
                             if !app.delete_comment_at_cursor() {
-                                app.set_message("No comment at cursor");
+                                if app.cursor_on_remote_thread() {
+                                    app.set_message("GitHub comment — read only in tuicr");
+                                } else {
+                                    app.set_message("No comment at cursor");
+                                }
                             }
                             continue;
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,7 @@ fn main() -> anyhow::Result<()> {
         app.clear_expired_message();
         app.poll_pr_load_events();
         app.poll_pr_open_events();
+        app.poll_pr_threads_events();
 
         // Render
         terminal.draw(|frame| {

--- a/src/model/comment.rs
+++ b/src/model/comment.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// Which side of the diff a line comment belongs to
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "lowercase")]
 pub enum LineSide {
     /// Comment on a deleted line (keyed by old_lineno)

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use super::comment::Comment;
 use super::diff_types::FileStatus;
+use crate::forge::remote_comments::PrCommentsVisibility;
 use crate::forge::traits::PrSessionKey;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,6 +84,12 @@ pub struct ReviewSession {
     /// `None` so existing local session JSON deserializes unchanged.
     #[serde(default)]
     pub pr_session_key: Option<PrSessionKey>,
+    /// Per-session visibility setting for existing remote forge comments.
+    /// Only meaningful in PR mode. Defaults to `Unresolved` so a fresh PR
+    /// session — or a session saved before this field existed — shows
+    /// unresolved threads.
+    #[serde(default)]
+    pub remote_comments_visibility: PrCommentsVisibility,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     #[serde(default)]
@@ -108,6 +115,7 @@ impl ReviewSession {
             diff_source,
             commit_range: None,
             pr_session_key: None,
+            remote_comments_visibility: PrCommentsVisibility::default(),
             created_at: now,
             updated_at: now,
             review_comments: Vec::new(),
@@ -383,6 +391,32 @@ mod tests {
         assert_eq!(session.diff_source, SessionDiffSource::WorkingTree);
         assert!(session.pr_session_key.is_none());
         assert!(session.commit_range.is_none());
+        // Per spec: an older session without remote_comments_visibility
+        // defaults to `Unresolved` on read so PR-mode behavior stays sane.
+        assert_eq!(
+            session.remote_comments_visibility,
+            PrCommentsVisibility::Unresolved
+        );
+    }
+
+    #[test]
+    fn should_round_trip_remote_comments_visibility_on_session() {
+        // given
+        let mut session = ReviewSession::new(
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+            "abcdef0123456789".to_string(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.remote_comments_visibility = PrCommentsVisibility::All;
+        // when
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: ReviewSession = serde_json::from_str(&json).unwrap();
+        // then
+        assert_eq!(
+            restored.remote_comments_visibility,
+            PrCommentsVisibility::All
+        );
     }
 
     #[test]

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -7,6 +7,9 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
 use crate::app::{CommentTypeDefinition, DiffSource};
 use crate::error::{Result, TuicrError};
+use crate::forge::remote_comments::{
+    PrCommentsVisibility, RemoteReviewThread, filter_threads, group_threads_by_path,
+};
 use crate::model::{CommentType, LineRange, LineSide, ReviewSession};
 
 /// (file_path, line_range, side, comment_type, content)
@@ -19,8 +22,14 @@ pub fn generate_export_content(
     diff_source: &DiffSource,
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
+    remote_threads: &[RemoteReviewThread],
 ) -> Result<String> {
-    if !session.has_comments() {
+    // In PR mode it's still useful to export PR identity + remote
+    // discussions even if the user has no local drafts. Outside PR mode
+    // we keep the existing behavior of erroring when nothing is to say.
+    let has_remote = matches!(diff_source, DiffSource::PullRequest(_))
+        && !filter_threads(remote_threads, PrCommentsVisibility::Unresolved).is_empty();
+    if !session.has_comments() && !has_remote {
         return Err(TuicrError::NoComments);
     }
     Ok(generate_markdown(
@@ -28,6 +37,7 @@ pub fn generate_export_content(
         diff_source,
         comment_types,
         show_legend,
+        remote_threads,
     ))
 }
 
@@ -36,8 +46,15 @@ pub fn export_to_clipboard(
     diff_source: &DiffSource,
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
+    remote_threads: &[RemoteReviewThread],
 ) -> Result<String> {
-    let content = generate_export_content(session, diff_source, comment_types, show_legend)?;
+    let content = generate_export_content(
+        session,
+        diff_source,
+        comment_types,
+        show_legend,
+        remote_threads,
+    )?;
     let via_terminal = copy_text_to_clipboard(&content)?;
     Ok(if via_terminal {
         "Review copied to clipboard (via terminal)".to_string()
@@ -154,6 +171,7 @@ fn generate_markdown(
     diff_source: &DiffSource,
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
+    remote_threads: &[RemoteReviewThread],
 ) -> String {
     let mut md = String::new();
 
@@ -314,6 +332,12 @@ fn generate_markdown(
     }
 
     // Output numbered list
+    let mut local_section_written = false;
+    if !all_comments.is_empty() {
+        let _ = writeln!(md, "## Local tuicr Comments");
+        let _ = writeln!(md);
+        local_section_written = true;
+    }
     for (i, (file, line_range, side, comment_type, content)) in all_comments.iter().enumerate() {
         let location = match (line_range, side) {
             // Range on deleted side (old lines)
@@ -341,6 +365,50 @@ fn generate_markdown(
             location,
             content
         );
+    }
+
+    // PR-mode-only: include unresolved remote discussions grouped by file.
+    if matches!(diff_source, DiffSource::PullRequest(_)) {
+        let unresolved: Vec<&RemoteReviewThread> =
+            filter_threads(remote_threads, PrCommentsVisibility::Unresolved);
+        if !unresolved.is_empty() {
+            if local_section_written {
+                let _ = writeln!(md);
+            }
+            let _ = writeln!(md, "## Existing GitHub Comments");
+            let _ = writeln!(md);
+
+            // Group threads by file to make the export easy to scan.
+            let owned_unresolved: Vec<RemoteReviewThread> =
+                unresolved.iter().map(|t| (*t).clone()).collect();
+            let groups = group_threads_by_path(&owned_unresolved);
+            let mut thread_n = 1;
+            for (path, threads) in groups {
+                let _ = writeln!(md, "### `{path}`");
+                let _ = writeln!(md);
+                for thread in threads {
+                    if let Some(root) = thread.root() {
+                        let author = root.author.as_deref().unwrap_or("unknown");
+                        let line_marker = root.line.map(|l| format!(":{l}")).unwrap_or_default();
+                        let _ = writeln!(
+                            md,
+                            "{thread_n}. `{path}{line_marker}` @{author} - {body}",
+                            body = root.body
+                        );
+                        if !root.url.is_empty() {
+                            let _ = writeln!(md, "   <{}>", root.url);
+                        }
+                        for reply in thread.replies() {
+                            let reply_author = reply.author.as_deref().unwrap_or("unknown");
+                            let _ =
+                                writeln!(md, "   - @{reply_author} - {body}", body = reply.body);
+                        }
+                        thread_n += 1;
+                    }
+                }
+                let _ = writeln!(md);
+            }
+        }
     }
 
     md
@@ -451,7 +519,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("I reviewed your code and have the following comments"));
@@ -492,7 +560,8 @@ mod tests {
             color: None,
         }];
 
-        let markdown = generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true);
+        let markdown =
+            generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true, &[]);
 
         assert!(markdown.contains("Comment types: QUESTION (ask for clarification)"));
         assert!(markdown.contains("**[QUESTION]**"));
@@ -505,7 +574,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         // Should have 2 numbered comments
@@ -522,8 +591,13 @@ mod tests {
             None,
         ));
 
-        let markdown =
-            generate_markdown(&session, &DiffSource::WorkingTree, &comment_types(), true);
+        let markdown = generate_markdown(
+            &session,
+            &DiffSource::WorkingTree,
+            &comment_types(),
+            true,
+            &[],
+        );
 
         assert!(markdown
             .contains("`Review Comment (scope: working tree changes)` - Please split this into smaller commits"));
@@ -543,6 +617,7 @@ mod tests {
             &DiffSource::CommitRange(vec!["abc1234567890".to_string()]),
             &comment_types(),
             true,
+            &[],
         );
 
         assert!(markdown.contains(
@@ -562,7 +637,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = export_to_clipboard(&session, &diff_source, &comment_types(), true);
+        let result = export_to_clipboard(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(result.is_err());
@@ -576,7 +651,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = generate_export_content(&session, &diff_source, &comment_types(), true);
+        let result = generate_export_content(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(result.is_ok());
@@ -598,7 +673,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = generate_export_content(&session, &diff_source, &comment_types(), true);
+        let result = generate_export_content(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(result.is_err());
@@ -615,7 +690,7 @@ mod tests {
         ]);
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("Reviewing commits: abc1234, def4567"));
@@ -628,7 +703,7 @@ mod tests {
         let diff_source = DiffSource::CommitRange(vec!["abc1234567890".to_string()]);
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("Reviewing commit: abc1234"));
@@ -689,7 +764,7 @@ mod tests {
         // given - simulate what would be copied during export
         let session = create_test_session();
         let diff_source = DiffSource::WorkingTree;
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
         let mut buffer: Vec<u8> = Vec::new();
 
         // when
@@ -731,7 +806,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("`src/main.rs:42`"));
@@ -764,7 +839,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("`src/main.rs:10-15`"));
@@ -797,7 +872,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("`src/main.rs:~20-~25`"));
@@ -829,7 +904,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("`src/main.rs:~30`"));
@@ -861,7 +936,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
 
         // then
         assert!(markdown.contains("`src/main.rs:50`"));
@@ -872,7 +947,7 @@ mod tests {
         let session = create_test_session();
         let diff_source = DiffSource::WorkingTree;
 
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), false);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), false, &[]);
 
         assert!(!markdown.contains("Comment types:"));
         assert!(markdown.contains("[SUGGESTION]"));
@@ -896,13 +971,173 @@ mod tests {
             ));
         }
 
-        let markdown =
-            generate_markdown(&session, &DiffSource::WorkingTree, &comment_types(), true);
+        let markdown = generate_markdown(
+            &session,
+            &DiffSource::WorkingTree,
+            &comment_types(),
+            true,
+            &[],
+        );
 
         assert!(markdown.contains("Comment types: PRAISE (positive feedback)"));
         assert!(!markdown.contains("NOTE"));
         assert!(!markdown.contains("SUGGESTION"));
         assert!(!markdown.contains("ISSUE"));
+    }
+
+    fn sample_pr_diff_source() -> DiffSource {
+        use crate::app::PullRequestDiffSource;
+        use crate::forge::traits::{ForgeRepository, PrSessionKey};
+        DiffSource::PullRequest(Box::new(PullRequestDiffSource {
+            key: PrSessionKey::new(
+                ForgeRepository::github("github.com", "agavra", "tuicr"),
+                125,
+                "abc1234deadbeef".to_string(),
+            ),
+            base_sha: "1234567890".to_string(),
+            title: "Support reviews".to_string(),
+            url: "https://github.com/agavra/tuicr/pull/125".to_string(),
+            head_ref_name: "reviews".to_string(),
+            base_ref_name: "main".to_string(),
+            state: "OPEN".to_string(),
+            closed: false,
+            merged: false,
+        }))
+    }
+
+    fn sample_remote_thread(
+        id: &str,
+        author: &str,
+        body: &str,
+        line: u32,
+        resolved: bool,
+    ) -> RemoteReviewThread {
+        use crate::forge::remote_comments::{RemoteCommentSide, RemoteReviewComment};
+        RemoteReviewThread {
+            id: id.to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(line),
+            side: RemoteCommentSide::Right,
+            is_resolved: resolved,
+            is_outdated: false,
+            comments: vec![RemoteReviewComment {
+                id: format!("{id}-root"),
+                author: Some(author.to_string()),
+                body: body.to_string(),
+                created_at: None,
+                path: "src/lib.rs".to_string(),
+                line: Some(line),
+                side: RemoteCommentSide::Right,
+                in_reply_to: None,
+                url: format!("https://github.com/agavra/tuicr/pull/125#discussion_{id}"),
+            }],
+        }
+    }
+
+    #[test]
+    fn should_include_unresolved_remote_threads_grouped_by_file_in_pr_export() {
+        // given a PR session with one local draft + one unresolved remote
+        // thread + one resolved (must be omitted)
+        let mut session = ReviewSession::new(
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+            "abc1234deadbeef".to_string(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.add_file(PathBuf::from("src/lib.rs"), FileStatus::Modified, 0);
+        if let Some(review) = session.get_file_mut(&PathBuf::from("src/lib.rs")) {
+            review.add_line_comment(
+                10,
+                Comment::new(
+                    "Local draft".to_string(),
+                    CommentType::Issue,
+                    Some(LineSide::New),
+                ),
+            );
+        }
+        let threads = vec![
+            sample_remote_thread("a", "alice", "Can this be simpler?", 42, false),
+            sample_remote_thread("b", "bob", "Old resolved", 99, true),
+        ];
+
+        // when
+        let markdown = generate_markdown(
+            &session,
+            &sample_pr_diff_source(),
+            &comment_types(),
+            true,
+            &threads,
+        );
+
+        // then
+        assert!(markdown.contains("Reviewing pull request agavra/tuicr#125"));
+        assert!(markdown.contains("## Local tuicr Comments"));
+        assert!(markdown.contains("[ISSUE]"));
+        assert!(markdown.contains("## Existing GitHub Comments"));
+        assert!(markdown.contains("### `src/lib.rs`"));
+        assert!(markdown.contains("@alice - Can this be simpler?"));
+        // Resolved thread is omitted from export per spec.
+        assert!(
+            !markdown.contains("Old resolved"),
+            "resolved thread leaked into export:\n{markdown}"
+        );
+    }
+
+    #[test]
+    fn should_export_pr_remote_threads_even_when_no_local_drafts() {
+        // given a PR session with no local comments but one unresolved remote thread
+        let session = ReviewSession::new(
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+            "abc1234deadbeef".to_string(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        let threads = vec![sample_remote_thread("a", "alice", "important", 5, false)];
+
+        // when
+        let result = generate_export_content(
+            &session,
+            &sample_pr_diff_source(),
+            &comment_types(),
+            true,
+            &threads,
+        );
+
+        // then — export succeeds even with no local comments
+        let content = result.unwrap();
+        assert!(content.contains("## Existing GitHub Comments"));
+        assert!(content.contains("@alice - important"));
+    }
+
+    #[test]
+    fn should_not_include_remote_comments_outside_pr_mode_in_export() {
+        // given — local working-tree mode + non-empty threads (should be ignored)
+        let mut session = ReviewSession::new(
+            PathBuf::from("/tmp"),
+            "abc".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::WorkingTree,
+        );
+        session.add_file(PathBuf::from("src/lib.rs"), FileStatus::Modified, 0);
+        if let Some(r) = session.get_file_mut(&PathBuf::from("src/lib.rs")) {
+            r.add_line_comment(
+                3,
+                Comment::new("Local".to_string(), CommentType::Note, Some(LineSide::New)),
+            );
+        }
+        let threads = vec![sample_remote_thread("a", "alice", "ignored", 5, false)];
+
+        // when
+        let markdown = generate_markdown(
+            &session,
+            &DiffSource::WorkingTree,
+            &comment_types(),
+            true,
+            &threads,
+        );
+
+        // then — the section is omitted in non-PR modes
+        assert!(!markdown.contains("Existing GitHub Comments"));
     }
 
     #[test]
@@ -937,7 +1172,8 @@ mod tests {
             },
         ];
 
-        let markdown = generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true);
+        let markdown =
+            generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true, &[]);
 
         assert!(markdown.contains("Comment types: QUESTION (ask for clarification)"));
         assert!(!markdown.contains("ISSUE"));

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -389,7 +389,7 @@ fn generate_markdown(
                 for thread in threads {
                     if let Some(root) = thread.root() {
                         let author = root.author.as_deref().unwrap_or("unknown");
-                        let line_marker = root.line.map(|l| format!(":{l}")).unwrap_or_default();
+                        let line_marker = thread.line.map(|l| format!(":{l}")).unwrap_or_default();
                         let _ = writeln!(
                             md,
                             "{thread_n}. `{path}{line_marker}` @{author} - {body}",
@@ -1025,9 +1025,6 @@ mod tests {
                 author: Some(author.to_string()),
                 body: body.to_string(),
                 created_at: None,
-                path: "src/lib.rs".to_string(),
-                line: Some(line),
-                side: RemoteCommentSide::Right,
                 in_reply_to: None,
                 url: format!("https://github.com/agavra/tuicr/pull/125#discussion_{id}"),
             }],

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -159,29 +159,22 @@ pub fn format_comment_input_lines(
     (result, cursor_info)
 }
 
-/// Format a remote (read-only) forge review comment for inline display.
+/// Format an entire remote (read-only) forge review thread as one fused
+/// box so it reads as a single discussion unit. Root comment opens the
+/// box; replies appear as `├─ ↳ @author ──` separator headers within the
+/// same box; the bottom rule appears once at the end.
 ///
-/// Visually distinct from local drafts: a `[github @author]` badge prefix
-/// replaces the `[ISSUE]` style local prefix, and resolved/outdated
-/// comments render with muted styling. Replies render with a `↳` glyph so
-/// the thread structure is visible without claiming extra lines.
-#[allow(clippy::too_many_arguments)]
-pub fn format_remote_comment_lines(
+/// Visually distinct from local drafts: the `[github @author]` badge on
+/// the root header, and a muted palette throughout for resolved/outdated
+/// threads.
+pub fn format_remote_thread_lines(
     theme: &Theme,
-    author: Option<&str>,
-    body: &str,
-    line_range: Option<LineRange>,
-    is_reply: bool,
+    thread: &crate::forge::remote_comments::RemoteReviewThread,
     muted: bool,
-    resolved: bool,
-    outdated: bool,
 ) -> Vec<Line<'static>> {
     let (badge_fg, border_fg, body_fg) = if muted {
-        // fg_dim everywhere for resolved/outdated.
         (theme.fg_dim, theme.fg_dim, theme.fg_dim)
     } else {
-        // Non-muted remote uses the dim color for the body so it doesn't
-        // compete with local drafts, but the badge keeps the forge accent.
         (
             theme.diff_hunk_header,
             theme.diff_hunk_header,
@@ -190,57 +183,59 @@ pub fn format_remote_comment_lines(
     };
 
     let badge_style = Style::default().fg(badge_fg).add_modifier(Modifier::BOLD);
+    let reply_badge_style = Style::default().fg(badge_fg);
     let border_style = Style::default().fg(border_fg);
     let body_style = Style::default().fg(body_fg);
 
-    let author = author.unwrap_or("unknown");
-    let mut badge_text = format!("[github @{author}");
-    if resolved {
-        badge_text.push_str(" resolved");
-    } else if outdated {
-        badge_text.push_str(" outdated");
-    }
-    badge_text.push_str("] ");
-
-    let line_info = match line_range {
+    let line_info = match thread.line.map(LineRange::single) {
         Some(range) if range.is_single() => format!("L{} ", range.start),
         Some(range) => format!("L{}-L{} ", range.start, range.end),
         None => String::new(),
     };
 
-    // Replies hang under the root with a `↳` glyph and indented border so
-    // the thread is one visual block.
-    let (top_prefix, side_prefix, bot_prefix) = if is_reply {
-        ("     ┃   ↳ ", "     ┃     ", "     ┃     ")
-    } else {
-        ("     ╭─ ", "     │ ", "     ╰")
-    };
-
     let mut result = Vec::new();
-    result.push(Line::from(vec![
-        Span::styled(top_prefix.to_string(), border_style),
-        Span::styled(badge_text, badge_style),
-        Span::styled(line_info, styles::dim_style(theme)),
-        Span::styled("─".repeat(20), border_style),
-    ]));
+    let mut iter = thread.comments.iter().peekable();
+    let mut is_first = true;
+    while let Some(comment) = iter.next() {
+        let author = comment.author.as_deref().unwrap_or("unknown");
+        if is_first {
+            let mut badge_text = format!("[github @{author}");
+            if thread.is_resolved {
+                badge_text.push_str(" resolved");
+            } else if thread.is_outdated {
+                badge_text.push_str(" outdated");
+            }
+            badge_text.push_str("] ");
+            result.push(Line::from(vec![
+                Span::styled("     ╭─ ".to_string(), border_style),
+                Span::styled(badge_text, badge_style),
+                Span::styled(line_info.clone(), styles::dim_style(theme)),
+                Span::styled("─".repeat(20), border_style),
+            ]));
+        } else {
+            result.push(Line::from(vec![
+                Span::styled("     ├─ ".to_string(), border_style),
+                Span::styled(format!("↳ @{author} "), reply_badge_style),
+                Span::styled("─".repeat(28), border_style),
+            ]));
+        }
 
-    for line in body.split('\n') {
-        result.push(Line::from(vec![
-            Span::styled(side_prefix.to_string(), border_style),
-            Span::styled(line.to_string(), body_style),
-        ]));
+        for line in comment.body.split('\n') {
+            result.push(Line::from(vec![
+                Span::styled("     │ ".to_string(), border_style),
+                Span::styled(line.to_string(), body_style),
+            ]));
+        }
+
+        is_first = false;
+        let _ = iter.peek();
     }
 
-    // Replies use a vertical line as the "bottom" too — they hang from
-    // the root and continue the thread visual.
-    if is_reply {
-        // No bottom rule for replies; the root's bottom carries it.
-    } else {
-        result.push(Line::from(vec![Span::styled(
-            bot_prefix.to_string() + &"─".repeat(38),
-            border_style,
-        )]));
-    }
+    result.push(Line::from(vec![Span::styled(
+        "     ╰".to_string() + &"─".repeat(38),
+        border_style,
+    )]));
+
     result
 }
 

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -159,6 +159,91 @@ pub fn format_comment_input_lines(
     (result, cursor_info)
 }
 
+/// Format a remote (read-only) forge review comment for inline display.
+///
+/// Visually distinct from local drafts: a `[github @author]` badge prefix
+/// replaces the `[ISSUE]` style local prefix, and resolved/outdated
+/// comments render with muted styling. Replies render with a `↳` glyph so
+/// the thread structure is visible without claiming extra lines.
+#[allow(clippy::too_many_arguments)]
+pub fn format_remote_comment_lines(
+    theme: &Theme,
+    author: Option<&str>,
+    body: &str,
+    line_range: Option<LineRange>,
+    is_reply: bool,
+    muted: bool,
+    resolved: bool,
+    outdated: bool,
+) -> Vec<Line<'static>> {
+    let (badge_fg, border_fg, body_fg) = if muted {
+        // fg_dim everywhere for resolved/outdated.
+        (theme.fg_dim, theme.fg_dim, theme.fg_dim)
+    } else {
+        // Non-muted remote uses the dim color for the body so it doesn't
+        // compete with local drafts, but the badge keeps the forge accent.
+        (
+            theme.diff_hunk_header,
+            theme.diff_hunk_header,
+            theme.fg_secondary,
+        )
+    };
+
+    let badge_style = Style::default().fg(badge_fg).add_modifier(Modifier::BOLD);
+    let border_style = Style::default().fg(border_fg);
+    let body_style = Style::default().fg(body_fg);
+
+    let author = author.unwrap_or("unknown");
+    let mut badge_text = format!("[github @{author}");
+    if resolved {
+        badge_text.push_str(" resolved");
+    } else if outdated {
+        badge_text.push_str(" outdated");
+    }
+    badge_text.push_str("] ");
+
+    let line_info = match line_range {
+        Some(range) if range.is_single() => format!("L{} ", range.start),
+        Some(range) => format!("L{}-L{} ", range.start, range.end),
+        None => String::new(),
+    };
+
+    // Replies hang under the root with a `↳` glyph and indented border so
+    // the thread is one visual block.
+    let (top_prefix, side_prefix, bot_prefix) = if is_reply {
+        ("     ┃   ↳ ", "     ┃     ", "     ┃     ")
+    } else {
+        ("     ╭─ ", "     │ ", "     ╰")
+    };
+
+    let mut result = Vec::new();
+    result.push(Line::from(vec![
+        Span::styled(top_prefix.to_string(), border_style),
+        Span::styled(badge_text, badge_style),
+        Span::styled(line_info, styles::dim_style(theme)),
+        Span::styled("─".repeat(20), border_style),
+    ]));
+
+    for line in body.split('\n') {
+        result.push(Line::from(vec![
+            Span::styled(side_prefix.to_string(), border_style),
+            Span::styled(line.to_string(), body_style),
+        ]));
+    }
+
+    // Replies use a vertical line as the "bottom" too — they hang from
+    // the root and continue the thread visual.
+    if is_reply {
+        // No bottom rule for replies; the root's bottom carries it.
+    } else {
+        result.push(Line::from(vec![Span::styled(
+            bot_prefix.to_string() + &"─".repeat(38),
+            border_style,
+        )]));
+    }
+    result
+}
+
 /// Format a comment as multiple lines with a box border (themed version)
 pub fn format_comment_lines(
     theme: &Theme,

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -811,6 +811,16 @@ fn render_context_line_side_by_side(
         );
         line_idx = new_line_idx;
         cursor_info_out = cursor_info;
+        if let Some(file) = ctx.app.diff_files.get(file_idx) {
+            line_idx = add_remote_threads_to_line(
+                new_ln,
+                LineSide::New,
+                ctx,
+                file.display_path(),
+                line_idx,
+                lines,
+            );
+        }
     }
 
     (line_idx, cursor_info_out)
@@ -892,6 +902,16 @@ fn render_deletion_addition_pair_side_by_side(
                 if cursor_info.is_some() {
                     cursor_info_out = cursor_info;
                 }
+                if let Some(file) = ctx.app.diff_files.get(file_idx) {
+                    line_idx = add_remote_threads_to_line(
+                        old_ln,
+                        LineSide::Old,
+                        ctx,
+                        file.display_path(),
+                        line_idx,
+                        lines,
+                    );
+                }
             }
         }
 
@@ -911,6 +931,16 @@ fn render_deletion_addition_pair_side_by_side(
                 line_idx = new_line_idx;
                 if cursor_info.is_some() {
                     cursor_info_out = cursor_info;
+                }
+                if let Some(file) = ctx.app.diff_files.get(file_idx) {
+                    line_idx = add_remote_threads_to_line(
+                        new_ln,
+                        LineSide::New,
+                        ctx,
+                        file.display_path(),
+                        line_idx,
+                        lines,
+                    );
                 }
             }
         }
@@ -956,6 +986,16 @@ fn render_standalone_addition_side_by_side(
         );
         line_idx = new_line_idx;
         cursor_info_out = cursor_info;
+        if let Some(file) = ctx.app.diff_files.get(file_idx) {
+            line_idx = add_remote_threads_to_line(
+                new_ln,
+                LineSide::New,
+                ctx,
+                file.display_path(),
+                line_idx,
+                lines,
+            );
+        }
     }
 
     (line_idx, cursor_info_out)
@@ -1032,6 +1072,69 @@ fn add_empty_column_spans(spans: &mut Vec<Span>, content_width: usize) {
 
 /// Add comments for a specific line.
 /// Returns (new_line_idx, optional cursor info for inline comment input)
+/// Render remote review threads anchored at this `(file, line, side)`
+/// position into the side-by-side rendering. Mirrors the unified-view
+/// helper but uses the side-by-side cursor indicator path.
+fn add_remote_threads_to_line(
+    line_num: u32,
+    side: LineSide,
+    ctx: &SideBySideContext,
+    file_path: &std::path::Path,
+    mut line_idx: usize,
+    lines: &mut Vec<Line>,
+) -> usize {
+    use crate::forge::remote_comments::{PrCommentsVisibility, RemoteCommentSide};
+    let visibility = ctx.app.session.remote_comments_visibility;
+    if matches!(visibility, PrCommentsVisibility::Hide) {
+        return line_idx;
+    }
+    let target_path = file_path.to_string_lossy();
+    for thread in &ctx.app.forge_review_threads {
+        let Some(muted) = visibility.render_decision(thread) else {
+            continue;
+        };
+        if thread.path != *target_path {
+            continue;
+        }
+        let Some(thread_line) = thread.line else {
+            continue;
+        };
+        if thread_line != line_num {
+            continue;
+        }
+        let matches_side = matches!(
+            (thread.side, side),
+            (RemoteCommentSide::Right, LineSide::New) | (RemoteCommentSide::Left, LineSide::Old)
+        );
+        if !matches_side {
+            continue;
+        }
+        for (idx, comment) in thread.comments.iter().enumerate() {
+            let is_reply = idx > 0;
+            let comment_lines = comment_panel::format_remote_comment_lines(
+                ctx.theme,
+                comment.author.as_deref(),
+                &comment.body,
+                comment.line.map(LineRange::single),
+                is_reply,
+                muted,
+                thread.is_resolved,
+                thread.is_outdated,
+            );
+            for mut comment_line in comment_lines {
+                let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+                comment_line.spans.insert(
+                    0,
+                    Span::styled(indicator, styles::current_line_indicator_style(ctx.theme)),
+                );
+                lines.push(comment_line);
+                line_idx += 1;
+            }
+        }
+    }
+    line_idx
+}
+
 fn add_comments_to_line(
     line_num: u32,
     line_comments: &std::collections::HashMap<u32, Vec<crate::model::Comment>>,
@@ -1155,4 +1258,222 @@ fn add_comments_to_line(
     }
 
     (line_idx, cursor_info_out)
+}
+
+#[cfg(test)]
+mod remote_comments_side_by_side_snapshot_tests {
+    //! Render-snapshot tests for inline remote review threads in the
+    //! side-by-side diff view. Confirms the badge appears at least once
+    //! when a thread is active and is hidden under `:comments hide`.
+    use crate::app::{App, DiffSource, DiffViewMode, InputMode, PullRequestDiffSource};
+    use crate::error::Result as TuicrResult;
+    use crate::error::TuicrError;
+    use crate::forge::remote_comments::{
+        PrCommentsVisibility, RemoteCommentSide, RemoteReviewComment, RemoteReviewThread,
+    };
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
+    use crate::model::{
+        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, ReviewSession, SessionDiffSource,
+    };
+    use crate::syntax::SyntaxHighlighter;
+    use crate::theme::Theme;
+    use crate::ui::render;
+    use crate::vcs::traits::{VcsBackend, VcsChangeStatus, VcsInfo, VcsType};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use std::path::{Path, PathBuf};
+
+    struct SnapshotVcs {
+        info: VcsInfo,
+    }
+
+    impl VcsBackend for SnapshotVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+        fn get_working_tree_diff(
+            &self,
+            _highlighter: &SyntaxHighlighter,
+        ) -> TuicrResult<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _start_line: u32,
+            _end_line: u32,
+        ) -> TuicrResult<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn get_change_status(&self) -> TuicrResult<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+    }
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    fn sample_diff_file() -> DiffFile {
+        let lines = vec![
+            DiffLine {
+                origin: LineOrigin::Context,
+                content: "first".to_string(),
+                old_lineno: Some(1),
+                new_lineno: Some(1),
+                highlighted_spans: None,
+            },
+            DiffLine {
+                origin: LineOrigin::Addition,
+                content: "second".to_string(),
+                old_lineno: None,
+                new_lineno: Some(2),
+                highlighted_spans: None,
+            },
+        ];
+        let hunk = DiffHunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            lines,
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 2,
+        };
+        let hunks = vec![hunk];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: Some(PathBuf::from("src/lib.rs")),
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    fn thread() -> RemoteReviewThread {
+        RemoteReviewThread {
+            id: "T".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(2),
+            side: RemoteCommentSide::Right,
+            is_resolved: false,
+            is_outdated: false,
+            comments: vec![RemoteReviewComment {
+                id: "C".to_string(),
+                author: Some("alice".to_string()),
+                body: "sbs hello".to_string(),
+                created_at: None,
+                path: "src/lib.rs".to_string(),
+                line: Some(2),
+                side: RemoteCommentSide::Right,
+                in_reply_to: None,
+                url: "https://example.com".to_string(),
+            }],
+        }
+    }
+
+    fn make_pr_app() -> App {
+        let pr = PullRequestDiffSource {
+            key: PrSessionKey::new(repo(), 125, "headsha".to_string()),
+            base_sha: "basesha".to_string(),
+            title: "test pr".to_string(),
+            url: "https://example.com".to_string(),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            state: "OPEN".to_string(),
+            closed: false,
+            merged: false,
+        };
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("forge:github.com/agavra/tuicr"),
+            head_commit: "headsha".to_string(),
+            branch_name: Some("feat".to_string()),
+            vcs_type: VcsType::File,
+        };
+        let mut session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            "headsha".to_string(),
+            Some("feat".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.pr_session_key = Some(pr.key.clone());
+        let mut app = App::build(
+            Box::new(SnapshotVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            vec![sample_diff_file()],
+            session,
+            DiffSource::PullRequest(Box::new(pr)),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build app");
+        app.diff_view_mode = DiffViewMode::SideBySide;
+        app
+    }
+
+    fn draw(app: &mut App) -> Buffer {
+        let backend = TestBackend::new(160, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app))
+            .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn body_text(buffer: &Buffer) -> String {
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn should_render_remote_comment_inline_in_side_by_side_diff() {
+        // given
+        let mut app = make_pr_app();
+        app.forge_review_threads = vec![thread()];
+        app.rebuild_annotations();
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = body_text(&buffer);
+        assert!(
+            body.contains("[github @alice]"),
+            "expected badge in side-by-side render:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_hide_remote_comments_under_comments_hide_in_side_by_side() {
+        // given
+        let mut app = make_pr_app();
+        app.forge_review_threads = vec![thread()];
+        app.set_remote_comments_visibility(PrCommentsVisibility::Hide);
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = body_text(&buffer);
+        assert!(
+            !body.contains("[github @alice"),
+            "remote comment leaked under Hide:\n{body}"
+        );
+    }
 }

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -1109,27 +1109,15 @@ fn add_remote_threads_to_line(
         if !matches_side {
             continue;
         }
-        for (idx, comment) in thread.comments.iter().enumerate() {
-            let is_reply = idx > 0;
-            let comment_lines = comment_panel::format_remote_comment_lines(
-                ctx.theme,
-                comment.author.as_deref(),
-                &comment.body,
-                comment.line.map(LineRange::single),
-                is_reply,
-                muted,
-                thread.is_resolved,
-                thread.is_outdated,
+        let thread_lines = comment_panel::format_remote_thread_lines(ctx.theme, thread, muted);
+        for mut comment_line in thread_lines {
+            let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+            comment_line.spans.insert(
+                0,
+                Span::styled(indicator, styles::current_line_indicator_style(ctx.theme)),
             );
-            for mut comment_line in comment_lines {
-                let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
-                comment_line.spans.insert(
-                    0,
-                    Span::styled(indicator, styles::current_line_indicator_style(ctx.theme)),
-                );
-                lines.push(comment_line);
-                line_idx += 1;
-            }
+            lines.push(comment_line);
+            line_idx += 1;
         }
     }
     line_idx
@@ -1371,9 +1359,6 @@ mod remote_comments_side_by_side_snapshot_tests {
                 author: Some("alice".to_string()),
                 body: "sbs hello".to_string(),
                 created_at: None,
-                path: "src/lib.rs".to_string(),
-                line: Some(2),
-                side: RemoteCommentSide::Right,
                 in_reply_to: None,
                 url: "https://example.com".to_string(),
             }],

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -988,32 +988,20 @@ fn render_remote_threads_for_anchor(
             continue;
         }
 
-        // Render each comment in the thread: root first (with header
-        // border), replies indented underneath.
-        for (idx, comment) in thread.comments.iter().enumerate() {
-            let is_reply = idx > 0;
-            let comment_lines = comment_panel::format_remote_comment_lines(
-                &app.theme,
-                comment.author.as_deref(),
-                &comment.body,
-                comment.line.map(crate::model::LineRange::single),
-                is_reply,
-                muted,
-                thread.is_resolved,
-                thread.is_outdated,
+        // Render the entire thread as one fused box so it reads as a
+        // single discussion unit.
+        let thread_lines = comment_panel::format_remote_thread_lines(&app.theme, thread, muted);
+        for mut comment_line in thread_lines {
+            let indicator = cursor_indicator(*line_idx, current_line_idx);
+            comment_line.spans.insert(
+                0,
+                ratatui::text::Span::styled(
+                    indicator,
+                    styles::current_line_indicator_style(&app.theme),
+                ),
             );
-            for mut comment_line in comment_lines {
-                let indicator = cursor_indicator(*line_idx, current_line_idx);
-                comment_line.spans.insert(
-                    0,
-                    ratatui::text::Span::styled(
-                        indicator,
-                        styles::current_line_indicator_style(&app.theme),
-                    ),
-                );
-                lines.push(comment_line);
-                *line_idx += 1;
-            }
+            lines.push(comment_line);
+            *line_idx += 1;
         }
     }
 }
@@ -1164,9 +1152,6 @@ mod remote_comments_snapshot_tests {
                 author: Some(author.to_string()),
                 body: body.to_string(),
                 created_at: None,
-                path: "src/lib.rs".to_string(),
-                line: Some(line),
-                side: RemoteCommentSide::Right,
                 in_reply_to: None,
                 url: "https://example.com/x".to_string(),
             }],

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -8,6 +8,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, ExpandDirection, FocusedPanel, GAP_EXPAND_BATCH, GapId, InputMode};
+use crate::forge::remote_comments::PrCommentsVisibility;
 use crate::model::{LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
@@ -591,6 +592,17 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                             }
                         }
 
+                        // Render remote review threads anchored at this old-side line.
+                        render_remote_threads_for_anchor(
+                            &mut lines,
+                            &mut line_idx,
+                            current_line_idx,
+                            app,
+                            path,
+                            old_ln,
+                            LineSide::Old,
+                        );
+
                         // Render inline input for new line comment (old side)
                         if is_line_comment_mode && app.editing_comment_id.is_none() {
                             let line_range = app
@@ -718,6 +730,17 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                 }
                             }
                         }
+
+                        // Render remote review threads anchored at this new-side line.
+                        render_remote_threads_for_anchor(
+                            &mut lines,
+                            &mut line_idx,
+                            current_line_idx,
+                            app,
+                            path,
+                            new_ln,
+                            LineSide::New,
+                        );
 
                         // Render inline input for new line comment (new side)
                         if is_line_comment_mode && app.editing_comment_id.is_none() {
@@ -917,6 +940,84 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     }
 }
 
+/// Render remote review threads anchored at `(path, line, side)` into the
+/// growing line buffer. No-op when `:comments hide` is active or when no
+/// threads anchor here. Resolved/outdated threads use muted styling per
+/// the spec; visible-but-resolved threads only render under `:comments all`.
+fn render_remote_threads_for_anchor(
+    lines: &mut Vec<ratatui::text::Line<'static>>,
+    line_idx: &mut usize,
+    current_line_idx: usize,
+    app: &App,
+    file_path: &std::path::Path,
+    line: u32,
+    side: LineSide,
+) {
+    let visibility = app.session.remote_comments_visibility;
+    if matches!(visibility, PrCommentsVisibility::Hide) {
+        return;
+    }
+    if app.forge_review_threads.is_empty() {
+        return;
+    }
+    let target_path = file_path.to_string_lossy();
+    for thread in &app.forge_review_threads {
+        let Some(muted) = visibility.render_decision(thread) else {
+            continue;
+        };
+        if thread.path != *target_path {
+            continue;
+        }
+        let Some(thread_line) = thread.line else {
+            continue;
+        };
+        if thread_line != line {
+            continue;
+        }
+        let matches_side = matches!(
+            (thread.side, side),
+            (
+                crate::forge::remote_comments::RemoteCommentSide::Right,
+                LineSide::New
+            ) | (
+                crate::forge::remote_comments::RemoteCommentSide::Left,
+                LineSide::Old
+            )
+        );
+        if !matches_side {
+            continue;
+        }
+
+        // Render each comment in the thread: root first (with header
+        // border), replies indented underneath.
+        for (idx, comment) in thread.comments.iter().enumerate() {
+            let is_reply = idx > 0;
+            let comment_lines = comment_panel::format_remote_comment_lines(
+                &app.theme,
+                comment.author.as_deref(),
+                &comment.body,
+                comment.line.map(crate::model::LineRange::single),
+                is_reply,
+                muted,
+                thread.is_resolved,
+                thread.is_outdated,
+            );
+            for mut comment_line in comment_lines {
+                let indicator = cursor_indicator(*line_idx, current_line_idx);
+                comment_line.spans.insert(
+                    0,
+                    ratatui::text::Span::styled(
+                        indicator,
+                        styles::current_line_indicator_style(&app.theme),
+                    ),
+                );
+                lines.push(comment_line);
+                *line_idx += 1;
+            }
+        }
+    }
+}
+
 /// Render a single expanded context line (shared by unified + side-by-side via unified path)
 fn render_expanded_context_line(
     lines: &mut Vec<Line<'_>>,
@@ -941,4 +1042,285 @@ fn render_expanded_context_line(
     ];
     lines.push(Line::from(line_spans));
     *line_idx += 1;
+}
+
+#[cfg(test)]
+mod remote_comments_snapshot_tests {
+    //! Render-snapshot tests for inline remote review threads in the
+    //! unified diff. We drive `ui::render` against `TestBackend` and check
+    //! for the `[github @author]` badge text on the expected row.
+    use crate::app::{App, DiffSource, InputMode, PullRequestDiffSource};
+    use crate::error::Result as TuicrResult;
+    use crate::error::TuicrError;
+    use crate::forge::remote_comments::{
+        PrCommentsVisibility, RemoteCommentSide, RemoteReviewComment, RemoteReviewThread,
+    };
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
+    use crate::model::{
+        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, ReviewSession, SessionDiffSource,
+    };
+    use crate::syntax::SyntaxHighlighter;
+    use crate::theme::Theme;
+    use crate::ui::render;
+    use crate::vcs::traits::{VcsBackend, VcsChangeStatus, VcsInfo, VcsType};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use std::path::{Path, PathBuf};
+
+    struct SnapshotVcs {
+        info: VcsInfo,
+    }
+
+    impl VcsBackend for SnapshotVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+        fn get_working_tree_diff(
+            &self,
+            _highlighter: &SyntaxHighlighter,
+        ) -> TuicrResult<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _start_line: u32,
+            _end_line: u32,
+        ) -> TuicrResult<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn get_change_status(&self) -> TuicrResult<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+    }
+
+    fn repo() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "tuicr")
+    }
+
+    fn sample_diff_file() -> DiffFile {
+        // Two-line file with one context line and one addition so we have
+        // a stable `line=2` anchor for the test thread.
+        let lines = vec![
+            DiffLine {
+                origin: LineOrigin::Context,
+                content: "first".to_string(),
+                old_lineno: Some(1),
+                new_lineno: Some(1),
+                highlighted_spans: None,
+            },
+            DiffLine {
+                origin: LineOrigin::Addition,
+                content: "second".to_string(),
+                old_lineno: None,
+                new_lineno: Some(2),
+                highlighted_spans: None,
+            },
+        ];
+        let hunk = DiffHunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            lines,
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 2,
+        };
+        let hunks = vec![hunk];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: Some(PathBuf::from("src/lib.rs")),
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    fn thread(
+        id: &str,
+        author: &str,
+        body: &str,
+        line: u32,
+        resolved: bool,
+        outdated: bool,
+    ) -> RemoteReviewThread {
+        RemoteReviewThread {
+            id: id.to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(line),
+            side: RemoteCommentSide::Right,
+            is_resolved: resolved,
+            is_outdated: outdated,
+            comments: vec![RemoteReviewComment {
+                id: format!("{id}-root"),
+                author: Some(author.to_string()),
+                body: body.to_string(),
+                created_at: None,
+                path: "src/lib.rs".to_string(),
+                line: Some(line),
+                side: RemoteCommentSide::Right,
+                in_reply_to: None,
+                url: "https://example.com/x".to_string(),
+            }],
+        }
+    }
+
+    fn make_pr_app() -> App {
+        let pr = PullRequestDiffSource {
+            key: PrSessionKey::new(repo(), 125, "headsha".to_string()),
+            base_sha: "basesha".to_string(),
+            title: "test pr".to_string(),
+            url: "https://example.com".to_string(),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            state: "OPEN".to_string(),
+            closed: false,
+            merged: false,
+        };
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("forge:github.com/agavra/tuicr"),
+            head_commit: "headsha".to_string(),
+            branch_name: Some("feat".to_string()),
+            vcs_type: VcsType::File,
+        };
+        let mut session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            "headsha".to_string(),
+            Some("feat".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.pr_session_key = Some(pr.key.clone());
+        App::build(
+            Box::new(SnapshotVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            vec![sample_diff_file()],
+            session,
+            DiffSource::PullRequest(Box::new(pr)),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build app")
+    }
+
+    fn draw(app: &mut App) -> Buffer {
+        let backend = TestBackend::new(140, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render(frame, app))
+            .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn body_text(buffer: &Buffer) -> String {
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn should_render_unresolved_remote_comment_inline_in_unified_diff() {
+        // given a PR app with one unresolved remote thread anchored on
+        // the addition line
+        let mut app = make_pr_app();
+        app.forge_review_threads = vec![thread("t1", "alice", "looks good?", 2, false, false)];
+        app.rebuild_annotations();
+        // when
+        let buffer = draw(&mut app);
+        // then — the badge appears somewhere in the rendered frame
+        let body = body_text(&buffer);
+        assert!(
+            body.contains("[github @alice]"),
+            "expected [github @alice] badge in:\n{body}"
+        );
+        assert!(
+            body.contains("looks good?"),
+            "expected remote comment body in:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_render_resolved_remote_comment_only_under_comments_all() {
+        // given a PR app with one resolved remote thread
+        let mut app = make_pr_app();
+        app.forge_review_threads = vec![thread(
+            "t1", "alice", "old note", 2, /* resolved */ true, false,
+        )];
+        // default Unresolved visibility — should not render
+        app.rebuild_annotations();
+        let before = body_text(&draw(&mut app));
+        assert!(
+            !before.contains("[github @alice"),
+            "resolved thread leaked under Unresolved:\n{before}"
+        );
+
+        // when — flip to All
+        assert!(app.set_remote_comments_visibility(PrCommentsVisibility::All));
+        // then — the resolved badge appears with the "resolved" marker
+        let after = body_text(&draw(&mut app));
+        assert!(
+            after.contains("[github @alice resolved]"),
+            "expected resolved badge in:\n{after}"
+        );
+    }
+
+    #[test]
+    fn should_hide_all_remote_comments_when_comments_hide() {
+        // given
+        let mut app = make_pr_app();
+        app.forge_review_threads = vec![thread("t1", "alice", "blocker", 2, false, false)];
+        app.rebuild_annotations();
+        // sanity: visible by default
+        let before = body_text(&draw(&mut app));
+        assert!(before.contains("[github @alice]"));
+
+        // when
+        assert!(app.set_remote_comments_visibility(PrCommentsVisibility::Hide));
+        // then
+        let after = body_text(&draw(&mut app));
+        assert!(
+            !after.contains("[github @alice"),
+            "comment leaked under Hide:\n{after}"
+        );
+    }
+
+    #[test]
+    fn should_render_outdated_marker_for_outdated_thread_under_all() {
+        // given
+        let mut app = make_pr_app();
+        app.forge_review_threads = vec![thread(
+            "t1",
+            "bob",
+            "stale anchor",
+            2,
+            false,
+            /* outdated */ true,
+        )];
+        // when — switch to all so the outdated thread is visible
+        app.set_remote_comments_visibility(PrCommentsVisibility::All);
+        let body = body_text(&draw(&mut app));
+        // then
+        assert!(
+            body.contains("[github @bob outdated]"),
+            "expected outdated badge in:\n{body}"
+        );
+    }
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -490,6 +490,27 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  :comments unresolved",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Show unresolved remote comments (PR mode, default)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :comments all",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Show all remote comments incl. resolved/outdated"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :comments hide",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Hide remote comments in PR mode"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  :set commits",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -261,7 +261,19 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::raw("")
         };
 
-        vec![mode_span, hints_span, dirty_indicator]
+        // Inline hint while remote review threads are still loading in PR
+        // mode. The diff is already visible; this just tells the user that
+        // existing GitHub discussions are still on the way.
+        let remote_loading = if app.forge_review_threads_loading {
+            Span::styled(
+                " Loading remote comments… ",
+                Style::default().fg(theme.fg_dim),
+            )
+        } else {
+            Span::raw("")
+        };
+
+        vec![mode_span, hints_span, dirty_indicator, remote_loading]
     };
 
     // Build message span and create right-aligned layout

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -273,7 +273,26 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::raw("")
         };
 
-        vec![mode_span, hints_span, dirty_indicator, remote_loading]
+        // Spinner banner while `:e` is mid-flight: the network half of
+        // the reload runs on a background thread so the user can keep
+        // scrolling, but we want a visible cue that it's working.
+        let reload_spinner = if let Some(reload) = app.pr_reload_state.as_ref() {
+            let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
+            Span::styled(
+                format!(" {glyph} Reloading PR… "),
+                Style::default().fg(theme.fg_dim),
+            )
+        } else {
+            Span::raw("")
+        };
+
+        vec![
+            mode_span,
+            hints_span,
+            dirty_indicator,
+            remote_loading,
+            reload_spinner,
+        ]
     };
 
     // Build message span and create right-aligned layout

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -273,37 +273,33 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Span::raw("")
         };
 
-        // Spinner banner while `:e` is mid-flight: the network half of
-        // the reload runs on a background thread so the user can keep
-        // scrolling, but we want a visible cue that it's working.
-        // Styled like an info message (fg + bg + bold) so it's not
-        // mistaken for static muted footer hints.
-        let reload_spinner = if let Some(reload) = app.pr_reload_state.as_ref() {
-            let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
+        vec![mode_span, hints_span, dirty_indicator, remote_loading]
+    };
+
+    // Right-aligned slot: while `:e` is in flight we put the spinner
+    // there instead of any pending message, mirroring how messages are
+    // placed. The user sees one prominent right-aligned indicator at a
+    // time. After the reload lands, the success message takes the slot
+    // back.
+    let (right_span, right_width) = if let Some(reload) = app.pr_reload_state.as_ref() {
+        let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
+        let content = format!(" {glyph} Reloading PR… ");
+        let width = content.len();
+        (
             Span::styled(
-                format!(" {glyph} Reloading PR… "),
+                content,
                 Style::default()
                     .fg(theme.message_info_fg)
                     .bg(theme.message_info_bg)
                     .add_modifier(Modifier::BOLD),
-            )
-        } else {
-            Span::raw("")
-        };
-
-        vec![
-            mode_span,
-            hints_span,
-            dirty_indicator,
-            remote_loading,
-            reload_spinner,
-        ]
+            ),
+            width,
+        )
+    } else {
+        build_message_span(app.message.as_ref(), theme)
     };
-
-    // Build message span and create right-aligned layout
-    let (message_span, message_width) = build_message_span(app.message.as_ref(), theme);
     let total_width = area.width as usize;
-    let spans = build_right_aligned_spans(left_spans, message_span, message_width, total_width);
+    let spans = build_right_aligned_spans(left_spans, right_span, right_width, total_width);
 
     let line = Line::from(spans);
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -276,11 +276,16 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         // Spinner banner while `:e` is mid-flight: the network half of
         // the reload runs on a background thread so the user can keep
         // scrolling, but we want a visible cue that it's working.
+        // Styled like an info message (fg + bg + bold) so it's not
+        // mistaken for static muted footer hints.
         let reload_spinner = if let Some(reload) = app.pr_reload_state.as_ref() {
             let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
             Span::styled(
                 format!(" {glyph} Reloading PR… "),
-                Style::default().fg(theme.fg_dim),
+                Style::default()
+                    .fg(theme.message_info_fg)
+                    .bg(theme.message_info_bg)
+                    .add_modifier(Modifier::BOLD),
             )
         } else {
             Span::raw("")


### PR DESCRIPTION
## Summary

PR 4 of the [forge integration v1 spec](../blob/main/docs/forge-integration-v1-spec.md). Adds read-only display, filtering, and export of existing GitHub review discussions in PR mode.

### In scope
- `RemoteReviewComment` and `RemoteReviewThread` domain types under `src/forge/remote_comments.rs` with `PrCommentsVisibility` (`Unresolved` default, `All`, `Hide`).
- `ForgeBackend::list_review_threads`; GitHub impl uses `gh api graphql` with pagination (`endCursor`/`hasNextPage`, hard-capped at 100 pages).
- Async fetch on PR open and `:e` reload via `spawn_pr_threads_fetch` + `poll_pr_threads_events`. The PR diff renders immediately; threads fade in once the fetch lands. Stale results are discarded by matching against the current PR's repo/number/head SHA.
- `:comments unresolved | all | hide` commands; visibility persists per session.
- Inline rendering in both unified and side-by-side diffs. `[github @alice]`, `[github @bob resolved]`, `[github @bob outdated]` badges; replies indented under the root with `↳`.
- PR-mode markdown export gains an `## Existing GitHub Comments` section grouped by file (unresolved only; resolved/outdated are omitted from export per spec).
- `Loading remote comments…` hint in the status bar while the fetch is in flight.
- Help popup updated with the three new commands.

### Out of scope (explicitly punted)
- Replying / resolving / unresolving threads.
- Editing / deleting remote comments.
- `:submit*`, locked comments, resolver UI (PR 5/6).
- README repositioning (PR 7).
- New CLI args.

## Key design choices

### GraphQL vs REST
v1 needs `:comments unresolved` filtering, which requires knowing each thread's `isResolved` and `isOutdated` state. The REST endpoints (\`pulls/comments\` and \`issues/comments\`) do not surface thread resolution state — that lives only on the GraphQL \`PullRequestReviewThread\` node. Per the spec's "GitHub Transport > Review comments and discussions" section we use \`gh api graphql\` with the existing \`GhCommandRunner\` seam so unit tests can drive parsing without touching the network. The same runner abstraction is what PR 1/3 use for everything else \`gh\`-related.

### Annotation parity with rendering
\`AnnotatedLine::RemoteThreadLine\` is pushed in matching count to the rendered comment box so cursor / scroll / search math stays correct. The shared \`thread_display_lines\` helper is used by both the annotation builder and the renderer to keep them in sync — divergence would silently break cursor placement.

### Outdated-line handling
GitHub returns \`line: null\` for outdated comments with the last-known anchor in \`originalLine\`. We fall back to \`originalLine\` so the renderer can still place the thread roughly where it was; the \`is_outdated\` flag drives both the muted styling and the suppression from \`:comments unresolved\`.

### Test seam for integration
\`App::open_pr_with_backend\` now also synchronously fetches threads via the same backend so integration tests can assert on \`forge_review_threads\` without spinning up the background thread + mpsc round-trip. Production paths still use \`spawn_pr_threads_fetch\` for the async behavior.

## Reviewer attention

- Lifecycle math in \`spawn_pr_threads_fetch\` + \`poll_pr_threads_events\` (stale-discard predicate uses repo + number + head SHA — see \`should_discard_stale_remote_threads_event_after_switching_pr\`).
- \`thread_display_lines\` parity with \`comment_panel::format_remote_comment_lines\` — if you change one, change the other or annotations will drift.
- Export filter (\`filter_threads(..., Unresolved)\`) is what enforces "resolved/outdated stays on GitHub". Confirm that matches your reading of the spec's Export Behavior section.
- The \`SyntaxHighlighter\` doesn't cross thread boundaries; we run \`prepare_open_pr\` on the main thread, then spawn the thread fetch separately.

## Test coverage

506 → 541 (+35) tests:

- \`forge::remote_comments\` — visibility filter behavior, threading helpers, serde round-trip.
- \`forge::github::review_threads\` — GraphQL parsing fixtures: single thread, multi-comment thread, resolved, outdated (with \`originalLine\` fallback), cross-file threads, empty array, null repository, malformed JSON, paginated query builder.
- \`forge::github::gh\` — end-to-end \`list_review_threads\` call through \`FakeGhRunner\`, asserts on the \`gh api graphql\` argv shape.
- \`model::review\` — \`remote_comments_visibility\` defaults / round-trips / legacy session JSON compatibility.
- \`app\` — opening a PR populates threads; visibility commands route through the command handler; non-PR mode warning; \`PrThreadsEvent\` apply/discard semantics.
- \`output::markdown\` — PR mode export includes unresolved threads grouped by file; export works with only remote threads; non-PR mode silently omits the section.
- \`ui::diff_unified::remote_comments_snapshot_tests\` — render unresolved comment, render resolved under \`:comments all\` with muted marker, render outdated marker, hide under \`:comments hide\`.
- \`ui::diff_side_by_side::remote_comments_side_by_side_snapshot_tests\` — render badge in side-by-side, hide under \`:comments hide\`.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test (541 passed)
- [ ] Manual: open a real GitHub PR with both unresolved and resolved review threads; verify default view only shows unresolved, \`:comments all\` adds the resolved ones with the muted marker, \`:comments hide\` clears them.
- [ ] Manual: \`:e\` re-fetches threads in place (no diff reparse) on same-head PR.
- [ ] Manual: confirm \`gh api graphql\` works on an enterprise host (\`--hostname\` is set when \`repo.host != "github.com"\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)