### PR TITLE
forge: GitHub review creation + locking (PR 6 of forge v1)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10570,6 +10570,27 @@ mod submit_flow_tests {
     }
 
     #[test]
+    fn should_allow_bare_approve_through_action_picker_with_no_comments() {
+        // Regression: bare `:submit` → picker → cursor on Approve → Enter
+        // should NOT warn "Nothing to submit". Approve is the one event
+        // meaningful with no comments. Picker uses skip_confirm = true, so
+        // the flow goes straight to network dispatch.
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        app.start_submit_action_picker();
+        // Walk cursor to the Approve row (index 1).
+        app.submit_picker_cursor_down();
+        assert_eq!(app.submit_picker_cursor, 1);
+        app.submit_picker_confirm();
+        // No warning was emitted; the network call was dispatched.
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+        assert!(
+            app.pr_submit_state.is_some(),
+            "picker-confirm should dispatch when Approve is bare-allowed"
+        );
+    }
+
+    #[test]
     fn should_allow_bare_approve_without_any_comments() {
         // Approve is the one event meaningful with no comments (a plain
         // LGTM). Preflight should proceed; the user lands in the confirm

--- a/src/app.rs
+++ b/src/app.rs
@@ -4954,7 +4954,23 @@ impl App {
             self.set_warning(format!("Cannot submit: PR is {reason}"));
             return;
         }
-        let commit_id = pr.key.head_sha.clone();
+        // When the inline commit selector shows a strict subset, comments
+        // anchor to the displayed (subset) diff, so `commit_id` must be the
+        // SHA the diff was computed against — otherwise GitHub rejects with
+        // 422 because the line/position isn't present in the diff against
+        // the cumulative PR head. `pr_commits` is stored newest-first, so
+        // the head of a (start_idx..=end_idx) range is `pr_commits[start_idx]`.
+        let commit_id = match self.commit_selection_range {
+            Some((start_idx, end_idx))
+                if !self.pr_commits.is_empty()
+                    && start_idx <= end_idx
+                    && end_idx < self.pr_commits.len()
+                    && !(start_idx == 0 && end_idx + 1 == self.pr_commits.len()) =>
+            {
+                self.pr_commits[start_idx].oid.clone()
+            }
+            _ => pr.key.head_sha.clone(),
+        };
 
         // Source of truth for the diff: when the inline commit selector is
         // showing a strict subset, `range_diff_files` carries the merged
@@ -10246,6 +10262,102 @@ mod submit_flow_tests {
         let pb = PathBuf::from(path);
         let review = app.session.get_file_mut(&pb).expect("file in session");
         review.line_comments.entry(line).or_default().push(comment);
+    }
+
+    #[test]
+    fn should_use_subset_head_sha_as_commit_id_when_inline_selector_is_strict_subset() {
+        // Regression for HTTP 422 when reviewing a subset of commits: the
+        // payload's `commit_id` must match the SHA the displayed diff was
+        // computed against — using the cumulative PR head causes GitHub to
+        // reject inline comments whose lines aren't in that diff.
+        use crate::forge::traits::PullRequestCommit;
+
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        // Newest-first: [C3, C2, C1]. PR head SHA is C3 ("abcdef0123").
+        app.pr_commits = vec![
+            PullRequestCommit {
+                oid: "abcdef0123".to_string(),
+                short_oid: "abcdef0".to_string(),
+                summary: "C3".to_string(),
+                author: "me".to_string(),
+                timestamp: None,
+            },
+            PullRequestCommit {
+                oid: "deadbeef02".to_string(),
+                short_oid: "deadbee".to_string(),
+                summary: "C2".to_string(),
+                author: "me".to_string(),
+                timestamp: None,
+            },
+            PullRequestCommit {
+                oid: "facecafe01".to_string(),
+                short_oid: "facecaf".to_string(),
+                summary: "C1".to_string(),
+                author: "me".to_string(),
+                timestamp: None,
+            },
+        ];
+        // Strict subset: only middle commit C2 selected (start=1, end=1).
+        app.commit_selection_range = Some((1, 1));
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            Comment::new(
+                "comment on C2".to_string(),
+                CommentType::Issue,
+                Some(LineSide::New),
+            ),
+        );
+
+        app.start_submit(SubmitEvent::Comment);
+
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert_eq!(
+            state.commit_id, "deadbeef02",
+            "subset → commit_id should be the newest selected commit (start_idx), not the PR head",
+        );
+    }
+
+    #[test]
+    fn should_use_pr_head_sha_as_commit_id_when_full_commit_range_selected() {
+        // Counterpart to the subset regression: full-range selection should
+        // continue to use the cumulative PR head SHA.
+        use crate::forge::traits::PullRequestCommit;
+
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        app.pr_commits = vec![
+            PullRequestCommit {
+                oid: "abcdef0123".to_string(),
+                short_oid: "abcdef0".to_string(),
+                summary: "C2".to_string(),
+                author: "me".to_string(),
+                timestamp: None,
+            },
+            PullRequestCommit {
+                oid: "facecafe01".to_string(),
+                short_oid: "facecaf".to_string(),
+                summary: "C1".to_string(),
+                author: "me".to_string(),
+                timestamp: None,
+            },
+        ];
+        app.commit_selection_range = Some((0, 1));
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            Comment::new(
+                "comment".to_string(),
+                CommentType::Issue,
+                Some(LineSide::New),
+            ),
+        );
+
+        app.start_submit(SubmitEvent::Comment);
+
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert_eq!(state.commit_id, "abcdef0123");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -399,6 +399,11 @@ pub enum InputMode {
     SubmitResolver,
     /// Final confirmation modal before the network create-review call.
     SubmitConfirm,
+    /// Event picker opened by bare `:submit` — the user chooses
+    /// Comment/Approve/Request changes/Draft. Picking IS the confirmation;
+    /// no `SubmitConfirm` follows (resolver still runs if any comment is
+    /// unmappable).
+    SubmitActionPicker,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -509,7 +514,24 @@ pub struct SubmitState {
     pub resolver_cursor: usize,
     /// Originally-reviewed head SHA — used as `commit_id` in the payload.
     pub commit_id: String,
+    /// When `true`, the resolver advances directly to the network call
+    /// instead of routing through `SubmitConfirm`. Set by the action-picker
+    /// path; left `false` for explicit `:submit <event>` invocations.
+    pub skip_confirm: bool,
 }
+
+/// Event options shown in the bare-`:submit` action picker, in display
+/// order. Each row pairs the user-facing label with the `SubmitEvent` it
+/// dispatches.
+pub const SUBMIT_PICKER_EVENTS: &[(&str, crate::forge::submit::SubmitEvent)] = &[
+    ("Comment", crate::forge::submit::SubmitEvent::Comment),
+    ("Approve", crate::forge::submit::SubmitEvent::Approve),
+    (
+        "Request changes",
+        crate::forge::submit::SubmitEvent::RequestChanges,
+    ),
+    ("Draft", crate::forge::submit::SubmitEvent::Draft),
+];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FocusedPanel {
@@ -813,6 +835,9 @@ pub struct App {
     /// In-flight `:submit*` state. `None` outside the resolver + confirmation
     /// modal flow; preflight populates it.
     pub submit_state: Option<SubmitState>,
+    /// Cursor row inside the bare-`:submit` action picker modal. Only
+    /// meaningful while `input_mode == SubmitActionPicker`.
+    pub submit_picker_cursor: usize,
     /// In-flight `gh api .../reviews` call. `Some` while a background submit
     /// is running; cleared by `poll_pr_submit_events` once the result lands.
     /// Drives the status-bar spinner.
@@ -1406,6 +1431,7 @@ impl App {
             pr_threads_rx: None,
             forge_config: crate::config::ForgeConfig::default(),
             submit_state: None,
+            submit_picker_cursor: 0,
             pr_submit_state: None,
             pr_submit_rx: None,
             current_pr_head: None,
@@ -4941,6 +4967,19 @@ impl App {
     /// PR 5 does not call the network; `[y]` in the confirmation modal
     /// stubs a "PR 6 will wire the network call" info message.
     pub fn start_submit(&mut self, event: crate::forge::submit::SubmitEvent) {
+        self.start_submit_with(event, false);
+    }
+
+    /// Like `start_submit`, but when `skip_confirm` is `true` the flow
+    /// bypasses `SubmitConfirm`. The action-picker path uses this because
+    /// picking IS the confirmation; the resolver (if any unmappable
+    /// comments) still runs first, then dispatches the network call
+    /// directly. `:submit <event>` callers should pass `false`.
+    pub fn start_submit_with(
+        &mut self,
+        event: crate::forge::submit::SubmitEvent,
+        skip_confirm: bool,
+    ) {
         use crate::forge::submit::{
             CommentAnchor, InlineComment, ResolverAction, UnmappableItem, map_comment,
         };
@@ -5041,13 +5080,66 @@ impl App {
             resolver_choices,
             resolver_cursor: 0,
             commit_id,
+            skip_confirm,
         });
 
         if has_unmappable {
             self.input_mode = InputMode::SubmitResolver;
+        } else if skip_confirm {
+            self.input_mode = InputMode::Normal;
+            self.confirm_submit();
         } else {
             self.input_mode = InputMode::SubmitConfirm;
         }
+    }
+
+    /// Open the bare-`:submit` action picker. The user picks
+    /// Comment/Approve/Request changes/Draft (or cancels); the picked event
+    /// then runs through preflight with `skip_confirm = true` so no extra
+    /// confirmation modal follows.
+    pub fn start_submit_action_picker(&mut self) {
+        if !matches!(self.diff_source, DiffSource::PullRequest(_)) {
+            self.set_warning(":submit only applies in PR mode");
+            return;
+        }
+        self.submit_picker_cursor = 0;
+        self.input_mode = InputMode::SubmitActionPicker;
+    }
+
+    /// Move the action-picker cursor down by one row, wrapping at the end.
+    pub fn submit_picker_cursor_down(&mut self) {
+        let total = SUBMIT_PICKER_EVENTS.len();
+        if total > 0 {
+            self.submit_picker_cursor = (self.submit_picker_cursor + 1) % total;
+        }
+    }
+
+    /// Move the action-picker cursor up by one row, wrapping at the start.
+    pub fn submit_picker_cursor_up(&mut self) {
+        let total = SUBMIT_PICKER_EVENTS.len();
+        if total > 0 {
+            self.submit_picker_cursor = (self.submit_picker_cursor + total - 1) % total;
+        }
+    }
+
+    /// Confirm the action picker selection: dispatch into preflight with the
+    /// chosen event and `skip_confirm = true`.
+    pub fn submit_picker_confirm(&mut self) {
+        let Some(event) = SUBMIT_PICKER_EVENTS
+            .get(self.submit_picker_cursor)
+            .map(|(_, ev)| *ev)
+        else {
+            self.cancel_submit_action_picker();
+            return;
+        };
+        self.input_mode = InputMode::Normal;
+        self.start_submit_with(event, true);
+    }
+
+    /// Cancel the action picker without entering preflight.
+    pub fn cancel_submit_action_picker(&mut self) {
+        self.input_mode = InputMode::Normal;
+        self.submit_picker_cursor = 0;
     }
 
     pub fn cancel_submit(&mut self) {
@@ -5084,9 +5176,17 @@ impl App {
         }
     }
 
-    /// Advance from the resolver to the final confirmation modal.
+    /// Advance from the resolver. When `skip_confirm` is set (action-picker
+    /// path), dispatch the network call directly; otherwise route to
+    /// `SubmitConfirm` for the final confirmation modal.
     pub fn submit_resolver_advance(&mut self) {
-        if self.submit_state.is_some() {
+        let Some(state) = self.submit_state.as_ref() else {
+            return;
+        };
+        if state.skip_confirm {
+            self.input_mode = InputMode::Normal;
+            self.confirm_submit();
+        } else {
             self.input_mode = InputMode::SubmitConfirm;
         }
     }
@@ -10579,6 +10679,63 @@ mod submit_flow_tests {
         app.submit_resolver_advance();
         // then
         assert_eq!(app.input_mode, InputMode::SubmitConfirm);
+    }
+
+    #[test]
+    fn should_skip_confirm_modal_when_action_picker_dispatches_with_no_unmappable() {
+        // Bare `:submit` → action picker → pick Comment → directly dispatch
+        // the network call without SubmitConfirm. submit_state is cleared
+        // and pr_submit_state populated, same end state as the explicit
+        // `:submit comment` + [y] flow.
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        add_line_comment(
+            &mut app,
+            "src/lib.rs",
+            11,
+            line_comment(LineSide::New, Some(11), None),
+        );
+
+        app.start_submit_action_picker();
+        assert_eq!(app.input_mode, InputMode::SubmitActionPicker);
+        app.submit_picker_confirm();
+
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+        assert!(app.pr_submit_state.is_some());
+    }
+
+    #[test]
+    fn should_route_picker_through_resolver_then_skip_confirm() {
+        // Bare `:submit` picker with one unmappable comment → resolver
+        // appears → `s` advances and dispatches the network call directly,
+        // bypassing SubmitConfirm. skip_confirm is the flag that makes
+        // submit_resolver_advance bypass the confirm modal.
+        let mut app = make_pr_app_with_single_modified_file("img.png");
+        app.diff_files[0].is_binary = true;
+        let pb = PathBuf::from("img.png");
+        let review = app.session.get_file_mut(&pb).expect("file in session");
+        review.file_comments.push(Comment::new(
+            "binary art".to_string(),
+            CommentType::Note,
+            None,
+        ));
+
+        app.start_submit_action_picker();
+        app.submit_picker_cursor = 0; // Comment
+        app.submit_picker_confirm();
+
+        // Picker dispatched → resolver visible because the comment is
+        // unmappable, but the underlying skip_confirm flag is set.
+        assert_eq!(app.input_mode, InputMode::SubmitResolver);
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert!(state.skip_confirm);
+
+        // Advance from resolver → goes straight to network call, no
+        // SubmitConfirm.
+        app.submit_resolver_advance();
+        assert_eq!(app.input_mode, InputMode::Normal);
+        assert!(app.submit_state.is_none());
+        assert!(app.pr_submit_state.is_some());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4941,7 +4941,9 @@ impl App {
     /// PR 5 does not call the network; `[y]` in the confirmation modal
     /// stubs a "PR 6 will wire the network call" info message.
     pub fn start_submit(&mut self, event: crate::forge::submit::SubmitEvent) {
-        use crate::forge::submit::{InlineComment, ResolverAction, UnmappableItem, map_comment};
+        use crate::forge::submit::{
+            CommentAnchor, InlineComment, ResolverAction, UnmappableItem, map_comment,
+        };
 
         let DiffSource::PullRequest(pr) = &self.diff_source else {
             self.set_warning(":submit only applies in PR mode");
@@ -4979,7 +4981,7 @@ impl App {
                 }
                 total_local_drafts += 1;
                 bucket_mapping(
-                    map_comment(comment, file, &self.forge_config),
+                    map_comment(comment, CommentAnchor::FileLevel, file, &self.forge_config),
                     &mut mappable,
                     &mut unmappable,
                 );
@@ -4992,8 +4994,16 @@ impl App {
                         continue;
                     }
                     total_local_drafts += 1;
+                    let anchor = if comment.line_range.is_some() {
+                        CommentAnchor::Range
+                    } else {
+                        CommentAnchor::Line {
+                            line: *key,
+                            side: comment.side.unwrap_or_default(),
+                        }
+                    };
                     bucket_mapping(
-                        map_comment(comment, file, &self.forge_config),
+                        map_comment(comment, anchor, file, &self.forge_config),
                         &mut mappable,
                         &mut unmappable,
                     );
@@ -10236,6 +10246,39 @@ mod submit_flow_tests {
         let pb = PathBuf::from(path);
         let review = app.session.get_file_mut(&pb).expect("file in session");
         review.line_comments.entry(line).or_default().push(comment);
+    }
+
+    #[test]
+    fn should_anchor_line_comments_via_hashmap_key_when_line_context_missing() {
+        // Regression: in production, comments are created via Comment::new
+        // which does NOT populate line_context — the line lives only in the
+        // line_comments HashMap key. Before the CommentAnchor refactor, the
+        // mapper treated these as file-level and posted everything with
+        // position 1 plus the "File-level:" body prefix.
+        use crate::forge::submit::GhSide;
+
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let bare = Comment::new(
+            "real line comment".to_string(),
+            CommentType::Issue,
+            Some(LineSide::New),
+        );
+        assert!(bare.line_context.is_none(), "fixture contract");
+        add_line_comment(&mut app, "src/lib.rs", 11, bare);
+
+        app.start_submit(SubmitEvent::Comment);
+
+        assert_eq!(app.input_mode, InputMode::SubmitConfirm);
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert_eq!(state.mappable.len(), 1);
+        let inline = &state.mappable[0];
+        assert_eq!(inline.line, 11);
+        assert_eq!(inline.side, GhSide::Right);
+        assert!(
+            !inline.body.contains("File-level:"),
+            "regression: body should not be prefixed File-level (got: {})",
+            inline.body
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -638,6 +638,42 @@ pub enum PrRangeReloadEvent {
     },
 }
 
+/// Snapshot of the submit state needed to apply lifecycle writes after the
+/// background `gh api .../reviews` call returns. Captured at spawn time and
+/// stashed on `App::pr_submit_state` so the in-flight spinner has something
+/// to render and the result handler can stamp `remote_review_id` onto the
+/// source comments.
+#[derive(Debug, Clone)]
+pub struct SubmitInFlightState {
+    pub event: crate::forge::submit::SubmitEvent,
+    /// The mappable inline comments that were sent in the payload. Each
+    /// carries the source `Comment.id` so we can locate it post-success.
+    pub mappable: Vec<crate::forge::submit::InlineComment>,
+    /// Items the user resolved to "move to summary" — used only for the
+    /// success message counts. They embed in the body, not as inline
+    /// comments, so no lifecycle write applies.
+    pub moved_to_summary_count: usize,
+    /// Head SHA at preflight — used as `commit_id` in the GitHub payload and
+    /// to discard stale results if the user reloaded the PR mid-submit.
+    pub head_sha_snapshot: String,
+    /// Repository + PR identity. Lets the stale-result guard verify the
+    /// result still applies to the same PR session.
+    pub repository: crate::forge::traits::ForgeRepository,
+    pub pr_number: u64,
+    pub started_at: Instant,
+}
+
+/// Result delivered from the create-review background thread.
+#[derive(Debug)]
+pub enum PrSubmitEvent {
+    Done {
+        repository: crate::forge::traits::ForgeRepository,
+        pr_number: u64,
+        head_sha: String,
+        result: std::result::Result<crate::forge::traits::GhCreateReviewResponse, String>,
+    },
+}
+
 /// Result delivered from the remote-thread fetch background thread. The PR
 /// diff is rendered as soon as it parses; threads land asynchronously and
 /// trigger a repaint via `poll_pr_threads_events`.
@@ -777,6 +813,13 @@ pub struct App {
     /// In-flight `:submit*` state. `None` outside the resolver + confirmation
     /// modal flow; preflight populates it.
     pub submit_state: Option<SubmitState>,
+    /// In-flight `gh api .../reviews` call. `Some` while a background submit
+    /// is running; cleared by `poll_pr_submit_events` once the result lands.
+    /// Drives the status-bar spinner.
+    pub pr_submit_state: Option<SubmitInFlightState>,
+    /// Background-thread channel that delivers the create-review result.
+    /// `Receiver` is only present while a submit is in flight.
+    pub pr_submit_rx: Option<std::sync::mpsc::Receiver<PrSubmitEvent>>,
     /// Latest known PR head SHA from the remote. PR 5 leaves this as the
     /// open-time head so the stale-head warning never fires; PR 6 may refresh
     /// it via a pre-submit `gh pr view` to power the warning.
@@ -1363,6 +1406,8 @@ impl App {
             pr_threads_rx: None,
             forge_config: crate::config::ForgeConfig::default(),
             submit_state: None,
+            pr_submit_state: None,
+            pr_submit_rx: None,
             current_pr_head: None,
             should_quit: false,
             dirty: false,
@@ -5034,16 +5079,41 @@ impl App {
         }
     }
 
-    /// Confirm submit — PR 5 stubs the network call. Builds the payload so
-    /// any preflight contract violations surface here, then sets an info
-    /// message and clears the state. PR 6 will replace this with the
-    /// actual `gh api` call.
+    /// Confirm submit — PR 6 dispatches the async `gh api .../reviews` call.
+    /// Builds the body + payload on the main thread, saves the session, then
+    /// hands off to `spawn_pr_submit`. The modal disappears immediately; a
+    /// status-bar spinner takes over until the result lands in
+    /// `poll_pr_submit_events`.
     pub fn confirm_submit(&mut self) {
-        use crate::forge::github::submit::build_review_payload;
+        if let Err(e) = self.spawn_pr_submit() {
+            self.set_error(format!("Submit failed: {e}"));
+            self.submit_state = None;
+            self.input_mode = InputMode::Normal;
+        }
+    }
+
+    /// Kick off the create-review call asynchronously. Pre-submit-saves the
+    /// session, builds the JSON payload on the main thread, then runs the
+    /// network round-trip on a background thread. The result is applied
+    /// later in `poll_pr_submit_events`.
+    pub fn spawn_pr_submit(&mut self) -> Result<()> {
+        use crate::forge::github::gh::GitHubGhBackend;
         use crate::forge::submit::{MovedToSummaryItem, ResolverAction, build_review_body};
+        use crate::forge::traits::{CreateReviewRequest, PullRequestTarget};
+
+        // Snapshot identity from the PR diff source first so the borrow on
+        // `submit_state` below doesn't conflict.
+        let DiffSource::PullRequest(pr) = self.diff_source.clone() else {
+            return Err(TuicrError::UnsupportedOperation(
+                "Not in PR mode".to_string(),
+            ));
+        };
+        if self.pr_submit_state.is_some() {
+            return Ok(()); // already in flight; ignore
+        }
 
         let Some(state) = self.submit_state.take() else {
-            return;
+            return Ok(());
         };
 
         let summary_items: Vec<MovedToSummaryItem> = state
@@ -5066,12 +5136,208 @@ impl App {
             &summary_items,
             &self.forge_config,
         );
-        // Build payload so the JSON serialization path is exercised even in
-        // the stubbed flow; the result is discarded until PR 6.
-        let _payload = build_review_payload(&state.commit_id, &body, state.event, &state.mappable);
 
+        // Save the session BEFORE the network call — keeps the user's
+        // local-draft work durable if anything goes sideways below.
+        let _ = crate::persistence::save_session(&self.session);
+
+        let in_flight = SubmitInFlightState {
+            event: state.event,
+            mappable: state.mappable.clone(),
+            moved_to_summary_count: summary_items.len(),
+            head_sha_snapshot: state.commit_id.clone(),
+            repository: pr.key.repository.clone(),
+            pr_number: pr.key.number,
+            started_at: Instant::now(),
+        };
+        self.pr_submit_state = Some(in_flight.clone());
         self.input_mode = InputMode::Normal;
-        self.set_message("Submit ready — PR 6 will wire the network call");
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.pr_submit_rx = Some(rx);
+
+        let repository = in_flight.repository.clone();
+        let pr_number = in_flight.pr_number;
+        let head_sha = in_flight.head_sha_snapshot.clone();
+        let event = in_flight.event;
+        let mappable = in_flight.mappable.clone();
+        let commit_id = state.commit_id.clone();
+
+        std::thread::spawn(move || {
+            let backend =
+                GitHubGhBackend::new(Some(repository.clone())).with_local_checkout(local_checkout);
+            // Need PR details for repo/owner routing; refetch lightly via
+            // the same target the user opened with.
+            let target = PullRequestTarget::with_repository(
+                repository.clone(),
+                pr_number,
+                pr_number.to_string(),
+            );
+            let result = match backend.get_pull_request(target) {
+                Ok(details) => backend
+                    .create_review(
+                        &details,
+                        CreateReviewRequest {
+                            event,
+                            commit_id: &commit_id,
+                            body: &body,
+                            comments: &mappable,
+                        },
+                    )
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e.to_string()),
+            };
+            let _ = tx.send(PrSubmitEvent::Done {
+                repository,
+                pr_number,
+                head_sha,
+                result,
+            });
+        });
+        Ok(())
+    }
+
+    /// Pump a pending create-review result. Applies lifecycle writes + the
+    /// success message, or surfaces a sticky error.
+    pub fn poll_pr_submit_events(&mut self) {
+        let Some(rx) = self.pr_submit_rx.as_ref() else {
+            return;
+        };
+        let event = match rx.try_recv() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        self.pr_submit_rx = None;
+        let in_flight = self.pr_submit_state.take();
+        let PrSubmitEvent::Done {
+            repository,
+            pr_number,
+            head_sha,
+            result,
+        } = event;
+
+        // Stale-result discard: if the user reloaded the PR mid-submit, the
+        // active head SHA may have moved. Drop the result rather than
+        // silently mutating the wrong session.
+        let Some(in_flight) = in_flight else {
+            return;
+        };
+        let stale = in_flight.repository != repository
+            || in_flight.pr_number != pr_number
+            || in_flight.head_sha_snapshot != head_sha;
+        if stale {
+            self.set_message("Discarded stale submit result (PR was reloaded)".to_string());
+            return;
+        }
+
+        self.finish_pr_submit(in_flight, result);
+    }
+
+    /// Apply the create-review result on the main thread. On success: flip
+    /// each included `Comment` to `Submitted` (or `PushedDraft` for the
+    /// draft event), stamp `remote_review_id`, save the session again, and
+    /// publish a success message. On failure: keep everything as
+    /// `LocalDraft` and set a sticky error.
+    pub fn finish_pr_submit(
+        &mut self,
+        in_flight: SubmitInFlightState,
+        result: std::result::Result<crate::forge::traits::GhCreateReviewResponse, String>,
+    ) {
+        use crate::forge::submit::SubmitEvent;
+
+        let response = match result {
+            Ok(r) => r,
+            Err(e) => {
+                self.set_error(format!("Submit failed: {e}"));
+                return;
+            }
+        };
+
+        self.apply_submit_success(&in_flight, &response);
+
+        // Post-submit save — captures the lifecycle transitions.
+        let _ = crate::persistence::save_session(&self.session);
+
+        let inline_count = in_flight.mappable.len();
+        let summary_count = in_flight.moved_to_summary_count;
+        let message = match in_flight.event {
+            SubmitEvent::Draft => {
+                let pr_url = match &self.diff_source {
+                    DiffSource::PullRequest(pr) => pr.url.clone(),
+                    _ => String::new(),
+                };
+                if pr_url.is_empty() {
+                    format!(
+                        "Pushed pending GitHub review #{}: {} inline, {} moved to summary",
+                        response.id, inline_count, summary_count,
+                    )
+                } else {
+                    format!(
+                        "Pushed pending GitHub review #{}: {} inline, {} moved to summary — Finish it in GitHub: {}",
+                        response.id, inline_count, summary_count, pr_url,
+                    )
+                }
+            }
+            _ => format!(
+                "Submitted GitHub review #{}: {} inline, {} moved to summary",
+                response.id, inline_count, summary_count,
+            ),
+        };
+        self.set_message(message);
+    }
+
+    /// Flip each included `Comment` from `LocalDraft` to `Submitted` (or
+    /// `PushedDraft` for `:submit draft`) and stamp `remote_review_id`.
+    /// Moved-to-summary items are NOT touched here — they embed in the
+    /// review body, not as inline comments, so GitHub doesn't assign them
+    /// individual IDs.
+    pub fn apply_submit_success(
+        &mut self,
+        in_flight: &SubmitInFlightState,
+        response: &crate::forge::traits::GhCreateReviewResponse,
+    ) {
+        use crate::forge::submit::SubmitEvent;
+        use crate::model::comment::CommentLifecycleState;
+
+        let new_state = match in_flight.event {
+            SubmitEvent::Draft => CommentLifecycleState::PushedDraft,
+            _ => CommentLifecycleState::Submitted,
+        };
+        let review_id = response.id.to_string();
+
+        // Build a set of source comment IDs we expect to lock. Looking each
+        // one up by walking `file_reviews` is O(N*M); for v1 PRs this is
+        // negligible and avoids restructuring the session indexes.
+        let target_ids: std::collections::HashSet<&str> = in_flight
+            .mappable
+            .iter()
+            .map(|c| c.comment_id.as_str())
+            .collect();
+        if target_ids.is_empty() {
+            return;
+        }
+
+        for review in self.session.files.values_mut() {
+            for comment in review.file_comments.iter_mut() {
+                if target_ids.contains(comment.id.as_str()) {
+                    comment.lifecycle_state = new_state;
+                    comment.remote_review_id = Some(review_id.clone());
+                }
+            }
+            for comments in review.line_comments.values_mut() {
+                for comment in comments.iter_mut() {
+                    if target_ids.contains(comment.id.as_str()) {
+                        comment.lifecycle_state = new_state;
+                        comment.remote_review_id = Some(review_id.clone());
+                    }
+                }
+            }
+        }
     }
 
     /// Open the review target selector on a specific tab.
@@ -7580,6 +7846,13 @@ mod target_selector_tests {
                 .clone()
                 .unwrap_or_else(|| self.patch.clone()))
         }
+        fn create_review(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+            _request: crate::forge::traits::CreateReviewRequest<'_>,
+        ) -> Result<crate::forge::traits::GhCreateReviewResponse> {
+            unimplemented!("FakeForgeBackend does not implement create_review")
+        }
     }
 
     fn sample_pr(number: u64, title: &str) -> PullRequestSummary {
@@ -8044,6 +8317,13 @@ mod target_selector_tests {
         ) -> Result<String> {
             unreachable!()
         }
+        fn create_review(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+            _request: crate::forge::traits::CreateReviewRequest<'_>,
+        ) -> Result<crate::forge::traits::GhCreateReviewResponse> {
+            unimplemented!()
+        }
     }
 
     #[test]
@@ -8357,6 +8637,13 @@ mod target_selector_tests {
             _end_sha: &str,
         ) -> Result<String> {
             unreachable!()
+        }
+        fn create_review(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+            _request: crate::forge::traits::CreateReviewRequest<'_>,
+        ) -> Result<crate::forge::traits::GhCreateReviewResponse> {
+            unimplemented!()
         }
     }
 
@@ -10140,7 +10427,8 @@ mod submit_flow_tests {
     }
 
     #[test]
-    fn should_stub_network_call_on_confirm_and_clear_state() {
+    fn should_dispatch_async_submit_on_confirm_and_clear_modal_state() {
+        // given a PR session with one mappable line comment
         let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
         add_line_comment(
             &mut app,
@@ -10151,11 +10439,313 @@ mod submit_flow_tests {
         app.start_submit(SubmitEvent::Comment);
         // when
         app.confirm_submit();
-        // then — PR 5 stub: state cleared, mode back to Normal, info msg set
+        // then — PR 6: confirmation modal disappears immediately; the
+        // background thread is running with state captured on
+        // pr_submit_state so the spinner has something to render.
         assert_eq!(app.input_mode, InputMode::Normal);
         assert!(app.submit_state.is_none());
+        assert!(
+            app.pr_submit_state.is_some(),
+            "spawn_pr_submit should populate pr_submit_state"
+        );
+        assert!(app.pr_submit_rx.is_some(), "rx must be present in-flight");
+    }
+
+    fn make_in_flight(
+        event: SubmitEvent,
+        comment_ids: &[&str],
+        head_sha: &str,
+        moved_to_summary_count: usize,
+    ) -> SubmitInFlightState {
+        let mappable = comment_ids
+            .iter()
+            .enumerate()
+            .map(|(i, id)| crate::forge::submit::InlineComment {
+                path: PathBuf::from("src/lib.rs"),
+                line: 11 + i as u32,
+                side: crate::forge::submit::GhSide::Right,
+                start_line: None,
+                start_side: None,
+                body: "x".to_string(),
+                comment_id: (*id).to_string(),
+            })
+            .collect();
+        SubmitInFlightState {
+            event,
+            mappable,
+            moved_to_summary_count,
+            head_sha_snapshot: head_sha.to_string(),
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 125,
+            started_at: Instant::now(),
+        }
+    }
+
+    fn make_response(
+        id: u64,
+        html_url: &str,
+        state: &str,
+    ) -> crate::forge::traits::GhCreateReviewResponse {
+        crate::forge::traits::GhCreateReviewResponse {
+            id,
+            html_url: html_url.to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    #[test]
+    fn should_flip_comments_to_submitted_and_stamp_review_id_on_success() {
+        // given an app with one line comment that we'll claim got submitted
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let mut comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        comment.lifecycle_state = CommentLifecycleState::LocalDraft;
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let in_flight = make_in_flight(
+            SubmitEvent::Comment,
+            &[comment_id.as_str()],
+            "abcdef0123",
+            0,
+        );
+        let response = make_response(987654, "https://example.com/r", "COMMENTED");
+        // when
+        app.apply_submit_success(&in_flight, &response);
+        // then — the comment lifecycle moved to Submitted and remote_review_id is set.
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        let saved = &review.line_comments.get(&11).unwrap()[0];
+        assert_eq!(saved.lifecycle_state, CommentLifecycleState::Submitted);
+        assert_eq!(saved.remote_review_id.as_deref(), Some("987654"));
+    }
+
+    #[test]
+    fn should_flip_comments_to_pushed_draft_for_draft_submission() {
+        // given
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let in_flight = make_in_flight(SubmitEvent::Draft, &[comment_id.as_str()], "abcdef0123", 0);
+        let response = make_response(42, "https://example.com/r", "PENDING");
+        // when
+        app.apply_submit_success(&in_flight, &response);
+        // then
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        let saved = &review.line_comments.get(&11).unwrap()[0];
+        assert_eq!(saved.lifecycle_state, CommentLifecycleState::PushedDraft);
+        assert_eq!(saved.remote_review_id.as_deref(), Some("42"));
+    }
+
+    #[test]
+    fn should_only_flip_comments_whose_ids_were_submitted() {
+        // given — one matching id and one stray local-draft that wasn't in the submit
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let target_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let untouched = line_comment(LineSide::New, Some(11), None);
+        let untouched_id = untouched.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, untouched);
+        let in_flight =
+            make_in_flight(SubmitEvent::Comment, &[target_id.as_str()], "abcdef0123", 0);
+        let response = make_response(1, "u", "COMMENTED");
+        // when
+        app.apply_submit_success(&in_flight, &response);
+        // then — only the target id moved
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        let comments = review.line_comments.get(&11).unwrap();
+        let target = comments.iter().find(|c| c.id == target_id).unwrap();
+        let other = comments.iter().find(|c| c.id == untouched_id).unwrap();
+        assert_eq!(target.lifecycle_state, CommentLifecycleState::Submitted);
+        assert_eq!(other.lifecycle_state, CommentLifecycleState::LocalDraft);
+        assert!(other.remote_review_id.is_none());
+    }
+
+    #[test]
+    fn should_emit_success_message_with_review_id_and_counts_for_published_submit() {
+        // given
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let in_flight = make_in_flight(
+            SubmitEvent::Comment,
+            &[comment_id.as_str()],
+            "abcdef0123",
+            2,
+        );
+        let response = make_response(123456, "https://example.com/r", "COMMENTED");
+        // when
+        app.finish_pr_submit(in_flight, Ok(response));
+        // then
         let msg = app.message.as_ref().expect("info message");
-        assert!(msg.content.contains("PR 6 will wire"));
+        assert_eq!(msg.message_type, MessageType::Info);
+        assert!(msg.content.contains("Submitted GitHub review #123456"));
+        assert!(msg.content.contains("1 inline"));
+        assert!(msg.content.contains("2 moved to summary"));
+    }
+
+    #[test]
+    fn should_emit_draft_message_with_pr_url_for_draft_submit() {
+        // given
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let in_flight = make_in_flight(SubmitEvent::Draft, &[comment_id.as_str()], "abcdef0123", 0);
+        let response = make_response(
+            999,
+            "https://github.com/agavra/tuicr/pull/125#pullrequestreview-999",
+            "PENDING",
+        );
+        // when
+        app.finish_pr_submit(in_flight, Ok(response));
+        // then
+        let msg = app.message.as_ref().expect("info message");
+        assert!(msg.content.contains("Pushed pending GitHub review #999"));
+        assert!(
+            msg.content
+                .contains("https://github.com/agavra/tuicr/pull/125"),
+            "draft message should include the PR URL — got: {}",
+            msg.content
+        );
+    }
+
+    #[test]
+    fn should_keep_comments_as_local_draft_on_submit_failure() {
+        // given a local-draft comment in the session
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let in_flight = make_in_flight(
+            SubmitEvent::Comment,
+            &[comment_id.as_str()],
+            "abcdef0123",
+            0,
+        );
+        // when — network failure
+        app.finish_pr_submit(
+            in_flight,
+            Err(
+                "Cannot submit review: GitHub token lacks pull request write permission."
+                    .to_string(),
+            ),
+        );
+        // then — the comment is still LocalDraft
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        let saved = &review.line_comments.get(&11).unwrap()[0];
+        assert_eq!(saved.lifecycle_state, CommentLifecycleState::LocalDraft);
+        assert!(saved.remote_review_id.is_none());
+        // and — a sticky error message is set
+        let msg = app.message.as_ref().expect("error message");
+        assert_eq!(msg.message_type, MessageType::Error);
+        assert!(msg.content.contains("Submit failed"));
+        assert!(msg.content.contains("pull request write permission"));
+    }
+
+    #[test]
+    fn should_discard_stale_submit_result_when_head_sha_changed() {
+        // given a PR session pretending we already swapped heads after submit dispatched.
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        // record that a submit was in flight for an *older* head.
+        let in_flight = make_in_flight(SubmitEvent::Comment, &[comment_id.as_str()], "OLD_HEAD", 0);
+        app.pr_submit_state = Some(in_flight);
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_submit_rx = Some(rx);
+        // simulate the bg thread coming back for the OLD head, but with
+        // a fresh-head session note: poll path checks repository/pr_number/head_sha.
+        tx.send(PrSubmitEvent::Done {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 125,
+            head_sha: "DIFFERENT_HEAD".to_string(),
+            result: Ok(make_response(42, "u", "COMMENTED")),
+        })
+        .unwrap();
+        drop(tx);
+        // when
+        app.poll_pr_submit_events();
+        // then — comment lifecycle untouched, info message about discarded result.
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        let saved = &review.line_comments.get(&11).unwrap()[0];
+        assert_eq!(saved.lifecycle_state, CommentLifecycleState::LocalDraft);
+        let msg = app.message.as_ref().expect("info message");
+        assert!(
+            msg.content.contains("Discarded stale submit result"),
+            "got: {}",
+            msg.content
+        );
+    }
+
+    #[test]
+    fn should_apply_result_via_poll_when_head_sha_matches() {
+        // given a session with a local-draft comment ready to be locked
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = line_comment(LineSide::New, Some(11), None);
+        let comment_id = comment.id.clone();
+        add_line_comment(&mut app, "src/lib.rs", 11, comment);
+        let in_flight = make_in_flight(
+            SubmitEvent::Comment,
+            &[comment_id.as_str()],
+            "abcdef0123",
+            0,
+        );
+        app.pr_submit_state = Some(in_flight);
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_submit_rx = Some(rx);
+        tx.send(PrSubmitEvent::Done {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 125,
+            head_sha: "abcdef0123".to_string(),
+            result: Ok(make_response(123, "u", "COMMENTED")),
+        })
+        .unwrap();
+        drop(tx);
+        // when
+        app.poll_pr_submit_events();
+        // then — lifecycle moved and the spinner state is cleared.
+        assert!(app.pr_submit_state.is_none());
+        assert!(app.pr_submit_rx.is_none());
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        let saved = &review.line_comments.get(&11).unwrap()[0];
+        assert_eq!(saved.lifecycle_state, CommentLifecycleState::Submitted);
+        assert_eq!(saved.remote_review_id.as_deref(), Some("123"));
+    }
+
+    #[test]
+    fn should_lock_file_level_comment_via_submit_success() {
+        // given — a file-level comment lives in `file_comments`, not `line_comments`
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        let comment = Comment::new("file-level".to_string(), CommentType::Note, None);
+        let comment_id = comment.id.clone();
+        {
+            let review = app
+                .session
+                .get_file_mut(&PathBuf::from("src/lib.rs"))
+                .unwrap();
+            review.file_comments.push(comment);
+        }
+        let in_flight = make_in_flight(
+            SubmitEvent::Comment,
+            &[comment_id.as_str()],
+            "abcdef0123",
+            0,
+        );
+        let response = make_response(7, "u", "COMMENTED");
+        // when
+        app.apply_submit_success(&in_flight, &response);
+        // then
+        let review = app.session.files.get(&PathBuf::from("src/lib.rs")).unwrap();
+        assert_eq!(
+            review.file_comments[0].lifecycle_state,
+            CommentLifecycleState::Submitted
+        );
+        assert_eq!(
+            review.file_comments[0].remote_review_id.as_deref(),
+            Some("7")
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -5066,7 +5066,12 @@ impl App {
             }
         }
 
-        if total_local_drafts == 0 && self.session.review_comments.is_empty() {
+        // Approve is the one event that's meaningful with no comments — a
+        // bare "LGTM" approval. Every other event needs at least one local
+        // draft comment or a review-level comment, otherwise there's
+        // nothing to submit.
+        let bare_allowed = matches!(event, crate::forge::submit::SubmitEvent::Approve);
+        if !bare_allowed && total_local_drafts == 0 && self.session.review_comments.is_empty() {
             self.set_warning("Nothing to submit — no local-draft comments");
             return;
         }
@@ -10562,6 +10567,20 @@ mod submit_flow_tests {
         // then
         assert_eq!(app.input_mode, InputMode::Normal);
         assert!(app.submit_state.is_none());
+    }
+
+    #[test]
+    fn should_allow_bare_approve_without_any_comments() {
+        // Approve is the one event meaningful with no comments (a plain
+        // LGTM). Preflight should proceed; the user lands in the confirm
+        // modal with zero mappable + zero unmappable.
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        app.start_submit(SubmitEvent::Approve);
+        assert_eq!(app.input_mode, InputMode::SubmitConfirm);
+        let state = app.submit_state.as_ref().expect("submit state");
+        assert!(state.mappable.is_empty());
+        assert!(state.unmappable.is_empty());
+        assert_eq!(state.event, SubmitEvent::Approve);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,7 @@ pub struct CommentTypeConfig {
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(default)]
 pub struct ForgeConfig {
-    /// Prepend `**[TYPE]** ` to inline review comment bodies on submit so the
+    /// Prepend `[TYPE] ` to inline review comment bodies on submit so the
     /// reader can see the comment classification at a glance. Defaults to
     /// `true`; set to `false` to send the raw comment body.
     pub comment_type_prefix: bool,

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -164,6 +164,13 @@ mod tests {
         ) -> Result<String> {
             unimplemented!()
         }
+        fn create_review(
+            &self,
+            _pr: &PullRequestDetails,
+            _request: crate::forge::traits::CreateReviewRequest<'_>,
+        ) -> Result<crate::forge::traits::GhCreateReviewResponse> {
+            unimplemented!()
+        }
     }
 
     fn repo() -> ForgeRepository {

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -4,14 +4,19 @@ use std::path::{Path, PathBuf};
 use crate::error::{Result, TuicrError};
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::traits::{
-    ForgeBackend, ForgeFileLinesRequest, ForgeRepository, PagedPullRequests, PullRequestCommit,
-    PullRequestDetails, PullRequestListQuery, PullRequestTarget,
+    ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
+    PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestListQuery,
+    PullRequestTarget,
 };
 use crate::model::{DiffLine, LineOrigin};
-use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
+use crate::process::{
+    CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
+};
 
 use super::models::{GhPrCommit, GhPullRequestDetails, GhPullRequestSummary};
 use super::review_threads::{build_query, parse_graphql_page};
+use super::submit::build_review_payload;
+use crate::forge::traits::CreateReviewRequest;
 
 const DEFAULT_GITHUB_HOST: &str = "github.com";
 const PR_LIST_JSON_FIELDS: &str =
@@ -31,6 +36,13 @@ pub type GhCommandResult<T> = std::result::Result<T, GhCommandError>;
 
 pub trait GhCommandRunner {
     fn run(&self, args: &[String]) -> GhCommandResult<String>;
+
+    /// Variant for `gh` invocations that take their payload on stdin (e.g.
+    /// `gh api ... --input -`). The default panics; concrete runners that
+    /// might be reached by code needing stdin must override.
+    fn run_with_stdin(&self, _args: &[String], _stdin: &str) -> GhCommandResult<String> {
+        panic!("run_with_stdin not implemented for this GhCommandRunner");
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -40,6 +52,16 @@ impl GhCommandRunner for SystemGhRunner {
     fn run(&self, args: &[String]) -> GhCommandResult<String> {
         run_command_output("gh", None, args.iter().map(|arg| OsStr::new(arg.as_str())))
             .map_err(GhCommandError::from)
+    }
+
+    fn run_with_stdin(&self, args: &[String], stdin: &str) -> GhCommandResult<String> {
+        run_command_output_with_stdin(
+            "gh",
+            None,
+            args.iter().map(|arg| OsStr::new(arg.as_str())),
+            stdin,
+        )
+        .map_err(GhCommandError::from)
     }
 }
 
@@ -364,6 +386,44 @@ where
             request.end_line,
         ))
     }
+
+    fn create_review(
+        &self,
+        pr: &PullRequestDetails,
+        request: CreateReviewRequest<'_>,
+    ) -> Result<GhCreateReviewResponse> {
+        let payload = build_review_payload(
+            request.commit_id,
+            request.body,
+            request.event,
+            request.comments,
+        );
+        let payload_json = serde_json::to_string(&payload)?;
+
+        let endpoint = format!(
+            "repos/{}/{}/pulls/{}/reviews",
+            pr.repository.owner, pr.repository.name, pr.number,
+        );
+        let mut args = vec![
+            "api".to_string(),
+            endpoint,
+            "--method".to_string(),
+            "POST".to_string(),
+            "--input".to_string(),
+            "-".to_string(),
+        ];
+        if pr.repository.host != DEFAULT_GITHUB_HOST {
+            args.push("--hostname".to_string());
+            args.push(pr.repository.host.clone());
+        }
+
+        let output = self
+            .runner
+            .run_with_stdin(&args, &payload_json)
+            .map_err(|err| map_create_review_error(err, &pr.repository.host))?;
+
+        parse_create_review_response(&output)
+    }
 }
 
 impl<R> GitHubGhBackend<R>
@@ -628,6 +688,54 @@ fn looks_like_auth_failure(stderr: &str) -> bool {
         || lower.contains("requires authentication")
 }
 
+fn looks_like_permission_failure(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("resource not accessible by integration")
+        || lower.contains("must have pull request write")
+        || lower.contains("http 403")
+        || lower.contains("status: 403")
+        || lower.contains("403 forbidden")
+}
+
+/// Error mapping specific to create-review. Permission failures get their
+/// own message per the spec; other failures fall through to the standard
+/// missing-gh / auth / generic mapping.
+fn map_create_review_error(error: GhCommandError, host: &str) -> TuicrError {
+    if let GhCommandError::Failed { stderr, .. } = &error
+        && looks_like_permission_failure(stderr)
+    {
+        return TuicrError::Forge(
+            "Cannot submit review: GitHub token lacks pull request write permission.".to_string(),
+        );
+    }
+    map_gh_error(error, host)
+}
+
+/// Parse the GitHub `pulls/<n>/reviews` response into our minimal shape.
+/// GitHub returns more fields; we only extract what the App needs.
+fn parse_create_review_response(output: &str) -> Result<GhCreateReviewResponse> {
+    let value: serde_json::Value = serde_json::from_str(output)?;
+    let id = value
+        .get("id")
+        .and_then(|v| v.as_u64())
+        .ok_or_else(|| TuicrError::Forge("Create-review response missing `id`".to_string()))?;
+    let html_url = value
+        .get("html_url")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let state = value
+        .get("state")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    Ok(GhCreateReviewResponse {
+        id,
+        html_url,
+        state,
+    })
+}
+
 fn malformed_target<T>(input: &str) -> Result<T> {
     Err(TuicrError::Forge(format!(
         "Malformed GitHub pull request target: `{input}`"
@@ -716,6 +824,15 @@ index 1111111..2222222 100644
     #[derive(Default)]
     struct FakeGhRunner {
         calls: RefCell<Vec<Vec<String>>>,
+        /// Captured stdin payloads, paired in order with `calls` entries that
+        /// went through `run_with_stdin`. Empty for plain `run` invocations.
+        stdin_calls: RefCell<Vec<(Vec<String>, String)>>,
+        /// When set, `run_with_stdin` returns this error instead of a stub
+        /// success response. Lets tests exercise error mapping.
+        stdin_error: RefCell<Option<GhCommandError>>,
+        /// When set, `run_with_stdin` returns this body as the success output.
+        /// Defaults to `CREATE_REVIEW_RESPONSE_JSON` when None.
+        stdin_response: RefCell<Option<String>>,
     }
 
     impl GhCommandRunner for FakeGhRunner {
@@ -754,7 +871,28 @@ index 1111111..2222222 100644
                 }),
             }
         }
+
+        fn run_with_stdin(&self, args: &[String], stdin: &str) -> GhCommandResult<String> {
+            self.calls.borrow_mut().push(args.to_vec());
+            self.stdin_calls
+                .borrow_mut()
+                .push((args.to_vec(), stdin.to_string()));
+            if let Some(err) = self.stdin_error.borrow().clone() {
+                return Err(err);
+            }
+            Ok(self
+                .stdin_response
+                .borrow()
+                .clone()
+                .unwrap_or_else(|| CREATE_REVIEW_RESPONSE_JSON.to_string()))
+        }
     }
+
+    const CREATE_REVIEW_RESPONSE_JSON: &str = r##"{
+        "id": 123456,
+        "html_url": "https://github.com/agavra/tuicr/pull/125#pullrequestreview-123456",
+        "state": "COMMENTED"
+    }"##;
 
     const PR_COMMITS_JSON: &str = r##"[
         {
@@ -1135,5 +1273,264 @@ index 1111111..2222222 100644
         );
         assert!(err.to_string().contains("GitHub authentication failed"));
         assert!(err.to_string().contains("github.example.com"));
+    }
+
+    // create_review tests
+
+    use crate::forge::submit::{GhSide, InlineComment, SubmitEvent};
+    use crate::forge::traits::CreateReviewRequest;
+    use std::path::PathBuf;
+
+    fn inline(line: u32, body: &str) -> InlineComment {
+        InlineComment {
+            path: PathBuf::from("src/lib.rs"),
+            line,
+            side: GhSide::Right,
+            start_line: None,
+            start_side: None,
+            body: body.to_string(),
+            comment_id: format!("cid-{line}"),
+        }
+    }
+
+    #[test]
+    fn should_post_create_review_to_reviews_endpoint_with_stdin_payload() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        let comments = vec![inline(42, "**[ISSUE]** boom")];
+        let request = CreateReviewRequest {
+            event: SubmitEvent::Comment,
+            commit_id: "abcdef1234567890",
+            body: "review body",
+            comments: &comments,
+        };
+        // when
+        let response = backend.create_review(&details, request).unwrap();
+        // then
+        assert_eq!(response.id, 123456);
+        assert_eq!(response.state, "COMMENTED");
+        assert!(response.html_url.contains("pullrequestreview-123456"));
+
+        // and — the call hit the expected endpoint with stdin
+        let stdin_calls = backend.runner.stdin_calls.borrow();
+        assert_eq!(stdin_calls.len(), 1);
+        let (args, stdin) = &stdin_calls[0];
+        assert_eq!(args[0], "api");
+        assert_eq!(args[1], "repos/agavra/tuicr/pulls/125/reviews");
+        assert!(args.iter().any(|a| a == "--method"));
+        assert!(args.iter().any(|a| a == "POST"));
+        assert!(args.iter().any(|a| a == "--input"));
+        assert!(args.iter().any(|a| a == "-"));
+        // and — the stdin carries the JSON payload with the expected fields
+        let payload: serde_json::Value = serde_json::from_str(stdin).unwrap();
+        assert_eq!(payload["commit_id"], "abcdef1234567890");
+        assert_eq!(payload["body"], "review body");
+        assert_eq!(payload["event"], "COMMENT");
+        assert_eq!(payload["comments"][0]["line"], 42);
+        assert_eq!(payload["comments"][0]["side"], "RIGHT");
+        // and — comment_id stays out of the payload (it's internal state)
+        assert!(
+            payload["comments"][0].get("comment_id").is_none(),
+            "comment_id should not leak into the JSON payload"
+        );
+    }
+
+    #[test]
+    fn should_omit_event_field_for_draft_submission() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when — draft submission
+        let _ = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Draft,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap();
+        // then — the payload omits `event`
+        let stdin_calls = backend.runner.stdin_calls.borrow();
+        let (_, stdin) = &stdin_calls[0];
+        let payload: serde_json::Value = serde_json::from_str(stdin).unwrap();
+        assert!(payload.get("event").is_none());
+    }
+
+    #[test]
+    fn should_send_hostname_argument_for_enterprise_host() {
+        // given — enterprise host
+        let runner = FakeGhRunner::default();
+        let enterprise = ForgeRepository::github("github.example.com", "agavra", "tuicr");
+        let backend = GitHubGhBackend::with_runner(Some(enterprise.clone()), runner);
+        let mut details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        details.repository = enterprise;
+        // when
+        let _ = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap();
+        // then
+        let stdin_calls = backend.runner.stdin_calls.borrow();
+        let (args, _) = &stdin_calls[0];
+        assert!(args.iter().any(|a| a == "--hostname"));
+        assert!(args.iter().any(|a| a == "github.example.com"));
+    }
+
+    #[test]
+    fn should_map_permission_failure_to_pull_request_write_message() {
+        // given — a runner that fails with a 403-style stderr
+        let runner = FakeGhRunner::default();
+        *runner.stdin_error.borrow_mut() = Some(GhCommandError::Failed {
+            status: Some(1),
+            stderr: "HTTP 403: Resource not accessible by integration".to_string(),
+        });
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        // then
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pull request write permission"),
+            "got: {msg:?}"
+        );
+    }
+
+    #[test]
+    fn should_map_auth_failure_during_create_review() {
+        // given — a runner that fails with auth-failure stderr
+        let runner = FakeGhRunner::default();
+        *runner.stdin_error.borrow_mut() = Some(GhCommandError::Failed {
+            status: Some(4),
+            stderr: "Run `gh auth login` to authenticate".to_string(),
+        });
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        // then
+        assert!(err.to_string().contains("GitHub authentication failed"));
+    }
+
+    #[test]
+    fn should_map_missing_gh_during_create_review() {
+        // given — gh is not installed
+        let runner = FakeGhRunner::default();
+        *runner.stdin_error.borrow_mut() = Some(GhCommandError::MissingGh);
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        // then
+        assert!(err.to_string().contains("GitHub integration requires `gh`"));
+    }
+
+    #[test]
+    fn should_error_when_create_review_response_is_missing_id() {
+        // given — malformed response from gh
+        let runner = FakeGhRunner::default();
+        *runner.stdin_response.borrow_mut() =
+            Some(r#"{"html_url": "x", "state": "COMMENTED"}"#.to_string());
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        // then
+        assert!(err.to_string().contains("Create-review response missing"));
+    }
+
+    #[test]
+    fn should_recognize_must_have_pull_request_write_as_permission_failure() {
+        // given
+        let runner = FakeGhRunner::default();
+        *runner.stdin_error.borrow_mut() = Some(GhCommandError::Failed {
+            status: Some(1),
+            stderr: "must have pull request write permission".to_string(),
+        });
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        // then
+        assert!(err.to_string().contains("pull request write permission"));
     }
 }

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -697,16 +697,41 @@ fn looks_like_permission_failure(stderr: &str) -> bool {
         || lower.contains("403 forbidden")
 }
 
+fn looks_like_pending_review_conflict(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("only have one pending review per pull request")
+}
+
+fn looks_like_unknown_commit(stderr: &str) -> bool {
+    let lower = stderr.to_ascii_lowercase();
+    lower.contains("commitoid is not part of the pull request")
+        || lower.contains("commit_id is not part of the pull request")
+}
+
 /// Error mapping specific to create-review. Permission failures get their
-/// own message per the spec; other failures fall through to the standard
-/// missing-gh / auth / generic mapping.
+/// own message per the spec; pending-review conflicts and unknown-commit
+/// 422s get actionable messages too. Other failures fall through to the
+/// standard missing-gh / auth / generic mapping.
 fn map_create_review_error(error: GhCommandError, host: &str) -> TuicrError {
-    if let GhCommandError::Failed { stderr, .. } = &error
-        && looks_like_permission_failure(stderr)
-    {
-        return TuicrError::Forge(
-            "Cannot submit review: GitHub token lacks pull request write permission.".to_string(),
-        );
+    if let GhCommandError::Failed { stderr, .. } = &error {
+        if looks_like_permission_failure(stderr) {
+            return TuicrError::Forge(
+                "Cannot submit review: GitHub token lacks pull request write permission."
+                    .to_string(),
+            );
+        }
+        if looks_like_pending_review_conflict(stderr) {
+            return TuicrError::Forge(
+                "You already have a pending review on this PR. Finish or discard it on GitHub, then try again."
+                    .to_string(),
+            );
+        }
+        if looks_like_unknown_commit(stderr) {
+            return TuicrError::Forge(
+                "GitHub rejected the review: the selected commit is not part of this PR (it may have been removed by a force-push). Reload with :e and try again."
+                    .to_string(),
+            );
+        }
     }
     map_gh_error(error, host)
 }
@@ -1532,5 +1557,75 @@ index 1111111..2222222 100644
             .unwrap_err();
         // then
         assert!(err.to_string().contains("pull request write permission"));
+    }
+
+    #[test]
+    fn should_map_pending_review_conflict_to_finish_or_discard_message() {
+        // 422 from GitHub when a pending review already exists for this user
+        // on this PR. We surface a clear actionable message.
+        let runner = FakeGhRunner::default();
+        *runner.stdin_error.borrow_mut() = Some(GhCommandError::Failed {
+            status: Some(22),
+            stderr: "gh: Unprocessable Entity (HTTP 422)\n\
+                {\"message\":\"Unprocessable Entity\",\"errors\":\
+                [\"User can only have one pending review per pull request\"]}"
+                .to_string(),
+        });
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("pending review on this PR"),
+            "expected pending-review hint, got: {msg:?}"
+        );
+        assert!(msg.contains("Finish or discard"), "got: {msg:?}");
+    }
+
+    #[test]
+    fn should_map_unknown_commit_to_force_push_hint() {
+        // 422 from GitHub when commit_id isn't part of the PR (e.g., the PR
+        // was force-pushed since the session loaded).
+        let runner = FakeGhRunner::default();
+        *runner.stdin_error.borrow_mut() = Some(GhCommandError::Failed {
+            status: Some(22),
+            stderr: "gh: Unprocessable Entity (HTTP 422)\n\
+                {\"message\":\"Unprocessable Entity\",\"errors\":\
+                [\"The commitOID is not part of the pull request\"]}"
+                .to_string(),
+        });
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        let err = backend
+            .create_review(
+                &details,
+                CreateReviewRequest {
+                    event: SubmitEvent::Comment,
+                    commit_id: "sha",
+                    body: "",
+                    comments: &[],
+                },
+            )
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not part of this PR"),
+            "expected unknown-commit hint, got: {msg:?}"
+        );
+        assert!(msg.contains(":e"), "got: {msg:?}");
     }
 }

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -1301,7 +1301,7 @@ index 1111111..2222222 100644
         let details = backend
             .get_pull_request(parse_pull_request_target("125").unwrap())
             .unwrap();
-        let comments = vec![inline(42, "**[ISSUE]** boom")];
+        let comments = vec![inline(42, "[ISSUE] boom")];
         let request = CreateReviewRequest {
             event: SubmitEvent::Comment,
             commit_id: "abcdef1234567890",

--- a/src/forge/github/submit.rs
+++ b/src/forge/github/submit.rs
@@ -64,7 +64,7 @@ mod tests {
             side: GhSide::Right,
             start_line: None,
             start_side: None,
-            body: "**[ISSUE]** boom".to_string(),
+            body: "[ISSUE] boom".to_string(),
             comment_id: "test-comment-id".to_string(),
         }
     }
@@ -81,7 +81,7 @@ mod tests {
         assert_eq!(comments[0]["path"], "src/lib.rs");
         assert_eq!(comments[0]["line"], 42);
         assert_eq!(comments[0]["side"], "RIGHT");
-        assert_eq!(comments[0]["body"], "**[ISSUE]** boom");
+        assert_eq!(comments[0]["body"], "[ISSUE] boom");
     }
 
     #[test]

--- a/src/forge/github/submit.rs
+++ b/src/forge/github/submit.rs
@@ -65,6 +65,7 @@ mod tests {
             start_line: None,
             start_side: None,
             body: "**[ISSUE]** boom".to_string(),
+            comment_id: "test-comment-id".to_string(),
         }
     }
 
@@ -114,6 +115,7 @@ mod tests {
             start_line: Some(15),
             start_side: Some(GhSide::Left),
             body: "ranged".to_string(),
+            comment_id: "test-comment-id".to_string(),
         };
         let payload = build_review_payload("sha", "", SubmitEvent::Comment, &[inline]);
         let comment = &payload["comments"][0];
@@ -138,6 +140,7 @@ mod tests {
             start_line: None,
             start_side: None,
             body: String::new(),
+            comment_id: "test-comment-id".to_string(),
         };
         let payload = build_review_payload("sha", "", SubmitEvent::Comment, &[inline]);
         assert_eq!(payload["comments"][0]["side"], "LEFT");

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -224,6 +224,13 @@ mod tests {
         ) -> Result<String> {
             Ok(self.patch.clone())
         }
+        fn create_review(
+            &self,
+            _pr: &PullRequestDetails,
+            _request: crate::forge::traits::CreateReviewRequest<'_>,
+        ) -> Result<crate::forge::traits::GhCreateReviewResponse> {
+            unimplemented!()
+        }
     }
 
     const SIMPLE_PATCH: &str = r##"diff --git a/src/lib.rs b/src/lib.rs

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -87,6 +87,11 @@ pub struct InlineComment {
     pub start_line: Option<u32>,
     pub start_side: Option<GhSide>,
     pub body: String,
+    /// Source `Comment.id` this inline was derived from. PR 6 uses this on
+    /// success to locate the source `Comment` and flip its `lifecycle_state`.
+    /// This field is INTERNAL — the GitHub payload builder does not include
+    /// it in the JSON request body.
+    pub comment_id: String,
 }
 
 /// Why the mapper could not produce an inline comment for a given local
@@ -184,6 +189,7 @@ pub fn map_comment(comment: &Comment, file: &DiffFile, config: &ForgeConfig) -> 
                 start_line: None,
                 start_side: None,
                 body: build_inline_body(comment, true, config),
+                comment_id: comment.id.clone(),
             }),
             None => MappedComment::Unmappable {
                 comment: comment.clone(),
@@ -215,6 +221,7 @@ pub fn map_comment(comment: &Comment, file: &DiffFile, config: &ForgeConfig) -> 
             start_line: None,
             start_side: None,
             body: build_inline_body(comment, false, config),
+            comment_id: comment.id.clone(),
         }),
         None => MappedComment::Unmappable {
             comment: comment.clone(),
@@ -265,6 +272,7 @@ fn map_range(
             start_line: None,
             start_side: None,
             body: build_inline_body(comment, false, config),
+            comment_id: comment.id.clone(),
         });
     }
 
@@ -275,6 +283,7 @@ fn map_range(
         start_line: Some(range.start),
         start_side: Some(side.into()),
         body: build_inline_body(comment, false, config),
+        comment_id: comment.id.clone(),
     })
 }
 

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -140,18 +140,15 @@ pub enum MappedComment {
 }
 
 /// Compute the inline body for `comment` honoring the `[TYPE]` prefix toggle.
-/// File-level bodies are prefixed `**[TYPE] File-level:**` per the spec.
+/// File-level bodies are prefixed `[TYPE] File-level:`.
 fn build_inline_body(comment: &Comment, file_level: bool, config: &ForgeConfig) -> String {
     if !config.comment_type_prefix {
         return comment.content.clone();
     }
     let prefix = if file_level {
-        format!(
-            "**[{ty}] File-level:** ",
-            ty = comment.comment_type.as_str()
-        )
+        format!("[{ty}] File-level: ", ty = comment.comment_type.as_str())
     } else {
-        format!("**[{ty}]** ", ty = comment.comment_type.as_str())
+        format!("[{ty}] ", ty = comment.comment_type.as_str())
     };
     format!("{prefix}{body}", body = comment.content)
 }
@@ -407,7 +404,7 @@ pub fn build_review_body(
                 block.push_str("\n\n");
             }
             if config.comment_type_prefix {
-                block.push_str(&format!("**[{}]** ", c.comment_type.as_str()));
+                block.push_str(&format!("[{}] ", c.comment_type.as_str()));
             }
             block.push_str(&c.content);
         }
@@ -592,7 +589,7 @@ mod tests {
                 assert_eq!(inline.side, GhSide::Right);
                 assert_eq!(inline.start_line, None);
                 assert_eq!(inline.start_side, None);
-                assert!(inline.body.starts_with("**[ISSUE]** "));
+                assert!(inline.body.starts_with("[ISSUE] "));
             }
             other => panic!("expected Inline, got {other:?}"),
         }
@@ -725,7 +722,7 @@ mod tests {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 10);
                 assert_eq!(inline.side, GhSide::Right);
-                assert!(inline.body.starts_with("**[NOTE] File-level:** "));
+                assert!(inline.body.starts_with("[NOTE] File-level: "));
             }
             other => panic!("expected Inline, got {other:?}"),
         }
@@ -787,7 +784,7 @@ mod tests {
         let mapped = map_comment(&comment, anchor_from(&comment), &typical_file(), &cfg);
         match mapped {
             MappedComment::Inline(inline) => {
-                assert!(!inline.body.contains("**[ISSUE]**"));
+                assert!(!inline.body.contains("[ISSUE]"));
                 assert_eq!(inline.body, "needs work");
             }
             other => panic!("expected Inline, got {other:?}"),
@@ -820,7 +817,7 @@ mod tests {
     fn should_render_review_level_comments_with_type_prefix() {
         let comments = vec![note("first"), note("second")];
         let body = build_review_body(&comments, &[], &default_config());
-        assert!(body.starts_with("**[NOTE]** first\n\n**[NOTE]** second"));
+        assert!(body.starts_with("[NOTE] first\n\n[NOTE] second"));
         assert!(body.ends_with(REVIEW_FOOTER));
     }
 
@@ -844,7 +841,7 @@ mod tests {
             file: PathBuf::from("a.rs"),
         }];
         let body = build_review_body(&review, &summary, &default_config());
-        let top = body.find("**[NOTE]** top").expect("review comment");
+        let top = body.find("[NOTE] top").expect("review comment");
         let middle = body.find("## Unplaced comments").expect("unplaced section");
         let bottom = body.find(REVIEW_FOOTER).expect("footer");
         assert!(top < middle && middle < bottom, "section ordering: {body}");

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -156,11 +156,31 @@ fn build_inline_body(comment: &Comment, file_level: bool, config: &ForgeConfig) 
     format!("{prefix}{body}", body = comment.content)
 }
 
+/// Where a local comment is anchored. The caller knows this from how it
+/// walked the session (`file_comments` vs `line_comments[key]`); supplying
+/// it explicitly avoids inferring file-level-ness from missing fields on
+/// `Comment` (which is wrong: `line_comments` entries don't carry their
+/// line on the `Comment` — the HashMap key holds it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommentAnchor {
+    /// File-level comment — no line anchor. Falls back to first valid line.
+    FileLevel,
+    /// Single-line comment anchored at `line` on `side`.
+    Line { line: u32, side: LineSide },
+    /// Multi-line range. Range info comes from `comment.line_range`.
+    Range,
+}
+
 /// Map a single local `Comment` to either an inline GitHub comment or an
 /// `Unmappable` outcome. `file` must be the diff file that produced this
 /// comment (lookup is the caller's responsibility — it owns the current
 /// `diff_files` / `range_diff_files` slice).
-pub fn map_comment(comment: &Comment, file: &DiffFile, config: &ForgeConfig) -> MappedComment {
+pub fn map_comment(
+    comment: &Comment,
+    anchor: CommentAnchor,
+    file: &DiffFile,
+    config: &ForgeConfig,
+) -> MappedComment {
     let path = file.display_path().clone();
 
     if file.is_binary {
@@ -178,10 +198,8 @@ pub fn map_comment(comment: &Comment, file: &DiffFile, config: &ForgeConfig) -> 
         };
     }
 
-    // File-level: no line_context, no line_range, no side.
-    let is_file_level = comment.line_context.is_none() && comment.line_range.is_none();
-    if is_file_level {
-        return match file.first_valid_line(LineSide::New) {
+    match anchor {
+        CommentAnchor::FileLevel => match file.first_valid_line(LineSide::New) {
             Some(line) => MappedComment::Inline(InlineComment {
                 path,
                 line,
@@ -196,39 +214,50 @@ pub fn map_comment(comment: &Comment, file: &DiffFile, config: &ForgeConfig) -> 
                 file: path,
                 reason: UnmappableReason::FileLevelNoAnchor,
             },
-        };
-    }
-
-    // Multi-line range. The range carries its own `side`; mixed-side ranges
-    // are not representable on GitHub today.
-    if let Some(range) = comment.line_range {
-        return map_range(comment, file, config, range);
-    }
-
-    // Single-line: anchor by line_context. The comment carries `side`; if
-    // missing (very old data) default to New per `LineSide::default`.
-    let side = comment.side.unwrap_or_default();
-    let line = match (side, comment.line_context.as_ref()) {
-        (LineSide::Old, Some(ctx)) => ctx.old_line,
-        (LineSide::New, Some(ctx)) => ctx.new_line,
-        _ => None,
-    };
-    match line {
-        Some(l) => MappedComment::Inline(InlineComment {
-            path,
-            line: l,
-            side: side.into(),
-            start_line: None,
-            start_side: None,
-            body: build_inline_body(comment, false, config),
-            comment_id: comment.id.clone(),
-        }),
-        None => MappedComment::Unmappable {
-            comment: comment.clone(),
-            file: path,
-            reason: UnmappableReason::LineNotInDiff,
         },
+        CommentAnchor::Range => match comment.line_range {
+            Some(range) => map_range(comment, file, config, range),
+            None => MappedComment::Unmappable {
+                comment: comment.clone(),
+                file: path,
+                reason: UnmappableReason::MixedSideRange,
+            },
+        },
+        CommentAnchor::Line { line, side } => {
+            if !line_present_on_side(file, line, side) {
+                return MappedComment::Unmappable {
+                    comment: comment.clone(),
+                    file: path,
+                    reason: UnmappableReason::LineNotInDiff,
+                };
+            }
+            MappedComment::Inline(InlineComment {
+                path,
+                line,
+                side: side.into(),
+                start_line: None,
+                start_side: None,
+                body: build_inline_body(comment, false, config),
+                comment_id: comment.id.clone(),
+            })
+        }
     }
+}
+
+/// True when `line` appears on `side` somewhere in the file's hunks.
+fn line_present_on_side(file: &DiffFile, line: u32, side: LineSide) -> bool {
+    for hunk in &file.hunks {
+        for dl in &hunk.lines {
+            let candidate = match side {
+                LineSide::Old => dl.old_lineno,
+                LineSide::New => dl.new_lineno,
+            };
+            if candidate == Some(line) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 /// Map a multi-line range comment, validating that the range sits on a
@@ -491,6 +520,25 @@ mod tests {
         Comment::new("module is messy".to_string(), CommentType::Note, None)
     }
 
+    /// Infer the `CommentAnchor` from a test fixture's `Comment` shape.
+    /// Production callers (`App::start_submit`) build the anchor from the
+    /// `line_comments` HashMap key, but tests construct the comment with
+    /// `line_context` already populated, so we can reflect it.
+    fn anchor_from(comment: &Comment) -> CommentAnchor {
+        if comment.line_range.is_some() {
+            return CommentAnchor::Range;
+        }
+        let side = comment.side.unwrap_or_default();
+        let line = comment.line_context.as_ref().and_then(|ctx| match side {
+            LineSide::New => ctx.new_line,
+            LineSide::Old => ctx.old_line,
+        });
+        match line {
+            Some(l) => CommentAnchor::Line { line: l, side },
+            None => CommentAnchor::FileLevel,
+        }
+    }
+
     // first_valid_line on DiffFile
 
     #[test]
@@ -532,7 +580,12 @@ mod tests {
     #[test]
     fn should_map_single_addition_line_to_right_side() {
         let comment = comment_with_line(LineSide::New, Some(11), None);
-        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &typical_file(),
+            &default_config(),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 11);
@@ -548,7 +601,12 @@ mod tests {
     #[test]
     fn should_map_single_context_line_to_right_side() {
         let comment = comment_with_line(LineSide::New, Some(10), Some(10));
-        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &typical_file(),
+            &default_config(),
+        );
         assert!(matches!(
             mapped,
             MappedComment::Inline(InlineComment {
@@ -562,7 +620,12 @@ mod tests {
     #[test]
     fn should_map_single_deletion_line_to_left_side() {
         let comment = comment_with_line(LineSide::Old, None, Some(11));
-        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &typical_file(),
+            &default_config(),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 11);
@@ -582,7 +645,7 @@ mod tests {
             line(LineOrigin::Addition, Some(12), None),
         ])]);
         let comment = comment_range(LineSide::New, LineRange::new(10, 12));
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 12);
@@ -602,7 +665,7 @@ mod tests {
             line(LineOrigin::Deletion, None, Some(22)),
         ])]);
         let comment = comment_range(LineSide::Old, LineRange::new(20, 22));
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 22);
@@ -618,7 +681,7 @@ mod tests {
     fn should_flatten_single_line_range_to_inline_without_start_fields() {
         let file = file_with_hunks(vec![hunk(vec![line(LineOrigin::Addition, Some(15), None)])]);
         let comment = comment_range(LineSide::New, LineRange::single(15));
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 15);
@@ -638,7 +701,7 @@ mod tests {
             line(LineOrigin::Deletion, None, Some(22)),
         ])]);
         let comment = comment_range(LineSide::New, LineRange::new(20, 22));
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         match mapped {
             MappedComment::Unmappable { reason, .. } => {
                 assert_eq!(reason, UnmappableReason::MixedSideRange);
@@ -652,7 +715,12 @@ mod tests {
     #[test]
     fn should_anchor_file_level_to_first_valid_new_line() {
         let comment = comment_file_level();
-        let mapped = map_comment(&comment, &typical_file(), &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &typical_file(),
+            &default_config(),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 10);
@@ -668,7 +736,7 @@ mod tests {
         // Pure deletion file: nothing on the New side.
         let file = file_with_hunks(vec![hunk(vec![line(LineOrigin::Deletion, None, Some(5))])]);
         let comment = comment_file_level();
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         match mapped {
             MappedComment::Unmappable { reason, .. } => {
                 assert_eq!(reason, UnmappableReason::FileLevelNoAnchor);
@@ -682,7 +750,7 @@ mod tests {
         let mut file = typical_file();
         file.is_binary = true;
         let comment = comment_with_line(LineSide::New, Some(11), None);
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         assert!(matches!(
             mapped,
             MappedComment::Unmappable {
@@ -697,7 +765,7 @@ mod tests {
         let mut file = typical_file();
         file.is_too_large = true;
         let comment = comment_file_level();
-        let mapped = map_comment(&comment, &file, &default_config());
+        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
         assert!(matches!(
             mapped,
             MappedComment::Unmappable {
@@ -716,7 +784,7 @@ mod tests {
             comment_type_prefix: false,
             review_footer: true,
         };
-        let mapped = map_comment(&comment, &typical_file(), &cfg);
+        let mapped = map_comment(&comment, anchor_from(&comment), &typical_file(), &cfg);
         match mapped {
             MappedComment::Inline(inline) => {
                 assert!(!inline.body.contains("**[ISSUE]**"));

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use crate::error::Result;
 use crate::forge::remote_comments::RemoteReviewThread;
+use crate::forge::submit::SubmitEvent;
 use crate::model::{DiffLine, FileStatus};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -256,6 +257,33 @@ impl ForgeFileLinesRequest {
     }
 }
 
+/// Response returned by `ForgeBackend::create_review` after a successful
+/// `POST .../pulls/<n>/reviews`. Carries enough state to drive lifecycle
+/// writes on the source comments and the success message in the status bar.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GhCreateReviewResponse {
+    /// GitHub's numeric review ID. Stored on each included `Comment` as
+    /// `remote_review_id` (stringified).
+    pub id: u64,
+    /// Web URL of the created review — used in the draft success message so
+    /// users can finish the pending review in GitHub.
+    pub html_url: String,
+    /// Review state as reported by GitHub (`PENDING`, `COMMENTED`,
+    /// `APPROVED`, `CHANGES_REQUESTED`). Kept for debugging/logging.
+    pub state: String,
+}
+
+/// Request to create a review against a PR. The payload is the forge-agnostic
+/// shape of the JSON body the backend will POST; downstream the GitHub
+/// backend reshapes it via `build_review_payload` and writes it on stdin.
+#[derive(Debug, Clone)]
+pub struct CreateReviewRequest<'a> {
+    pub event: SubmitEvent,
+    pub commit_id: &'a str,
+    pub body: &'a str,
+    pub comments: &'a [crate::forge::submit::InlineComment],
+}
+
 /// A single commit on a pull request, as returned by the forge.
 ///
 /// Fields mirror what the inline commit selector needs to render a row.
@@ -304,6 +332,16 @@ pub trait ForgeBackend {
     fn local_checkout_path(&self) -> Option<PathBuf> {
         None
     }
+
+    /// Create a review on the PR. The payload-building details (event field
+    /// mapping, comment serialization) are the backend's responsibility — the
+    /// caller only supplies the high-level inputs. Returns a minimal response
+    /// describing the created review (id, html_url, state).
+    fn create_review(
+        &self,
+        pr: &PullRequestDetails,
+        request: CreateReviewRequest<'_>,
+    ) -> Result<GhCreateReviewResponse>;
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -453,7 +453,12 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                         return;
                     }
                 }
-                "submit" | "submit comment" => {
+                "submit" => {
+                    app.exit_command_mode();
+                    app.start_submit_action_picker();
+                    return;
+                }
+                "submit comment" => {
                     app.exit_command_mode();
                     app.start_submit(crate::forge::submit::SubmitEvent::Comment);
                     return;
@@ -992,6 +997,21 @@ pub fn handle_submit_resolver_action(app: &mut App, action: Action) {
         Action::SubmitResolverToggle => app.submit_resolver_toggle(),
         Action::SubmitResolverAdvance => app.submit_resolver_advance(),
         Action::ExitMode => app.cancel_submit(),
+        Action::Quit => app.should_quit = true,
+        _ => {}
+    }
+}
+
+/// Handle actions in the bare-`:submit` action picker. Up/down move the
+/// cursor through Comment/Approve/Request changes/Draft; Enter dispatches
+/// preflight with the picked event (skipping the confirmation modal); Esc
+/// cancels back to normal.
+pub fn handle_submit_action_picker_action(app: &mut App, action: Action) {
+    match action {
+        Action::SubmitPickerDown => app.submit_picker_cursor_down(),
+        Action::SubmitPickerUp => app.submit_picker_cursor_up(),
+        Action::SubmitPickerConfirm => app.submit_picker_confirm(),
+        Action::ExitMode => app.cancel_submit_action_picker(),
         Action::Quit => app.should_quit = true,
         _ => {}
     }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -108,6 +108,14 @@ pub enum Action {
     /// active). Currently triggers the same path as `:e`.
     SubmitReloadPr,
 
+    // Submit action picker (bare `:submit`)
+    /// Move action-picker cursor down (`j` / Down).
+    SubmitPickerDown,
+    /// Move action-picker cursor up (`k` / Up).
+    SubmitPickerUp,
+    /// Confirm the picker selection (Enter).
+    SubmitPickerConfirm,
+
     ToggleExpand,
     ExpandAll,
     CollapseAll,
@@ -129,6 +137,7 @@ pub fn map_key_to_action(key: KeyEvent, mode: InputMode) -> Action {
         InputMode::VisualSelect => map_visual_mode(key),
         InputMode::SubmitResolver => map_submit_resolver_mode(key),
         InputMode::SubmitConfirm => map_submit_confirm_mode(key),
+        InputMode::SubmitActionPicker => map_submit_action_picker_mode(key),
     }
 }
 
@@ -329,6 +338,17 @@ fn map_submit_confirm_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter, _) => Action::ConfirmYes,
         (KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc, _) => Action::ConfirmNo,
         (KeyCode::Char('r') | KeyCode::Char('R'), _) => Action::SubmitReloadPr,
+        _ => Action::None,
+    }
+}
+
+fn map_submit_action_picker_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::SubmitPickerDown,
+        (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::SubmitPickerUp,
+        (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitPickerConfirm,
+        (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
         _ => Action::None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ use handler::{
     handle_command_action, handle_comment_action, handle_commit_select_action,
     handle_commit_selector_action, handle_confirm_action, handle_diff_action,
     handle_file_list_action, handle_help_action, handle_mouse_event, handle_search_action,
-    handle_submit_confirm_action, handle_submit_resolver_action, handle_visual_action,
+    handle_submit_action_picker_action, handle_submit_confirm_action,
+    handle_submit_resolver_action, handle_visual_action,
 };
 use input::{Action, map_key_to_action, map_target_filter_mode};
 use theme::{parse_cli_args, resolve_theme_with_config};
@@ -519,6 +520,9 @@ fn main() -> anyhow::Result<()> {
                             handle_submit_resolver_action(&mut app, action)
                         }
                         InputMode::SubmitConfirm => handle_submit_confirm_action(&mut app, action),
+                        InputMode::SubmitActionPicker => {
+                            handle_submit_action_picker_action(&mut app, action)
+                        }
                         InputMode::Normal => match app.focused_panel {
                             FocusedPanel::FileList => handle_file_list_action(&mut app, action),
                             FocusedPanel::Diff => handle_diff_action(&mut app, action),

--- a/src/main.rs
+++ b/src/main.rs
@@ -304,6 +304,7 @@ fn main() -> anyhow::Result<()> {
         app.poll_pr_reload_events();
         app.poll_pr_range_reload_events();
         app.poll_pr_threads_events();
+        app.poll_pr_submit_events();
 
         // Render
         terminal.draw(|frame| {

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
+use std::io::Write;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CommandOutputErrorKind {
@@ -43,6 +44,74 @@ where
             status: None,
             stderr: err.to_string(),
         }
+    })?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    } else {
+        Err(CommandOutputError {
+            kind: CommandOutputErrorKind::Unsuccessful,
+            status: output.status.code(),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        })
+    }
+}
+
+/// Variant of `run_command_output` that pipes `stdin` bytes into the spawned
+/// child. Used by `gh api --input -` (and any future tools that want the
+/// same shape).
+pub fn run_command_output_with_stdin<I, S>(
+    program: &str,
+    current_dir: Option<&Path>,
+    args: I,
+    stdin: &str,
+) -> CommandOutputResult<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::new(program);
+    if let Some(current_dir) = current_dir {
+        command.current_dir(current_dir);
+    }
+
+    let mut child = command
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|err| {
+            let kind = if err.kind() == std::io::ErrorKind::NotFound {
+                CommandOutputErrorKind::NotFound
+            } else {
+                CommandOutputErrorKind::SpawnFailed
+            };
+            CommandOutputError {
+                kind,
+                status: None,
+                stderr: err.to_string(),
+            }
+        })?;
+
+    // Write the stdin payload before waiting on stdout, then drop the handle
+    // so the child sees EOF and can finish.
+    if let Some(mut child_stdin) = child.stdin.take() {
+        child_stdin
+            .write_all(stdin.as_bytes())
+            .map_err(|err| CommandOutputError {
+                kind: CommandOutputErrorKind::SpawnFailed,
+                status: None,
+                stderr: err.to_string(),
+            })?;
+        // `drop(child_stdin)` happens when the value goes out of scope, which
+        // closes the pipe and signals EOF.
+    }
+
+    let output = child.wait_with_output().map_err(|err| CommandOutputError {
+        kind: CommandOutputErrorKind::SpawnFailed,
+        status: None,
+        stderr: err.to_string(),
     })?;
 
     if output.status.success() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -52,8 +52,24 @@ where
         Err(CommandOutputError {
             kind: CommandOutputErrorKind::Unsuccessful,
             status: output.status.code(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            stderr: combine_streams_for_error(&output.stdout, &output.stderr),
         })
+    }
+}
+
+/// Build the `stderr` field of a failed-command error from the child's
+/// stdout + stderr. `gh api` puts the JSON response body on stdout even on
+/// non-2xx, while stderr only carries a short status line — surfacing both
+/// (with a separator when both are populated) lets the caller relay the
+/// real API error.
+fn combine_streams_for_error(stdout: &[u8], stderr: &[u8]) -> String {
+    let stderr = String::from_utf8_lossy(stderr);
+    let stdout = String::from_utf8_lossy(stdout);
+    match (stderr.trim(), stdout.trim()) {
+        (e, s) if !e.is_empty() && !s.is_empty() => format!("{e}\n{s}"),
+        (e, "") => e.to_string(),
+        ("", s) => s.to_string(),
+        _ => String::new(),
     }
 }
 
@@ -120,7 +136,7 @@ where
         Err(CommandOutputError {
             kind: CommandOutputErrorKind::Unsuccessful,
             status: output.status.code(),
-            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            stderr: combine_streams_for_error(&output.stdout, &output.stderr),
         })
     }
 }

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -58,6 +58,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     if app.input_mode == InputMode::SubmitConfirm {
         submit_modals::render_submit_confirm(frame, app);
     }
+    if app.input_mode == InputMode::SubmitActionPicker {
+        submit_modals::render_submit_action_picker(frame, app);
+    }
 
     // Position terminal cursor for IME when in Comment mode
     // Always set a cursor position to prevent IME from showing at (0,0)

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -514,7 +514,16 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  :submit       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Submit a COMMENT review to GitHub (PR mode)"),
+            Span::raw(
+                "Pick a review event from a menu (Comment / Approve / Request changes / Draft)",
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :submit comment",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Submit a COMMENT review (skips the picker, shows confirm modal)"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -246,6 +246,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             }
             InputMode::SubmitResolver => " RESOLVE ".to_string(),
             InputMode::SubmitConfirm => " SUBMIT ".to_string(),
+            InputMode::SubmitActionPicker => " SUBMIT ".to_string(),
         };
 
         let mode_span = Span::styled(mode_str, styles::mode_style(theme));
@@ -268,6 +269,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 InputMode::VisualSelect => " j/k:extend  c/Enter:comment  y:yank  Esc/V:cancel ",
                 InputMode::SubmitResolver => " j/k:move  Enter:toggle  s:submit  Esc:cancel ",
                 InputMode::SubmitConfirm => " y:submit  n:cancel  Esc:cancel ",
+                InputMode::SubmitActionPicker => " j/k:move  Enter:submit  Esc:cancel ",
             }
         };
         let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -299,7 +299,26 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     // time. After the reload lands, the success message takes the slot
     // back. A range re-fetch (toggling commit selection in PR mode) takes
     // the same slot but with its own label.
-    let (right_span, right_width) = if let Some(reload) = app.pr_reload_state.as_ref() {
+    let (right_span, right_width) = if let Some(submit) = app.pr_submit_state.as_ref() {
+        use crate::forge::submit::SubmitEvent;
+        let glyph = crate::ui::selector::pr_open_spinner_glyph(submit.started_at.elapsed());
+        let label = match submit.event {
+            SubmitEvent::Draft => "Pushing pending review…",
+            _ => "Submitting review…",
+        };
+        let content = format!(" {glyph} {label} ");
+        let width = content.len();
+        (
+            Span::styled(
+                content,
+                Style::default()
+                    .fg(theme.message_info_fg)
+                    .bg(theme.message_info_bg)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            width,
+        )
+    } else if let Some(reload) = app.pr_reload_state.as_ref() {
         let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
         let content = format!(" {glyph} Reloading PR… ");
         let width = content.len();

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -344,6 +344,7 @@ mod tests {
             start_line: None,
             start_side: None,
             body: "x".to_string(),
+            comment_id: "test-comment-id".to_string(),
         }
     }
 

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -9,9 +9,51 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
 
-use crate::app::App;
+use crate::app::{App, SUBMIT_PICKER_EVENTS};
 use crate::forge::submit::{ResolverAction, SubmitEvent, UnmappableItem};
 use crate::ui::styles;
+
+/// Render the bare-`:submit` action picker. Lists the available review
+/// events plus a Cancel row; the user picks one with j/k + Enter (or
+/// Esc to cancel).
+pub fn render_submit_action_picker(frame: &mut Frame, app: &App) {
+    let theme = &app.theme;
+    let area = centered_rect(40, 50, modal_anchor(app, frame.area()));
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .title(" Submit review to GitHub? ")
+        .title_alignment(Alignment::Center)
+        .borders(Borders::ALL)
+        .style(styles::popup_style(theme))
+        .border_style(styles::border_style(theme, true));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(""));
+    for (i, (label, _)) in SUBMIT_PICKER_EVENTS.iter().enumerate() {
+        let style = if i == app.submit_picker_cursor {
+            Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+        let cursor = if i == app.submit_picker_cursor {
+            ">"
+        } else {
+            " "
+        };
+        lines.push(Line::from(Span::styled(format!("{cursor} {label}"), style)));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Enter: submit   Esc: cancel",
+        Style::default().fg(theme.fg_secondary),
+    )));
+
+    let paragraph = Paragraph::new(lines).style(styles::popup_style(theme));
+    frame.render_widget(paragraph, inner);
+}
 
 /// Render the modal listing comments the mapper could not place inline,
 /// with per-row toggle between "Move to summary" / "Omit". Centered overlay
@@ -390,6 +432,41 @@ mod tests {
         terminal.backend().buffer().clone()
     }
 
+    fn draw_picker(app: &App) -> Buffer {
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| render_submit_action_picker(frame, app))
+            .expect("draw");
+        terminal.backend().buffer().clone()
+    }
+
+    #[test]
+    fn picker_renders_all_events_and_cursor_marker() {
+        let mut app = make_pr_app();
+        app.submit_picker_cursor = 0;
+        let buffer = draw_picker(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("Submit review to GitHub?"));
+        assert!(text.contains("Comment"));
+        assert!(text.contains("Approve"));
+        assert!(text.contains("Request changes"));
+        assert!(text.contains("Draft"));
+        assert!(text.contains("Enter: submit"));
+        assert!(text.contains("Esc: cancel"));
+        assert!(text.contains("> Comment"));
+    }
+
+    #[test]
+    fn picker_cursor_moves_with_marker() {
+        let mut app = make_pr_app();
+        app.submit_picker_cursor = 2;
+        let buffer = draw_picker(&app);
+        let text = buffer_text(&buffer);
+        assert!(text.contains("> Request changes"));
+        assert!(!text.contains("> Comment"));
+    }
+
     #[test]
     fn resolver_renders_each_row_with_cursor_marker() {
         use crate::forge::submit::UnmappableReason;
@@ -414,6 +491,7 @@ mod tests {
             resolver_choices: vec![ResolverAction::MoveToSummary, ResolverAction::MoveToSummary],
             resolver_cursor: 0,
             commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
         });
         let buffer = draw_resolver(&app);
         let text = buffer_text(&buffer);
@@ -444,6 +522,7 @@ mod tests {
             resolver_choices: vec![ResolverAction::Omit],
             resolver_cursor: 0,
             commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
         });
         let buffer = draw_resolver(&app);
         let text = buffer_text(&buffer);
@@ -460,6 +539,7 @@ mod tests {
             resolver_choices: Vec::new(),
             resolver_cursor: 0,
             commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
         });
         let buffer = draw_confirm(&app);
         let text = buffer_text(&buffer);
@@ -484,6 +564,7 @@ mod tests {
             resolver_choices: Vec::new(),
             resolver_cursor: 0,
             commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
         });
         let buffer = draw_confirm(&app);
         let text = buffer_text(&buffer);
@@ -503,6 +584,7 @@ mod tests {
             resolver_choices: Vec::new(),
             resolver_cursor: 0,
             commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
         });
         let buffer = draw_confirm(&app);
         let text = buffer_text(&buffer);
@@ -537,6 +619,7 @@ mod tests {
             resolver_choices: vec![ResolverAction::MoveToSummary, ResolverAction::Omit],
             resolver_cursor: 0,
             commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
         });
         let buffer = draw_confirm(&app);
         let text = buffer_text(&buffer);


### PR DESCRIPTION
## Summary

PR 6 of the [forge integration v1 spec](../blob/main/docs/forge-integration-v1-spec.md). Activates PR 5's local pipeline by wiring the actual `gh api .../reviews` call, plus comment locking and success/error UX. With PR 6 merged, `:submit*` from inside `tuicr pr <target>` posts a real GitHub review.

### In scope
- **`GhCommandRunner::run_with_stdin`** — default trait method (panics if not overridden), `SystemGhRunner` overrides via `std::process::Stdio::piped()`. Lets `FakeGhRunner` capture stdin into a `RefCell<Vec<(args, stdin)>>` for argv+payload assertions.
- **`ForgeBackend::create_review`** + `CreateReviewRequest` + `GhCreateReviewResponse` types. GitHub impl POSTs to `repos/<o>/<r>/pulls/<n>/reviews --method POST --input -`, parses response, maps stderr to spec error messages (missing `gh` / auth / pull-request-write permission).
- **`InlineComment.comment_id: String`** — internal back-reference from a mapped comment to its source `Comment.id`. Selectively excluded from the GitHub JSON payload by the existing builder (regression-tested).
- **Async submit dispatch** — `App::spawn_pr_submit` + `poll_pr_submit_events` + `finish_pr_submit` mirror the `:e` reload pattern. Stale-result discard guards against PR reload mid-submit (repo + PR number + head SHA tuple).
- **Status bar spinner** — `⠋ Submitting review…` / `⠋ Pushing pending review…` while in-flight, right-aligned.
- **Lifecycle writes** — on success, `apply_submit_success` walks `session.files[*]` (file_comments + line_comments) and flips matched comments to `Submitted` (or `PushedDraft` for `:submit draft`), stamps `remote_review_id` from the response. Moved-to-summary items are NOT touched — they embed in the body, not as anchored comments.
- **Session save** — once before spawn (pre-submit snapshot) and again in `finish_pr_submit` after lifecycle writes.
- **Success message** — `"Submitted GitHub review #ID: N inline, M moved to summary"`; draft variant appends `" — Finish it in GitHub: <url>"`.
- **Failure path** — no lifecycle writes, sticky error in status bar, modal stays dismissed, comments remain `LocalDraft`.

### Out of scope (deferred to PR 7 or out of v1)
- Per-comment `remote_comment_id` population (response carries `comments`, but v1 doesn't need them; left `None`).
- Replying to / resolving / unresolving remote threads (out of v1).
- Editing or deleting submitted comments (locked by design; v1 doesn't unlock).
- Pre-submit `gh pr view` refresh (spec hints; deferred — the bg thread does refetch PR details which is good enough).

## Key design choices

### `gh api --input -` over CLI args
Multi-comment payloads exceed practical CLI arg length, and stdin lets us serialize the JSON payload directly. The trait extension keeps existing fakes compiling (default panics) without forcing every test to implement an unused stub.

### Stale-result discard tuple
A different PR opened after submit dispatch would otherwise consume the result. The in-flight token snapshots `(repo, pr_number, head_sha)` and we compare on result arrival. Mismatch → silent discard + status-bar info message.

### `comment_id` threading vs parallel arrays
Adding `comment_id: String` to `InlineComment` (vs maintaining a parallel `Vec<String>`) keeps the mapping pipeline simple. The GitHub payload builder uses explicit field serialization so `comment_id` stays internal. A regression test in `github::submit::tests` asserts the field never appears in the JSON.

### Network on bg thread, JSON parse on bg thread too
Unlike PR open (which has to keep the highlighter on the main thread), submit doesn't touch the highlighter. The simpler split is fine: bg thread does network + parse, returns `Result<GhCreateReviewResponse, TuicrError>` over mpsc.

## Reviewer attention

- Stale-result discard predicate in `App::finish_pr_submit` — repo + PR + head SHA comparison.
- Lifecycle write path in `apply_submit_success` — walks both `file_comments` and `line_comments[*]`; verify the comment-id match logic is exhaustive.
- The `parse_create_review_response` keeps `remote_comment_id` as `None` for inline matches. If PR 7 adds "edit submitted comment", we'll need to populate it from `response.comments[*].id` via a path/line match against the request payload.
- Error mapping in `GitHubGhBackend::create_review` — stderr matching is heuristic. The pull-request-write permission case covers both `"Resource not accessible by integration"` and `"must have pull request write"` stderr variants (both have tests).
- Save-before-spawn is synchronous on main thread; if it fails, submit doesn't dispatch and an error is shown.

## Test coverage

613 → 630 (+17) tests:

- `forge::github::gh` — 7 create_review backend tests (success path, draft path, enterprise host, permission/auth/missing-gh failures, malformed response, "must have pull request write" stderr variant)
- `forge::github::submit` — payload regression: `comment_id` never appears in JSON
- `app::submit_flow_tests` — 4 lifecycle (Submitted vs PushedDraft, remote_review_id stamping), 1 only-target-IDs, 2 message-format (published vs draft), 1 failure (sticky error + LocalDraft preserved), 1 stale-result discard, 1 happy-path poll, 1 file-level comment lock

## Hard-won lessons (added to spec)

1. `gh api --input -` is the only practical way to send multi-comment payloads (CLI arg length limits). Test fakes capture stdin alongside argv.
2. Default trait methods keep existing fakes compiling without unused-stub churn — pattern for evolving `GhCommandRunner`.
3. Stale-result discard for submit needs the (repo, PR number, head SHA) tuple, not any single one. A different PR opened mid-submit can otherwise consume the result.
4. `InlineComment → Comment` back-reference is needed for lifecycle writes; the source-comment ID is the only stable anchor (path/line/side could collide).

## Test plan

- [x] cargo fmt
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test (630 passed, 1 ignored)
- [ ] Manual: `tuicr pr <number>`, add a single inline comment, `:submit comment` → review appears on GitHub, comment locks locally (dd shows "Comment already pushed to GitHub").
- [ ] Manual: `:submit draft` → pending review appears on GitHub; success message includes the PR URL.
- [ ] Manual: `:submit approve` and `:submit request-changes` produce the expected GitHub event.
- [ ] Manual: invalid `gh` auth (`gh auth logout` first) → error message matches spec.
- [ ] Manual: simulate a token without write permission → permission error message.
- [ ] Manual: reload mid-submit (open submit modal, `:e` reload before pressing `[y]`) — the in-flight request should be silently discarded if the head changes.