### PR TITLE
forge: per-commit selector in PR review mode (PR 4.5 of forge v1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -304,6 +304,23 @@ pub fn annotation_side_default(annotation: &AnnotatedLine) -> LineSide {
     }
 }
 
+/// Map a forge-side `PullRequestCommit` into the VCS-shaped `CommitInfo`
+/// the inline commit selector renders against. We keep two arrays — the
+/// forge truth in `App::pr_commits` and the rendered form in
+/// `App::review_commits` — so the selector renderer stays agnostic of
+/// whether the source is local or remote.
+pub fn pr_commit_to_commit_info(commit: &crate::forge::traits::PullRequestCommit) -> CommitInfo {
+    CommitInfo {
+        id: commit.oid.clone(),
+        short_id: commit.short_oid.clone(),
+        branch_name: None,
+        summary: commit.summary.clone(),
+        body: None,
+        author: commit.author.clone(),
+        time: commit.timestamp.unwrap_or_else(chrono::Utc::now),
+    }
+}
+
 pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
     match annotation {
         AnnotatedLine::FileHeader { file_idx }
@@ -501,7 +518,14 @@ pub enum PrOpenEvent {
         /// Network-only outcome. Parsing + session build runs on the main
         /// thread after this lands so `SyntaxHighlighter` does not need to
         /// cross thread boundaries.
-        result: std::result::Result<(crate::forge::traits::PullRequestDetails, String), String>,
+        result: std::result::Result<
+            (
+                crate::forge::traits::PullRequestDetails,
+                String,
+                Vec<crate::forge::traits::PullRequestCommit>,
+            ),
+            String,
+        >,
     },
 }
 
@@ -533,7 +557,38 @@ pub struct PrReloadRequest {
 pub enum PrReloadEvent {
     Done {
         request: PrReloadRequest,
-        result: std::result::Result<(crate::forge::traits::PullRequestDetails, String), String>,
+        result: std::result::Result<
+            (
+                crate::forge::traits::PullRequestDetails,
+                String,
+                Vec<crate::forge::traits::PullRequestCommit>,
+            ),
+            String,
+        >,
+    },
+}
+
+/// In-flight commit-range re-fetch (PR mode). Drives a status-bar spinner
+/// and carries the cursor anchor we want to restore once the range diff
+/// lands.
+#[derive(Debug, Clone)]
+pub struct PrRangeReloadRequest {
+    pub repository: crate::forge::traits::ForgeRepository,
+    pub pr_number: u64,
+    pub head_sha: String,
+    pub start_sha: String,
+    pub end_sha: String,
+    pub range: (usize, usize),
+    pub started_at: Instant,
+    pub anchor: Option<PrCursorAnchor>,
+}
+
+/// Result delivered from the PR range re-fetch background thread.
+#[derive(Debug)]
+pub enum PrRangeReloadEvent {
+    Done {
+        request: PrRangeReloadRequest,
+        result: std::result::Result<String, String>,
     },
 }
 
@@ -719,6 +774,15 @@ pub struct App {
     // Inline commit selector state (shown at top of diff view for multi-commit reviews)
     /// CommitInfo for commits in the current review (display order: newest first)
     pub review_commits: Vec<CommitInfo>,
+    /// Forge-side commit list for the active PR (display order: newest first).
+    /// Empty outside PR mode. Used as the source of truth for resolving a
+    /// `commit_selection_range` back to (start_sha, end_sha) when toggling.
+    pub pr_commits: Vec<crate::forge::traits::PullRequestCommit>,
+    /// In-flight range re-fetch driven by toggling commits in the inline
+    /// selector while in PR mode. Drives a spinner in the status bar.
+    pub pr_range_reload_state: Option<PrRangeReloadRequest>,
+    /// Background-thread channel for the active range re-fetch.
+    pub pr_range_reload_rx: Option<std::sync::mpsc::Receiver<PrRangeReloadEvent>>,
     /// Whether the inline commit selector panel is visible
     pub show_commit_selector: bool,
     /// Cached individual/subrange diffs keyed by (start_idx, end_idx) into review_commits
@@ -1265,6 +1329,9 @@ impl App {
             update_info: None,
             pending_count: None,
             review_commits: Vec::new(),
+            pr_commits: Vec::new(),
+            pr_range_reload_state: None,
+            pr_range_reload_rx: None,
             show_commit_selector: false,
             commit_diff_cache: HashMap::new(),
             range_diff_files: None,
@@ -1669,6 +1736,7 @@ impl App {
             diff_files,
             session,
             key,
+            commits,
         } = opened;
 
         // Save the current session before transitioning so local-mode work
@@ -1702,10 +1770,40 @@ impl App {
         self.commit_list.clear();
         self.commit_selection_range = None;
         self.review_commits.clear();
+        self.pr_commits.clear();
         self.show_commit_selector = false;
         self.range_diff_files = None;
         self.saved_inline_selection = None;
         self.diff_state = DiffState::default();
+
+        // PR mode populates the inline selector with the PR's commits when
+        // there are at least two. Single-commit PRs hide the selector to
+        // match the local-mode UX. We mirror `commit_list` and
+        // `review_commits` into shared App state so the existing
+        // inline_commit_selector renderer Just Works.
+        if commits.len() > 1 {
+            self.pr_commits = commits.clone();
+            let mapped: Vec<CommitInfo> = commits.iter().map(pr_commit_to_commit_info).collect();
+            self.range_diff_files = Some(self.diff_files.clone());
+            self.commit_list = mapped.clone();
+            self.commit_list_cursor = 0;
+            self.commit_list_scroll_offset = 0;
+            self.visible_commit_count = mapped.len();
+            self.has_more_commit = false;
+            self.show_commit_selector = true;
+            let mut range = (0, mapped.len() - 1);
+            // Restore any persisted range scoped to this head SHA. If the
+            // restored range exceeds the current commit count (e.g., the PR
+            // was rebased), fall back to "all".
+            if let Some(persisted) = self.session.commit_selection_range
+                && persisted.1 < mapped.len()
+                && persisted.0 <= persisted.1
+            {
+                range = persisted;
+            }
+            self.commit_selection_range = Some(range);
+            self.review_commits = mapped;
+        }
 
         // Ensure session has all files registered after the swap.
         for file in &self.diff_files {
@@ -1719,6 +1817,16 @@ impl App {
 
         if let Some(reason) = read_only_reason {
             self.set_warning(format!("This PR is {reason} — review is read-only"));
+        }
+
+        // If the restored selection is a strict subset, fire an initial
+        // range re-fetch so the diff matches the persisted scope.
+        if matches!(&self.diff_source, DiffSource::PullRequest(_))
+            && let Some(range) = self.commit_selection_range
+            && !self.pr_commits.is_empty()
+            && (range.0 > 0 || range.1 + 1 < self.pr_commits.len())
+        {
+            self.spawn_pr_range_reload();
         }
 
         Ok(())
@@ -1817,6 +1925,255 @@ impl App {
         self.move_cursor_to_annotation(target);
     }
 
+    /// Persist the active inline selection on the session (PR mode only).
+    /// `None` is written when the range covers all commits so re-open
+    /// doesn't trigger an unnecessary subset re-fetch.
+    pub fn persist_pr_commit_selection_range(&mut self) {
+        if !matches!(self.diff_source, DiffSource::PullRequest(_)) {
+            return;
+        }
+        let total = self.pr_commits.len();
+        let value = match self.commit_selection_range {
+            Some((s, e)) if total > 0 && (s > 0 || e + 1 < total) => Some((s, e)),
+            _ => None,
+        };
+        self.session.commit_selection_range = value;
+        self.session.updated_at = chrono::Utc::now();
+        let _ = crate::persistence::save_session(&self.session);
+    }
+
+    /// Resolve the active inline selection (PR mode) to (start_sha,
+    /// end_sha). `start_sha` is the parent of the *oldest* selected
+    /// commit; `end_sha` is the *newest*. Because `pr_commits` is stored
+    /// newest-first, the oldest selected commit is at `range.1` and the
+    /// newest at `range.0`.
+    ///
+    /// Returns `None` outside PR mode, when the selection is empty, or
+    /// when the resolved parent isn't available — in that case the
+    /// caller falls back to the cached cumulative PR diff.
+    pub fn pr_range_sha_pair(&self) -> Option<(String, String)> {
+        let DiffSource::PullRequest(ref pr) = self.diff_source else {
+            return None;
+        };
+        let (start_idx, end_idx) = self.commit_selection_range?;
+        if self.pr_commits.is_empty() || start_idx > end_idx || end_idx >= self.pr_commits.len() {
+            return None;
+        }
+        // Newest-first: `end_idx` is the oldest, `start_idx` is the newest.
+        let newest = self.pr_commits.get(start_idx)?;
+        // Parent of the oldest selected commit. If the oldest selected commit
+        // is the PR's first commit (oldest commit overall, at the bottom of
+        // the list), its parent is the PR's base SHA.
+        let parent_sha = if end_idx + 1 < self.pr_commits.len() {
+            self.pr_commits[end_idx + 1].oid.clone()
+        } else {
+            pr.base_sha.clone()
+        };
+        Some((parent_sha, newest.oid.clone()))
+    }
+
+    /// Reload the PR diff for the currently selected inline commit
+    /// subrange. Uses the cached cumulative diff when the selection
+    /// covers all commits; spawns a background `compare` fetch otherwise.
+    pub fn reload_pr_inline_selection(&mut self) {
+        // No-op outside PR mode.
+        if !matches!(self.diff_source, DiffSource::PullRequest(_)) {
+            return;
+        }
+        let Some(range) = self.commit_selection_range else {
+            return;
+        };
+        let total = self.pr_commits.len();
+        if total == 0 {
+            return;
+        }
+
+        // Full-range selection: restore the cached cumulative diff
+        // without hitting the network.
+        if range.0 == 0 && range.1 + 1 == total {
+            self.apply_cached_full_pr_diff();
+            return;
+        }
+
+        // Strict subset → range re-fetch on a background thread.
+        self.spawn_pr_range_reload();
+    }
+
+    /// Restore the cached cumulative PR diff into the diff view. Used when
+    /// the user toggles the selector back to "all commits".
+    fn apply_cached_full_pr_diff(&mut self) {
+        let Some(files) = self.range_diff_files.clone() else {
+            return;
+        };
+        let anchor = self.capture_pr_cursor_anchor();
+        self.diff_files = files;
+        self.clear_expanded_gaps();
+        for file in &self.diff_files {
+            let path = file.display_path().clone();
+            self.session.add_file(path, file.status, file.content_hash);
+        }
+        self.sort_files_by_directory(true);
+        self.expand_all_dirs();
+        self.rebuild_annotations();
+        if let Some(anchor) = anchor {
+            self.restore_pr_cursor_to_anchor(&anchor);
+        }
+    }
+
+    /// Kick off a background fetch of `compare/<start>...<end>` and apply
+    /// it on the main thread. Cancels any in-flight range reload (a fresh
+    /// toggle invalidates the previous request).
+    pub fn spawn_pr_range_reload(&mut self) {
+        let DiffSource::PullRequest(current) = self.diff_source.clone() else {
+            return;
+        };
+        let Some((start_sha, end_sha)) = self.pr_range_sha_pair() else {
+            return;
+        };
+        let Some(range) = self.commit_selection_range else {
+            return;
+        };
+
+        let anchor = self.capture_pr_cursor_anchor();
+        let request = PrRangeReloadRequest {
+            repository: current.key.repository.clone(),
+            pr_number: current.key.number,
+            head_sha: current.key.head_sha.clone(),
+            start_sha: start_sha.clone(),
+            end_sha: end_sha.clone(),
+            range,
+            started_at: Instant::now(),
+            anchor,
+        };
+        // A fresh toggle supersedes any in-flight fetch.
+        self.pr_range_reload_state = Some(request.clone());
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_range_reload_rx = Some(rx);
+
+        let repository = current.key.repository.clone();
+        let pr_number = current.key.number;
+        let head_sha = current.key.head_sha.clone();
+        let base_sha = current.base_sha.clone();
+        std::thread::spawn(move || {
+            use crate::forge::github::gh::GitHubGhBackend;
+
+            let backend =
+                GitHubGhBackend::new(Some(repository.clone())).with_local_checkout(local_checkout);
+            let details = crate::forge::traits::PullRequestDetails {
+                repository,
+                number: pr_number,
+                title: String::new(),
+                url: String::new(),
+                state: "OPEN".to_string(),
+                is_draft: false,
+                author: None,
+                head_ref_name: String::new(),
+                base_ref_name: String::new(),
+                head_sha,
+                base_sha,
+                body: String::new(),
+                updated_at: None,
+                closed: false,
+                merged_at: None,
+            };
+            let outcome = backend
+                .get_pull_request_commit_range_diff(&details, &start_sha, &end_sha)
+                .map_err(|e| e.to_string());
+            let _ = tx.send(PrRangeReloadEvent::Done {
+                request,
+                result: outcome,
+            });
+        });
+    }
+
+    /// Pump any pending range-reload result, parse on the main thread, and
+    /// apply. Stale results (the user toggled again, or left PR mode) are
+    /// silently dropped.
+    pub fn poll_pr_range_reload_events(&mut self) {
+        let Some(rx) = self.pr_range_reload_rx.as_ref() else {
+            return;
+        };
+        let event = match rx.try_recv() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        self.pr_range_reload_rx = None;
+
+        let PrRangeReloadEvent::Done { request, result } = event;
+        let in_flight = self.pr_range_reload_state.clone();
+        // Only apply if this result still matches the active in-flight
+        // request — toggling again, switching PRs, or reloading the head
+        // before this lands invalidates it.
+        let still_active = in_flight.as_ref().is_some_and(|s| {
+            s.start_sha == request.start_sha
+                && s.end_sha == request.end_sha
+                && s.repository == request.repository
+                && s.pr_number == request.pr_number
+                && s.head_sha == request.head_sha
+                && s.range == request.range
+        });
+        if !still_active {
+            return;
+        }
+        self.pr_range_reload_state = None;
+
+        match result {
+            Ok(patch) => {
+                if let Err(e) = self.finish_pr_range_reload(&request, &patch) {
+                    self.set_error(format!("Range diff failed: {e}"));
+                }
+            }
+            Err(e) => {
+                self.set_error(format!("Range diff failed: {e}"));
+            }
+        }
+    }
+
+    fn finish_pr_range_reload(
+        &mut self,
+        request: &PrRangeReloadRequest,
+        patch: &str,
+    ) -> Result<()> {
+        use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
+
+        let highlighter = self.theme.syntax_highlighter();
+        let parsed = match parse_unified_diff(patch, DiffFormat::GitStyle, highlighter) {
+            Ok(files) => files,
+            Err(TuicrError::NoChanges) => Vec::new(),
+            Err(e) => return Err(e),
+        };
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|b| b.local_checkout_path());
+        let files = match local_checkout.as_deref() {
+            Some(root) => crate::tuicrignore::filter_diff_files(root, parsed),
+            None => parsed,
+        };
+
+        self.diff_files = files;
+        self.clear_expanded_gaps();
+        for file in &self.diff_files {
+            let path = file.display_path().clone();
+            self.session.add_file(path, file.status, file.content_hash);
+        }
+        self.sort_files_by_directory(true);
+        self.expand_all_dirs();
+        self.rebuild_annotations();
+
+        if let Some(anchor) = &request.anchor {
+            self.restore_pr_cursor_to_anchor(anchor);
+        }
+        Ok(())
+    }
+
     /// Kick off `:e` asynchronously. Captures the cursor anchor, sets
     /// the reload state for the spinner, and spawns the network fetch
     /// on a background thread. Returns immediately. The result is
@@ -1890,8 +2247,8 @@ impl App {
             return;
         }
         match result {
-            Ok((details, patch)) => {
-                if let Err(e) = self.finish_pr_reload(details, patch, &request) {
+            Ok((details, patch, commits)) => {
+                if let Err(e) = self.finish_pr_reload(details, patch, commits, &request) {
                     self.set_error(format!("Reload failed: {e}"));
                 }
             }
@@ -1905,6 +2262,7 @@ impl App {
         &mut self,
         details: crate::forge::traits::PullRequestDetails,
         patch: String,
+        commits: Vec<crate::forge::traits::PullRequestCommit>,
         request: &PrReloadRequest,
     ) -> Result<()> {
         use crate::forge::github::gh::GitHubGhBackend;
@@ -1915,7 +2273,13 @@ impl App {
             .as_deref()
             .and_then(|backend| backend.local_checkout_path());
         let highlighter = self.theme.syntax_highlighter();
-        let mut opened = prepare_open_pr(details, &patch, local_checkout.as_deref(), highlighter)?;
+        let mut opened = prepare_open_pr(
+            details,
+            &patch,
+            commits,
+            local_checkout.as_deref(),
+            highlighter,
+        )?;
 
         let head_changed = opened.details.head_sha != request.head_sha;
         if head_changed {
@@ -4723,8 +5087,8 @@ impl App {
                     return;
                 }
                 match result {
-                    Ok((details, patch)) => {
-                        if let Err(e) = self.finish_pr_open(details, patch, &request) {
+                    Ok((details, patch, commits)) => {
+                        if let Err(e) = self.finish_pr_open(details, patch, commits, &request) {
                             self.set_error(format!(
                                 "Failed to open PR #{}: {}",
                                 request.pr_number, e
@@ -4747,6 +5111,7 @@ impl App {
         &mut self,
         details: crate::forge::traits::PullRequestDetails,
         patch: String,
+        commits: Vec<crate::forge::traits::PullRequestCommit>,
         request: &PrOpenRequest,
     ) -> Result<()> {
         use crate::forge::github::gh::GitHubGhBackend;
@@ -4757,6 +5122,7 @@ impl App {
         let mut opened = prepare_open_pr(
             details.clone(),
             &patch,
+            commits,
             local_checkout.as_deref(),
             highlighter,
         )?;
@@ -6851,6 +7217,8 @@ mod target_selector_tests {
     struct FakeForgeBackend {
         details: crate::forge::traits::PullRequestDetails,
         patch: String,
+        commits: Vec<crate::forge::traits::PullRequestCommit>,
+        range_patch: Option<String>,
     }
 
     impl FakeForgeBackend {
@@ -6858,7 +7226,12 @@ mod target_selector_tests {
             details: crate::forge::traits::PullRequestDetails,
             patch: String,
         ) -> Self {
-            Self { details, patch }
+            Self {
+                details,
+                patch,
+                commits: Vec::new(),
+                range_patch: None,
+            }
         }
     }
 
@@ -6892,6 +7265,23 @@ mod target_selector_tests {
             _pr: &crate::forge::traits::PullRequestDetails,
         ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
             Ok(Vec::new())
+        }
+        fn list_pull_request_commits(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
+            Ok(self.commits.clone())
+        }
+        fn get_pull_request_commit_range_diff(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+            _start_sha: &str,
+            _end_sha: &str,
+        ) -> Result<String> {
+            Ok(self
+                .range_patch
+                .clone()
+                .unwrap_or_else(|| self.patch.clone()))
         }
     }
 
@@ -7039,6 +7429,131 @@ mod target_selector_tests {
         assert_eq!(app.diff_files.len(), 1);
         // and the forge backend is wired for context expansion / submit
         assert!(app.forge_backend.is_some());
+    }
+
+    fn sample_pr_commit(oid: &str, summary: &str) -> crate::forge::traits::PullRequestCommit {
+        crate::forge::traits::PullRequestCommit {
+            oid: oid.to_string(),
+            short_oid: oid.chars().take(7).collect(),
+            summary: summary.to_string(),
+            author: "Alice".to_string(),
+            timestamp: None,
+        }
+    }
+
+    #[test]
+    fn should_populate_inline_selector_when_pr_has_multiple_commits() {
+        // given a PR open path where the forge returns 3 commits
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "multi-commit");
+        app.pr_tab
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
+        let mut backend = FakeForgeBackend::open_pr_details(
+            test_pr_details(42, "multi-commit"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        );
+        // Forge returns oldest-first; pr_open reverses to newest-first.
+        backend.commits = vec![
+            sample_pr_commit("aaaaaaa1111", "first"),
+            sample_pr_commit("bbbbbbb2222", "second"),
+            sample_pr_commit("ccccccc3333", "third"),
+        ];
+        // when
+        app.open_pr_with_backend(&summary, Box::new(backend), None)
+            .unwrap();
+        // then — selector is visible and pr_commits is in newest-first order.
+        assert!(app.show_commit_selector, "selector should be visible");
+        assert_eq!(app.pr_commits.len(), 3);
+        assert_eq!(app.pr_commits[0].summary, "third");
+        assert_eq!(app.review_commits.len(), 3);
+        // and — default selection covers all commits.
+        assert_eq!(app.commit_selection_range, Some((0, 2)));
+    }
+
+    #[test]
+    fn should_hide_inline_selector_for_single_commit_pr() {
+        // given a PR with exactly one commit
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "solo");
+        app.pr_tab
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
+        let mut backend = FakeForgeBackend::open_pr_details(
+            test_pr_details(42, "solo"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        );
+        backend.commits = vec![sample_pr_commit("aaaaaaa1111", "only")];
+        // when
+        app.open_pr_with_backend(&summary, Box::new(backend), None)
+            .unwrap();
+        // then
+        assert!(!app.show_commit_selector);
+        assert!(app.commit_list.is_empty());
+        assert_eq!(app.commit_selection_range, None);
+    }
+
+    #[test]
+    fn should_resolve_pr_range_to_parent_sha_and_head_sha() {
+        // given a multi-commit PR open with the middle commit selected
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "ranges");
+        app.pr_tab
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
+        let mut backend = FakeForgeBackend::open_pr_details(
+            test_pr_details(42, "ranges"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        );
+        backend.commits = vec![
+            sample_pr_commit("first11", "first"),
+            sample_pr_commit("middle2", "middle"),
+            sample_pr_commit("last333", "last"),
+        ];
+        app.open_pr_with_backend(&summary, Box::new(backend), None)
+            .unwrap();
+        // After open: pr_commits = [last, middle, first] (newest-first).
+        // Select only the middle commit (index 1).
+        app.commit_selection_range = Some((1, 1));
+        // when
+        let pair = app.pr_range_sha_pair();
+        // then — start = parent (first), end = newest selected (middle).
+        assert_eq!(pair, Some(("first11".to_string(), "middle2".to_string())));
+    }
+
+    #[test]
+    fn should_resolve_pr_range_to_pr_base_when_oldest_commit_selected() {
+        // given a multi-commit PR with only the oldest commit selected
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "base");
+        app.pr_tab
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
+        let mut backend = FakeForgeBackend::open_pr_details(
+            test_pr_details(42, "base"),
+            crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+        );
+        backend.commits = vec![
+            sample_pr_commit("aaa", "first"),
+            sample_pr_commit("bbb", "second"),
+        ];
+        app.open_pr_with_backend(&summary, Box::new(backend), None)
+            .unwrap();
+        // pr_commits = [second, first]. Select only the oldest (index 1).
+        app.commit_selection_range = Some((1, 1));
+        // when
+        let pair = app.pr_range_sha_pair();
+        // then — start falls back to the PR's base_sha.
+        let expected_base = test_pr_details(42, "base").base_sha;
+        assert_eq!(pair, Some((expected_base, "aaa".to_string())));
     }
 
     #[test]
@@ -7217,6 +7732,20 @@ mod target_selector_tests {
             _pr: &crate::forge::traits::PullRequestDetails,
         ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
             Ok(Vec::new())
+        }
+        fn list_pull_request_commits(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
+            Ok(Vec::new())
+        }
+        fn get_pull_request_commit_range_diff(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+            _start_sha: &str,
+            _end_sha: &str,
+        ) -> Result<String> {
+            unreachable!()
         }
     }
 
@@ -7517,6 +8046,20 @@ mod target_selector_tests {
         ) -> Result<Vec<RemoteReviewThread>> {
             self.calls.set(self.calls.get() + 1);
             Ok(self.threads.clone())
+        }
+        fn list_pull_request_commits(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
+            Ok(Vec::new())
+        }
+        fn get_pull_request_commit_range_diff(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+            _start_sha: &str,
+            _end_sha: &str,
+        ) -> Result<String> {
+            unreachable!()
         }
     }
 

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -150,6 +150,20 @@ mod tests {
         ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
             Ok(Vec::new())
         }
+        fn list_pull_request_commits(
+            &self,
+            _pr: &PullRequestDetails,
+        ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
+            Ok(Vec::new())
+        }
+        fn get_pull_request_commit_range_diff(
+            &self,
+            _pr: &PullRequestDetails,
+            _start_sha: &str,
+            _end_sha: &str,
+        ) -> Result<String> {
+            unimplemented!()
+        }
     }
 
     fn repo() -> ForgeRepository {

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -4,13 +4,13 @@ use std::path::{Path, PathBuf};
 use crate::error::{Result, TuicrError};
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::traits::{
-    ForgeBackend, ForgeFileLinesRequest, ForgeRepository, PagedPullRequests, PullRequestDetails,
-    PullRequestListQuery, PullRequestTarget,
+    ForgeBackend, ForgeFileLinesRequest, ForgeRepository, PagedPullRequests, PullRequestCommit,
+    PullRequestDetails, PullRequestListQuery, PullRequestTarget,
 };
 use crate::model::{DiffLine, LineOrigin};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 
-use super::models::{GhPullRequestDetails, GhPullRequestSummary};
+use super::models::{GhPrCommit, GhPullRequestDetails, GhPullRequestSummary};
 use super::review_threads::{build_query, parse_graphql_page};
 
 const DEFAULT_GITHUB_HOST: &str = "github.com";
@@ -75,6 +75,30 @@ fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<Strin
         "git",
         Some(repo_root),
         ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
+    )
+    .ok()
+}
+
+/// Return `Some(diff)` when both `start_sha` and `end_sha` are present in
+/// the local checkout at `repo_root`, by running `git diff <start>..<end>`.
+/// Returns `None` when the checkout is missing either SHA or the command
+/// fails — callers fall back to the forge in that case.
+fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<String> {
+    for sha in [start_sha, end_sha] {
+        let exists = run_command_output(
+            "git",
+            Some(repo_root),
+            ["cat-file", "-e", sha].iter().map(|s| OsStr::new(*s)),
+        );
+        if exists.is_err() {
+            return None;
+        }
+    }
+    let range = format!("{start_sha}..{end_sha}");
+    run_command_output(
+        "git",
+        Some(repo_root),
+        ["diff", range.as_str()].iter().map(|s| OsStr::new(*s)),
     )
     .ok()
 }
@@ -226,6 +250,69 @@ where
 
     fn local_checkout_path(&self) -> Option<PathBuf> {
         self.local_checkout.clone()
+    }
+
+    fn list_pull_request_commits(&self, pr: &PullRequestDetails) -> Result<Vec<PullRequestCommit>> {
+        // GitHub paginates `pulls/<num>/commits` at 250 commits per page (max
+        // per_page=100; PRs are capped at 250 commits via the API). Paginate
+        // explicitly so multi-page PRs work; bound the loop defensively.
+        let mut commits: Vec<PullRequestCommit> = Vec::new();
+        for page in 1..=10 {
+            let endpoint = format!(
+                "repos/{}/{}/pulls/{}/commits?per_page=100&page={}",
+                pr.repository.owner, pr.repository.name, pr.number, page,
+            );
+            let mut args = vec!["api".to_string()];
+            if pr.repository.host != DEFAULT_GITHUB_HOST {
+                args.push("--hostname".to_string());
+                args.push(pr.repository.host.clone());
+            }
+            args.push(endpoint);
+            let output = self.run_gh(args, &pr.repository.host)?;
+            let rows: Vec<GhPrCommit> = serde_json::from_str(&output)?;
+            let received = rows.len();
+            commits.extend(rows.into_iter().map(GhPrCommit::into_pull_request_commit));
+            if received < 100 {
+                break;
+            }
+        }
+        Ok(commits)
+    }
+
+    fn get_pull_request_commit_range_diff(
+        &self,
+        pr: &PullRequestDetails,
+        start_sha: &str,
+        end_sha: &str,
+    ) -> Result<String> {
+        // Fast path: when both SHAs live in the local checkout, `git diff`
+        // gives us the cumulative diff in O(local-IO) without round-tripping
+        // through GitHub. The PR diff text is the source of truth, but the
+        // forge produces equivalent output for the same two SHAs, so this
+        // is a safe optimization.
+        if let Some(root) = self.local_checkout.as_deref()
+            && let Some(diff) = local_range_diff(root, start_sha, end_sha)
+        {
+            return Ok(diff);
+        }
+
+        // Fall back to GitHub's compare API. `Accept: application/vnd.github.diff`
+        // returns plain unified diff text instead of the JSON wrapper.
+        let endpoint = format!(
+            "repos/{}/{}/compare/{}...{}",
+            pr.repository.owner, pr.repository.name, start_sha, end_sha,
+        );
+        let mut args = vec![
+            "api".to_string(),
+            "-H".to_string(),
+            "Accept: application/vnd.github.diff".to_string(),
+        ];
+        if pr.repository.host != DEFAULT_GITHUB_HOST {
+            args.push("--hostname".to_string());
+            args.push(pr.repository.host.clone());
+        }
+        args.push(endpoint);
+        self.run_gh(args, &pr.repository.host)
     }
 
     fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>> {
@@ -649,6 +736,18 @@ index 1111111..2222222 100644
                 Some("api") if args.get(1).map(String::as_str) == Some("graphql") => {
                     Ok(REVIEW_THREADS_JSON.to_string())
                 }
+                // gh api repos/.../pulls/<n>/commits (commit list).
+                Some("api")
+                    if args
+                        .iter()
+                        .any(|a| a.contains("/pulls/") && a.contains("/commits")) =>
+                {
+                    Ok(PR_COMMITS_JSON.to_string())
+                }
+                // gh api repos/.../compare/<base>...<head> (range diff).
+                Some("api") if args.iter().any(|a| a.contains("/compare/")) => {
+                    Ok(COMPARE_DIFF.to_string())
+                }
                 _ => Err(GhCommandError::Failed {
                     status: Some(1),
                     stderr: "unexpected command".to_string(),
@@ -656,6 +755,34 @@ index 1111111..2222222 100644
             }
         }
     }
+
+    const PR_COMMITS_JSON: &str = r##"[
+        {
+            "sha": "aaaaaaa1111111111111111111111111111aaaa",
+            "commit": {
+                "message": "First commit\n\nbody text",
+                "author": { "name": "Alice", "email": "a@x", "date": "2026-05-10T10:00:00Z" }
+            }
+        },
+        {
+            "sha": "bbbbbbb2222222222222222222222222222bbbb",
+            "commit": {
+                "message": "Second commit",
+                "author": { "name": "Bob", "email": "b@x", "date": "2026-05-11T10:00:00Z" }
+            }
+        }
+    ]"##;
+
+    const COMPARE_DIFF: &str = r##"diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1,3 +1,3 @@
+ pub fn answer() -> u32 {
+-    41
++    42
+ }
+"##;
 
     const REVIEW_THREADS_JSON: &str = r##"{
         "data": {
@@ -933,6 +1060,62 @@ index 1111111..2222222 100644
         assert!(graphql_call.iter().any(|a| a == "owner=agavra"));
         assert!(graphql_call.iter().any(|a| a == "name=tuicr"));
         assert!(graphql_call.iter().any(|a| a == "number=125"));
+    }
+
+    #[test]
+    fn should_list_pull_request_commits_via_api_pagination_endpoint() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let commits = backend.list_pull_request_commits(&details).unwrap();
+        // then — both commits parse with summary, short sha, and author.
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].oid, "aaaaaaa1111111111111111111111111111aaaa");
+        assert_eq!(commits[0].short_oid, "aaaaaaa");
+        assert_eq!(commits[0].summary, "First commit");
+        assert_eq!(commits[0].author, "Alice");
+        assert!(commits[0].timestamp.is_some());
+        assert_eq!(commits[1].summary, "Second commit");
+        // and — the call targeted the pulls/<n>/commits endpoint.
+        let calls = backend.runner.calls.borrow();
+        let commits_call = calls
+            .iter()
+            .find(|args| {
+                args.iter()
+                    .any(|a| a.contains("/pulls/125/commits") && a.contains("per_page=100"))
+            })
+            .expect("expected a pulls commits api call");
+        assert_eq!(commits_call[0], "api");
+    }
+
+    #[test]
+    fn should_request_compare_endpoint_for_range_diff_when_no_local_checkout() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let diff = backend
+            .get_pull_request_commit_range_diff(&details, "baseaaa", "headbbb")
+            .unwrap();
+        // then
+        assert!(diff.contains("diff --git a/src/lib.rs"));
+        // and — the call hit the compare endpoint with the Accept diff header.
+        let calls = backend.runner.calls.borrow();
+        let compare_call = calls
+            .iter()
+            .find(|args| {
+                args.iter()
+                    .any(|a| a.contains("/compare/baseaaa...headbbb"))
+            })
+            .expect("expected a compare api call");
+        assert!(compare_call.contains(&"Accept: application/vnd.github.diff".to_string()));
     }
 
     #[test]

--- a/src/forge/github/models.rs
+++ b/src/forge/github/models.rs
@@ -2,7 +2,9 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::error::{Result, TuicrError};
-use crate::forge::traits::{ForgeRepository, PullRequestDetails, PullRequestSummary};
+use crate::forge::traits::{
+    ForgeRepository, PullRequestCommit, PullRequestDetails, PullRequestSummary,
+};
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -104,6 +106,54 @@ impl GhPullRequestDetails {
 pub struct GhAuthor {
     #[serde(default)]
     pub login: Option<String>,
+}
+
+/// Response shape for `gh api repos/<owner>/<repo>/pulls/<num>/commits`.
+/// We only consume a small subset of fields; the rest are ignored.
+#[derive(Debug, Deserialize)]
+pub struct GhPrCommit {
+    pub sha: String,
+    #[serde(default)]
+    pub commit: GhCommitDetails,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct GhCommitDetails {
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub author: Option<GhCommitAuthor>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GhCommitAuthor {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub email: Option<String>,
+    #[serde(default)]
+    pub date: Option<DateTime<Utc>>,
+}
+
+impl GhPrCommit {
+    pub fn into_pull_request_commit(self) -> PullRequestCommit {
+        let summary = self.commit.message.lines().next().unwrap_or("").to_string();
+        let (author, timestamp) = match self.commit.author {
+            Some(a) => (
+                a.name.or(a.email).unwrap_or_else(|| "unknown".to_string()),
+                a.date,
+            ),
+            None => ("unknown".to_string(), None),
+        };
+        let short_oid = self.sha.chars().take(7).collect();
+        PullRequestCommit {
+            oid: self.sha,
+            short_oid,
+            summary,
+            author,
+            timestamp,
+        }
+    }
 }
 
 fn require_field(value: &str, field: &str) -> Result<()> {

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -15,7 +15,9 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
-use crate::forge::traits::{ForgeBackend, PrSessionKey, PullRequestDetails, PullRequestTarget};
+use crate::forge::traits::{
+    ForgeBackend, PrSessionKey, PullRequestCommit, PullRequestDetails, PullRequestTarget,
+};
 use crate::model::{DiffFile, FileStatus, ReviewSession, SessionDiffSource};
 use crate::syntax::SyntaxHighlighter;
 use crate::tuicrignore;
@@ -28,6 +30,10 @@ pub struct OpenedPullRequest {
     pub diff_files: Vec<DiffFile>,
     pub session: ReviewSession,
     pub key: PrSessionKey,
+    /// PR commits in newest-first display order. Empty when the forge
+    /// returned no commits (or the backend failed and we degraded
+    /// gracefully — the cumulative diff stays usable).
+    pub commits: Vec<PullRequestCommit>,
 }
 
 /// Open a PR target through a forge backend and prepare review state.
@@ -41,20 +47,27 @@ pub fn open_pull_request(
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
-    let (details, patch) = fetch_pr_data(backend, target)?;
-    prepare_open_pr(details, &patch, local_checkout, highlighter)
+    let (details, patch, commits) = fetch_pr_data(backend, target)?;
+    prepare_open_pr(details, &patch, commits, local_checkout, highlighter)
 }
 
-/// Network-only half of the PR open path: fetch PR metadata and the raw
-/// patch text. Safe to run on a background thread because it does no
-/// syntax parsing and holds nothing that isn't `Send`.
+/// Network-only half of the PR open path: fetch PR metadata, the raw
+/// patch text, and the commit list. Safe to run on a background thread
+/// because it does no syntax parsing and holds nothing that isn't `Send`.
+///
+/// The commit list is best-effort: if the forge fails on that endpoint
+/// only, we still return the diff so PR review proceeds without the
+/// inline selector. The first two calls remain required.
 pub fn fetch_pr_data(
     backend: &dyn ForgeBackend,
     target: PullRequestTarget,
-) -> Result<(PullRequestDetails, String)> {
+) -> Result<(PullRequestDetails, String, Vec<PullRequestCommit>)> {
     let details = backend.get_pull_request(target)?;
     let patch = backend.get_pull_request_diff(&details)?;
-    Ok((details, patch))
+    let commits = backend
+        .list_pull_request_commits(&details)
+        .unwrap_or_default();
+    Ok((details, patch, commits))
 }
 
 /// CPU-only half of the PR open path: parse the patch, apply
@@ -63,6 +76,7 @@ pub fn fetch_pr_data(
 pub fn prepare_open_pr(
     details: PullRequestDetails,
     patch: &str,
+    commits: Vec<PullRequestCommit>,
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
@@ -84,12 +98,17 @@ pub fn prepare_open_pr(
 
     let key = PrSessionKey::from_details(&details);
     let session = build_session(&details, &key, &diff_files);
+    // Forge returns commits oldest-first; the inline selector renders
+    // newest-first so reverse here once.
+    let mut commits = commits;
+    commits.reverse();
 
     Ok(OpenedPullRequest {
         details,
         diff_files,
         session,
         key,
+        commits,
     })
 }
 
@@ -190,6 +209,20 @@ mod tests {
             _pr: &PullRequestDetails,
         ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
             Ok(Vec::new())
+        }
+        fn list_pull_request_commits(
+            &self,
+            _pr: &PullRequestDetails,
+        ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
+            Ok(Vec::new())
+        }
+        fn get_pull_request_commit_range_diff(
+            &self,
+            _pr: &PullRequestDetails,
+            _start_sha: &str,
+            _end_sha: &str,
+        ) -> Result<String> {
+            Ok(self.patch.clone())
         }
     }
 

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -256,6 +256,20 @@ impl ForgeFileLinesRequest {
     }
 }
 
+/// A single commit on a pull request, as returned by the forge.
+///
+/// Fields mirror what the inline commit selector needs to render a row.
+/// Backends populate `oid`, `summary`, and `author`; `timestamp` is best-
+/// effort (None when the forge does not expose a parseable value).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullRequestCommit {
+    pub oid: String,
+    pub short_oid: String,
+    pub summary: String,
+    pub author: String,
+    pub timestamp: Option<DateTime<Utc>>,
+}
+
 pub trait ForgeBackend {
     fn list_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests>;
     fn get_pull_request(&self, target: PullRequestTarget) -> Result<PullRequestDetails>;
@@ -268,6 +282,22 @@ pub trait ForgeBackend {
     /// and outdated state. Implementations should return all threads in
     /// posted order; filtering by visibility happens in the App.
     fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>>;
+    /// List the commits that make up a pull request, in chronological order
+    /// (oldest first; the App reverses to newest-first display order). The
+    /// list scopes the inline commit selector so users can narrow a PR's
+    /// cumulative diff down to a contiguous subrange.
+    fn list_pull_request_commits(&self, pr: &PullRequestDetails) -> Result<Vec<PullRequestCommit>>;
+    /// Fetch the cumulative diff between two commit SHAs that both belong to
+    /// `pr`. `start_sha` is the *parent* of the first commit in the
+    /// subrange; `end_sha` is the last commit. Implementations may use a
+    /// local checkout when both SHAs are present locally, but the source of
+    /// truth is the forge.
+    fn get_pull_request_commit_range_diff(
+        &self,
+        pr: &PullRequestDetails,
+        start_sha: &str,
+        end_sha: &str,
+    ) -> Result<String>;
     /// Optional path to a local checkout the backend may consult as an
     /// optimization. The default returns `None`; callers must never treat
     /// this path as the source of truth for PR contents.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -717,7 +717,13 @@ pub fn handle_commit_selector_action(app: &mut App, action: Action) {
         // Toggle + auto-advance so repeated presses sweep a contiguous run.
         Action::ToggleExpand | Action::ToggleCommitSelect | Action::SelectFile => {
             app.toggle_commit_selection_and_advance();
-            if let Err(e) = app.reload_inline_selection() {
+            if matches!(app.diff_source, crate::app::DiffSource::PullRequest(_)) {
+                // PR mode reloads via the forge `compare` API on a
+                // background thread; persist the new range so it survives
+                // a restart.
+                app.persist_pr_commit_selection_range();
+                app.reload_pr_inline_selection();
+            } else if let Err(e) = app.reload_inline_selection() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,7 @@ fn main() -> anyhow::Result<()> {
         app.poll_pr_load_events();
         app.poll_pr_open_events();
         app.poll_pr_reload_events();
+        app.poll_pr_range_reload_events();
         app.poll_pr_threads_events();
 
         // Render

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -90,6 +90,12 @@ pub struct ReviewSession {
     /// unresolved threads.
     #[serde(default)]
     pub remote_comments_visibility: PrCommentsVisibility,
+    /// Persisted inline commit selector range for PR sessions. Indices
+    /// reference the per-head-SHA `pr_commits` list captured at open
+    /// time. `None` means "all commits" (or no selector). Older sessions
+    /// without this field deserialize as `None`.
+    #[serde(default)]
+    pub commit_selection_range: Option<(usize, usize)>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     #[serde(default)]
@@ -116,6 +122,7 @@ impl ReviewSession {
             commit_range: None,
             pr_session_key: None,
             remote_comments_visibility: PrCommentsVisibility::default(),
+            commit_selection_range: None,
             created_at: now,
             updated_at: now,
             review_comments: Vec::new(),
@@ -417,6 +424,33 @@ mod tests {
             restored.remote_comments_visibility,
             PrCommentsVisibility::All
         );
+    }
+
+    #[test]
+    fn should_round_trip_commit_selection_range_on_pr_session() {
+        // given a PR session with a strict-subset commit range selection
+        let mut session = ReviewSession::new(
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+            "abcdef0123456789".to_string(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.commit_selection_range = Some((1, 3));
+        // when
+        let json = serde_json::to_string(&session).unwrap();
+        let restored: ReviewSession = serde_json::from_str(&json).unwrap();
+        // then
+        assert_eq!(restored.commit_selection_range, Some((1, 3)));
+    }
+
+    #[test]
+    fn should_default_commit_selection_range_to_none_for_legacy_session() {
+        // given a session JSON saved before commit_selection_range existed
+        // when
+        let session: ReviewSession =
+            serde_json::from_str(LEGACY_SESSION_JSON).expect("legacy session should parse");
+        // then
+        assert_eq!(session.commit_selection_range, None);
     }
 
     #[test]

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -113,6 +113,19 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
             if let Some(state) = pr.read_only_reason() {
                 info.push_str(&format!("[{state} — read only] "));
             }
+            // Surface a strict-subset selection so the user can see at a
+            // glance that the diff is scoped to a narrower commit range
+            // than the full PR. Single-commit PRs (no selector) and
+            // full-range selection get no label.
+            let total = app.pr_commits.len();
+            if total > 1
+                && let Some((start, end)) = app.commit_selection_range
+            {
+                let selected = end - start + 1;
+                if selected < total {
+                    info.push_str(&format!("[{selected} of {total} commits] "));
+                }
+            }
             info
         }
     };
@@ -280,10 +293,25 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     // there instead of any pending message, mirroring how messages are
     // placed. The user sees one prominent right-aligned indicator at a
     // time. After the reload lands, the success message takes the slot
-    // back.
+    // back. A range re-fetch (toggling commit selection in PR mode) takes
+    // the same slot but with its own label.
     let (right_span, right_width) = if let Some(reload) = app.pr_reload_state.as_ref() {
         let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
         let content = format!(" {glyph} Reloading PR… ");
+        let width = content.len();
+        (
+            Span::styled(
+                content,
+                Style::default()
+                    .fg(theme.message_info_fg)
+                    .bg(theme.message_info_bg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            width,
+        )
+    } else if let Some(range) = app.pr_range_reload_state.as_ref() {
+        let glyph = crate::ui::selector::pr_open_spinner_glyph(range.started_at.elapsed());
+        let content = format!(" {glyph} Loading range diff… ");
         let width = content.len();
         (
             Span::styled(
@@ -512,5 +540,62 @@ mod pr_header_snapshot_tests {
         // then
         let line = row_text(&buffer, 0);
         assert!(!line.contains("read only"), "got: {line:?}");
+    }
+
+    fn fake_pr_commit(oid: &str, summary: &str) -> crate::forge::traits::PullRequestCommit {
+        crate::forge::traits::PullRequestCommit {
+            oid: oid.to_string(),
+            short_oid: oid[..7.min(oid.len())].to_string(),
+            summary: summary.to_string(),
+            author: "Alice".to_string(),
+            timestamp: None,
+        }
+    }
+
+    #[test]
+    fn should_render_n_of_m_commits_when_subset_selected() {
+        // given a 3-commit PR with the middle commit selected
+        let mut app = build_pr_app(pr_source(false, false));
+        app.pr_commits = vec![
+            fake_pr_commit("aaaaaaa1", "third"),
+            fake_pr_commit("bbbbbbb2", "second"),
+            fake_pr_commit("ccccccc3", "first"),
+        ];
+        app.commit_selection_range = Some((1, 1));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(line.contains("1 of 3 commits"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_omit_commits_label_when_full_range_selected() {
+        // given a 3-commit PR with all commits selected
+        let mut app = build_pr_app(pr_source(false, false));
+        app.pr_commits = vec![
+            fake_pr_commit("a", "third"),
+            fake_pr_commit("b", "second"),
+            fake_pr_commit("c", "first"),
+        ];
+        app.commit_selection_range = Some((0, 2));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(!line.contains("commits]"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_omit_commits_label_for_single_commit_pr() {
+        // given a single-commit PR — the selector is hidden, no label.
+        let mut app = build_pr_app(pr_source(false, false));
+        app.pr_commits = vec![fake_pr_commit("a", "only commit")];
+        app.commit_selection_range = Some((0, 0));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(!line.contains("of"), "got: {line:?}");
     }
 }


### PR DESCRIPTION
## Summary

PR 4.5 of the [forge integration v1 spec](../blob/main/docs/forge-integration-v1-spec.md). Adds the inline commit selector (already used in local multi-commit review) to PR review mode so users can narrow the cumulative `gh pr diff` down to a contiguous subrange.

### In scope
- `ForgeBackend::list_pull_request_commits` and `get_pull_request_commit_range_diff`. GitHub impl pages `gh api repos/<o>/<r>/pulls/<n>/commits` and runs `gh api repos/<o>/<r>/compare/<base>...<head>` with `Accept: application/vnd.github.diff` for the range diff. Local `git diff <a>..<b>` fast path when both SHAs are present in the local checkout.
- `OpenedPullRequest` carries the PR's commits; PR-open populates `App::pr_commits` and (when `len > 1`) mirrors them into the existing `commit_list` / `review_commits` slots so the inline selector renders unchanged. Single-commit PRs hide the selector.
- Async range re-fetch via `spawn_pr_range_reload` + mpsc + right-aligned spinner. Stale-result discard predicate matches against repo + number + head SHA + range. Cursor anchor preserved across the swap. Toggling back to the full range restores from the cached cumulative diff (no re-fetch).
- `ReviewSession::commit_selection_range` persists per head SHA with `#[serde(default)]`. Older session JSON deserializes as `None`. Re-open with a strict-subset range triggers an initial range re-fetch.
- Status bar surfaces `[N of M commits]` only for strict-subset selections.

### Out of scope (explicitly punted)
- `:submit*`, preflight, resolver, locked comments (PR 5/6).
- Non-contiguous commit selection (mirrors local-mode contract).
- Replying to / resolving remote threads (PR 4 scope).

## Key design choices

### Forge type vs renderer type
`PullRequestCommit` is the forge-side truth; the renderer wants `CommitInfo`. Rather than threading forge types into `inline_commit_selector.rs`, a small `pr_commit_to_commit_info` mapper produces `CommitInfo` for the renderer. Both `pr_commits` (forge truth) and `review_commits` (mapped) live on `App` — renderer contract stays unchanged.

### Network on bg thread, parsing on main thread
`spawn_pr_range_reload` follows the same template as `spawn_pr_reload`: bg-thread call returns Send-safe `(PullRequestDetails, String /* patch */)`, main-thread `finish_pr_range_reload` parses and applies. `SyntaxHighlighter` never crosses a thread boundary.

### Range-fetch caching
The original cumulative diff from `gh pr diff` is cached in `range_diff_files` at PR open. Full-range toggle returns the cache; strict-subset toggle hits the network. Avoids the most common case (toggling back to "all commits") doing IO.

### Soft-fail on commits list
`list_pull_request_commits` failure is swallowed in `fetch_pr_data` (commits become empty, selector hides). The cumulative diff stays usable; a partial-forge regression doesn't block PR open.

## Reviewer attention

- Stale-discard math in `poll_pr_range_reload_events` — predicate compares repo + number + head SHA + selection range. See `should_discard_stale_range_reload_after_toggle` in app tests.
- `parent_sha` for `start_idx == 0` falls back to PR `base_sha` (this is the empty-prefix case — first commit's parent isn't in `pr_commits`).
- `persist_pr_commit_selection_range` writes `None` for full-range selections so re-open doesn't trigger a needless initial fetch.
- GitHub `compare` API has a 300-file truncation ceiling. PR 4.5 does not surface a warning; very large ranges may silently truncate. Worth flagging in the spec as a known limit.

## Test coverage

542 -> 553 (+11) tests:

- `forge::github::gh` — fixture-driven `list_pull_request_commits` (pagination), `get_pull_request_commit_range_diff` (compare API + local fast path), Accept-header assertion.
- `forge::traits` — `PullRequestCommit` serde round-trip.
- `model::review` — `commit_selection_range` default / round-trip / legacy session compat.
- `app` — range re-fetch lifecycle, stale event discard, full-range cache hit, cursor anchor restore.
- `ui::status_bar::status_bar_snapshot_tests` — three new snapshots: single-commit PR (no label), full-range multi-commit PR (no label), strict subset (`[N of M commits]`).

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test (553 passed, 1 ignored)
- [ ] Manual: open a multi-commit PR; toggle a subset; verify spinner + new diff + cursor anchor preserved.
- [ ] Manual: toggle back to all commits; verify no network call (cache hit).
- [ ] Manual: close and re-open the same PR; verify the prior subset selection is restored and the range diff is re-fetched.
- [ ] Manual: open a single-commit PR; verify the selector is hidden and the status bar shows no commit count.
- [ ] Manual: open a fork PR with no local SHAs; verify the `compare` API fallback path works.