### PR TITLE
forge: submit preflight + resolver + payload (PR 5 of forge v1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -393,6 +393,12 @@ pub enum InputMode {
     Confirm,
     CommitSelect,
     VisualSelect,
+    /// Modal listing comments that cannot be mapped to GitHub inline review
+    /// comments. The user toggles between "move to summary" / "omit" for
+    /// each row, then `s` advances to `SubmitConfirm`.
+    SubmitResolver,
+    /// Final confirmation modal before the network create-review call.
+    SubmitConfirm,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -463,6 +469,46 @@ impl PullRequestDiffSource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfirmAction {
     CopyAndQuit,
+}
+
+/// Push a `MappedComment` onto the appropriate bucket. Free function so the
+/// preflight walk doesn't need to keep `self` borrowed mutably.
+fn bucket_mapping(
+    mapped: crate::forge::submit::MappedComment,
+    mappable: &mut Vec<crate::forge::submit::InlineComment>,
+    unmappable: &mut Vec<crate::forge::submit::UnmappableItem>,
+) {
+    use crate::forge::submit::{MappedComment, UnmappableItem};
+    match mapped {
+        MappedComment::Inline(inline) => mappable.push(inline),
+        MappedComment::Unmappable {
+            comment,
+            file,
+            reason,
+        } => unmappable.push(UnmappableItem {
+            comment,
+            file,
+            reason,
+        }),
+    }
+}
+
+/// In-flight `:submit*` state, populated by preflight and consumed by the
+/// resolver + confirmation modals. Lives on `App::submit_state` so the same
+/// preflight output can flow from resolver to confirmation without recomputing.
+#[derive(Debug, Clone)]
+pub struct SubmitState {
+    pub event: crate::forge::submit::SubmitEvent,
+    /// Comments that mapped cleanly to inline GitHub review comments.
+    pub mappable: Vec<crate::forge::submit::InlineComment>,
+    /// Comments that did not map, paired with the resolver action the user
+    /// has chosen for each (defaults to `MoveToSummary` per spec).
+    pub unmappable: Vec<crate::forge::submit::UnmappableItem>,
+    pub resolver_choices: Vec<crate::forge::submit::ResolverAction>,
+    /// Cursor row inside the resolver modal.
+    pub resolver_cursor: usize,
+    /// Originally-reviewed head SHA — used as `commit_id` in the payload.
+    pub commit_id: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -723,6 +769,18 @@ pub struct App {
     /// Background-thread channel that delivers remote-thread fetch results.
     /// `Receiver` is only present while a fetch is in flight.
     pub pr_threads_rx: Option<std::sync::mpsc::Receiver<PrThreadsEvent>>,
+
+    /// `[forge]` section settings resolved at startup. Drives the body/footer
+    /// formatting on submit. Defaults to `ForgeConfig::default()` when the
+    /// section is missing.
+    pub forge_config: crate::config::ForgeConfig,
+    /// In-flight `:submit*` state. `None` outside the resolver + confirmation
+    /// modal flow; preflight populates it.
+    pub submit_state: Option<SubmitState>,
+    /// Latest known PR head SHA from the remote. PR 5 leaves this as the
+    /// open-time head so the stale-head warning never fires; PR 6 may refresh
+    /// it via a pre-submit `gh pr view` to power the warning.
+    pub current_pr_head: Option<String>,
 
     pub should_quit: bool,
     pub dirty: bool,
@@ -1303,6 +1361,9 @@ impl App {
             forge_review_threads: Vec::new(),
             forge_review_threads_loading: false,
             pr_threads_rx: None,
+            forge_config: crate::config::ForgeConfig::default(),
+            submit_state: None,
+            current_pr_head: None,
             should_quit: false,
             dirty: false,
             quit_warned: false,
@@ -1712,6 +1773,7 @@ impl App {
         // Wire the forge backend so context expansion routes through it.
         app.forge_backend = Some(Box::new(backend));
         app.forge_repository = Some(target_repo);
+        app.current_pr_head = Some(details_for_threads.head_sha.clone());
         if let DiffSource::PullRequest(pr) = &app.diff_source.clone()
             && pr.is_read_only()
         {
@@ -1764,6 +1826,9 @@ impl App {
         self.forge_review_threads = Vec::new();
         self.forge_review_threads_loading = false;
         self.pr_threads_rx = None;
+        // Latest known remote head — equal to the session head at open time;
+        // refreshed by future `gh pr view` calls in PR 6.
+        self.current_pr_head = Some(details.head_sha.clone());
         self.input_mode = InputMode::Normal;
         self.focused_panel = FocusedPanel::Diff;
         self.clear_expanded_gaps();
@@ -4240,6 +4305,52 @@ impl App {
         }
     }
 
+    /// True when the cursor sits on a local comment whose lifecycle state
+    /// has been pushed/submitted to the forge. Such comments are locked from
+    /// edit/delete in tuicr to prevent the local state from drifting from
+    /// what GitHub now stores.
+    pub fn cursor_on_locked_comment(&self) -> bool {
+        let Some(location) = self.find_comment_at_cursor() else {
+            return false;
+        };
+        match location {
+            CommentLocation::Review { index } => self
+                .session
+                .review_comments
+                .get(index)
+                .is_some_and(|c| c.is_locked()),
+            CommentLocation::File { path, index } => self
+                .session
+                .files
+                .get(&path)
+                .and_then(|review| review.file_comments.get(index))
+                .is_some_and(|c| c.is_locked()),
+            CommentLocation::Line {
+                path,
+                line,
+                side,
+                index,
+            } => self
+                .session
+                .files
+                .get(&path)
+                .and_then(|review| review.line_comments.get(&line))
+                .and_then(|comments| {
+                    let mut side_idx = 0;
+                    for c in comments {
+                        if c.side.unwrap_or(LineSide::New) == side {
+                            if side_idx == index {
+                                return Some(c);
+                            }
+                            side_idx += 1;
+                        }
+                    }
+                    None
+                })
+                .is_some_and(|c| c.is_locked()),
+        }
+    }
+
     /// Find the comment at the current cursor position
     /// True when the cursor is on a row that belongs to a fetched-from-GitHub
     /// review thread. Remote threads are read-only in v1; surfaced as a
@@ -4775,6 +4886,192 @@ impl App {
     pub fn exit_confirm_mode(&mut self) {
         self.input_mode = InputMode::Normal;
         self.pending_confirm = None;
+    }
+
+    /// Drive `:submit*` preflight: walk every local-draft comment in the
+    /// current PR session, map each one against the displayed diff, bucket
+    /// the results, and transition into the resolver (when there are
+    /// unmappable comments) or the final-confirmation modal.
+    ///
+    /// PR 5 does not call the network; `[y]` in the confirmation modal
+    /// stubs a "PR 6 will wire the network call" info message.
+    pub fn start_submit(&mut self, event: crate::forge::submit::SubmitEvent) {
+        use crate::forge::submit::{InlineComment, ResolverAction, UnmappableItem, map_comment};
+
+        let DiffSource::PullRequest(pr) = &self.diff_source else {
+            self.set_warning(":submit only applies in PR mode");
+            return;
+        };
+        if pr.is_read_only() {
+            let reason = pr.read_only_reason().unwrap_or("read only");
+            self.set_warning(format!("Cannot submit: PR is {reason}"));
+            return;
+        }
+        let commit_id = pr.key.head_sha.clone();
+
+        // Source of truth for the diff: when the inline commit selector is
+        // showing a strict subset, `range_diff_files` carries the merged
+        // subset diff; otherwise `diff_files` is canonical.
+        let files: Vec<&DiffFile> = match self.range_diff_files.as_ref() {
+            Some(range) => range.iter().collect(),
+            None => self.diff_files.iter().collect(),
+        };
+
+        let mut mappable: Vec<InlineComment> = Vec::new();
+        let mut unmappable: Vec<UnmappableItem> = Vec::new();
+        let mut total_local_drafts = 0_usize;
+
+        // Walk file-level and line comments in display order. Review-level
+        // comments (session.review_comments) are NOT inline-mapped; they
+        // appear in the body via `build_review_body`.
+        for file in &files {
+            let Some(review) = self.session.files.get(file.display_path()) else {
+                continue;
+            };
+            for comment in &review.file_comments {
+                if comment.is_locked() {
+                    continue;
+                }
+                total_local_drafts += 1;
+                bucket_mapping(
+                    map_comment(comment, file, &self.forge_config),
+                    &mut mappable,
+                    &mut unmappable,
+                );
+            }
+            let mut keys: Vec<&u32> = review.line_comments.keys().collect();
+            keys.sort();
+            for key in keys {
+                for comment in &review.line_comments[key] {
+                    if comment.is_locked() {
+                        continue;
+                    }
+                    total_local_drafts += 1;
+                    bucket_mapping(
+                        map_comment(comment, file, &self.forge_config),
+                        &mut mappable,
+                        &mut unmappable,
+                    );
+                }
+            }
+        }
+
+        if total_local_drafts == 0 && self.session.review_comments.is_empty() {
+            self.set_warning("Nothing to submit — no local-draft comments");
+            return;
+        }
+
+        let resolver_choices = vec![ResolverAction::default(); unmappable.len()];
+        let has_unmappable = !unmappable.is_empty();
+        self.submit_state = Some(SubmitState {
+            event,
+            mappable,
+            unmappable,
+            resolver_choices,
+            resolver_cursor: 0,
+            commit_id,
+        });
+
+        if has_unmappable {
+            self.input_mode = InputMode::SubmitResolver;
+        } else {
+            self.input_mode = InputMode::SubmitConfirm;
+        }
+    }
+
+    pub fn cancel_submit(&mut self) {
+        self.submit_state = None;
+        self.input_mode = InputMode::Normal;
+    }
+
+    /// Move the resolver cursor down by one row, clamped to the last row.
+    pub fn submit_resolver_cursor_down(&mut self) {
+        if let Some(state) = self.submit_state.as_mut()
+            && state.resolver_cursor + 1 < state.unmappable.len()
+        {
+            state.resolver_cursor += 1;
+        }
+    }
+
+    pub fn submit_resolver_cursor_up(&mut self) {
+        if let Some(state) = self.submit_state.as_mut()
+            && state.resolver_cursor > 0
+        {
+            state.resolver_cursor -= 1;
+        }
+    }
+
+    pub fn submit_resolver_toggle(&mut self) {
+        use crate::forge::submit::ResolverAction;
+        if let Some(state) = self.submit_state.as_mut()
+            && let Some(choice) = state.resolver_choices.get_mut(state.resolver_cursor)
+        {
+            *choice = match choice {
+                ResolverAction::MoveToSummary => ResolverAction::Omit,
+                ResolverAction::Omit => ResolverAction::MoveToSummary,
+            };
+        }
+    }
+
+    /// Advance from the resolver to the final confirmation modal.
+    pub fn submit_resolver_advance(&mut self) {
+        if self.submit_state.is_some() {
+            self.input_mode = InputMode::SubmitConfirm;
+        }
+    }
+
+    /// True iff the original review head and the latest known PR head
+    /// disagree. PR 5 cannot trigger this (the open-time head equals
+    /// `current_pr_head`), but the field is exposed so the renderer can
+    /// fold the warning in once PR 6 refreshes the remote head.
+    pub fn submit_head_is_stale(&self) -> bool {
+        let Some(state) = self.submit_state.as_ref() else {
+            return false;
+        };
+        match self.current_pr_head.as_deref() {
+            Some(latest) => latest != state.commit_id,
+            None => false,
+        }
+    }
+
+    /// Confirm submit — PR 5 stubs the network call. Builds the payload so
+    /// any preflight contract violations surface here, then sets an info
+    /// message and clears the state. PR 6 will replace this with the
+    /// actual `gh api` call.
+    pub fn confirm_submit(&mut self) {
+        use crate::forge::github::submit::build_review_payload;
+        use crate::forge::submit::{MovedToSummaryItem, ResolverAction, build_review_body};
+
+        let Some(state) = self.submit_state.take() else {
+            return;
+        };
+
+        let summary_items: Vec<MovedToSummaryItem> = state
+            .unmappable
+            .iter()
+            .zip(state.resolver_choices.iter())
+            .filter_map(|(item, action)| {
+                if *action == ResolverAction::MoveToSummary {
+                    Some(MovedToSummaryItem {
+                        comment: item.comment.clone(),
+                        file: item.file.clone(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let body = build_review_body(
+            &self.session.review_comments,
+            &summary_items,
+            &self.forge_config,
+        );
+        // Build payload so the JSON serialization path is exercised even in
+        // the stubbed flow; the result is discarded until PR 6.
+        let _payload = build_review_payload(&state.commit_id, &body, state.event, &state.mappable);
+
+        self.input_mode = InputMode::Normal;
+        self.set_message("Submit ready — PR 6 will wire the network call");
     }
 
     /// Open the review target selector on a specific tab.
@@ -9515,5 +9812,402 @@ mod visual_selection_tests {
         let (start, end) = sel.ordered();
         assert_eq!(start, p(7, 5));
         assert_eq!(end, p(7, 20));
+    }
+}
+
+#[cfg(test)]
+mod submit_flow_tests {
+    //! Tests for the `:submit*` preflight / resolver / confirmation
+    //! orchestration. Driven through the App methods rather than the key
+    //! handlers so we exercise the state machine directly.
+    use super::*;
+    use crate::forge::submit::{ResolverAction, SubmitEvent, UnmappableReason};
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
+    use crate::model::comment::{Comment, CommentLifecycleState, CommentType, LineContext};
+    use crate::model::diff_types::{DiffHunk, DiffLine, FileStatus, LineOrigin};
+    use crate::vcs::traits::{VcsChangeStatus, VcsType};
+
+    struct DummyVcs {
+        info: VcsInfo,
+    }
+
+    impl VcsBackend for DummyVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+        fn get_working_tree_diff(&self, _h: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+        fn fetch_context_lines(
+            &self,
+            _p: &Path,
+            _s: FileStatus,
+            _start: u32,
+            _end: u32,
+        ) -> Result<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn get_change_status(&self) -> Result<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+    }
+
+    fn make_pr_app_with_single_modified_file(file_path: &str) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp/repo"),
+            head_commit: "abcdef0123".to_string(),
+            branch_name: Some("feat".to_string()),
+            vcs_type: VcsType::File,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::PullRequest,
+        );
+        let diff_file = DiffFile {
+            old_path: Some(PathBuf::from(file_path)),
+            new_path: Some(PathBuf::from(file_path)),
+            status: FileStatus::Modified,
+            hunks: vec![DiffHunk {
+                header: "@@".to_string(),
+                old_start: 1,
+                old_count: 0,
+                new_start: 1,
+                new_count: 0,
+                lines: vec![
+                    DiffLine {
+                        origin: LineOrigin::Context,
+                        content: "a".to_string(),
+                        old_lineno: Some(10),
+                        new_lineno: Some(10),
+                        highlighted_spans: None,
+                    },
+                    DiffLine {
+                        origin: LineOrigin::Addition,
+                        content: "b".to_string(),
+                        old_lineno: None,
+                        new_lineno: Some(11),
+                        highlighted_spans: None,
+                    },
+                ],
+            }],
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash: 0,
+        };
+        let pr_source = PullRequestDiffSource {
+            key: PrSessionKey::new(
+                ForgeRepository::github("github.com", "agavra", "tuicr"),
+                125,
+                "abcdef0123".to_string(),
+            ),
+            base_sha: "0000".to_string(),
+            title: "test pr".to_string(),
+            url: "https://github.com/agavra/tuicr/pull/125".to_string(),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            state: "OPEN".to_string(),
+            closed: false,
+            merged: false,
+        };
+        let mut app = App::build(
+            Box::new(DummyVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            vec![diff_file],
+            session,
+            DiffSource::PullRequest(Box::new(pr_source)),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build app");
+        app.current_pr_head = Some("abcdef0123".to_string());
+        app
+    }
+
+    fn line_comment(side: LineSide, new: Option<u32>, old: Option<u32>) -> Comment {
+        let mut c = Comment::new("body".to_string(), CommentType::Issue, Some(side));
+        c.line_context = Some(LineContext {
+            new_line: new,
+            old_line: old,
+            content: String::new(),
+        });
+        c
+    }
+
+    fn add_line_comment(app: &mut App, path: &str, line: u32, comment: Comment) {
+        let pb = PathBuf::from(path);
+        let review = app.session.get_file_mut(&pb).expect("file in session");
+        review.line_comments.entry(line).or_default().push(comment);
+    }
+
+    #[test]
+    fn should_open_confirm_directly_when_all_comments_map() {
+        // given a PR session with one mappable line comment
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+        // when
+        app.start_submit(SubmitEvent::Comment);
+        // then — went straight to confirmation, no resolver
+        assert_eq!(app.input_mode, InputMode::SubmitConfirm);
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert_eq!(state.mappable.len(), 1);
+        assert!(state.unmappable.is_empty());
+        assert_eq!(state.commit_id, "abcdef0123");
+        assert_eq!(state.event, SubmitEvent::Comment);
+    }
+
+    #[test]
+    fn should_open_resolver_when_any_comment_is_unmappable() {
+        // given a PR session with one mappable + one file-level on a
+        // binary file (unmappable).
+        let mut app = make_pr_app_with_single_modified_file("img.png");
+        // mark file binary in diff_files
+        app.diff_files[0].is_binary = true;
+        // file-level comment in session
+        let pb = PathBuf::from("img.png");
+        let review = app.session.get_file_mut(&pb).expect("file in session");
+        review
+            .file_comments
+            .push(Comment::new("oof".to_string(), CommentType::Note, None));
+        // when
+        app.start_submit(SubmitEvent::Comment);
+        // then — resolver entered with one unmappable
+        assert_eq!(app.input_mode, InputMode::SubmitResolver);
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert_eq!(state.unmappable.len(), 1);
+        assert_eq!(state.unmappable[0].reason, UnmappableReason::BinaryFile);
+        assert_eq!(state.resolver_choices.len(), 1);
+        // Default action is MoveToSummary per spec
+        assert_eq!(state.resolver_choices[0], ResolverAction::MoveToSummary);
+    }
+
+    #[test]
+    fn should_skip_locked_comments_during_preflight() {
+        // given a single locked comment
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let mut c = line_comment(LineSide::New, Some(11), None);
+        c.lifecycle_state = CommentLifecycleState::Submitted;
+        add_line_comment(&mut app, "src/lib.rs", 11, c);
+        // when
+        app.start_submit(SubmitEvent::Comment);
+        // then — preflight aborted with the "nothing to submit" warning
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+    }
+
+    #[test]
+    fn should_warn_when_no_local_drafts_exist() {
+        // given a PR session with zero comments
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        // when
+        app.start_submit(SubmitEvent::Comment);
+        // then
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+    }
+
+    #[test]
+    fn should_warn_when_submitting_without_pr_mode() {
+        // given an app NOT in PR mode
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp"),
+            head_commit: "head".to_string(),
+            branch_name: Some("main".to_string()),
+            vcs_type: VcsType::Git,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::WorkingTree,
+        );
+        let mut app = App::build(
+            Box::new(DummyVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            Vec::new(),
+            session,
+            DiffSource::WorkingTree,
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build app");
+        // when
+        app.start_submit(SubmitEvent::Comment);
+        // then
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+    }
+
+    #[test]
+    fn should_warn_when_pr_is_closed_or_merged() {
+        // given a closed PR
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        if let DiffSource::PullRequest(pr) = &mut app.diff_source {
+            pr.closed = true;
+        }
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+        // when
+        app.start_submit(SubmitEvent::Comment);
+        // then
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+    }
+
+    #[test]
+    fn should_cancel_submit_clears_state_and_returns_to_normal() {
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+        app.start_submit(SubmitEvent::Comment);
+        // when
+        app.cancel_submit();
+        // then
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+    }
+
+    #[test]
+    fn should_toggle_resolver_action_between_move_and_omit() {
+        let mut app = make_pr_app_with_single_modified_file("img.png");
+        app.diff_files[0].is_binary = true;
+        let pb = PathBuf::from("img.png");
+        let review = app.session.get_file_mut(&pb).expect("file in session");
+        review
+            .file_comments
+            .push(Comment::new("a".to_string(), CommentType::Note, None));
+        review
+            .file_comments
+            .push(Comment::new("b".to_string(), CommentType::Note, None));
+        app.start_submit(SubmitEvent::Comment);
+        // when — toggle row 0
+        app.submit_resolver_toggle();
+        // then
+        let state = app.submit_state.as_ref().unwrap();
+        assert_eq!(state.resolver_choices[0], ResolverAction::Omit);
+        assert_eq!(state.resolver_choices[1], ResolverAction::MoveToSummary);
+        // when toggle again
+        app.submit_resolver_toggle();
+        let state = app.submit_state.as_ref().unwrap();
+        assert_eq!(state.resolver_choices[0], ResolverAction::MoveToSummary);
+    }
+
+    #[test]
+    fn should_advance_from_resolver_to_confirm() {
+        let mut app = make_pr_app_with_single_modified_file("img.png");
+        app.diff_files[0].is_binary = true;
+        let pb = PathBuf::from("img.png");
+        let review = app.session.get_file_mut(&pb).expect("file in session");
+        review
+            .file_comments
+            .push(Comment::new("a".to_string(), CommentType::Note, None));
+        app.start_submit(SubmitEvent::Comment);
+        assert_eq!(app.input_mode, InputMode::SubmitResolver);
+        // when
+        app.submit_resolver_advance();
+        // then
+        assert_eq!(app.input_mode, InputMode::SubmitConfirm);
+    }
+
+    #[test]
+    fn should_stub_network_call_on_confirm_and_clear_state() {
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+        app.start_submit(SubmitEvent::Comment);
+        // when
+        app.confirm_submit();
+        // then — PR 5 stub: state cleared, mode back to Normal, info msg set
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+        let msg = app.message.as_ref().expect("info message");
+        assert!(msg.content.contains("PR 6 will wire"));
+    }
+
+    #[test]
+    fn should_report_stale_head_when_current_differs_from_session_head() {
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+        // simulate a refresh having spotted a newer remote head
+        app.current_pr_head = Some("ffff5678".to_string());
+        app.start_submit(SubmitEvent::Comment);
+        assert!(app.submit_head_is_stale());
+    }
+
+    #[test]
+    fn should_report_head_not_stale_when_current_matches_session_head() {
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+        app.start_submit(SubmitEvent::Comment);
+        assert!(!app.submit_head_is_stale());
+    }
+
+    #[test]
+    fn should_detect_locked_comment_under_cursor_for_dd_path() {
+        // given an app with a locked line comment registered against the
+        // diff. We just verify the App helper sees the lock — exercising
+        // the handler keypath itself is covered in integration tests.
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let mut c = line_comment(LineSide::New, Some(11), None);
+        c.lifecycle_state = CommentLifecycleState::PushedDraft;
+        add_line_comment(&mut app, "src/lib.rs", 11, c);
+        // No cursor positioning here — `cursor_on_locked_comment` resolves
+        // through `find_comment_at_cursor` which depends on annotations.
+        // The annotation indices use 0..N; with a single line comment on
+        // line 11 there's exactly one LineComment annotation. We point the
+        // cursor at it via diff_state.
+        app.rebuild_annotations();
+        // Find the LineComment annotation index.
+        let idx = app
+            .line_annotations
+            .iter()
+            .position(|a| matches!(a, AnnotatedLine::LineComment { .. }))
+            .expect("expected a LineComment annotation");
+        app.diff_state.cursor_line = idx;
+        assert!(app.cursor_on_locked_comment());
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -15,6 +15,27 @@ pub struct CommentTypeConfig {
     pub color: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ForgeConfig {
+    /// Prepend `**[TYPE]** ` to inline review comment bodies on submit so the
+    /// reader can see the comment classification at a glance. Defaults to
+    /// `true`; set to `false` to send the raw comment body.
+    pub comment_type_prefix: bool,
+    /// Append the `<sub>Reviewed with tuicr…</sub>` footer to the GitHub
+    /// review body on submit. Defaults to `true`.
+    pub review_footer: bool,
+}
+
+impl Default for ForgeConfig {
+    fn default() -> Self {
+        Self {
+            comment_type_prefix: true,
+            review_footer: true,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct AppConfig {
@@ -32,6 +53,9 @@ pub struct AppConfig {
     pub mouse: Option<bool>,
     pub transparent_background: Option<bool>,
     pub scroll_offset: Option<usize>,
+    /// `[forge]` section settings. Always present; `None` means "no override"
+    /// and downstream code should treat it as `ForgeConfig::default()`.
+    pub forge: Option<ForgeConfig>,
 }
 
 /// Known top-level config keys. Used to warn about typos.
@@ -50,7 +74,10 @@ const KNOWN_KEYS: &[&str] = &[
     "mouse",
     "transparent_background",
     "scroll_offset",
+    "forge",
 ];
+
+const FORGE_KNOWN_KEYS: &[&str] = &["comment_type_prefix", "review_footer"];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ConfigLoadOutcome {
@@ -215,6 +242,9 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         mouse: read_bool(table, "mouse", &mut warnings),
         transparent_background: read_bool(table, "transparent_background", &mut warnings),
         scroll_offset: read_usize(table, "scroll_offset", &mut warnings),
+        forge: table
+            .get("forge")
+            .and_then(|v| parse_forge(v, &mut warnings)),
     };
 
     for key in table.keys() {
@@ -227,6 +257,53 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         config: Some(config),
         warnings,
     })
+}
+
+/// Parse the `[forge]` section, returning `Some` with overridden values when
+/// any of the recognized keys are set and `None` when the section is empty (so
+/// downstream consumers can fall back to `ForgeConfig::default()`).
+fn parse_forge(value: &Value, warnings: &mut Vec<String>) -> Option<ForgeConfig> {
+    let Some(table) = value.as_table() else {
+        warnings.push("Warning: Config key 'forge' must be a table; ignoring value".to_string());
+        return None;
+    };
+
+    for key in table.keys() {
+        if !FORGE_KNOWN_KEYS.contains(&key.as_str()) {
+            warnings.push(format!(
+                "Warning: Unknown config key 'forge.{key}', ignoring"
+            ));
+        }
+    }
+
+    let defaults = ForgeConfig::default();
+    let mut cfg = defaults.clone();
+    let mut any_override = false;
+
+    if let Some(v) = read_forge_bool(table, "comment_type_prefix", warnings) {
+        cfg.comment_type_prefix = v;
+        any_override = true;
+    }
+    if let Some(v) = read_forge_bool(table, "review_footer", warnings) {
+        cfg.review_footer = v;
+        any_override = true;
+    }
+
+    if any_override { Some(cfg) } else { None }
+}
+
+/// Like `read_bool`, but emits a `forge.<key>` qualified warning so the user
+/// can locate the misconfigured field.
+fn read_forge_bool(table: &toml::Table, key: &str, warnings: &mut Vec<String>) -> Option<bool> {
+    let val = table.get(key)?;
+    if let Some(b) = val.as_bool() {
+        Some(b)
+    } else {
+        warnings.push(format!(
+            "Warning: Config key 'forge.{key}' must be a boolean; ignoring value"
+        ));
+        None
+    }
 }
 
 fn parse_comment_types(
@@ -782,6 +859,119 @@ mod tests {
         assert_eq!(comment_types.len(), 1);
         assert_eq!(comment_types[0].id, "note");
         assert_eq!(outcome.warnings.len(), 3);
+    }
+
+    // forge
+
+    #[test]
+    fn should_default_forge_to_none_when_section_missing() {
+        let outcome = parse_config("");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.forge.clone()),
+            None
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_forge_section_overriding_defaults() {
+        let outcome = parse_config(
+            r#"[forge]
+comment_type_prefix = false
+review_footer = false
+"#,
+        );
+        let forge = outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.forge.clone())
+            .expect("forge section should parse");
+        assert!(!forge.comment_type_prefix);
+        assert!(!forge.review_footer);
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_default_forge_to_none_when_section_is_empty_table() {
+        // An empty `[forge]` block does not override anything; downstream
+        // consumers fall back to defaults.
+        let outcome = parse_config("[forge]\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.forge.clone()),
+            None
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_on_unknown_forge_keys() {
+        let outcome = parse_config(
+            r#"[forge]
+review_footer = true
+foo = "bar"
+"#,
+        );
+        let forge = outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.forge.clone())
+            .expect("forge section should parse");
+        assert!(forge.review_footer);
+        assert!(forge.comment_type_prefix);
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Unknown config key 'forge.foo', ignoring"
+        );
+    }
+
+    #[test]
+    fn should_warn_and_ignore_forge_value_with_wrong_type() {
+        let outcome = parse_config(
+            r#"[forge]
+comment_type_prefix = "yes"
+"#,
+        );
+        // Wrong-type fields fall back to defaults; with no other overrides
+        // the section is `None`.
+        assert!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.forge.clone())
+                .is_none()
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(
+            outcome.warnings[0].contains("forge.comment_type_prefix"),
+            "warning should be qualified, got {:?}",
+            outcome.warnings[0]
+        );
+    }
+
+    #[test]
+    fn should_warn_when_forge_is_not_a_table() {
+        let outcome = parse_config("forge = true\n");
+        assert!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.forge.clone())
+                .is_none()
+        );
+        assert_eq!(
+            outcome.warnings,
+            vec!["Warning: Config key 'forge' must be a table; ignoring value".to_string()]
+        );
+    }
+
+    #[test]
+    fn forge_defaults_are_both_true() {
+        // Guard against silent changes to public defaults — both knobs ship
+        // enabled per the spec.
+        let cfg = ForgeConfig::default();
+        assert!(cfg.comment_type_prefix);
+        assert!(cfg.review_footer);
     }
 
     #[test]

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -1,3 +1,4 @@
 pub mod gh;
 pub mod models;
 pub mod review_threads;
+pub mod submit;

--- a/src/forge/github/submit.rs
+++ b/src/forge/github/submit.rs
@@ -1,0 +1,145 @@
+//! GitHub-specific submit-time concerns.
+//!
+//! Right now this is just the JSON payload shape for `POST repos/<owner>/<repo>/pulls/<number>/reviews`.
+//! Future entries (e.g. error mapping, response parsing) belong here.
+
+use serde_json::{Map, Value};
+
+use crate::forge::submit::{InlineComment, SubmitEvent};
+
+/// Build the JSON body for the GitHub create-review API call.
+///
+/// `commit_id` is the head SHA the comments were authored against (NOT
+/// necessarily the PR's current head — see the stale-head warning in the
+/// confirmation modal). `event` controls the published-vs-draft behavior:
+/// `SubmitEvent::Draft` omits the `event` field entirely so GitHub creates a
+/// PENDING review, per the spec.
+pub fn build_review_payload(
+    commit_id: &str,
+    body: &str,
+    event: SubmitEvent,
+    comments: &[InlineComment],
+) -> Value {
+    let mut payload = Map::new();
+    payload.insert("commit_id".to_string(), Value::from(commit_id));
+    payload.insert("body".to_string(), Value::from(body));
+    if let Some(event_str) = event.github_event() {
+        payload.insert("event".to_string(), Value::from(event_str));
+    }
+    payload.insert(
+        "comments".to_string(),
+        Value::Array(comments.iter().map(inline_comment_json).collect()),
+    );
+    Value::Object(payload)
+}
+
+fn inline_comment_json(comment: &InlineComment) -> Value {
+    let mut obj = Map::new();
+    obj.insert(
+        "path".to_string(),
+        Value::from(comment.path.to_string_lossy().to_string()),
+    );
+    obj.insert("line".to_string(), Value::from(comment.line));
+    obj.insert("side".to_string(), Value::from(comment.side.as_str()));
+    obj.insert("body".to_string(), Value::from(comment.body.clone()));
+    if let Some(start) = comment.start_line {
+        obj.insert("start_line".to_string(), Value::from(start));
+    }
+    if let Some(start_side) = comment.start_side {
+        obj.insert("start_side".to_string(), Value::from(start_side.as_str()));
+    }
+    Value::Object(obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::submit::GhSide;
+    use std::path::PathBuf;
+
+    fn inline(line: u32) -> InlineComment {
+        InlineComment {
+            path: PathBuf::from("src/lib.rs"),
+            line,
+            side: GhSide::Right,
+            start_line: None,
+            start_side: None,
+            body: "**[ISSUE]** boom".to_string(),
+        }
+    }
+
+    #[test]
+    fn should_emit_commit_id_body_event_and_comments_for_comment_event() {
+        let payload =
+            build_review_payload("abc1234", "body text", SubmitEvent::Comment, &[inline(42)]);
+        assert_eq!(payload["commit_id"], "abc1234");
+        assert_eq!(payload["body"], "body text");
+        assert_eq!(payload["event"], "COMMENT");
+        let comments = payload["comments"].as_array().expect("comments array");
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0]["path"], "src/lib.rs");
+        assert_eq!(comments[0]["line"], 42);
+        assert_eq!(comments[0]["side"], "RIGHT");
+        assert_eq!(comments[0]["body"], "**[ISSUE]** boom");
+    }
+
+    #[test]
+    fn should_emit_event_approve_for_approve_submission() {
+        let payload = build_review_payload("sha", "body", SubmitEvent::Approve, &[]);
+        assert_eq!(payload["event"], "APPROVE");
+    }
+
+    #[test]
+    fn should_emit_event_request_changes_for_request_changes_submission() {
+        let payload = build_review_payload("sha", "body", SubmitEvent::RequestChanges, &[]);
+        assert_eq!(payload["event"], "REQUEST_CHANGES");
+    }
+
+    #[test]
+    fn should_omit_event_for_draft_submission() {
+        let payload = build_review_payload("sha", "body", SubmitEvent::Draft, &[]);
+        assert!(
+            payload
+                .as_object()
+                .is_some_and(|m| !m.contains_key("event"))
+        );
+    }
+
+    #[test]
+    fn should_include_start_line_and_start_side_for_multi_line_comment() {
+        let inline = InlineComment {
+            path: PathBuf::from("src/main.rs"),
+            line: 20,
+            side: GhSide::Left,
+            start_line: Some(15),
+            start_side: Some(GhSide::Left),
+            body: "ranged".to_string(),
+        };
+        let payload = build_review_payload("sha", "", SubmitEvent::Comment, &[inline]);
+        let comment = &payload["comments"][0];
+        assert_eq!(comment["start_line"], 15);
+        assert_eq!(comment["start_side"], "LEFT");
+        assert_eq!(comment["line"], 20);
+        assert_eq!(comment["side"], "LEFT");
+    }
+
+    #[test]
+    fn should_emit_empty_comments_array_when_none_supplied() {
+        let payload = build_review_payload("sha", "body", SubmitEvent::Comment, &[]);
+        assert_eq!(payload["comments"].as_array().map(|a| a.len()), Some(0));
+    }
+
+    #[test]
+    fn should_use_left_side_when_inline_targets_old_side() {
+        let inline = InlineComment {
+            path: PathBuf::from("a.rs"),
+            line: 7,
+            side: GhSide::Left,
+            start_line: None,
+            start_side: None,
+            body: String::new(),
+        };
+        let payload = build_review_payload("sha", "", SubmitEvent::Comment, &[inline]);
+        assert_eq!(payload["comments"][0]["side"], "LEFT");
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -10,6 +10,7 @@ pub mod github;
 pub mod pr_open;
 pub mod remote_comments;
 pub mod selector;
+pub mod submit;
 pub mod traits;
 
 use std::path::Path;

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -124,7 +124,7 @@ impl UnmappableReason {
 }
 
 /// Outcome of mapping one local `Comment` against the displayed diff.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MappedComment {
     Inline(InlineComment),
     Unmappable {
@@ -312,7 +312,7 @@ fn range_endpoints_present(file: &DiffFile, range: LineRange, side: LineSide) ->
 }
 
 /// Output of preflight — drives the resolver and confirmation modal.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PreflightResult {
     pub event: SubmitEvent,
     pub mappable: Vec<InlineComment>,
@@ -325,7 +325,7 @@ pub struct PreflightResult {
 
 /// A bundled view of an unmappable comment together with the file path and
 /// reason, for the resolver UI.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UnmappableItem {
     pub comment: Comment,
     pub file: PathBuf,
@@ -344,7 +344,7 @@ pub enum ResolverAction {
 }
 
 /// A single line in the "Unplaced comments" section of the review body.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MovedToSummaryItem {
     pub comment: Comment,
     pub file: PathBuf,

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -1,0 +1,799 @@
+//! Cross-forge submission logic for tuicr-authored reviews.
+//!
+//! This module converts a set of local-draft `Comment`s plus the parsed PR
+//! diff into a forge-agnostic `MappedComment` stream that downstream code
+//! (currently the GitHub payload builder) consumes. The mapping rules and
+//! body/footer formatting live here so future forge backends inherit them.
+//!
+//! PR 5 wires the local preflight, resolver, and final-confirmation modal
+//! against these types. The actual `gh api` call is deferred to PR 6.
+
+use std::path::PathBuf;
+
+use crate::config::ForgeConfig;
+use crate::model::comment::Comment;
+use crate::model::{DiffFile, LineRange, LineSide};
+
+/// Which forge review event a `:submit*` command corresponds to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmitEvent {
+    /// `:submit` / `:submit comment` — publish a `COMMENT` review.
+    Comment,
+    /// `:submit approve` — publish an `APPROVE` review.
+    Approve,
+    /// `:submit request-changes` — publish a `REQUEST_CHANGES` review.
+    RequestChanges,
+    /// `:submit draft` — create a pending GitHub review (no `event` field).
+    Draft,
+}
+
+impl SubmitEvent {
+    /// GitHub `event` field value, if any. `Draft` returns `None` because the
+    /// pending-review behavior is triggered by omitting `event`.
+    pub fn github_event(self) -> Option<&'static str> {
+        match self {
+            SubmitEvent::Comment => Some("COMMENT"),
+            SubmitEvent::Approve => Some("APPROVE"),
+            SubmitEvent::RequestChanges => Some("REQUEST_CHANGES"),
+            SubmitEvent::Draft => None,
+        }
+    }
+
+    /// Short human-readable label for the confirmation modal.
+    pub fn human_label(self) -> &'static str {
+        match self {
+            SubmitEvent::Comment => "Comment",
+            SubmitEvent::Approve => "Approve",
+            SubmitEvent::RequestChanges => "Request changes",
+            SubmitEvent::Draft => "Draft (pending review)",
+        }
+    }
+}
+
+/// GitHub's per-comment `side` field. Maps 1:1 to `LineSide`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GhSide {
+    Left,
+    Right,
+}
+
+impl GhSide {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GhSide::Left => "LEFT",
+            GhSide::Right => "RIGHT",
+        }
+    }
+}
+
+impl From<LineSide> for GhSide {
+    fn from(value: LineSide) -> Self {
+        match value {
+            LineSide::Old => GhSide::Left,
+            LineSide::New => GhSide::Right,
+        }
+    }
+}
+
+/// A single inline review comment ready to be serialized into GitHub's
+/// `comments` array. Bodies already include the `[TYPE]` prefix when the
+/// active `ForgeConfig` enables it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineComment {
+    pub path: PathBuf,
+    pub line: u32,
+    pub side: GhSide,
+    /// Multi-line range start. `None` for single-line comments.
+    pub start_line: Option<u32>,
+    pub start_side: Option<GhSide>,
+    pub body: String,
+}
+
+/// Why the mapper could not produce an inline comment for a given local
+/// `Comment`. Used by the resolver UI to explain the choice to the user and
+/// to seed the "Unplaced comments" summary section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnmappableReason {
+    /// Range spans both Old and Deletion sides — GitHub multi-line comments
+    /// must stay on a single side.
+    MixedSideRange,
+    /// File-level comment, but the file has no first-valid line anchor on
+    /// the New side (binary, too-large, or pure deletion with no Old line).
+    FileLevelNoAnchor,
+    /// The file is binary; no anchor can be derived.
+    BinaryFile,
+    /// The file exceeded the renderer's too-large threshold and was not
+    /// diffed.
+    TooLargeFile,
+    /// The cursor line was outside any hunk's coverage. Should not happen
+    /// for line comments authored through tuicr today, but we keep the
+    /// variant so the resolver can surface a clear message if it ever does.
+    LineNotInDiff,
+}
+
+impl UnmappableReason {
+    pub fn human_label(&self) -> &'static str {
+        match self {
+            UnmappableReason::MixedSideRange => "range spans both diff sides",
+            UnmappableReason::FileLevelNoAnchor => "no valid anchor line",
+            UnmappableReason::BinaryFile => "binary file",
+            UnmappableReason::TooLargeFile => "file too large",
+            UnmappableReason::LineNotInDiff => "line not in current diff",
+        }
+    }
+}
+
+/// Outcome of mapping one local `Comment` against the displayed diff.
+#[derive(Debug, Clone)]
+pub enum MappedComment {
+    Inline(InlineComment),
+    Unmappable {
+        comment: Comment,
+        file: PathBuf,
+        reason: UnmappableReason,
+    },
+}
+
+/// Compute the inline body for `comment` honoring the `[TYPE]` prefix toggle.
+/// File-level bodies are prefixed `**[TYPE] File-level:**` per the spec.
+fn build_inline_body(comment: &Comment, file_level: bool, config: &ForgeConfig) -> String {
+    if !config.comment_type_prefix {
+        return comment.content.clone();
+    }
+    let prefix = if file_level {
+        format!(
+            "**[{ty}] File-level:** ",
+            ty = comment.comment_type.as_str()
+        )
+    } else {
+        format!("**[{ty}]** ", ty = comment.comment_type.as_str())
+    };
+    format!("{prefix}{body}", body = comment.content)
+}
+
+/// Map a single local `Comment` to either an inline GitHub comment or an
+/// `Unmappable` outcome. `file` must be the diff file that produced this
+/// comment (lookup is the caller's responsibility — it owns the current
+/// `diff_files` / `range_diff_files` slice).
+pub fn map_comment(comment: &Comment, file: &DiffFile, config: &ForgeConfig) -> MappedComment {
+    let path = file.display_path().clone();
+
+    if file.is_binary {
+        return MappedComment::Unmappable {
+            comment: comment.clone(),
+            file: path,
+            reason: UnmappableReason::BinaryFile,
+        };
+    }
+    if file.is_too_large {
+        return MappedComment::Unmappable {
+            comment: comment.clone(),
+            file: path,
+            reason: UnmappableReason::TooLargeFile,
+        };
+    }
+
+    // File-level: no line_context, no line_range, no side.
+    let is_file_level = comment.line_context.is_none() && comment.line_range.is_none();
+    if is_file_level {
+        return match file.first_valid_line(LineSide::New) {
+            Some(line) => MappedComment::Inline(InlineComment {
+                path,
+                line,
+                side: GhSide::Right,
+                start_line: None,
+                start_side: None,
+                body: build_inline_body(comment, true, config),
+            }),
+            None => MappedComment::Unmappable {
+                comment: comment.clone(),
+                file: path,
+                reason: UnmappableReason::FileLevelNoAnchor,
+            },
+        };
+    }
+
+    // Multi-line range. The range carries its own `side`; mixed-side ranges
+    // are not representable on GitHub today.
+    if let Some(range) = comment.line_range {
+        return map_range(comment, file, config, range);
+    }
+
+    // Single-line: anchor by line_context. The comment carries `side`; if
+    // missing (very old data) default to New per `LineSide::default`.
+    let side = comment.side.unwrap_or_default();
+    let line = match (side, comment.line_context.as_ref()) {
+        (LineSide::Old, Some(ctx)) => ctx.old_line,
+        (LineSide::New, Some(ctx)) => ctx.new_line,
+        _ => None,
+    };
+    match line {
+        Some(l) => MappedComment::Inline(InlineComment {
+            path,
+            line: l,
+            side: side.into(),
+            start_line: None,
+            start_side: None,
+            body: build_inline_body(comment, false, config),
+        }),
+        None => MappedComment::Unmappable {
+            comment: comment.clone(),
+            file: path,
+            reason: UnmappableReason::LineNotInDiff,
+        },
+    }
+}
+
+/// Map a multi-line range comment, validating that the range sits on a
+/// single diff side.
+fn map_range(
+    comment: &Comment,
+    file: &DiffFile,
+    config: &ForgeConfig,
+    range: LineRange,
+) -> MappedComment {
+    let path = file.display_path().clone();
+    let side = match comment.side {
+        Some(s) => s,
+        // No explicit side is treated as ambiguous for a range; surface it
+        // through the resolver rather than guessing.
+        None => {
+            return MappedComment::Unmappable {
+                comment: comment.clone(),
+                file: path,
+                reason: UnmappableReason::MixedSideRange,
+            };
+        }
+    };
+
+    // Verify both ends of the range exist on `side`. The hunks may not
+    // contain every intermediate line (the user could have selected across
+    // a gap), but the start and end must be anchorable.
+    if !range_endpoints_present(file, range, side) {
+        return MappedComment::Unmappable {
+            comment: comment.clone(),
+            file: path,
+            reason: UnmappableReason::MixedSideRange,
+        };
+    }
+
+    if range.is_single() {
+        return MappedComment::Inline(InlineComment {
+            path,
+            line: range.start,
+            side: side.into(),
+            start_line: None,
+            start_side: None,
+            body: build_inline_body(comment, false, config),
+        });
+    }
+
+    MappedComment::Inline(InlineComment {
+        path,
+        line: range.end,
+        side: side.into(),
+        start_line: Some(range.start),
+        start_side: Some(side.into()),
+        body: build_inline_body(comment, false, config),
+    })
+}
+
+/// True when both the start and end of `range` appear on the requested side
+/// somewhere in `file`'s hunks. Used to detect ranges that would straddle a
+/// side boundary (e.g. user selected through deleted+added lines).
+fn range_endpoints_present(file: &DiffFile, range: LineRange, side: LineSide) -> bool {
+    let mut saw_start = false;
+    let mut saw_end = false;
+    for hunk in &file.hunks {
+        for line in &hunk.lines {
+            let lineno = match side {
+                LineSide::New => match line.origin {
+                    crate::model::LineOrigin::Context | crate::model::LineOrigin::Addition => {
+                        line.new_lineno
+                    }
+                    crate::model::LineOrigin::Deletion => None,
+                },
+                LineSide::Old => match line.origin {
+                    crate::model::LineOrigin::Deletion => line.old_lineno,
+                    _ => None,
+                },
+            };
+            if let Some(n) = lineno {
+                if n == range.start {
+                    saw_start = true;
+                }
+                if n == range.end {
+                    saw_end = true;
+                }
+            }
+        }
+    }
+    saw_start && saw_end
+}
+
+/// Output of preflight — drives the resolver and confirmation modal.
+#[derive(Debug, Clone)]
+pub struct PreflightResult {
+    pub event: SubmitEvent,
+    pub mappable: Vec<InlineComment>,
+    pub unmappable: Vec<UnmappableItem>,
+    /// Originally-reviewed PR head SHA for the comments — `commit_id` in the
+    /// GitHub payload. The caller captures this from `pr_session_key.head_sha`
+    /// at preflight time so a subsequent reload does not steal the anchor.
+    pub commit_id: String,
+}
+
+/// A bundled view of an unmappable comment together with the file path and
+/// reason, for the resolver UI.
+#[derive(Debug, Clone)]
+pub struct UnmappableItem {
+    pub comment: Comment,
+    pub file: PathBuf,
+    pub reason: UnmappableReason,
+}
+
+/// What the resolver decided to do with an unmappable comment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ResolverAction {
+    /// Render the comment into the review body under "Unplaced comments".
+    /// Spec: default action for unmappable comments.
+    #[default]
+    MoveToSummary,
+    /// Drop the comment from this submit entirely.
+    Omit,
+}
+
+/// A single line in the "Unplaced comments" section of the review body.
+#[derive(Debug, Clone)]
+pub struct MovedToSummaryItem {
+    pub comment: Comment,
+    pub file: PathBuf,
+}
+
+/// Builds the GitHub review body. Returns an empty string when there's
+/// nothing to say (no summary items, no footer, no review-level comments).
+///
+/// `review_level` are tuicr's review-level comments (`session.review_comments`)
+/// already-formatted for the body. They appear above the unplaced section.
+pub fn build_review_body(
+    review_level: &[Comment],
+    moved_to_summary: &[MovedToSummaryItem],
+    config: &ForgeConfig,
+) -> String {
+    let mut sections: Vec<String> = Vec::new();
+
+    if !review_level.is_empty() {
+        let mut block = String::new();
+        for (i, c) in review_level.iter().enumerate() {
+            if i > 0 {
+                block.push_str("\n\n");
+            }
+            if config.comment_type_prefix {
+                block.push_str(&format!("**[{}]** ", c.comment_type.as_str()));
+            }
+            block.push_str(&c.content);
+        }
+        sections.push(block);
+    }
+
+    if !moved_to_summary.is_empty() {
+        let mut block = String::from("## Unplaced comments\n");
+        for item in moved_to_summary {
+            let prefix = if config.comment_type_prefix {
+                format!("[{}] ", item.comment.comment_type.as_str())
+            } else {
+                String::new()
+            };
+            let path = item.file.display();
+            block.push_str(&format!(
+                "- {prefix}{path}: {body}\n",
+                body = item.comment.content
+            ));
+        }
+        // strip trailing newline so join below produces one blank line, not two
+        if block.ends_with('\n') {
+            block.pop();
+        }
+        sections.push(block);
+    }
+
+    if config.review_footer {
+        sections.push(REVIEW_FOOTER.to_string());
+    }
+
+    sections.join("\n\n")
+}
+
+/// Footer appended to every tuicr-authored GitHub review body (when
+/// `forge.review_footer` is enabled). Kept as a constant so it's trivial to
+/// snapshot-test in the body builder.
+pub const REVIEW_FOOTER: &str =
+    "<sub>Reviewed with [tuicr](https://github.com/agavra/tuicr).</sub>";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::comment::{Comment, CommentType, LineContext, LineRange, LineSide};
+    use crate::model::diff_types::{DiffHunk, DiffLine, FileStatus, LineOrigin};
+    use std::path::PathBuf;
+
+    fn line(origin: LineOrigin, new: Option<u32>, old: Option<u32>) -> DiffLine {
+        DiffLine {
+            origin,
+            content: String::new(),
+            old_lineno: old,
+            new_lineno: new,
+            highlighted_spans: None,
+        }
+    }
+
+    fn hunk(lines: Vec<DiffLine>) -> DiffHunk {
+        DiffHunk {
+            header: "@@".to_string(),
+            old_start: 1,
+            old_count: 0,
+            new_start: 1,
+            new_count: 0,
+            lines,
+        }
+    }
+
+    fn file_with_hunks(hunks: Vec<DiffHunk>) -> DiffFile {
+        DiffFile {
+            old_path: Some(PathBuf::from("src/lib.rs")),
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash: 0,
+        }
+    }
+
+    fn typical_file() -> DiffFile {
+        file_with_hunks(vec![hunk(vec![
+            line(LineOrigin::Context, Some(10), Some(10)),
+            line(LineOrigin::Deletion, None, Some(11)),
+            line(LineOrigin::Addition, Some(11), None),
+            line(LineOrigin::Context, Some(12), Some(12)),
+        ])])
+    }
+
+    fn default_config() -> ForgeConfig {
+        ForgeConfig::default()
+    }
+
+    fn comment_with_line(side: LineSide, new: Option<u32>, old: Option<u32>) -> Comment {
+        let mut c = Comment::new("needs work".to_string(), CommentType::Issue, Some(side));
+        c.line_context = Some(LineContext {
+            new_line: new,
+            old_line: old,
+            content: String::new(),
+        });
+        c
+    }
+
+    fn comment_range(side: LineSide, range: LineRange) -> Comment {
+        Comment::new_with_range("ranged".to_string(), CommentType::Note, Some(side), range)
+    }
+
+    fn comment_file_level() -> Comment {
+        Comment::new("module is messy".to_string(), CommentType::Note, None)
+    }
+
+    // first_valid_line on DiffFile
+
+    #[test]
+    fn should_return_first_addition_line_on_new_side() {
+        let file = file_with_hunks(vec![hunk(vec![
+            line(LineOrigin::Deletion, None, Some(11)),
+            line(LineOrigin::Addition, Some(20), None),
+            line(LineOrigin::Context, Some(21), Some(13)),
+        ])]);
+        assert_eq!(file.first_valid_line(LineSide::New), Some(20));
+    }
+
+    #[test]
+    fn should_return_first_deletion_line_on_old_side() {
+        let file = file_with_hunks(vec![hunk(vec![
+            line(LineOrigin::Addition, Some(20), None),
+            line(LineOrigin::Deletion, None, Some(11)),
+            line(LineOrigin::Deletion, None, Some(12)),
+        ])]);
+        assert_eq!(file.first_valid_line(LineSide::Old), Some(11));
+    }
+
+    #[test]
+    fn should_return_none_for_binary_file_first_valid_line() {
+        let mut file = typical_file();
+        file.is_binary = true;
+        assert!(file.first_valid_line(LineSide::New).is_none());
+    }
+
+    #[test]
+    fn should_return_none_for_too_large_file_first_valid_line() {
+        let mut file = typical_file();
+        file.is_too_large = true;
+        assert!(file.first_valid_line(LineSide::New).is_none());
+    }
+
+    // Single-line mapping
+
+    #[test]
+    fn should_map_single_addition_line_to_right_side() {
+        let comment = comment_with_line(LineSide::New, Some(11), None);
+        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.line, 11);
+                assert_eq!(inline.side, GhSide::Right);
+                assert_eq!(inline.start_line, None);
+                assert_eq!(inline.start_side, None);
+                assert!(inline.body.starts_with("**[ISSUE]** "));
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_map_single_context_line_to_right_side() {
+        let comment = comment_with_line(LineSide::New, Some(10), Some(10));
+        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        assert!(matches!(
+            mapped,
+            MappedComment::Inline(InlineComment {
+                side: GhSide::Right,
+                line: 10,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn should_map_single_deletion_line_to_left_side() {
+        let comment = comment_with_line(LineSide::Old, None, Some(11));
+        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.line, 11);
+                assert_eq!(inline.side, GhSide::Left);
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    // Range mapping
+
+    #[test]
+    fn should_map_new_side_range_to_right_start_and_end() {
+        let file = file_with_hunks(vec![hunk(vec![
+            line(LineOrigin::Addition, Some(10), None),
+            line(LineOrigin::Addition, Some(11), None),
+            line(LineOrigin::Addition, Some(12), None),
+        ])]);
+        let comment = comment_range(LineSide::New, LineRange::new(10, 12));
+        let mapped = map_comment(&comment, &file, &default_config());
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.line, 12);
+                assert_eq!(inline.start_line, Some(10));
+                assert_eq!(inline.side, GhSide::Right);
+                assert_eq!(inline.start_side, Some(GhSide::Right));
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_map_old_side_range_to_left_start_and_end() {
+        let file = file_with_hunks(vec![hunk(vec![
+            line(LineOrigin::Deletion, None, Some(20)),
+            line(LineOrigin::Deletion, None, Some(21)),
+            line(LineOrigin::Deletion, None, Some(22)),
+        ])]);
+        let comment = comment_range(LineSide::Old, LineRange::new(20, 22));
+        let mapped = map_comment(&comment, &file, &default_config());
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.line, 22);
+                assert_eq!(inline.start_line, Some(20));
+                assert_eq!(inline.side, GhSide::Left);
+                assert_eq!(inline.start_side, Some(GhSide::Left));
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_flatten_single_line_range_to_inline_without_start_fields() {
+        let file = file_with_hunks(vec![hunk(vec![line(LineOrigin::Addition, Some(15), None)])]);
+        let comment = comment_range(LineSide::New, LineRange::single(15));
+        let mapped = map_comment(&comment, &file, &default_config());
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.line, 15);
+                assert_eq!(inline.start_line, None);
+                assert_eq!(inline.start_side, None);
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_mark_mixed_side_range_as_unmappable() {
+        // Range claims New side but file only has Old-side lines at 20-22.
+        let file = file_with_hunks(vec![hunk(vec![
+            line(LineOrigin::Deletion, None, Some(20)),
+            line(LineOrigin::Deletion, None, Some(21)),
+            line(LineOrigin::Deletion, None, Some(22)),
+        ])]);
+        let comment = comment_range(LineSide::New, LineRange::new(20, 22));
+        let mapped = map_comment(&comment, &file, &default_config());
+        match mapped {
+            MappedComment::Unmappable { reason, .. } => {
+                assert_eq!(reason, UnmappableReason::MixedSideRange);
+            }
+            other => panic!("expected Unmappable, got {other:?}"),
+        }
+    }
+
+    // File-level mapping
+
+    #[test]
+    fn should_anchor_file_level_to_first_valid_new_line() {
+        let comment = comment_file_level();
+        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.line, 10);
+                assert_eq!(inline.side, GhSide::Right);
+                assert!(inline.body.starts_with("**[NOTE] File-level:** "));
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_mark_file_level_without_new_anchor_as_unmappable() {
+        // Pure deletion file: nothing on the New side.
+        let file = file_with_hunks(vec![hunk(vec![line(LineOrigin::Deletion, None, Some(5))])]);
+        let comment = comment_file_level();
+        let mapped = map_comment(&comment, &file, &default_config());
+        match mapped {
+            MappedComment::Unmappable { reason, .. } => {
+                assert_eq!(reason, UnmappableReason::FileLevelNoAnchor);
+            }
+            other => panic!("expected Unmappable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_mark_binary_file_comment_as_unmappable() {
+        let mut file = typical_file();
+        file.is_binary = true;
+        let comment = comment_with_line(LineSide::New, Some(11), None);
+        let mapped = map_comment(&comment, &file, &default_config());
+        assert!(matches!(
+            mapped,
+            MappedComment::Unmappable {
+                reason: UnmappableReason::BinaryFile,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn should_mark_too_large_file_comment_as_unmappable() {
+        let mut file = typical_file();
+        file.is_too_large = true;
+        let comment = comment_file_level();
+        let mapped = map_comment(&comment, &file, &default_config());
+        assert!(matches!(
+            mapped,
+            MappedComment::Unmappable {
+                reason: UnmappableReason::TooLargeFile,
+                ..
+            }
+        ));
+    }
+
+    // Body prefix toggle
+
+    #[test]
+    fn should_omit_type_prefix_when_config_disables_it() {
+        let comment = comment_with_line(LineSide::New, Some(11), None);
+        let cfg = ForgeConfig {
+            comment_type_prefix: false,
+            review_footer: true,
+        };
+        let mapped = map_comment(&comment, &typical_file(), &cfg);
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert!(!inline.body.contains("**[ISSUE]**"));
+                assert_eq!(inline.body, "needs work");
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    // build_review_body
+
+    fn note(content: &str) -> Comment {
+        Comment::new(content.to_string(), CommentType::Note, None)
+    }
+
+    #[test]
+    fn should_return_empty_body_when_no_inputs_and_footer_disabled() {
+        let cfg = ForgeConfig {
+            comment_type_prefix: true,
+            review_footer: false,
+        };
+        let body = build_review_body(&[], &[], &cfg);
+        assert_eq!(body, "");
+    }
+
+    #[test]
+    fn should_return_footer_only_when_no_review_comments_and_no_summary() {
+        let body = build_review_body(&[], &[], &default_config());
+        assert_eq!(body, REVIEW_FOOTER);
+    }
+
+    #[test]
+    fn should_render_review_level_comments_with_type_prefix() {
+        let comments = vec![note("first"), note("second")];
+        let body = build_review_body(&comments, &[], &default_config());
+        assert!(body.starts_with("**[NOTE]** first\n\n**[NOTE]** second"));
+        assert!(body.ends_with(REVIEW_FOOTER));
+    }
+
+    #[test]
+    fn should_render_unplaced_comments_section_before_footer() {
+        let item = MovedToSummaryItem {
+            comment: Comment::new("kaboom".to_string(), CommentType::Issue, None),
+            file: PathBuf::from("src/lib.rs"),
+        };
+        let body = build_review_body(&[], &[item], &default_config());
+        assert!(body.contains("## Unplaced comments"));
+        assert!(body.contains("- [ISSUE] src/lib.rs: kaboom"));
+        assert!(body.ends_with(REVIEW_FOOTER));
+    }
+
+    #[test]
+    fn should_render_all_three_sections_in_order() {
+        let review = vec![note("top")];
+        let summary = vec![MovedToSummaryItem {
+            comment: Comment::new("middle".to_string(), CommentType::Note, None),
+            file: PathBuf::from("a.rs"),
+        }];
+        let body = build_review_body(&review, &summary, &default_config());
+        let top = body.find("**[NOTE]** top").expect("review comment");
+        let middle = body.find("## Unplaced comments").expect("unplaced section");
+        let bottom = body.find(REVIEW_FOOTER).expect("footer");
+        assert!(top < middle && middle < bottom, "section ordering: {body}");
+    }
+
+    #[test]
+    fn should_omit_type_prefix_in_body_when_disabled() {
+        let cfg = ForgeConfig {
+            comment_type_prefix: false,
+            review_footer: false,
+        };
+        let comments = vec![note("just text")];
+        let body = build_review_body(&comments, &[], &cfg);
+        assert_eq!(body, "just text");
+    }
+
+    // SubmitEvent
+
+    #[test]
+    fn should_map_each_event_to_correct_github_field() {
+        assert_eq!(SubmitEvent::Comment.github_event(), Some("COMMENT"));
+        assert_eq!(SubmitEvent::Approve.github_event(), Some("APPROVE"));
+        assert_eq!(
+            SubmitEvent::RequestChanges.github_event(),
+            Some("REQUEST_CHANGES")
+        );
+        assert_eq!(SubmitEvent::Draft.github_event(), None);
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -453,6 +453,26 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                         return;
                     }
                 }
+                "submit" | "submit comment" => {
+                    app.exit_command_mode();
+                    app.start_submit(crate::forge::submit::SubmitEvent::Comment);
+                    return;
+                }
+                "submit approve" => {
+                    app.exit_command_mode();
+                    app.start_submit(crate::forge::submit::SubmitEvent::Approve);
+                    return;
+                }
+                "submit request-changes" => {
+                    app.exit_command_mode();
+                    app.start_submit(crate::forge::submit::SubmitEvent::RequestChanges);
+                    return;
+                }
+                "submit draft" => {
+                    app.exit_command_mode();
+                    app.start_submit(crate::forge::submit::SubmitEvent::Draft);
+                    return;
+                }
                 "comments unresolved" | "comments all" | "comments hide" => {
                     use crate::forge::remote_comments::PrCommentsVisibility;
                     if !matches!(app.diff_source, app::DiffSource::PullRequest(_)) {
@@ -923,6 +943,9 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             }
         }
         Action::AddFileComment => app.enter_comment_mode(true, None),
+        Action::EditComment if app.cursor_on_locked_comment() => {
+            app.set_message("Comment already pushed to GitHub — read only in tuicr");
+        }
         Action::EditComment if !app.enter_edit_mode() => {
             if app.cursor_on_remote_thread() {
                 app.set_message("GitHub comment — read only in tuicr");
@@ -956,6 +979,40 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }
+        _ => {}
+    }
+}
+
+/// Handle actions in the submit resolver modal: pick what to do with each
+/// comment that did not map to an inline GitHub review comment.
+pub fn handle_submit_resolver_action(app: &mut App, action: Action) {
+    match action {
+        Action::SubmitResolverDown => app.submit_resolver_cursor_down(),
+        Action::SubmitResolverUp => app.submit_resolver_cursor_up(),
+        Action::SubmitResolverToggle => app.submit_resolver_toggle(),
+        Action::SubmitResolverAdvance => app.submit_resolver_advance(),
+        Action::ExitMode => app.cancel_submit(),
+        Action::Quit => app.should_quit = true,
+        _ => {}
+    }
+}
+
+/// Handle actions in the final submit confirmation modal.
+pub fn handle_submit_confirm_action(app: &mut App, action: Action) {
+    match action {
+        Action::ConfirmYes => app.confirm_submit(),
+        Action::ConfirmNo => app.cancel_submit(),
+        // Only meaningful when the stale-head warning is visible.
+        Action::SubmitReloadPr
+            if app.submit_head_is_stale()
+                && matches!(app.diff_source, app::DiffSource::PullRequest(_)) =>
+        {
+            app.cancel_submit();
+            if let Err(e) = app.spawn_pr_reload() {
+                app.set_error(format!("Reload failed: {e}"));
+            }
+        }
+        Action::Quit => app.should_quit = true,
         _ => {}
     }
 }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -95,6 +95,19 @@ pub enum Action {
     /// Begin editing the local filter inside the PR tab (`/`).
     BeginTargetFilter,
 
+    // Submit resolver
+    /// Move resolver cursor down (`j` / Down).
+    SubmitResolverDown,
+    /// Move resolver cursor up (`k` / Up).
+    SubmitResolverUp,
+    /// Toggle the action for the row under the resolver cursor (Enter).
+    SubmitResolverToggle,
+    /// Advance from resolver to final confirmation (`s`).
+    SubmitResolverAdvance,
+    /// Reload the PR in submit confirm (`r`, only when stale-head warning is
+    /// active). Currently triggers the same path as `:e`.
+    SubmitReloadPr,
+
     ToggleExpand,
     ExpandAll,
     CollapseAll,
@@ -114,6 +127,8 @@ pub fn map_key_to_action(key: KeyEvent, mode: InputMode) -> Action {
         InputMode::Confirm => map_confirm_mode(key),
         InputMode::CommitSelect => map_commit_select_mode(key),
         InputMode::VisualSelect => map_visual_mode(key),
+        InputMode::SubmitResolver => map_submit_resolver_mode(key),
+        InputMode::SubmitConfirm => map_submit_confirm_mode(key),
     }
 }
 
@@ -293,6 +308,27 @@ fn map_confirm_mode(key: KeyEvent) -> Action {
     match key.code {
         KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => Action::ConfirmYes,
         KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => Action::ConfirmNo,
+        _ => Action::None,
+    }
+}
+
+fn map_submit_resolver_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::SubmitResolverDown,
+        (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::SubmitResolverUp,
+        (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitResolverToggle,
+        (KeyCode::Char(' '), KeyModifiers::NONE) => Action::SubmitResolverToggle,
+        (KeyCode::Char('s'), KeyModifiers::NONE) => Action::SubmitResolverAdvance,
+        (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        _ => Action::None,
+    }
+}
+
+fn map_submit_confirm_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter, _) => Action::ConfirmYes,
+        (KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc, _) => Action::ConfirmNo,
+        (KeyCode::Char('r') | KeyCode::Char('R'), _) => Action::SubmitReloadPr,
         _ => Action::None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use handler::{
     handle_command_action, handle_comment_action, handle_commit_select_action,
     handle_commit_selector_action, handle_confirm_action, handle_diff_action,
     handle_file_list_action, handle_help_action, handle_mouse_event, handle_search_action,
-    handle_visual_action,
+    handle_submit_confirm_action, handle_submit_resolver_action, handle_visual_action,
 };
 use input::{Action, map_key_to_action, map_target_filter_mode};
 use theme::{parse_cli_args, resolve_theme_with_config};
@@ -181,6 +181,11 @@ fn main() -> anyhow::Result<()> {
         Ok(mut app) => {
             app.supports_keyboard_enhancement = keyboard_enhancement_supported;
             startup_warnings.extend(app.vcs.startup_warnings());
+            if let Some(cfg) = config_outcome.config.as_ref()
+                && let Some(forge_cfg) = cfg.forge.clone()
+            {
+                app.forge_config = forge_cfg;
+            }
             app
         }
         Err(e) => {
@@ -389,7 +394,11 @@ fn main() -> anyhow::Result<()> {
                     if pending_d {
                         pending_d = false;
                         if key.code == crossterm::event::KeyCode::Char('d') {
-                            if !app.delete_comment_at_cursor() {
+                            if app.cursor_on_locked_comment() {
+                                app.set_message(
+                                    "Comment already pushed to GitHub — read only in tuicr",
+                                );
+                            } else if !app.delete_comment_at_cursor() {
                                 if app.cursor_on_remote_thread() {
                                     app.set_message("GitHub comment — read only in tuicr");
                                 } else {
@@ -505,6 +514,10 @@ fn main() -> anyhow::Result<()> {
                         InputMode::Confirm => handle_confirm_action(&mut app, action),
                         InputMode::CommitSelect => handle_commit_select_action(&mut app, action),
                         InputMode::VisualSelect => handle_visual_action(&mut app, action),
+                        InputMode::SubmitResolver => {
+                            handle_submit_resolver_action(&mut app, action)
+                        }
+                        InputMode::SubmitConfirm => handle_submit_confirm_action(&mut app, action),
                         InputMode::Normal => match app.focused_panel {
                             FocusedPanel::FileList => handle_file_list_action(&mut app, action),
                             FocusedPanel::Diff => handle_diff_action(&mut app, action),

--- a/src/model/comment.rs
+++ b/src/model/comment.rs
@@ -124,14 +124,14 @@ impl<'de> Deserialize<'de> for CommentType {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LineContext {
     pub new_line: Option<u32>,
     pub old_line: Option<u32>,
     pub content: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Comment {
     pub id: String,
     pub content: String,

--- a/src/model/comment.rs
+++ b/src/model/comment.rs
@@ -47,6 +47,28 @@ impl LineRange {
     }
 }
 
+/// Lifecycle state of a local comment relative to the remote forge.
+///
+/// `LocalDraft` is editable in tuicr. `PushedDraft` and `Submitted` are locked:
+/// they have been written to GitHub and edits/deletions in tuicr would diverge
+/// from the remote. PR 5 introduces the field and the lock check; PR 6 wires
+/// the transitions on successful submit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum CommentLifecycleState {
+    #[default]
+    LocalDraft,
+    PushedDraft,
+    Submitted,
+}
+
+impl CommentLifecycleState {
+    /// True for any state that has already been written to the remote forge.
+    pub fn is_locked(self) -> bool {
+        !matches!(self, CommentLifecycleState::LocalDraft)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub enum CommentType {
     #[default]
@@ -124,6 +146,18 @@ pub struct Comment {
     /// None for file-level comments or single-line comments (backward compatibility)
     #[serde(default)]
     pub line_range: Option<LineRange>,
+    /// Where this comment sits in its remote forge lifecycle. Old session
+    /// JSON predates this field and rehydrates as `LocalDraft`.
+    #[serde(default)]
+    pub lifecycle_state: CommentLifecycleState,
+    /// Remote review ID this comment belongs to once submitted/pushed.
+    /// `None` while still `LocalDraft`.
+    #[serde(default)]
+    pub remote_review_id: Option<String>,
+    /// Remote review-comment ID once GitHub assigns one. Only meaningful for
+    /// inline comments; review-level / summary comments don't get one.
+    #[serde(default)]
+    pub remote_comment_id: Option<String>,
 }
 
 impl Comment {
@@ -136,6 +170,9 @@ impl Comment {
             line_context: None,
             side,
             line_range: None,
+            lifecycle_state: CommentLifecycleState::default(),
+            remote_review_id: None,
+            remote_comment_id: None,
         }
     }
 
@@ -154,7 +191,16 @@ impl Comment {
             line_context: None,
             side,
             line_range: Some(line_range),
+            lifecycle_state: CommentLifecycleState::default(),
+            remote_review_id: None,
+            remote_comment_id: None,
         }
+    }
+
+    /// True if this comment has been pushed/submitted to the forge and is
+    /// therefore locked from local edits/deletions.
+    pub fn is_locked(&self) -> bool {
+        self.lifecycle_state.is_locked()
     }
 }
 
@@ -347,6 +393,67 @@ mod tests {
             let range = comment.line_range.unwrap();
             assert_eq!(range.start, 10);
             assert_eq!(range.end, 15);
+        }
+
+        #[test]
+        fn should_default_lifecycle_state_to_local_draft_for_new_comment() {
+            // given/when
+            let comment = Comment::new("hi".to_string(), CommentType::Note, None);
+            // then
+            assert_eq!(comment.lifecycle_state, CommentLifecycleState::LocalDraft);
+            assert!(!comment.is_locked());
+            assert!(comment.remote_review_id.is_none());
+            assert!(comment.remote_comment_id.is_none());
+        }
+
+        #[test]
+        fn should_report_pushed_and_submitted_comments_as_locked() {
+            // given
+            let mut pushed = Comment::new("p".to_string(), CommentType::Note, None);
+            pushed.lifecycle_state = CommentLifecycleState::PushedDraft;
+            let mut submitted = Comment::new("s".to_string(), CommentType::Note, None);
+            submitted.lifecycle_state = CommentLifecycleState::Submitted;
+            // then
+            assert!(pushed.is_locked());
+            assert!(submitted.is_locked());
+        }
+
+        #[test]
+        fn should_roundtrip_lifecycle_fields_via_serde() {
+            // given
+            let mut original = Comment::new("body".to_string(), CommentType::Issue, None);
+            original.lifecycle_state = CommentLifecycleState::Submitted;
+            original.remote_review_id = Some("R_kgDOEx".to_string());
+            original.remote_comment_id = Some("RC_kgDOEx".to_string());
+            // when
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: Comment = serde_json::from_str(&json).unwrap();
+            // then
+            assert_eq!(restored.lifecycle_state, CommentLifecycleState::Submitted);
+            assert_eq!(restored.remote_review_id.as_deref(), Some("R_kgDOEx"));
+            assert_eq!(restored.remote_comment_id.as_deref(), Some("RC_kgDOEx"));
+        }
+
+        #[test]
+        fn should_default_lifecycle_fields_for_pre_pr5_comment_json() {
+            // given — JSON saved before PR 5 introduced lifecycle fields.
+            let json = r#"{
+                "id": "legacy",
+                "content": "pre-pr5",
+                "comment_type": "note",
+                "created_at": "2024-01-01T00:00:00Z",
+                "line_context": null
+            }"#;
+            // when
+            let comment: Comment =
+                serde_json::from_str(json).expect("pre-PR-5 comment JSON should parse");
+            // then
+            assert_eq!(comment.lifecycle_state, CommentLifecycleState::LocalDraft);
+            assert!(comment.remote_review_id.is_none());
+            assert!(comment.remote_comment_id.is_none());
+            // and the rest of the comment survived
+            assert_eq!(comment.id, "legacy");
+            assert_eq!(comment.content, "pre-pr5");
         }
     }
 }

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 use crate::hash::Fnv1aHasher;
+use crate::model::comment::LineSide;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -95,6 +96,41 @@ impl DiffFile {
             .as_ref()
             .or(self.old_path.as_ref())
             .expect("DiffFile must have at least one path")
+    }
+
+    /// First line number in display order that carries a value on `side`.
+    ///
+    /// On `LineSide::New`, returns the first context or addition line; on
+    /// `LineSide::Old`, the first deletion line. Used by the submission
+    /// mapper to anchor file-level comments per the spec (a file-level
+    /// comment posts on the first valid visible line on the right side, or
+    /// the first deleted line for pure-deletion files).
+    ///
+    /// Returns `None` for binary, too-large, or empty-hunk files, and for
+    /// the requested side when the file has no lines on that side (e.g. a
+    /// pure addition has no Old-side anchor).
+    pub fn first_valid_line(&self, side: LineSide) -> Option<u32> {
+        if self.is_binary || self.is_too_large {
+            return None;
+        }
+        for hunk in &self.hunks {
+            for line in &hunk.lines {
+                let candidate = match side {
+                    LineSide::New => match line.origin {
+                        LineOrigin::Context | LineOrigin::Addition => line.new_lineno,
+                        LineOrigin::Deletion => None,
+                    },
+                    LineSide::Old => match line.origin {
+                        LineOrigin::Deletion => line.old_lineno,
+                        _ => None,
+                    },
+                };
+                if let Some(n) = candidate {
+                    return Some(n);
+                }
+            }
+        }
+        None
     }
 
     /// Returns `(additions, deletions)` for this file.

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -9,7 +9,7 @@ use crate::ui::diff_view::render_diff_view;
 use crate::ui::file_list::render_file_list;
 use crate::ui::inline_commit_selector::render_inline_commit_selector;
 use crate::ui::selector::render_commit_select;
-use crate::ui::{comment_panel, help_popup, status_bar, styles};
+use crate::ui::{comment_panel, help_popup, status_bar, styles, submit_modals};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     frame.render_widget(
@@ -49,6 +49,14 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // Render confirm dialog if in confirm mode
     if app.input_mode == InputMode::Confirm {
         comment_panel::render_confirm_dialog(frame, app, "Copy review to clipboard?");
+    }
+
+    // Submit-flow modals.
+    if app.input_mode == InputMode::SubmitResolver {
+        submit_modals::render_submit_resolver(frame, app);
+    }
+    if app.input_mode == InputMode::SubmitConfirm {
+        submit_modals::render_submit_confirm(frame, app);
     }
 
     // Position terminal cursor for IME when in Comment mode

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -511,6 +511,34 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  :submit       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Submit a COMMENT review to GitHub (PR mode)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :submit approve",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Submit an APPROVE review to GitHub"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :submit request-changes",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Submit a REQUEST_CHANGES review to GitHub"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :submit draft",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Push a pending (draft) review to GitHub"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  :set commits",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ pub mod inline_commit_selector;
 pub mod selector;
 pub mod status_bar;
 pub mod styles;
+pub mod submit_modals;
 pub mod text_utils;
 
 pub use app_layout::render;

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -244,6 +244,8 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     " VISUAL ".to_string()
                 }
             }
+            InputMode::SubmitResolver => " RESOLVE ".to_string(),
+            InputMode::SubmitConfirm => " SUBMIT ".to_string(),
         };
 
         let mode_span = Span::styled(mode_str, styles::mode_style(theme));
@@ -264,6 +266,8 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                     " j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit "
                 }
                 InputMode::VisualSelect => " j/k:extend  c/Enter:comment  y:yank  Esc/V:cancel ",
+                InputMode::SubmitResolver => " j/k:move  Enter:toggle  s:submit  Esc:cancel ",
+                InputMode::SubmitConfirm => " y:submit  n:cancel  Esc:cancel ",
             }
         };
         let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -33,6 +33,7 @@ pub fn render_submit_resolver(frame: &mut Frame, app: &App) {
 
     let block = Block::default()
         .title(title)
+        .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .style(styles::popup_style(theme))
         .border_style(styles::border_style(theme, true));
@@ -94,6 +95,7 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
 
     let block = Block::default()
         .title(title)
+        .title_alignment(Alignment::Center)
         .borders(Borders::ALL)
         .style(styles::popup_style(theme))
         .border_style(styles::border_style(theme, true));
@@ -165,7 +167,6 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
 
     let paragraph = Paragraph::new(lines)
         .style(styles::popup_style(theme))
-        .alignment(Alignment::Center)
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, inner);
 }

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -3,7 +3,7 @@
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
+    layout::{Alignment, Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
@@ -165,6 +165,7 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
 
     let paragraph = Paragraph::new(lines)
         .style(styles::popup_style(theme))
+        .alignment(Alignment::Center)
         .wrap(Wrap { trim: false });
     frame.render_widget(paragraph, inner);
 }

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -21,7 +21,7 @@ pub fn render_submit_resolver(frame: &mut Frame, app: &App) {
     let Some(state) = app.submit_state.as_ref() else {
         return;
     };
-    let area = centered_rect(70, 50, frame.area());
+    let area = centered_rect(70, 50, modal_anchor(app, frame.area()));
 
     frame.render_widget(Clear, area);
 
@@ -84,7 +84,7 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
     let Some(state) = app.submit_state.as_ref() else {
         return;
     };
-    let area = centered_rect(60, 70, frame.area());
+    let area = centered_rect(60, 70, modal_anchor(app, frame.area()));
 
     frame.render_widget(Clear, area);
 
@@ -223,6 +223,13 @@ fn prompt_spans(stale: bool, event: SubmitEvent) -> Vec<Span<'static>> {
         spans.push(Span::raw("reload"));
     }
     spans
+}
+
+/// The submit modals should center over the diff pane when one is visible
+/// (file list off to the side would otherwise tug the visual centre left).
+/// Falls back to the full frame when no diff area is laid out yet.
+fn modal_anchor(app: &App, fallback: Rect) -> Rect {
+    app.diff_area.unwrap_or(fallback)
 }
 
 fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -1,0 +1,536 @@
+//! Modal renderers for `:submit*`: the unmappable-comment resolver and the
+//! final confirmation. Driven off `App::submit_state`.
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+use crate::app::App;
+use crate::forge::submit::{ResolverAction, SubmitEvent, UnmappableItem};
+use crate::ui::styles;
+
+/// Render the modal listing comments the mapper could not place inline,
+/// with per-row toggle between "Move to summary" / "Omit". Centered overlay
+/// with a 70%-wide / 50%-tall area to give the rows breathing room.
+pub fn render_submit_resolver(frame: &mut Frame, app: &App) {
+    let theme = &app.theme;
+    let Some(state) = app.submit_state.as_ref() else {
+        return;
+    };
+    let area = centered_rect(70, 50, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let n = state.unmappable.len();
+    let title = format!(
+        " {n} comment{s} cannot be posted inline ",
+        s = if n == 1 { "" } else { "s" }
+    );
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .style(styles::popup_style(theme))
+        .border_style(styles::border_style(theme, true));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::with_capacity(n + 4);
+    lines.push(Line::from(""));
+    for (i, (item, action)) in state
+        .unmappable
+        .iter()
+        .zip(state.resolver_choices.iter())
+        .enumerate()
+    {
+        let cursor = if i == state.resolver_cursor { ">" } else { " " };
+        let action_label = match action {
+            ResolverAction::MoveToSummary => "[x] Move to summary",
+            ResolverAction::Omit => "[ ] Omit             ",
+        };
+        let style = if i == state.resolver_cursor {
+            Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        lines.push(Line::from(Span::styled(
+            format!("{cursor} {action_label}  {row}", row = describe_row(item)),
+            style,
+        )));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Enter: toggle action   s: submit   Esc: cancel",
+        Style::default().fg(theme.fg_secondary),
+    )));
+
+    let paragraph = Paragraph::new(lines)
+        .style(styles::popup_style(theme))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
+}
+
+/// Render the final confirmation modal before submit. Shows the counts and
+/// surface the stale-head warning when the open-time head and the latest
+/// known PR head disagree.
+pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
+    let theme = &app.theme;
+    let Some(state) = app.submit_state.as_ref() else {
+        return;
+    };
+    let area = centered_rect(60, 70, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let title = match state.event {
+        SubmitEvent::Draft => " Push pending GitHub review? ".to_string(),
+        _ => " Submit review to GitHub? ".to_string(),
+    };
+
+    let block = Block::default()
+        .title(title)
+        .borders(Borders::ALL)
+        .style(styles::popup_style(theme))
+        .border_style(styles::border_style(theme, true));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let moved_count = state
+        .resolver_choices
+        .iter()
+        .filter(|a| **a == ResolverAction::MoveToSummary)
+        .count();
+    let omit_count = state.resolver_choices.len() - moved_count;
+    let body_summary = body_summary_label(app, moved_count);
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(""));
+    if !matches!(state.event, SubmitEvent::Draft) {
+        lines.push(Line::from(format!(
+            "Event: {label}",
+            label = state.event.human_label()
+        )));
+    }
+    lines.push(Line::from(format!("Inline: {n}", n = state.mappable.len())));
+    lines.push(Line::from(format!("Moved to summary: {moved_count}")));
+    lines.push(Line::from(format!("Omitted: {omit_count}")));
+    lines.push(Line::from(format!("Body: {body_summary}")));
+    lines.push(Line::from(format!(
+        "Head: {sha}",
+        sha = short_sha(&state.commit_id)
+    )));
+
+    let stale = app.submit_head_is_stale();
+    if stale {
+        lines.push(Line::from(""));
+        let current = app
+            .current_pr_head
+            .as_deref()
+            .map(short_sha)
+            .unwrap_or_else(|| "?".to_string());
+        lines.push(Line::from(Span::styled(
+            format!("Current PR head: {current}"),
+            Style::default().fg(theme.pending),
+        )));
+        lines.push(Line::from(Span::styled(
+            "Warning: this review targets an older PR revision.",
+            Style::default().fg(theme.pending),
+        )));
+        lines.push(Line::from(Span::styled(
+            "Some comments may appear outdated on GitHub.",
+            Style::default().fg(theme.pending),
+        )));
+    }
+
+    if matches!(state.event, SubmitEvent::Draft) {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "This will create a pending GitHub review.",
+            Style::default().fg(theme.fg_secondary),
+        )));
+        lines.push(Line::from(Span::styled(
+            "It will not publish until you finish it in GitHub.",
+            Style::default().fg(theme.fg_secondary),
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(prompt_spans(stale, state.event)));
+
+    let paragraph = Paragraph::new(lines)
+        .style(styles::popup_style(theme))
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, inner);
+}
+
+fn describe_row(item: &UnmappableItem) -> String {
+    let kind = item.comment.comment_type.as_str();
+    let path = item.file.display();
+    let preview: String = item.comment.content.chars().take(40).collect();
+    let ellipsis = if item.comment.content.chars().count() > 40 {
+        "…"
+    } else {
+        ""
+    };
+    let reason = item.reason.human_label();
+    format!("{path} [{kind}] {preview}{ellipsis}  ({reason})")
+}
+
+fn body_summary_label(app: &App, moved_count: usize) -> String {
+    let review_level = app.session.review_comments.len();
+    match (review_level, moved_count, app.forge_config.review_footer) {
+        (0, 0, false) => "empty".to_string(),
+        (0, 0, true) => "footer only".to_string(),
+        (n, 0, _) => format!("{n} review comment{s}", s = plural(n)),
+        (0, m, _) => format!("{m} unplaced comment{s}", s = plural(m)),
+        (n, m, _) => format!("{n} review comment{sn} + {m} unplaced", sn = plural(n)),
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 { "" } else { "s" }
+}
+
+fn short_sha(sha: &str) -> String {
+    sha.chars().take(7).collect()
+}
+
+fn prompt_spans(stale: bool, event: SubmitEvent) -> Vec<Span<'static>> {
+    let primary = match event {
+        SubmitEvent::Draft => "push draft",
+        _ => "submit",
+    };
+    let mut spans = vec![
+        Span::styled("[y] ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(format!("{primary}    ")),
+        Span::styled("[n] ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("cancel"),
+    ];
+    if stale {
+        spans.push(Span::raw("    "));
+        spans.push(Span::styled(
+            "[r] ",
+            Style::default().add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw("reload"));
+    }
+    spans
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Percentage(percent_y)]).flex(Flex::Center);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)]).flex(Flex::Center);
+    let [area] = vertical.areas(area);
+    let [area] = horizontal.areas(area);
+    area
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{App, DiffSource, InputMode, PullRequestDiffSource, SubmitState};
+    use crate::error::Result as TuicrResult;
+    use crate::error::TuicrError;
+    use crate::forge::submit::{GhSide, InlineComment};
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
+    use crate::model::ReviewSession;
+    use crate::model::comment::{Comment, CommentType};
+    use crate::model::diff_types::FileStatus;
+    use crate::model::{DiffFile, DiffLine, SessionDiffSource};
+    use crate::syntax::SyntaxHighlighter;
+    use crate::theme::Theme;
+    use crate::vcs::traits::{VcsBackend, VcsChangeStatus, VcsInfo, VcsType};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use std::path::{Path, PathBuf};
+
+    struct SnapshotVcs {
+        info: VcsInfo,
+    }
+
+    impl VcsBackend for SnapshotVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+        fn get_working_tree_diff(&self, _h: &SyntaxHighlighter) -> TuicrResult<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+        fn fetch_context_lines(
+            &self,
+            _p: &Path,
+            _s: FileStatus,
+            _start: u32,
+            _end: u32,
+        ) -> TuicrResult<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn get_change_status(&self) -> TuicrResult<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+    }
+
+    fn make_pr_app() -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp"),
+            head_commit: "abcdef0123".to_string(),
+            branch_name: Some("feat".to_string()),
+            vcs_type: VcsType::File,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::PullRequest,
+        );
+        let pr_source = PullRequestDiffSource {
+            key: PrSessionKey::new(
+                ForgeRepository::github("github.com", "agavra", "tuicr"),
+                125,
+                "abcdef0123".to_string(),
+            ),
+            base_sha: "0000".to_string(),
+            title: "test".to_string(),
+            url: "https://example".to_string(),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            state: "OPEN".to_string(),
+            closed: false,
+            merged: false,
+        };
+        let mut app = App::build(
+            Box::new(SnapshotVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            Vec::new(),
+            session,
+            DiffSource::PullRequest(Box::new(pr_source)),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build app");
+        app.current_pr_head = Some("abcdef0123".to_string());
+        app
+    }
+
+    fn inline(line: u32) -> InlineComment {
+        InlineComment {
+            path: PathBuf::from("src/lib.rs"),
+            line,
+            side: GhSide::Right,
+            start_line: None,
+            start_side: None,
+            body: "x".to_string(),
+        }
+    }
+
+    fn unmappable_item(
+        file: &str,
+        ty: CommentType,
+        body: &str,
+        reason: crate::forge::submit::UnmappableReason,
+    ) -> UnmappableItem {
+        UnmappableItem {
+            comment: Comment::new(body.to_string(), ty, None),
+            file: PathBuf::from(file),
+            reason,
+        }
+    }
+
+    fn buffer_text(buffer: &Buffer) -> String {
+        let mut out = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    fn draw_resolver(app: &App) -> Buffer {
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_submit_resolver(frame, app))
+            .expect("draw");
+        terminal.backend().buffer().clone()
+    }
+
+    fn draw_confirm(app: &App) -> Buffer {
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_submit_confirm(frame, app))
+            .expect("draw");
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn resolver_renders_each_row_with_cursor_marker() {
+        use crate::forge::submit::UnmappableReason;
+        let mut app = make_pr_app();
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Comment,
+            mappable: Vec::new(),
+            unmappable: vec![
+                unmappable_item(
+                    "src/lib.rs",
+                    CommentType::Issue,
+                    "needs fixing",
+                    UnmappableReason::FileLevelNoAnchor,
+                ),
+                unmappable_item(
+                    "img.png",
+                    CommentType::Note,
+                    "binary art",
+                    UnmappableReason::BinaryFile,
+                ),
+            ],
+            resolver_choices: vec![ResolverAction::MoveToSummary, ResolverAction::MoveToSummary],
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+        });
+        let buffer = draw_resolver(&app);
+        let text = buffer_text(&buffer);
+        assert!(
+            text.contains("2 comments cannot be posted inline"),
+            "title: {text}"
+        );
+        assert!(text.contains("src/lib.rs"));
+        assert!(text.contains("img.png"));
+        assert!(text.contains("Enter: toggle action"));
+        // Cursor marker on row 0
+        assert!(text.contains("> [x] Move to summary"));
+    }
+
+    #[test]
+    fn resolver_marks_omit_rows_with_empty_brackets() {
+        use crate::forge::submit::UnmappableReason;
+        let mut app = make_pr_app();
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Comment,
+            mappable: Vec::new(),
+            unmappable: vec![unmappable_item(
+                "x.rs",
+                CommentType::Note,
+                "n",
+                UnmappableReason::FileLevelNoAnchor,
+            )],
+            resolver_choices: vec![ResolverAction::Omit],
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+        });
+        let buffer = draw_resolver(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("[ ] Omit"), "omit marker: {text}");
+    }
+
+    #[test]
+    fn confirm_renders_event_and_counts_for_comment_submission() {
+        let mut app = make_pr_app();
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Comment,
+            mappable: vec![inline(11), inline(12)],
+            unmappable: Vec::new(),
+            resolver_choices: Vec::new(),
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+        });
+        let buffer = draw_confirm(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("Submit review to GitHub?"), "title: {text}");
+        assert!(text.contains("Event: Comment"), "event line: {text}");
+        assert!(text.contains("Inline: 2"));
+        assert!(text.contains("Head: abcdef0"));
+        assert!(text.contains("[y]"));
+        assert!(text.contains("[n]"));
+        // No stale-head warning when current_pr_head matches
+        assert!(!text.contains("Warning: this review targets"));
+    }
+
+    #[test]
+    fn confirm_shows_stale_head_warning_with_reload_option() {
+        let mut app = make_pr_app();
+        app.current_pr_head = Some("ffff5678".to_string());
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::RequestChanges,
+            mappable: vec![inline(11)],
+            unmappable: Vec::new(),
+            resolver_choices: Vec::new(),
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+        });
+        let buffer = draw_confirm(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("Event: Request changes"));
+        assert!(text.contains("Current PR head: ffff567"));
+        assert!(text.contains("Warning: this review targets"));
+        assert!(text.contains("[r]"));
+    }
+
+    #[test]
+    fn confirm_shows_pending_review_title_and_no_event_line_for_draft() {
+        let mut app = make_pr_app();
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Draft,
+            mappable: vec![inline(11)],
+            unmappable: Vec::new(),
+            resolver_choices: Vec::new(),
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+        });
+        let buffer = draw_confirm(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("Push pending GitHub review?"));
+        // The "Event:" prefix should not appear for draft submissions
+        assert!(!text.contains("Event: "), "draft body: {text}");
+        assert!(text.contains("[y]"));
+        assert!(text.contains("push draft"));
+    }
+
+    #[test]
+    fn confirm_reflects_moved_to_summary_counts() {
+        use crate::forge::submit::UnmappableReason;
+        let mut app = make_pr_app();
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Comment,
+            mappable: vec![inline(11)],
+            unmappable: vec![
+                unmappable_item(
+                    "a.rs",
+                    CommentType::Note,
+                    "x",
+                    UnmappableReason::FileLevelNoAnchor,
+                ),
+                unmappable_item(
+                    "b.rs",
+                    CommentType::Note,
+                    "y",
+                    UnmappableReason::FileLevelNoAnchor,
+                ),
+            ],
+            resolver_choices: vec![ResolverAction::MoveToSummary, ResolverAction::Omit],
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+        });
+        let buffer = draw_confirm(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("Moved to summary: 1"), "counts: {text}");
+        assert!(text.contains("Omitted: 1"));
+    }
+}


### PR DESCRIPTION
## Summary

PR 5 of the [forge integration v1 spec](../blob/main/docs/forge-integration-v1-spec.md). Adds the **local pipeline** for submitting a tuicr-authored review to GitHub: comment lifecycle, mapping, preflight, resolver, and final confirmation. The actual `gh api .../reviews` network call is deferred to PR 6 — `[y]` on the confirmation modal currently emits `Submit ready — PR 6 will wire the network call`.

### In scope
- **Comment lifecycle model** — `CommentLifecycleState::{LocalDraft, PushedDraft, Submitted}` plus `remote_review_id` / `remote_comment_id` on `Comment`. All new fields `#[serde(default)]` so older session JSON deserializes as `LocalDraft + None`. `Comment::is_locked()` helper.
- **`[forge]` config section** — `ForgeConfig { comment_type_prefix, review_footer }` parsed under `[forge]`, both default `true`. Surfaces typo warnings via the existing config-loading path.
- **Cross-forge mapper** (`src/forge/submit.rs`) — `MappedComment::{Inline, Unmappable}` with full rule coverage per spec: single Context/Addition → `RIGHT`, single Deletion → `LEFT`, single-side ranges, file-level → first valid New-side line, mixed-side / binary / too-large / line-not-in-diff → `Unmappable`. `DiffFile::first_valid_line(side)` helper added.
- **Body + payload builders** — `forge::submit::build_review_body` (review-level + Unplaced section + footer, each togglable via config) and `forge::github::submit::build_review_payload` (omits `event` for draft, exact JSON shape per spec). `commit_id` always uses the originally-reviewed head SHA.
- **`:submit*` commands** — `:submit`, `:submit comment`, `:submit approve`, `:submit request-changes`, `:submit draft` all wired through `App::start_submit`. Preflight errors out for non-PR mode / closed PR / no drafts.
- **Resolver modal** (`InputMode::SubmitResolver`) — per-row Move/Omit toggle, cursor + REVERSED highlight. Defaults to Move-to-summary per spec mockup.
- **Final confirmation modal** (`InputMode::SubmitConfirm`) — counts, body summary, stale-head warning paragraph + `[r] reload` option when applicable, draft-variant title.
- **Stale-head plumbing** — `App::current_pr_head` populated at PR open and on `:e` reload. PR 5 cannot trigger the warning organically (no pre-submit refresh); the field is ready for PR 6.
- **Lock check** — `EditComment` and the `dd` delete path now check `comment.is_locked()` and surface "Comment already pushed to GitHub — read only in tuicr". Dormant in PR 5; activates once PR 6 writes lifecycle transitions.
- **Help popup + status bar** — `:submit*` entries documented; the new modes show mode-specific hints.

### Out of scope (deferred to PR 6 / PR 7)
- `gh api repos/.../reviews` network call.
- Lifecycle transitions `local_draft → pushed_draft | submitted` on successful submit.
- Pre-submit `gh pr view` refresh that would populate `current_pr_head` for organic stale-head detection.
- README repositioning (PR 7).
- Replying / resolving remote threads (out of v1).

## Key design choices

### Mapper as a free function over `(Comment, DiffFile, ForgeConfig)`
The mapper doesn't need `App` borrows and benefits from a flat input contract: fixture-test friendly, no async, no state machine. `bucket_mapping` is a free helper invoked from `App::start_submit` to sidestep a self-borrow during the walk.

### `commit_id` is the originally-reviewed head SHA
Even with the stale-head warning shown, the payload's `commit_id` uses the head SHA captured at PR open. This anchors comments to the diff they were authored against; if the user wants to review the new head, they `:e` reload (which creates a new session keyed by the new head SHA, leaving old-head drafts in the old session).

### Cross-forge vs GitHub-specific split
The body builder (`forge::submit::build_review_body`) is cross-forge. The JSON payload shape (`forge::github::submit::build_review_payload`) is GitHub-specific. The spec's "config applies to GitHub in v1 and can apply to future forge backends" language drove the split.

### Lock check piggybacks on existing `cursor_on_remote_thread`
Same handler sites (delete path in main.rs, edit path in handler.rs). Local locked comments get the same read-only message as PR 4's remote threads — consistent UX, separate state checks.

## Reviewer attention

- Lifecycle-state serde defaults (`model/comment.rs`). Legacy-JSON round-trip test is `should_default_lifecycle_state_for_legacy_session_json`.
- Mapper rule coverage in `forge/submit.rs` — one test per spec rule. If you read the spec's "Diff and Mapping" section and disagree with a mapping, the test will be obvious to flip.
- Payload-builder fixtures in `forge/github/submit.rs` — `event` field is _absent_ for draft (not `null`); confirm this matches `gh api` expectations.
- Stale-head warning will not fire organically until PR 6 adds a pre-submit refresh. Tests construct a fake stale state to exercise the render path.
- `SubmitState::commit_id` is the snapshot; `App::current_pr_head` is the live value. The `submit_head_is_stale` predicate is what gates the warning.

## Test coverage

553 → 613 (+60) tests:

- `model::comment` lifecycle round-trip + legacy-JSON: 4
- `config` `[forge]` section: 7
- `forge::submit` mapper + body + `first_valid_line`: 23
- `forge::github::submit` payload per event type: 7
- `app::submit_flow_tests` state machine + lock check: 13
- `ui::submit_modals` render snapshots: 6

## Hard-won lessons (added to spec)

1. `Comment` is not `Eq` — types containing it must use `Clone` + `match` patterns rather than `derive(Eq)`.
2. TestBackend modal sizing — a 60%×40% modal on 120×24 = 72×9 (7 content rows after borders); the confirmation modal needed 70% height to fit all lines.
3. Clippy nudges `if`+`match` toward `Action::X if cond1 && cond2 =>` arm guards over nested `if` blocks.

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test (613 passed, 1 ignored)
- [ ] Manual: PR mode with a mix of single/range/file-level comments → `:submit` shows the confirmation modal with the right counts.
- [ ] Manual: include a comment on a binary file → resolver lists it as unmappable; toggle Omit; confirm body excludes it.
- [ ] Manual: `:submit draft` shows the draft-variant title.
- [ ] Manual: simulate a stale head (manually set `current_pr_head` to a different SHA) → confirmation shows the warning + `[r]` reload option.
- [ ] Manual: try `:submit` outside PR mode → clean error message, no state mutation.