### PR TITLE
Use clap for CLI parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Repository-managed agent integrations:
 ### Dependencies
 
 - `ratatui` + `crossterm`: TUI framework
+- `clap`: CLI argument parsing
 - `git2`: Native git operations
 - `serde` + `serde_json`: Session serialization
 - `toml`: User config parsing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +270,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,6 +317,12 @@ checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
@@ -1046,6 +1142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,6 +1532,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
@@ -2518,6 +2626,7 @@ dependencies = [
  "arboard",
  "base64",
  "chrono",
+ "clap",
  "crossterm",
  "directories",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Utilities
+clap = { version = "4.5", features = ["derive"] }
 directories = "6.0"
 ureq = { version = "3", features = ["json"] }
 unicode-width = "0.2"

--- a/README.md
+++ b/README.md
@@ -104,12 +104,18 @@ Detection order: Jujutsu → Git → Mercurial. Jujutsu is tried first because j
 | `-r` / `--revisions <REVSET>` | Commit range/Revision set to review. Exact syntax depends on VCS backend (Git, JJ, Hg) |
 | `--theme <THEME>` | Color theme override (`dark`, `light`, `ayu-light`, `onedark`, `github-light`, `github-dark`, `catppuccin-latte`, `catppuccin-frappe`, `catppuccin-macchiato`, `catppuccin-mocha`, `gruvbox-dark`, `gruvbox-light`, `nord-dark`, `nord-light`, `nord-dark-high-contrast`, `nord-light-high-contrast`, `solarized-light`, `solarized-dark`, `tokyo-night-storm`) |
 | `--appearance <MODE>` | Appearance mode for default theme (`dark`, `light`, `system`) |
+| `-p` / `--path <PATH>` | Filter diff to a specific file or directory |
+| `-w` / `--working-tree` | Include uncommitted changes |
+| `--file <PATH>` | Open a file for annotation without VCS |
 | `--stdout` | Output to stdout instead of clipboard when exporting |
 | `--no-update-check` | Skip checking for updates on startup |
+| `-V` / `--version` | Print version |
+| `-h` / `--help` | Print help |
 
 By default, `tuicr` starts in commit selection mode.  
 If staged or unstaged changes exist, the first selectable entries are `Staged changes` and/or `Unstaged changes`.  
 When `-r` / `--revisions` is provided, `tuicr` opens that revision range directly.
+Invalid or unknown CLI arguments exit non-zero.
 On narrow terminals (less than 100 columns), `tuicr` starts with the file list hidden; toggle it with `;e`.
 
 ### Configuration

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -2,8 +2,9 @@
 //!
 //! Provides dark and light themes with automatic terminal background detection.
 
-use std::{process::Command, sync::OnceLock};
+use std::{ffi::OsString, process::Command, sync::OnceLock};
 
+use clap::{CommandFactory, FromArgMatches, Parser};
 use ratatui::style::Color;
 use two_face::theme::EmbeddedThemeName;
 
@@ -1371,6 +1372,64 @@ pub struct CliArgs {
     pub file_path: Option<String>,
 }
 
+/// Raw clap-backed command-line arguments.
+#[derive(Debug, Clone, Parser)]
+#[command(
+    name = "tuicr",
+    version,
+    about = "Review AI-generated diffs like a GitHub pull request",
+    args_override_self = true,
+    disable_help_subcommand = true
+)]
+struct RawCliArgs {
+    /// Commit range/Revset to review. Syntax depends on VCS backend.
+    #[arg(short = 'r', long = "revisions", value_name = "REVSET", value_parser = parse_non_empty_value)]
+    revisions: Option<String>,
+
+    /// Color theme to use.
+    #[arg(long = "theme", value_name = "THEME", value_parser = parse_theme_arg)]
+    theme: Option<ThemeArg>,
+
+    /// Appearance mode for default theme. Used when no explicit theme is set.
+    #[arg(long = "appearance", value_name = "MODE", value_parser = parse_appearance_arg)]
+    appearance: Option<AppearanceArg>,
+
+    /// Filter diff to a specific file or directory.
+    #[arg(short = 'p', long = "path", value_name = "PATH", value_parser = parse_non_empty_value)]
+    path_filter: Option<String>,
+
+    /// Include uncommitted changes.
+    #[arg(short = 'w', long = "working-tree")]
+    working_tree: bool,
+
+    /// Open a file for annotation without VCS.
+    #[arg(long = "file", value_name = "PATH", value_parser = parse_non_empty_value)]
+    file_path: Option<String>,
+
+    /// Output to stdout instead of clipboard when exporting.
+    #[arg(long = "stdout")]
+    output_to_stdout: bool,
+
+    /// Skip checking for updates on startup.
+    #[arg(long = "no-update-check")]
+    no_update_check: bool,
+}
+
+impl From<RawCliArgs> for CliArgs {
+    fn from(raw: RawCliArgs) -> Self {
+        Self {
+            theme: raw.theme,
+            appearance: raw.appearance,
+            output_to_stdout: raw.output_to_stdout,
+            no_update_check: raw.no_update_check,
+            revisions: raw.revisions,
+            working_tree: raw.working_tree,
+            path_filter: raw.path_filter,
+            file_path: raw.file_path,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AppearanceArg {
     Light,
@@ -1692,204 +1751,68 @@ impl Theme {
     }
 }
 
-/// Print version and exit
-fn print_version() -> ! {
-    println!("tuicr {}", env!("CARGO_PKG_VERSION"));
-    std::process::exit(0);
-}
-
-/// Print help message and exit
-fn print_help() -> ! {
-    let name = std::env::args()
-        .next()
-        .and_then(|p| {
-            std::path::Path::new(&p)
-                .file_name()
-                .map(|s| s.to_string_lossy().into_owned())
-        })
-        .unwrap_or_else(|| "tuicr".to_string());
-    let valid_values = ThemeArg::valid_values_display();
-    let appearance_values = AppearanceArg::valid_values_display();
+fn build_cli_command() -> clap::Command {
     let config_path = config_path_hint();
-    println!(
-        "tuicr - Review AI-generated diffs like a GitHub pull request
-
-Usage: {name} [OPTIONS]
-
-Options:
-  -r, --revisions <REVSET>  Commit range/Revset to review (syntax depends on VCS backend)
-  --theme <THEME>        Color theme to use
-                          Valid values: {valid_values}
-  --appearance <MODE>    Appearance mode for default theme
-                         Valid values: {appearance_values}
-                         Used when no explicit theme is set
-                         Precedence: --appearance > {config_path} > system
-  -p, --path <PATH>     Filter diff to a specific file or directory
-  -w, --working-tree     Include uncommitted changes (skip commit selector when used alone,
-                         combine with commits when used with -r)
-  --file <PATH>          Open a file for annotation (no VCS required)
-  --stdout               Output to stdout instead of clipboard when exporting
-  --no-update-check      Skip checking for updates on startup
-  -V, --version          Print version
-  -h, --help             Print this help message
-
-Press ? in the application for keybinding help."
-    );
-    std::process::exit(0);
+    RawCliArgs::command().after_help(format!(
+        "Theme values: {}\nAppearance values: {}\nAppearance precedence: --appearance > {config_path} > system\n\nPress ? in the application for keybinding help.",
+        ThemeArg::valid_values_display(),
+        AppearanceArg::valid_values_display(),
+    ))
 }
 
-/// Parse CLI arguments from command line
-///
-/// We use a handrolled argument parser instead of clap to keep binary size
-/// small and build times fast. If we end up needing more complex argument
-/// handling, we can revisit this decision.
-pub fn parse_cli_args() -> CliArgs {
-    let args: Vec<String> = std::env::args().collect();
-    parse_cli_args_from(&args).unwrap_or_else(|err| {
-        eprintln!("Error: {err}");
-        std::process::exit(2);
+fn parse_theme_arg(value: &str) -> Result<ThemeArg, String> {
+    if value.is_empty() {
+        return Err(format!(
+            "--theme requires a value ({})",
+            ThemeArg::valid_values_display()
+        ));
+    }
+
+    ThemeArg::from_str(value).ok_or_else(|| {
+        format!(
+            "Unknown theme '{value}'. Valid options: {}",
+            ThemeArg::valid_values_display()
+        )
     })
 }
 
-fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
-    let mut cli_args = CliArgs::default();
-
-    for i in 0..args.len() {
-        // Handle --version / -V
-        if args[i] == "--version" || args[i] == "-V" {
-            print_version();
-        }
-
-        // Handle --help / -h
-        if args[i] == "--help" || args[i] == "-h" {
-            print_help();
-        }
-
-        // Handle --stdout
-        if args[i] == "--stdout" {
-            cli_args.output_to_stdout = true;
-        }
-
-        // Handle --no-update-check
-        if args[i] == "--no-update-check" {
-            cli_args.no_update_check = true;
-        }
-
-        // Handle -w / --working-tree
-        if args[i] == "-w" || args[i] == "--working-tree" {
-            cli_args.working_tree = true;
-        }
-
-        // Handle --theme value
-        if args[i] == "--theme" {
-            let valid_values = ThemeArg::valid_values_display();
-            let value = args
-                .get(i + 1)
-                .ok_or_else(|| format!("--theme requires a value ({valid_values})"))?;
-
-            if value.starts_with('-') {
-                return Err(format!("--theme requires a value ({valid_values})"));
-            }
-
-            cli_args.theme = ThemeArg::from_str(value)
-                .ok_or_else(|| format!("Unknown theme '{value}'. Valid options: {valid_values}"))
-                .map(Some)?;
-        }
-        // Handle --theme=value
-        if let Some(value) = args[i].strip_prefix("--theme=") {
-            let valid_values = ThemeArg::valid_values_display();
-            if value.is_empty() {
-                return Err(format!("--theme requires a value ({valid_values})"));
-            }
-
-            cli_args.theme = ThemeArg::from_str(value)
-                .ok_or_else(|| format!("Unknown theme '{value}'. Valid options: {valid_values}"))
-                .map(Some)?;
-        }
-
-        // Handle --appearance value
-        if args[i] == "--appearance" {
-            let valid_values = AppearanceArg::valid_values_display();
-            let value = args
-                .get(i + 1)
-                .ok_or_else(|| format!("--appearance requires a value ({valid_values})"))?;
-
-            if value.starts_with('-') {
-                return Err(format!("--appearance requires a value ({valid_values})"));
-            }
-
-            cli_args.appearance = AppearanceArg::from_str(value)
-                .ok_or_else(|| {
-                    format!("Unknown appearance '{value}'. Valid options: {valid_values}")
-                })
-                .map(Some)?;
-        }
-
-        // Handle --appearance=value
-        if let Some(value) = args[i].strip_prefix("--appearance=") {
-            let valid_values = AppearanceArg::valid_values_display();
-            if value.is_empty() {
-                return Err(format!("--appearance requires a value ({valid_values})"));
-            }
-
-            cli_args.appearance = AppearanceArg::from_str(value)
-                .ok_or_else(|| {
-                    format!("Unknown appearance '{value}'. Valid options: {valid_values}")
-                })
-                .map(Some)?;
-        }
-
-        // Handle -p / --path value
-        if args[i] == "-p" || args[i] == "--path" {
-            let value = args
-                .get(i + 1)
-                .ok_or_else(|| "--path requires a file or directory path".to_string())?;
-            if value.starts_with('-') {
-                return Err("--path requires a file or directory path".to_string());
-            }
-            cli_args.path_filter = Some(value.clone());
-        }
-        // Handle --path=value
-        if let Some(value) = args[i].strip_prefix("--path=") {
-            if value.is_empty() {
-                return Err("--path requires a file or directory path".to_string());
-            }
-            cli_args.path_filter = Some(value.to_string());
-        }
-
-        // Handle --file value
-        if args[i] == "--file" {
-            let value = args
-                .get(i + 1)
-                .ok_or_else(|| "--file requires a file path".to_string())?;
-            if value.starts_with('-') {
-                return Err("--file requires a file path".to_string());
-            }
-            cli_args.file_path = Some(value.clone());
-        }
-        // Handle --file=value
-        if let Some(value) = args[i].strip_prefix("--file=") {
-            if value.is_empty() {
-                return Err("--file requires a file path".to_string());
-            }
-            cli_args.file_path = Some(value.to_string());
-        }
-
-        // Handle -r / --revisions value
-        if args[i] == "-r" || args[i] == "--revisions" {
-            if let Some(value) = args.get(i + 1) {
-                cli_args.revisions = Some(value.clone());
-            } else {
-                eprintln!("Warning: {0} requires a value", args[i]);
-            }
-        }
-        // Handle --revisions=value
-        if let Some(value) = args[i].strip_prefix("--revisions=") {
-            cli_args.revisions = Some(value.to_string());
-        }
+fn parse_appearance_arg(value: &str) -> Result<AppearanceArg, String> {
+    if value.is_empty() {
+        return Err(format!(
+            "--appearance requires a value ({})",
+            AppearanceArg::valid_values_display()
+        ));
     }
 
-    Ok(cli_args)
+    AppearanceArg::from_str(value).ok_or_else(|| {
+        format!(
+            "Unknown appearance '{value}'. Valid options: {}",
+            AppearanceArg::valid_values_display()
+        )
+    })
+}
+
+fn parse_non_empty_value(value: &str) -> Result<String, String> {
+    if value.is_empty() {
+        Err("value cannot be empty".to_string())
+    } else {
+        Ok(value.to_string())
+    }
+}
+
+/// Parse CLI arguments from command line
+pub fn parse_cli_args() -> CliArgs {
+    parse_cli_args_from(std::env::args_os()).unwrap_or_else(|err| err.exit())
+}
+
+fn parse_cli_args_from<I, T>(args: I) -> Result<CliArgs, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let matches = build_cli_command().try_get_matches_from(args)?;
+    let raw = RawCliArgs::from_arg_matches(&matches)?;
+    Ok(raw.into())
 }
 
 #[cfg(test)]
@@ -1897,9 +1820,15 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    fn parse_for_test(args: &[&str]) -> Result<CliArgs, String> {
+    fn parse_for_test(args: &[&str]) -> Result<CliArgs, clap::Error> {
         let args = args.iter().map(|s| s.to_string()).collect::<Vec<_>>();
-        parse_cli_args_from(&args)
+        parse_cli_args_from(args)
+    }
+
+    fn parse_error_for_test(args: &[&str]) -> String {
+        parse_for_test(args)
+            .expect_err("parse should fail")
+            .to_string()
     }
 
     #[test]
@@ -1977,21 +1906,61 @@ mod tests {
     }
 
     #[test]
+    fn should_parse_revisions_long_flag() {
+        let parsed = parse_for_test(&["tuicr", "--revisions", "main..feature"])
+            .expect("parse should succeed");
+        assert_eq!(parsed.revisions, Some("main..feature".to_string()));
+    }
+
+    #[test]
+    fn should_parse_revisions_equals_syntax() {
+        let parsed =
+            parse_for_test(&["tuicr", "--revisions=HEAD~2.."]).expect("parse should succeed");
+        assert_eq!(parsed.revisions, Some("HEAD~2..".to_string()));
+    }
+
+    #[test]
+    fn should_error_when_revisions_value_missing() {
+        let err = parse_error_for_test(&["tuicr", "--revisions"]);
+        assert!(err.contains("--revisions"));
+        assert!(err.contains("value"));
+    }
+
+    #[test]
+    fn should_error_when_revisions_equals_empty() {
+        let err = parse_error_for_test(&["tuicr", "--revisions="]);
+        assert!(err.contains("value cannot be empty"));
+    }
+
+    #[test]
+    fn should_parse_stdout_flag() {
+        let parsed = parse_for_test(&["tuicr", "--stdout"]).expect("parse should succeed");
+        assert!(parsed.output_to_stdout);
+    }
+
+    #[test]
+    fn should_parse_no_update_check_flag() {
+        let parsed = parse_for_test(&["tuicr", "--no-update-check"]).expect("parse should succeed");
+        assert!(parsed.no_update_check);
+    }
+
+    #[test]
     fn should_error_for_invalid_theme_in_separate_arg() {
-        let err = parse_for_test(&["tuicr", "--theme", "nope"]).expect_err("parse should fail");
+        let err = parse_error_for_test(&["tuicr", "--theme", "nope"]);
         assert!(err.contains("Unknown theme 'nope'"));
     }
 
     #[test]
     fn should_error_for_invalid_theme_in_equals_arg() {
-        let err = parse_for_test(&["tuicr", "--theme=nope"]).expect_err("parse should fail");
+        let err = parse_error_for_test(&["tuicr", "--theme=nope"]);
         assert!(err.contains("Unknown theme 'nope'"));
     }
 
     #[test]
     fn should_error_when_theme_value_missing() {
-        let err = parse_for_test(&["tuicr", "--theme"]).expect_err("parse should fail");
-        assert!(err.contains("--theme requires a value"));
+        let err = parse_error_for_test(&["tuicr", "--theme"]);
+        assert!(err.contains("--theme"));
+        assert!(err.contains("value"));
     }
 
     #[test]
@@ -2003,8 +1972,7 @@ mod tests {
 
     #[test]
     fn should_error_for_invalid_appearance() {
-        let err =
-            parse_for_test(&["tuicr", "--appearance", "nope"]).expect_err("parse should fail");
+        let err = parse_error_for_test(&["tuicr", "--appearance", "nope"]);
         assert!(err.contains("Unknown appearance 'nope'"));
     }
 
@@ -2255,14 +2223,54 @@ mod tests {
 
     #[test]
     fn should_error_when_path_value_missing() {
-        let err = parse_for_test(&["tuicr", "--path"]).expect_err("parse should fail");
-        assert!(err.contains("--path requires a file or directory path"));
+        let err = parse_error_for_test(&["tuicr", "--path"]);
+        assert!(err.contains("--path"));
+        assert!(err.contains("value"));
     }
 
     #[test]
     fn should_error_when_path_equals_empty() {
-        let err = parse_for_test(&["tuicr", "--path="]).expect_err("parse should fail");
-        assert!(err.contains("--path requires a file or directory path"));
+        let err = parse_error_for_test(&["tuicr", "--path="]);
+        assert!(err.contains("value cannot be empty"));
+    }
+
+    #[test]
+    fn should_error_for_unknown_short_flag_cluster() {
+        let err = parse_error_for_test(&["tuicr", "-version"]);
+        assert!(err.contains("unexpected argument") || err.contains("unknown argument"));
+    }
+
+    #[test]
+    fn should_error_for_unknown_long_flag() {
+        let err = parse_error_for_test(&["tuicr", "--unknown"]);
+        assert!(err.contains("--unknown"));
+    }
+
+    #[test]
+    fn should_parse_file_path() {
+        let parsed =
+            parse_for_test(&["tuicr", "--file", "notes.md"]).expect("parse should succeed");
+        assert_eq!(parsed.file_path, Some("notes.md".to_string()));
+    }
+
+    #[test]
+    fn should_parse_file_equals_syntax() {
+        let parsed =
+            parse_for_test(&["tuicr", "--file=docs/review.md"]).expect("parse should succeed");
+        assert_eq!(parsed.file_path, Some("docs/review.md".to_string()));
+    }
+
+    #[test]
+    fn should_error_when_file_value_missing() {
+        let err = parse_error_for_test(&["tuicr", "--file"]);
+        assert!(err.contains("--file"));
+        assert!(err.contains("value"));
+    }
+
+    #[test]
+    fn should_error_when_file_equals_empty() {
+        let err = parse_error_for_test(&["tuicr", "--file="]);
+        assert!(err.contains("value cannot be empty"));
     }
 
     #[test]
@@ -2285,5 +2293,45 @@ mod tests {
             .expect("parse should succeed");
         assert_eq!(parsed.path_filter, Some("src/".to_string()));
         assert_eq!(parsed.revisions, Some("HEAD~3..".to_string()));
+    }
+
+    #[test]
+    fn should_parse_multiple_cli_options_together() {
+        let parsed = parse_for_test(&[
+            "tuicr",
+            "--theme",
+            "github-dark",
+            "--appearance",
+            "dark",
+            "--stdout",
+            "--no-update-check",
+            "-w",
+            "-p",
+            "src",
+            "-r",
+            "main..feature",
+        ])
+        .expect("parse should succeed");
+
+        assert_eq!(parsed.theme, Some(ThemeArg::GithubDark));
+        assert_eq!(parsed.appearance, Some(AppearanceArg::Dark));
+        assert!(parsed.output_to_stdout);
+        assert!(parsed.no_update_check);
+        assert!(parsed.working_tree);
+        assert_eq!(parsed.path_filter, Some("src".to_string()));
+        assert_eq!(parsed.revisions, Some("main..feature".to_string()));
+    }
+
+    #[test]
+    fn should_return_help_without_parsing_app_args() {
+        let err = parse_for_test(&["tuicr", "--help"]).expect_err("help should short-circuit");
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    #[test]
+    fn should_return_version_without_parsing_app_args() {
+        let err =
+            parse_for_test(&["tuicr", "--version"]).expect_err("version should short-circuit");
+        assert_eq!(err.kind(), clap::error::ErrorKind::DisplayVersion);
     }
 }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled CLI argument parser with a clap-backed parser while preserving the existing `CliArgs` shape used by startup code.
- Reject unknown or malformed arguments at parse time, including `-version` and missing values for `--revisions`.
- Update CLI documentation and dependency notes for the new parser.

## Why

Fixes #226. The previous parser ignored unknown arguments and could continue into app startup, so inputs like `-version` were not reported as invalid.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- Compared installed `tuicr` with the modified build for `--version`, `-V`, `--help`, `-version`, `--unknown`, invalid `--theme`, and missing-value flags.
