### PR TITLE
update README: GitHub PR integration work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,24 @@ src/
 │   └── jj/              # Jujutsu backend (always compiled)
 │       └── mod.rs       # JjBackend: uses jj CLI, parses with diff_parser::GitStyle
 │
+├── forge/               # Remote forge integration (GitHub PR review, experimental)
+│   ├── mod.rs           # detect_github_repository() — parse origin URL to ForgeRepository
+│   ├── traits.rs        # ForgeBackend trait, ForgeRepository, PullRequestTarget,
+│   │                    # PullRequestDetails, PrSessionKey, CreateReviewRequest,
+│   │                    # GhCreateReviewResponse, ForgeFileLinesRequest
+│   ├── pr_open.rs       # Async pr-open flow: build session from details + diff
+│   ├── selector.rs      # Review target selector state (Local | Pull Requests tabs)
+│   ├── context.rs       # Remote context expansion via ForgeBackend::fetch_file_lines
+│   ├── remote_comments.rs # RemoteReviewThread shape + visibility filter
+│   ├── submit.rs        # Submit pipeline: preflight mapping, resolver actions,
+│   │                    # InlineComment payload, build_review_body, SubmitEvent
+│   └── github/          # GitHub backend (only forge in v1, via `gh` CLI)
+│       ├── mod.rs       # GitHubGhBackend: ForgeBackend impl
+│       ├── gh.rs        # GhCommandRunner: spawn `gh`, parse output, error mapping
+│       ├── models.rs    # JSON parsing for `gh` REST + GraphQL responses
+│       ├── review_threads.rs # GraphQL query for existing review threads
+│       └── submit.rs    # build_review_payload, create_review wiring
+│
 ├── model/
 │   ├── mod.rs
 │   ├── comment.rs       # Comment, CommentType (Note/Suggestion/Issue/Praise)
@@ -129,15 +147,90 @@ Repository-managed agent integrations:
 - `chrono`: Timestamps
 - `thiserror` + `anyhow`: Error handling
 
+## Forge integration
+
+PR review (`tuicr pr <target>`) is the only feature in `src/forge/`. The trait shape is forge-agnostic so other forges can plug in later; v1 only ships a GitHub backend that shells out to `gh`.
+
+### ForgeBackend trait
+
+`src/forge/traits.rs`. Required methods:
+
+- `list_pull_requests` — paged list for the selector's Pull Requests tab.
+- `get_pull_request` — details for a `PullRequestTarget` (resolves to `PullRequestDetails`).
+- `get_pull_request_diff` — the cumulative PR diff as a unified-diff string.
+- `list_pull_request_commits` — commits on the PR for the inline subset selector.
+- `get_pull_request_commit_range_diff` — cumulative diff for a contiguous subrange (`start_sha` is the parent of the first selected commit; `end_sha` is the last).
+- `list_review_threads` — existing GitHub comments + resolved/outdated state.
+- `fetch_file_lines` — remote context expansion in the diff view.
+- `create_review` — POST a review with inline comments via `CreateReviewRequest`.
+
+### Async pattern
+
+Network calls run on a background thread. Parsing + state mutation run on the main thread. The pattern across `spawn_pr_open` / `spawn_pr_reload` / `spawn_pr_submit`:
+
+1. Snapshot the request inputs on the main thread (no `&App` lives across the spawn).
+2. Spawn a thread that returns only `Send` data — typically `Result<(PullRequestDetails, String, Vec<PullRequestCommit>)>` or similar tuples.
+3. The thread sends the result on an `mpsc` channel; `poll_*_events()` drains the channel each tick.
+4. The main-thread `finish_*` function parses the diff and builds the `ReviewSession`. `SyntaxHighlighter` is not trivially `Send`, so parsing has to happen on the main thread.
+
+In-flight requests carry an identity tuple (repo, PR#, head SHA). A late result is discarded if the user has since opened a different PR.
+
+### Session key + lifecycle
+
+`PrSessionKey { repository, number, head_sha }` identifies a PR review session. Same PR + same head = same session = drafts reattach. New commit on the PR = new key = new session.
+
+Each `Comment` carries a `lifecycle` field:
+
+- `local_draft` — local-only, editable
+- `pushed_draft` — submitted with event=Draft (still a GitHub pending review)
+- `submitted` — submitted with Comment/Approve/RequestChanges, locked from further edits
+
+Submit failure leaves comments at `local_draft`. Success transitions to `submitted` or `pushed_draft` atomically per the response.
+
+### Submit pipeline (`src/forge/submit.rs`)
+
+1. **Preflight** maps each local comment to a GitHub-style inline anchor (path + line + side) by walking the displayed diff hunks.
+2. Unmappable comments go to the **resolver modal**: each one is either moved to the review summary or omitted.
+3. The **confirmation modal** shows counts and warns if the PR head advanced since load.
+4. The payload posts via `gh api --input -` (stdin, not CLI args, because CLI arg length limits would bite on multi-comment payloads).
+
+### Hard-won gotchas
+
+These are non-obvious things the implementation chain hit. Worth preserving for future maintainers.
+
+1. **`gh pr diff` must NOT use `--patch`.** That flag returns per-commit mbox patches and produces duplicate file entries. Plain `gh pr diff` returns the cumulative diff. Regression test: `should_not_pass_patch_flag_to_gh_pr_diff`.
+
+2. **GraphQL thread anchors live on `PullRequestReviewThread`, not the comment.** `path`, `line`, `originalLine`, `diffSide` are thread fields. Putting them on `PullRequestReviewComment` returns a schema error.
+
+3. **Network on the background thread, parsing on the main thread.** `SyntaxHighlighter` is not `Send`. Background threads return Send-safe data; the main thread parses and builds the session. Used by `spawn_pr_open` / `spawn_pr_reload` / `spawn_pr_submit`.
+
+4. **`apply_initial_load(Err(...))` is a no-op when the tab is already `Loaded`.** It only transitions `Loading → Error`. For transient errors during reload or submit, use `App::set_error()` (the message bar) instead.
+
+5. **Anchor restore must scroll.** Setting `diff_state.cursor_line` without calling `move_cursor_to_annotation` leaves the viewport at the top.
+
+6. **`Comment` line anchor lives in the `HashMap` key, not on `Comment.line_context`.** Production code creates comments via `Comment::new` without populating `line_context`. The submit mapper takes an explicit `CommentAnchor` parameter — never infer "file-level" from `line_context.is_none()`.
+
+7. **`gh api --input -` over CLI args.** The only practical way to send a multi-comment payload. See `GhCommandRunner::run_with_stdin`.
+
+8. **`gh api` writes the response body to STDOUT on non-2xx**, while STDERR only carries the short status line. The error formatter combines both so the user sees the actual GitHub error.
+
+9. **Stale-result discard for submit needs (repo, PR#, head SHA).** A different PR opened mid-submit could otherwise consume the result and apply lifecycle writes to the wrong comments.
+
+10. **TestBackend modal sizing.** A 60%×40% modal on 120×24 is 72×9 (7 content rows after borders). The submit confirmation modal needs 70% height to fit. The submit-action picker needs 50% height to fit the footer line.
+
+11. **Subset-mode `commit_id`.** When a strict subset of PR commits is selected, the payload's `commit_id` must be `pr_commits[start_idx].oid` (the newest selected commit). Using the cumulative PR head returns a misleading 422: `commitOID is not part of the pull request` — even though the SHA *is* in the PR.
+
+12. **`cd` into the worktree before running `cargo`.** `cargo` resolves `Cargo.toml` from `pwd`. Running gates from the wrong worktree silently exercises the wrong tree.
+
 ### Keeping Docs Updated
 
 When adding user-facing features, update the relevant documentation:
 
 | Document | Update when adding/changing... |
 |----------|-------------------------------|
-| `README.md` | Keybindings, commands (`:*`), CLI flags, features list, installation methods, agent integration setup |
+| `README.md` | Keybindings, commands (`:*`), CLI flags, features list, installation methods, agent integration setup, forge limitations |
 | `src/ui/help_popup.rs` | Keybindings or commands (update the `help_text` vector) |
-| `AGENTS.md` | Module structure, repo-managed agent integrations, key types, data flow, dependencies |
+| `AGENTS.md` | Module structure, repo-managed agent integrations, key types, data flow, dependencies, forge invariants and gotchas |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,84 +1,50 @@
-# tuicr: TUI for Code Review
+# tuicr
 
-<a href="https://crates.io/crates/tuicr" target="_blank"><img src="https://img.shields.io/crates/v/tuicr" alt="Crates.io"></a>
-<a href="https://github.com/agavra/tuicr/blob/main/LICENSE" target="_blank"><img src="https://img.shields.io/crates/l/tuicr" alt="License"></a>
-<a href="https://tuicr.dev" target="_blank"><img src="https://img.shields.io/badge/website-tuicr.dev-green" alt="Website"></a>
+**A code review TUI with vim keybindings. Export to GitHub or clipboard.**
 
-Review AI-generated diffs like a GitHub pull request, right from your terminal.
+[![Crates.io](https://img.shields.io/crates/v/tuicr)](https://crates.io/crates/tuicr)
+[![License](https://img.shields.io/crates/l/tuicr)](./LICENSE)
+[![Website](https://img.shields.io/badge/website-tuicr.dev-green)](https://tuicr.dev)
 
 ![demo](./public/tuicr-demo.gif)
 
-## Why I built this
-
-I use Claude a lot but there's no middle ground between "review every change"
-and "accept all edits". Reviewing every change slows things down to human speed,
-but accepting all edits makes the final review painful since I end up leaving
-comments one at a time and wait after each fix.
-
-`tuicr` is the middle ground. Let the agent loose, review the changes like a
-normal PR, drop comments where needed, and export everything as structured
-feedback the agent can act on in one pass.
-
-It makes my AI-assisted development go brrrrrr.
-
 > [!TIP]
-> I pronounce it "tweaker"
+> Pronounced "tweaker".
 
-## Overview
+## What it does
 
-A GitHub-style diff viewer in your terminal with vim keybindings. Scroll through
-changed files, leave comments, mark files as reviewed, and copy your full review
-to clipboard in a format ready to paste back to the agent.
+- GitHub-style continuous diff in the terminal. Scroll through every changed file in one stream.
+- PR-style comments at the line, range, file, and review level, with classifications like
+  `issue`, `suggestion`, `note`, and `praise`.
+- Three export targets: push a real PR review to GitHub, copy structured markdown to your
+  clipboard, or pipe to stdout.
+- Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR.
 
-## Features
-
-- **Infinite scroll diff view** - All changed files in one continuous scroll (GitHub-style)
-- **Vim keybindings** - Navigate with `j/k`, `Ctrl-d/u`, `g/G`, `{/}`, `[/]`
-- **Expandable context** - Press Enter on "... expand (N lines) ..." to reveal hidden context between hunks
-- **Comments** - Add review-level, file-level, or line-level comments with types
-- **Visual mode** - Select line ranges with `v` / `V` and comment on multiple lines at once
-- **Review tracking** - Mark files as reviewed, persist progress to disk
-- **`.tuicrignore` support** - Exclude matching files from review diffs
-- **Clipboard export** - Copy structured Markdown optimized for LLM consumption
-- **Session persistence** - Reviews auto-save and reload on restart
-- **Jujutsu support** - Built-in jj support (tried first since jj repos are Git-backed)
-- **Mercurial support** - Built-in hg support
-
-## Installation
-
-### Homebrew (macOS/Linux)
+## Install
 
 ```bash
+curl -fsSL tuicr.dev/install.sh | sh
+# or
 brew install agavra/tap/tuicr
 ```
 
-### Pre-built binaries
-
-Download the latest release for your platform from [GitHub Releases](https://github.com/agavra/tuicr/releases).
-
-### Mise (macOS/Linux/Windows)
-
-```
-mise use github:agavra/tuicr
-```
-
-### From crates.io
+<details>
+<summary>Other install methods (cargo, mise, nix, binaries, source)</summary>
 
 ```bash
+# Cargo
 cargo install tuicr
-```
 
-### Using Nix
+# Mise
+mise use github:agavra/tuicr
 
-```bash
-# build tuirc (links binary to ./result/bin/tuirc)
-nix build github:agavra/tuicr
-
-# or just run with
+# Nix
 nix run github:agavra/tuicr
 ```
 
-### From source
+Pre-built binaries: [GitHub Releases](https://github.com/agavra/tuicr/releases)
+
+From source:
 
 ```bash
 git clone https://github.com/agavra/tuicr.git
@@ -86,324 +52,126 @@ cd tuicr
 cargo install --path .
 ```
 
-## Usage
+</details>
 
-Run `tuicr` in any git, jujutsu, or mercurial repository:
+## Quick start
 
 ```bash
-cd /path/to/your/repo
-tuicr
+tuicr                       # Pick from a commit selector
+tuicr -w                    # Uncommitted changes (skip selector)
+tuicr -r main..HEAD         # Commit range
+tuicr pr 125                # GitHub PR
+tuicr --stdout              # Pipe the review to stdout
 ```
 
-Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because jj repos are Git-backed.
+Inside tuicr, navigate with `j`/`k`, press `c` to comment, then `y` to copy the review or
+`:submit` to push it to GitHub. Auto-detects git, jj, or mercurial.
 
-### Options
+## How it compares
 
-| Flag | Description |
-|------|-------------|
-| `-r` / `--revisions <REVSET>` | Commit range/Revision set to review. Exact syntax depends on VCS backend (Git, JJ, Hg) |
-| `--theme <THEME>` | Color theme override (`dark`, `light`, `ayu-light`, `onedark`, `github-light`, `github-dark`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`, `gruvbox-dark`, `gruvbox-light`, `nord-dark`, `nord-light`, `nord-dark-high-contrast`, `nord-light-high-contrast`, `solarized-light`, `solarized-dark`, `tokyo-night-storm`) |
-| `--appearance <MODE>` | Appearance mode for default theme (`dark`, `light`, `system`) |
-| `--stdout` | Output to stdout instead of clipboard when exporting |
-| `--no-update-check` | Skip checking for updates on startup |
+| | tuicr | [hunk](https://github.com/modem-dev/hunk) | [lumen](https://github.com/jnsahaj/lumen) | `gh pr review` | `git diff` |
+|---|:---:|:---:|:---:|:---:|:---:|
+| TUI diff viewer | ✅ | ✅ | ✅ | | |
+| Write comments in the TUI | ✅ | agent-only¹ | ✅ | | |
+| Vim keybindings | ✅ | | partial² | | |
+| Push inline review to GitHub | ✅ | | | partial³ | |
+| Agent-ready markdown export | ✅ | via CLI skill | | | |
+| git / jj / hg | ✅ / ✅ / ✅ | ✅ / ✅ / | ✅ / ✅ / | | ✅ / / |
+| Single static binary | ✅ | (needs Node) | ✅ | ✅ | ✅ |
 
-By default, `tuicr` starts in commit selection mode.  
-If staged or unstaged changes exist, the first selectable entries are `Staged changes` and/or `Unstaged changes`.  
-When `-r` / `--revisions` is provided, `tuicr` opens that revision range directly.
-On narrow terminals (less than 100 columns), `tuicr` starts with the file list hidden; toggle it with `;e`.
+¹ Hunk has a `hunk session comment add` CLI for agents to inject notes into a live TUI session.
+No in-TUI commenting keybinding.
 
-### Configuration
+² Lumen has `j`/`k` navigation but no broader vim model (visual mode, `{N}G`, `Ctrl-d`/`Ctrl-u`,
+etc.).
 
-Set a default theme in:
-- Linux/macOS: `$XDG_CONFIG_HOME/tuicr/config.toml` (default: `~/.config/tuicr/config.toml`)
-- Windows: `%APPDATA%\tuicr\config.toml`
+³ `gh pr review` posts approve/comment/request-changes at the review level only. No inline line
+comments.
 
-Examples:
+## Export your review
 
-```toml
-theme = "catppuccin-mocha"
+When you're done reviewing, send your comments wherever the work continues.
 
-appearance = "system"
-theme_dark = "gruvbox-dark"
-theme_light = "gruvbox-light"
+### To GitHub
 
-show_file_list = false
-diff_view = "side-by-side"
-backend = "libgit2"
-wrap = true
-cursor_line = false
-transparent_background = false
-scroll_offset = 5
+`:submit` opens a picker for Comment, Approve, Request changes, or Draft. Inline comments land
+on the right lines as a real PR review; review-level comments become the review summary.
+Requires `gh` authenticated to the repo.
 
-comment_types = [
-  { id = "note", label = "question", definition = "ask for clarification", color = "yellow" },
-  { id = "suggestion", definition = "possible improvements" },
-  { id = "issue", definition = "problems to fix" },
-  { id = "praise", definition = "positive feedback" },
-  { id = "nit", label = "nitpick", definition = "small optional tweaks", color = "#d19a66" }
-]
-```
+### To your coding agent
 
-`show_file_list` controls whether the file list panel is visible on startup (default: `true`). Toggle at runtime with `;e`.
-
-`diff_view` sets the default diff layout: `"unified"` (default) or `"side-by-side"`. Toggle at runtime with `:diff`.
-
-`backend` selects the Git implementation: `"libgit2"` (default for normal Git repos) or `"cli"`. Sparse checkout repositories are automatically routed to the Git CLI backend because libgit2 does not support sparse-index checkouts reliably.
-
-`wrap` enables line wrapping in the diff view (default: `false`). Toggle at runtime with `:set wrap!`.
-
-`cursor_line` highlights the current cursor line and visual selection in the diff view (default: `true`). Set to `false` to disable.
-
-`transparent_background` lets the terminal background show through panels (default: `true`). Set to `false` to paint the theme's `panel_bg` color instead.
-
-`scroll_offset` keeps a minimum number of lines visible above and below the cursor when scrolling (similar to Vim's `scrolloff`). Default: `0` (no margin).
-
-`comment_types` replaces the default list and defines Tab cycle order.
-Each entry requires `id` and can optionally set `label`, `definition`, and `color`.
-Color accepts terminal names (for example `yellow`, `light_red`) or hex (`#RRGGBB`).
-
-#### How `comment_types` works
-
-- `id` is the stable internal value that is saved in sessions and used for matching.
-- `label` is the visible tag shown in UI and export (`[QUESTION]`, `[NITPICK]`, etc.).
-- `definition` is guidance text for LLMs, included in the exported `Comment types:` legend.
-- `color` controls the comment badge/border color in the TUI.
-- Declaring `comment_types` is a full replacement, if you define 2 types, only those 2 are available.
-- If `comment_types` is missing, tuicr uses defaults: `note`, `suggestion`, `issue`, `praise`.
-- Invalid entries are ignored with startup warnings, if all entries are invalid, tuicr falls back to defaults.
-
-Minimal replacement example:
-
-```toml
-comment_types = [
-  { id = "question", definition = "ask for clarification" },
-  { id = "blocker", color = "red", definition = "must be fixed before merge" }
-]
-```
-
-Theme resolution precedence:
-1. `--theme <THEME>`
-2. `theme` in config file path above (OS-specific)
-3. `theme_dark` + `theme_light` in config (selected by appearance)
-4. `theme_dark` only or `theme_light` only in config (appearance ignored)
-5. `--appearance <MODE>` (only when no explicit theme or variants are set)
-6. `appearance` in config (only when no explicit theme or variants are set)
-7. built-in default (`system`)
-
-Notes:
-- Invalid `--theme` values cause an immediate non-zero exit.
-- Unknown keys in `config.toml` are ignored with a startup warning.
-
-### Ignoring Files With `.tuicrignore`
-
-`tuicr` reads `.tuicrignore` from the repository root and excludes matching files from all review diffs.
-
-Rules follow gitignore-style pattern matching, including `!` negation.
-
-Example:
-
-```gitignore
-target/
-dist/
-*.lock
-!Cargo.lock
-```
-
-### Mouse
-
-Mouse support is **on by default**. To disable, set in your config:
-
-```toml
-mouse = false
-```
-
-| Action | Effect |
-|--------|--------|
-| Wheel up/down | Scroll the panel under the cursor (file list, diff, commit list, or help popup) without moving the cursor line |
-| Click on a file | Jump to that file (lazygit-style) |
-| Click on a directory | Expand or collapse it |
-| Click on a diff line | Position the cursor on that line |
-| Click on a commit | Toggle selection (or expand the row to load more) |
-| Drag in diff | Highlight a range; press `y` to copy the selected source lines |
-
-For full native terminal selection across the whole UI, hold your terminal's bypass modifier while dragging (commonly **Shift** or **Option/Alt**, depending on the terminal). Check your terminal's docs if neither works.
-
-### Keybindings
-
-#### Navigation
-
-| Key | Action |
-|-----|--------|
-| `j` / `↓` | Scroll down |
-| `k` / `↑` | Scroll up |
-| `h` / `←` | Scroll left |
-| `l` / `→` | Scroll right |
-| `Ctrl-d` / `Ctrl-u` | Half page down/up |
-| `Ctrl-f` / `Ctrl-b` | Full page down/up |
-| `g` / `G` | Go to first/last file |
-| `{N}G` | Go to source line N in current file |
-| `{` / `}` | Jump to previous/next file |
-| `[` / `]` | Jump to previous/next hunk |
-| `/` | Search within diff |
-| `n` / `N` | Next/previous search match |
-| `Enter` | Expand/collapse hidden context between hunks |
-| `zt` | Scroll cursor to top of screen |
-| `zz` | Center cursor on screen |
-| `zb` | Scroll cursor to bottom of screen |
-
-#### File Tree
-
-| Key | Action |
-|-----|--------|
-| `Space` | Toggle expand directory |
-| `Enter` | Expand directory / Jump to file in diff |
-| `o` | Expand all directories |
-| `O` | Collapse all directories |
-
-#### Panel Focus
-
-| Key | Action |
-|-----|--------|
-| `Tab` / `Shift-Tab` | Toggle focus forward/backward between file list, diff, and commit selector |
-| `;h` | Focus file list (left panel) |
-| `;l` | Focus diff view (right panel) |
-| `;k` | Focus commit selector (top panel) |
-| `;j` | Focus diff view |
-| `;e` | Toggle file list visibility |
-| `Enter` | Select file (when file list is focused) |
-
-#### Review Actions
-
-| Key | Action |
-|-----|--------|
-| `r` | Toggle file reviewed |
-| `c` | Add line comment (or file comment if not on a diff line) |
-| `C` | Add file comment |
-| `;c` | Add review comment |
-| `v` / `V` | Enter visual mode for range comments |
-| `dd` | Delete comment at cursor |
-| `i` | Edit comment at cursor |
-| `y` | Copy review to clipboard |
-
-#### Visual Mode
-
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Extend selection down/up |
-| `c` / `Enter` | Create comment for selected range |
-| `Esc` / `v` / `V` | Cancel selection |
-
-#### Comment Mode
-
-| Key | Action |
-|-----|--------|
-| `Tab` / `Shift-Tab` | Cycle comment type forward/backward (from `comment_types` order) |
-| `Enter` / `Ctrl-Enter` / `Ctrl-s` | Save comment |
-| `Shift-Enter` / `Ctrl-j` | Insert newline |
-| `←` / `→` | Move cursor |
-| `Ctrl-w` / `Alt-Backspace` / `Cmd-Backspace` | Delete word |
-| `Ctrl-u` | Clear line |
-| `Esc` / `Ctrl-c` | Cancel |
-
-#### Commands
-
-| Command | Action |
-|---------|--------|
-| `:w` | Save session |
-| `:e` (`:reload`) | Reload diff files |
-| `:clip` (`:export`) | Copy review to clipboard |
-| `:diff` | Toggle diff view (unified / side-by-side) |
-| `:commits` | Select commits to review |
-| `:set wrap` | Enable line wrap in diff view |
-| `:set wrap!` | Toggle line wrap in diff view |
-| `:set commits` | Show inline commit selector |
-| `:set nocommits` | Hide inline commit selector |
-| `:set commits!` | Toggle inline commit selector |
-| `:clear` | Clear all comments |
-| `:version` | Show tuicr version |
-| `:update` | Check for updates |
-| `:q` | Quit (warns if unsaved) |
-| `:q!` | Force quit |
-| `:x` / `:wq` | Save and quit (prompts to copy if comments exist) |
-| `?` | Toggle help |
-| `q` | Quick quit |
-
-#### Commit Selection (startup)
-
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Move selection |
-| `Space` | Toggle commit selection |
-| `Enter` | Confirm and load diff |
-| `q` / `Esc` | Quit |
-
-#### Inline Commit Selector (multi-commit reviews)
-
-When reviewing multiple commits, an inline commit selector panel appears at the top of the diff view. Focus it with `;k` or `Tab`.
-
-| Key | Action |
-|-----|--------|
-| `j` / `k` | Navigate commits |
-| `Space` / `Enter` | Toggle commit selection (updates diff) |
-| `(` / `)` | Cycle through individual commits |
-| `Esc` | Return focus to diff |
-
-#### Confirm Dialogs
-
-| Key | Action |
-|-----|--------|
-| `y` / `Enter` | Yes |
-| `n` / `Esc` | No |
-
-## Review Output
-
-When you export your review (`:clip` or confirm on `:wq`), `tuicr` copies structured Markdown to your clipboard. The format is optimized for pasting into AI agent conversations:
+`y` or `:clip` copies a structured markdown block to your clipboard. Each comment has a number,
+a classification, and a file/line anchor:
 
 ```markdown
 I reviewed your code and have the following comments. Please address them.
 
 Comment types: ISSUE (problems to fix), SUGGESTION (improvements), NOTE (observations), PRAISE (positive feedback)
 
-1. **[SUGGESTION]** `src/auth.rs` - Consider adding unit tests
-2. **[ISSUE]** `src/auth.rs:42` - Magic number should be a named constant
-3. **[NOTE]** `src/auth.rs:50-55` - This block could be refactored
+1. [SUGGESTION] `src/auth.rs` - Consider adding unit tests
+2. [ISSUE] `src/auth.rs:42` - Magic number should be a named constant
+3. [NOTE] `src/auth.rs:50-55` - This block could be refactored
 ```
 
-Each comment is numbered and self-contained with its file path and line number or range (if applicable).
-If `comment_types` is configured, this legend and the `[TYPE]` tags reflect your configured labels and definitions.
+Paste it back to any coding agent (Claude, Codex, Cursor, etc).
 
-## Session Persistence
+For an agent-driven workflow where your agent opens tuicr in a tmux split pane, see
+[skills/tuicr/SKILL.md](skills/tuicr/SKILL.md).
 
-Sessions are automatically saved to `~/.local/share/tuicr/reviews/` (XDG compliant). When you reopen `tuicr` in the same repository, your previous review progress (comments, reviewed status) is restored.
+### To stdout
 
-## Agent Integrations
-
-tuicr ships a repo-managed skill bundle at `skills/tuicr/`.
-
-It opens tuicr in a tmux split pane so you can review changes interactively and feed comments back to your coding agent.
-
-**Usage:** `/tuicr` or ask your coding agent to "review my changes with tuicr".
-
-### Claude Code
-
-**Prerequisites:** Claude Code running inside tmux, tuicr installed.
-
-**Installation** (choose one):
+Run with `--stdout` to pipe the markdown to another process:
 
 ```bash
-# Copy the shared skill into Claude's local skills directory
-mkdir -p ~/.claude/skills
-cp -r /path/to/tuicr/skills/tuicr ~/.claude/skills/tuicr
+tuicr --stdout > review.md
+tuicr --stdout | pbcopy
 ```
 
-### Codex
+## Configuration
 
-**Prerequisites:** Codex running inside tmux, tuicr installed.
+Path: `~/.config/tuicr/config.toml` on Linux/macOS, `%APPDATA%\tuicr\config.toml` on Windows.
 
-**Installation**:
+```toml
+theme = "catppuccin-mocha"
+diff_view = "side-by-side"   # or "unified"
+appearance = "system"        # or "dark" / "light"
+mouse = true
 
-```bash
-# Copy the shared skill into the local agents skills directory
-mkdir -p ~/.agents/skills
-cp -r /path/to/tuicr/skills/tuicr ~/.agents/skills/tuicr
+[[comment_types]]
+id = "issue"
+color = "red"
+definition = "must fix before merge"
 ```
+
+Themes: `dark`, `light`, `ayu-light`, `ayu-mirage`, `onedark`, `github-light`, `github-dark`,
+`catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`,
+`gruvbox-dark`, `gruvbox-light`, `nord-dark`, `nord-light`, `nord-dark-high-contrast`,
+`nord-light-high-contrast`, `solarized-light`, `solarized-dark`, `tokyo-night-storm`.
+
+Full options, theme resolution precedence, `comment_types` semantics, and `.tuicrignore` rules in
+[docs/CONFIG.md](docs/CONFIG.md).
+
+## Keybindings
+
+A first-session cheatsheet. Press `?` inside tuicr for the full reference.
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Down / up |
+| `Ctrl-d` / `Ctrl-u` | Half-page down / up |
+| `g` / `G` | Top / bottom |
+| `{` / `}` | Previous / next file |
+| `[` / `]` | Previous / next hunk |
+| `/` | Search |
+| `c` / `C` | Add line / file comment |
+| `v` / `V` | Visual mode (range comment) |
+| `r` | Toggle file reviewed |
+| `y` | Copy review to clipboard |
+| `:submit` | Push review to GitHub |
+| `?` | Toggle full help |
+
+Full reference in [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md).
+
+## License
+
+MIT licensed. Contribution notes in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,124 @@
+# Configuration
+
+tuicr reads a TOML config file at startup.
+
+| Platform | Path |
+|----------|------|
+| Linux / macOS | `$XDG_CONFIG_HOME/tuicr/config.toml` (default: `~/.config/tuicr/config.toml`) |
+| Windows | `%APPDATA%\tuicr\config.toml` |
+
+Unknown keys are ignored with a startup warning.
+
+## Full example
+
+```toml
+theme = "catppuccin-mocha"
+appearance = "system"
+theme_dark = "gruvbox-dark"
+theme_light = "gruvbox-light"
+
+diff_view = "side-by-side"
+show_file_list = true
+mouse = true
+wrap = false
+cursor_line = true
+transparent_background = true
+scroll_offset = 5
+
+backend = "libgit2"
+
+comment_types = [
+  { id = "note", label = "question", definition = "ask for clarification", color = "yellow" },
+  { id = "suggestion", definition = "possible improvements" },
+  { id = "issue", definition = "problems to fix" },
+  { id = "praise", definition = "positive feedback" },
+  { id = "nit", label = "nitpick", definition = "small optional tweaks", color = "#d19a66" },
+]
+```
+
+## Options
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `theme` | (none) | Explicit theme. See [Themes](#themes) for valid values. |
+| `appearance` | `system` | `dark`, `light`, or `system`. Used when no explicit theme is set. |
+| `theme_dark` | (none) | Theme for dark appearance (paired with `theme_light`). |
+| `theme_light` | (none) | Theme for light appearance (paired with `theme_dark`). |
+| `diff_view` | `unified` | `unified` or `side-by-side`. Toggle in-app with `:diff`. |
+| `show_file_list` | `true` | Whether the file list panel is visible on startup. Toggle with `;e`. |
+| `mouse` | `true` | Wheel scrolling, clicks, and drag-to-select. |
+| `wrap` | `false` | Line wrap in the diff view. Toggle with `:set wrap!`. |
+| `cursor_line` | `true` | Highlight the current cursor line and visual selection. |
+| `transparent_background` | `true` | Let the terminal background show through panels. `false` paints the theme's `panel_bg`. |
+| `scroll_offset` | `0` | Minimum lines visible above and below the cursor when scrolling (like Vim's `scrolloff`). |
+| `backend` | `libgit2` | Git backend: `libgit2` or `cli`. Sparse-checkout repos auto-route to `cli`. |
+| `comment_types` | (built-in) | Comment categories. See [Comment types](#comment-types). |
+
+## Themes
+
+Built-in themes:
+
+`dark`, `light`, `ayu-light`, `ayu-mirage`, `onedark`, `github-light`, `github-dark`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`, `gruvbox-dark`, `gruvbox-light`, `nord-dark`, `nord-light`, `nord-dark-high-contrast`, `nord-light-high-contrast`, `solarized-light`, `solarized-dark`, `tokyo-night-storm`.
+
+### Resolution precedence
+
+When multiple sources are set, tuicr resolves the theme in this order:
+
+1. `--theme <THEME>` flag
+2. `theme` in the config file
+3. `theme_dark` + `theme_light` in config (chosen by appearance)
+4. `theme_dark` alone or `theme_light` alone in config (appearance ignored)
+5. `--appearance <MODE>` flag (only when no explicit theme or variants are set)
+6. `appearance` in config (only when no explicit theme or variants are set)
+7. Built-in default (`system`)
+
+Invalid `--theme` values cause an immediate non-zero exit.
+
+## Comment types
+
+Comment categories control:
+
+- The classification badge shown in the TUI (color + label)
+- The `[TYPE]` tag in the exported markdown
+- The Tab cycle order in comment mode
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | yes | Stable internal value. Saved in sessions and used for matching. |
+| `label` | no | Visible tag in UI and export (`[QUESTION]`, `[NITPICK]`). Defaults to `id` uppercased. |
+| `definition` | no | Guidance text for LLMs, included in the exported `Comment types:` legend. |
+| `color` | no | Comment badge / border color. Terminal name (`yellow`, `light_red`) or hex (`#RRGGBB`). |
+
+### Defaults
+
+If `comment_types` is missing, tuicr uses: `note`, `suggestion`, `issue`, `praise`.
+
+### Replacement semantics
+
+`comment_types` is a full replacement. If you define 2 types, only those 2 are available. Invalid entries are ignored with startup warnings; if every entry is invalid, tuicr falls back to defaults.
+
+### Minimal example
+
+```toml
+comment_types = [
+  { id = "question", definition = "ask for clarification" },
+  { id = "blocker", color = "red", definition = "must be fixed before merge" },
+]
+```
+
+## .tuicrignore
+
+tuicr reads `.tuicrignore` from the repository root and excludes matching files from all review diffs. Rules follow gitignore-style pattern matching, including `!` negation.
+
+`.gitignore` is also honored automatically.
+
+Example:
+
+```gitignore
+target/
+dist/
+*.lock
+!Cargo.lock
+```

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -1,0 +1,151 @@
+# Keybindings
+
+Full reference. Press `?` inside tuicr for an in-app version of this list.
+
+## Navigation
+
+| Key | Action |
+|-----|--------|
+| `j` / `↓` | Scroll down |
+| `k` / `↑` | Scroll up |
+| `h` / `←` | Scroll left |
+| `l` / `→` | Scroll right |
+| `Ctrl-d` / `Ctrl-u` | Half page down / up |
+| `Ctrl-f` / `Ctrl-b` | Full page down / up |
+| `g` / `G` | Go to first / last file |
+| `{N}G` | Go to source line N in current file |
+| `{` / `}` | Jump to previous / next file |
+| `[` / `]` | Jump to previous / next hunk |
+| `/` | Search within diff |
+| `n` / `N` | Next / previous search match |
+| `Enter` | Expand or collapse hidden context between hunks |
+| `zt` | Scroll cursor to top of screen |
+| `zz` | Center cursor on screen |
+| `zb` | Scroll cursor to bottom of screen |
+
+## File tree
+
+| Key | Action |
+|-----|--------|
+| `Space` | Toggle expand directory |
+| `Enter` | Expand directory / jump to file in diff |
+| `o` | Expand all directories |
+| `O` | Collapse all directories |
+
+## Panel focus
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift-Tab` | Cycle focus forward / backward between file list, diff, and commit selector |
+| `;h` | Focus file list (left panel) |
+| `;l` | Focus diff view (right panel) |
+| `;k` | Focus commit selector (top panel) |
+| `;j` | Focus diff view |
+| `;e` | Toggle file list visibility |
+| `Enter` | Select file (when file list is focused) |
+
+## Review actions
+
+| Key | Action |
+|-----|--------|
+| `r` | Toggle file reviewed |
+| `c` | Add line comment (or file comment if not on a diff line) |
+| `C` | Add file comment |
+| `;c` | Add review comment |
+| `v` / `V` | Enter visual mode for range comments |
+| `dd` | Delete comment at cursor |
+| `i` | Edit comment at cursor |
+| `y` | Copy review to clipboard |
+
+## Visual mode
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Extend selection down / up |
+| `c` / `Enter` | Create comment for selected range |
+| `Esc` / `v` / `V` | Cancel selection |
+
+## Comment mode
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift-Tab` | Cycle comment type forward / backward (per `comment_types` order) |
+| `Enter` / `Ctrl-Enter` / `Ctrl-s` | Save comment |
+| `Shift-Enter` / `Ctrl-j` | Insert newline |
+| `←` / `→` | Move cursor |
+| `Ctrl-w` / `Alt-Backspace` / `Cmd-Backspace` | Delete word |
+| `Ctrl-u` | Clear line |
+| `Esc` / `Ctrl-c` | Cancel |
+
+## Commands
+
+| Command | Action |
+|---------|--------|
+| `:w` | Save session |
+| `:e` (`:reload`) | Reload diff files |
+| `:clip` (`:export`) | Copy review to clipboard |
+| `:diff` | Toggle diff view (unified / side-by-side) |
+| `:commits` | Select commits to review |
+| `:submit` | Open submit picker (Comment / Approve / Request changes / Draft) |
+| `:submit comment` | Submit a Comment review |
+| `:submit approve` | Submit an Approve review |
+| `:submit request-changes` | Submit a Request-changes review |
+| `:submit draft` | Submit a Draft review (pending on GitHub) |
+| `:set wrap` | Enable line wrap in diff view |
+| `:set wrap!` | Toggle line wrap in diff view |
+| `:set commits` | Show inline commit selector |
+| `:set nocommits` | Hide inline commit selector |
+| `:set commits!` | Toggle inline commit selector |
+| `:clear` | Clear all comments |
+| `:clearc` | Clear comments without clearing reviewed marks |
+| `:version` | Show tuicr version |
+| `:update` | Check for updates |
+| `:q` | Quit (warns if unsaved) |
+| `:q!` | Force quit |
+| `:x` / `:wq` | Save and quit (prompts to copy if comments exist) |
+| `ZZ` | Save and quit |
+| `ZQ` | Quit without saving |
+| `?` | Toggle help |
+| `q` | Quick quit |
+
+## Commit selection (startup)
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Move selection |
+| `Space` | Toggle commit selection |
+| `Enter` | Confirm and load diff |
+| `q` / `Esc` | Quit |
+
+## Inline commit selector
+
+Shown at the top of the diff when reviewing multiple commits. Focus it with `;k` or `Tab`.
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Navigate commits |
+| `Space` / `Enter` | Toggle commit selection (updates diff) |
+| `(` / `)` | Cycle through individual commits |
+| `Esc` | Return focus to diff |
+
+## Confirm dialogs
+
+| Key | Action |
+|-----|--------|
+| `y` / `Enter` | Yes |
+| `n` / `Esc` | No |
+
+## Mouse
+
+Mouse support is on by default. Disable with `mouse = false` in config.
+
+| Action | Effect |
+|--------|--------|
+| Wheel up / down | Scroll the panel under the cursor (file list, diff, commit list, or help popup) without moving the cursor line |
+| Click on a file | Jump to that file (lazygit-style) |
+| Click on a directory | Expand or collapse it |
+| Click on a diff line | Position the cursor on that line |
+| Click on a commit | Toggle selection (or expand the row to load more) |
+| Drag in diff | Highlight a range; press `y` to copy the selected source lines |
+
+For full native terminal selection across the UI, hold your terminal's bypass modifier while dragging (usually **Shift** or **Option/Alt**, depending on the terminal).

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1714,7 +1714,7 @@ fn print_help() -> ! {
     let appearance_values = AppearanceArg::valid_values_display();
     let config_path = config_path_hint();
     println!(
-        "tuicr - Review AI-generated diffs like a GitHub pull request
+        "tuicr - A code review TUI with vim keybindings. Export to GitHub or clipboard.
 
 Usage: {name} [OPTIONS]
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -227,6 +227,33 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
+            "Submit Action Picker (PR mode)",
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  j/k       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Navigate review events"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Enter     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Submit the selected event"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  Esc       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Cancel"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
             "File Tree",
             Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )),
@@ -332,7 +359,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  j/k       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Extend selection up/down"),
+            Span::raw("Extend selection down/up"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
## Summary

Final slice of the [forge integration v1](../blob/main/docs/forge-integration-v1-spec.md). Docs + polish only — no behavior changes.

README rewritten from scratch around terminal code review, with three export targets surfaced as their own section. Adds a "How it compares" matrix vs hunk, lumen, `gh pr review`, and `git diff`. Keybinding and configuration reference migrated to `docs/` so the README itself stays under 200 lines. AGENTS.md absorbs the hard-won lessons that should outlast the spec doc.

### README.md (rewrite from scratch)

Replaces the previous "Local mode / PR mode (experimental)" framing. Net diff: ~410 lines → ~180 lines.

- **Tagline:** *A code review TUI with vim keybindings. Export to GitHub or clipboard.*
- **What it does** — 4-bullet feature summary.
- **Install** — `curl -fsSL tuicr.dev/install.sh | sh` and `brew install agavra/tap/tuicr` as the two visible options; cargo, mise, nix, binaries, source folded into a `<details>` block.
- **Quick start** — 5 invocation examples (`tuicr`, `-w`, `-r main..HEAD`, `pr 125`, `--stdout`) plus a one-line workflow teaser.
- **How it compares** — 8-row matrix vs hunk, lumen, `gh pr review`, and `git diff`, with footnotes for nuanced cells.
- **Export your review** — three equal subsections covering GitHub `:submit`, agent-ready clipboard via `y`/`:clip`, and `--stdout` for piping.
- **Configuration** — minimal example, theme list, link to `docs/CONFIG.md`.
- **Keybindings** — 12-row cheatsheet, link to `docs/KEYBINDINGS.md`.
- Drops the old "Why I built this" section.

### docs/KEYBINDINGS.md (new)

Full keybinding reference. Carries the 11 tables that were previously inline in the README (Navigation, File tree, Panel focus, Review actions, Visual mode, Comment mode, Commands, Commit selection, Inline commit selector, Confirm dialogs, Mouse). All `:submit*` variants documented.

### docs/CONFIG.md (new)

Full configuration reference. Every option in a table with defaults, theme list and resolution precedence (7 steps), full `comment_types` semantics with replacement rules, and `.tuicrignore` rules.

### src/theme/mod.rs

`--help` tagline updated from *"Review AI-generated diffs like a GitHub pull request"* to match the new README tagline. One-line change.

### AGENTS.md (unchanged from earlier PR work)

- Project tree updated with the full `src/forge/` subtree (`traits.rs`, `submit.rs`, `pr_open.rs`, `context.rs`, `remote_comments.rs`, and `github/{gh,models,review_threads,submit}.rs`).
- New "Forge integration" section covers `ForgeBackend` trait surface, the network-bg / parse-main split, mpsc + poll pattern, session-key shape, comment lifecycle (`local_draft | pushed_draft | submitted`), and submit pipeline (preflight → resolver → confirm → `gh api --input -`).
- "Hard-won gotchas" subsection captures the 12 lessons accumulated through PRs 1-6.

### src/ui/help_popup.rs (unchanged from earlier PR work)

- Added "Submit Action Picker (PR mode)" section.
- Fixed long-standing Visual Mode `j/k` description ("up/down" → "down/up").

## Companion change (separate branch)

`install.sh` is on the `site` branch and serves at `tuicr.dev/install.sh` so the curl one-liner in the README works. POSIX `sh`, supports macOS / Linux / MINGW, x86_64 / aarch64. Shows an install plan, prompts for confirmation via `/dev/tty` (or `TUICR_INSTALL_YES=1` to skip), and emits light color when stdout is a tty (honors `NO_COLOR`).

## Reviewer attention

- The README drops the "experimental" callout on PR mode. `:submit` and `tuicr pr <target>` are present-tense features in the new framing, not previews. Confirm this matches your release intent.
- The matrix calls out three "agent-only" / "partial" cells with footnotes — sanity-check the hunk / lumen / `gh pr review` claims before merge.
- New `docs/` directory replaces the inline keybinding/config tables. The cross-references in the README point at `docs/KEYBINDINGS.md` and `docs/CONFIG.md` and will resolve once merged.

## Test plan

- [x] cargo fmt
- [ ] cargo clippy --all-targets --all-features -- -D warnings
- [ ] cargo test
- [ ] Manual: render the README on github.com and verify the matrix table, the install `<details>` block, and `docs/` links resolve.
- [ ] Manual: `tuicr --help` shows the new tagline.
- [ ] Manual: open help popup in tuicr (`?`) and scroll past the Submit Action Picker section.