### PR TITLE
app: select only cursor commit from all-selected state

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3816,6 +3816,13 @@ impl App {
                 self.commit_selection_range = Some((cursor, cursor));
             }
             Some((start, end)) => {
+                let all_commits_selected =
+                    self.commit_list.len() > 1 && start == 0 && end == self.commit_list.len() - 1;
+                if all_commits_selected {
+                    self.commit_selection_range = Some((cursor, cursor));
+                    return;
+                }
+
                 if cursor >= start && cursor <= end {
                     // Cursor is within the range - shrink or deselect
                     if start == end {
@@ -5231,6 +5238,38 @@ mod commit_selection_tests {
         let app = build_app(vec![normal_commit("abc123"), App::staged_commit_entry()]);
 
         assert_eq!(app.special_commit_count(), 0);
+    }
+
+    #[test]
+    fn toggle_commit_selection_from_all_selected_selects_only_cursor() {
+        for cursor in 0..3 {
+            let mut app = build_app(vec![
+                normal_commit("abc123"),
+                normal_commit("def456"),
+                normal_commit("789abc"),
+            ]);
+            app.commit_selection_range = Some((0, 2));
+            app.commit_list_cursor = cursor;
+
+            app.toggle_commit_selection();
+
+            assert_eq!(app.commit_selection_range, Some((cursor, cursor)));
+        }
+    }
+
+    #[test]
+    fn toggle_commit_selection_keeps_partial_range_shrink_behavior() {
+        let mut app = build_app(vec![
+            normal_commit("abc123"),
+            normal_commit("def456"),
+            normal_commit("789abc"),
+        ]);
+        app.commit_selection_range = Some((0, 1));
+        app.commit_list_cursor = 0;
+
+        app.toggle_commit_selection();
+
+        assert_eq!(app.commit_selection_range, Some((1, 1)));
     }
 }
 


### PR DESCRIPTION
## Summary
- When every commit is selected in the inline commit selector, the first toggle now selects only the cursor commit.
- Keeps the existing partial-range shrink behavior for non-all-selected ranges.
- Adds regression coverage for first, middle, and last cursor positions in the all-selected state.

Fixes #299

## Test plan
- [x] `cargo fmt`
- [x] `git diff --check`
- [x] `cargo test commit_selection` — all 4 commit selection tests pass
- [x] `cargo test` — all 402 tests pass, 1 ignored, when run outside the sandbox
- [x] Manual: run `cargo run`, focus the commit selector, press Space on a commit while all commits are selected, and confirm only that commit remains selected