### PR TITLE
ui: make it more beauitful

### DIFF
--- a/src/ui/commit_row.rs
+++ b/src/ui/commit_row.rs
@@ -1,0 +1,280 @@
+//! Shared commit-row rendering used by both the fullscreen review-target
+//! selector and the inline commit selector shown above the diff. Keeps the
+//! row layout (cursor arrow, range bar, checkbox, hash, branch chip, summary,
+//! author/date) consistent across surfaces.
+
+use chrono::{DateTime, Utc};
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+
+use crate::app::{STAGED_SELECTION_ID, UNSTAGED_SELECTION_ID};
+use crate::theme::Theme;
+use crate::ui::styles;
+use crate::ui::text_utils::truncate_str;
+use crate::vcs::CommitInfo;
+
+pub const CURSOR_GLYPH: &str = "\u{25b8}"; // ▸
+pub const RANGE_BAR_GLYPH: &str = "\u{258c}"; // ▌
+pub const SELECTED_BOX_GLYPH: &str = "\u{25a3}"; // ▣
+pub const UNSELECTED_BOX_GLYPH: &str = "\u{25a2}"; // ▢
+
+pub struct CommitRowSpec<'a> {
+    pub commit: &'a CommitInfo,
+    pub is_cursor: bool,
+    pub is_selected: bool,
+    pub theme: &'a Theme,
+}
+
+pub fn render_commit_row<'a>(spec: &CommitRowSpec<'a>) -> Line<'a> {
+    let theme = spec.theme;
+
+    let row_text_style = if spec.is_cursor {
+        styles::selected_style(theme)
+    } else if spec.is_selected {
+        Style::default().fg(theme.fg_secondary)
+    } else {
+        Style::default().fg(theme.fg_primary)
+    };
+
+    let mut spans: Vec<Span<'a>> = Vec::with_capacity(10);
+    spans.push(Span::styled(
+        if spec.is_cursor {
+            format!("{CURSOR_GLYPH} ")
+        } else {
+            "  ".to_string()
+        },
+        row_text_style,
+    ));
+    spans.push(Span::styled(
+        if spec.is_selected {
+            format!("{RANGE_BAR_GLYPH} ")
+        } else {
+            "  ".to_string()
+        },
+        styles::range_bar_style(theme),
+    ));
+    spans.push(Span::styled(
+        if spec.is_selected {
+            format!("{SELECTED_BOX_GLYPH} ")
+        } else {
+            format!("{UNSELECTED_BOX_GLYPH} ")
+        },
+        if spec.is_selected {
+            styles::reviewed_style(theme)
+        } else {
+            styles::pending_style(theme)
+        },
+    ));
+
+    if spec.commit.id == STAGED_SELECTION_ID || spec.commit.id == UNSTAGED_SELECTION_ID {
+        let tag = if spec.commit.id == STAGED_SELECTION_ID {
+            " \u{00b7} staged \u{00b7}   "
+        } else {
+            " \u{00b7} unstaged \u{00b7} "
+        };
+        spans.push(Span::styled(tag, styles::pseudo_commit_tag_style(theme)));
+        spans.push(Span::styled(spec.commit.summary.clone(), row_text_style));
+        return Line::from(spans);
+    }
+
+    spans.push(Span::styled(
+        format!("{} ", spec.commit.short_id),
+        styles::hash_style(theme),
+    ));
+
+    if let Some(branch_name) = &spec.commit.branch_name {
+        spans.push(Span::styled(
+            format!("[{}] ", truncate_str(branch_name, 20)),
+            styles::branch_style(theme),
+        ));
+    }
+
+    spans.push(Span::styled(
+        truncate_str(&spec.commit.summary, 50),
+        row_text_style,
+    ));
+
+    let when = format_relative_short(&spec.commit.time);
+    spans.push(Span::styled(
+        format!("  {} \u{00b7} {}", spec.commit.author, when),
+        Style::default().fg(theme.fg_secondary),
+    ));
+
+    Line::from(spans)
+}
+
+/// Compact relative time used in selector rows: `5m`, `3h`, `2d`, `6w`, `4mo`,
+/// `2y`, or `just now`. Mirrors `format_relative_time` in `selector.rs` but
+/// without the trailing "ago" so rows stay tight.
+pub fn format_relative_short(time: &DateTime<Utc>) -> String {
+    let now = Utc::now();
+    let delta = now.signed_duration_since(*time);
+    if delta.num_seconds() < 60 {
+        return "just now".to_string();
+    }
+    let mins = delta.num_minutes();
+    if mins < 60 {
+        return format!("{mins}m");
+    }
+    let hours = delta.num_hours();
+    if hours < 24 {
+        return format!("{hours}h");
+    }
+    let days = delta.num_days();
+    if days < 7 {
+        return format!("{days}d");
+    }
+    if days < 30 {
+        return format!("{}w", days / 7);
+    }
+    if days < 365 {
+        return format!("{}mo", days / 30);
+    }
+    format!("{}y", days / 365)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn commit(id: &str, summary: &str, branch: Option<&str>) -> CommitInfo {
+        CommitInfo {
+            id: id.to_string(),
+            short_id: id[..7.min(id.len())].to_string(),
+            branch_name: branch.map(|s| s.to_string()),
+            summary: summary.to_string(),
+            body: None,
+            author: "alice".to_string(),
+            time: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        }
+    }
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>()
+    }
+
+    #[test]
+    fn should_render_cursor_arrow_when_is_cursor() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "Add feature", Some("main"));
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            is_cursor: true,
+            is_selected: false,
+            theme: &theme,
+        });
+        // then
+        let text = line_text(&line);
+        assert!(text.starts_with(CURSOR_GLYPH), "got: {text:?}");
+    }
+
+    #[test]
+    fn should_render_range_bar_when_selected() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "Add feature", None);
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            is_cursor: false,
+            is_selected: true,
+            theme: &theme,
+        });
+        // then
+        let text = line_text(&line);
+        assert!(text.contains(RANGE_BAR_GLYPH), "got: {text:?}");
+        assert!(text.contains(SELECTED_BOX_GLYPH), "got: {text:?}");
+    }
+
+    #[test]
+    fn should_render_empty_box_when_not_selected() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "Add feature", None);
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            is_cursor: false,
+            is_selected: false,
+            theme: &theme,
+        });
+        // then
+        let text = line_text(&line);
+        assert!(!text.contains(RANGE_BAR_GLYPH), "got: {text:?}");
+        assert!(text.contains(UNSELECTED_BOX_GLYPH), "got: {text:?}");
+    }
+
+    #[test]
+    fn should_render_pseudo_commit_with_tag_and_drop_metadata() {
+        // given
+        let theme = Theme::dark();
+        let c = commit(STAGED_SELECTION_ID, "Staged changes", None);
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            is_cursor: false,
+            is_selected: false,
+            theme: &theme,
+        });
+        // then
+        let text = line_text(&line);
+        assert!(text.contains("staged"), "got: {text:?}");
+        assert!(text.contains("Staged changes"), "got: {text:?}");
+        assert!(!text.contains("alice"), "should drop author: {text:?}");
+    }
+
+    #[test]
+    fn should_render_branch_chip_when_present() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "Add feature", Some("feat/foo"));
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            is_cursor: false,
+            is_selected: false,
+            theme: &theme,
+        });
+        // then
+        let text = line_text(&line);
+        assert!(text.contains("[feat/foo]"), "got: {text:?}");
+    }
+
+    #[test]
+    fn should_format_short_relative_time_buckets() {
+        // given
+        let now = Utc::now();
+        // when / then
+        assert_eq!(format_relative_short(&now), "just now");
+        assert_eq!(
+            format_relative_short(&(now - chrono::Duration::minutes(5))),
+            "5m"
+        );
+        assert_eq!(
+            format_relative_short(&(now - chrono::Duration::hours(3))),
+            "3h"
+        );
+        assert_eq!(
+            format_relative_short(&(now - chrono::Duration::days(2))),
+            "2d"
+        );
+        assert_eq!(
+            format_relative_short(&(now - chrono::Duration::days(20))),
+            "2w"
+        );
+        assert_eq!(
+            format_relative_short(&(now - chrono::Duration::days(60))),
+            "2mo"
+        );
+        assert_eq!(
+            format_relative_short(&(now - chrono::Duration::days(800))),
+            "2y"
+        );
+    }
+}

--- a/src/ui/commit_row.rs
+++ b/src/ui/commit_row.rs
@@ -10,13 +10,20 @@ use ratatui::text::{Line, Span};
 use crate::app::{STAGED_SELECTION_ID, UNSTAGED_SELECTION_ID};
 use crate::theme::Theme;
 use crate::ui::styles;
-use crate::ui::text_utils::truncate_str;
+use crate::ui::text_utils::{truncate_or_pad, truncate_str};
 use crate::vcs::CommitInfo;
 
 pub const CURSOR_GLYPH: &str = "\u{25b8}"; // ▸
 pub const RANGE_BAR_GLYPH: &str = "\u{258c}"; // ▌
 pub const SELECTED_BOX_GLYPH: &str = "\u{25a3}"; // ▣
 pub const UNSELECTED_BOX_GLYPH: &str = "\u{25a2}"; // ▢
+
+// Fixed column widths so author/date land at the same x across every row.
+// Branch column gets `[branch_name]` padded to width including brackets and a
+// trailing space; rows without a branch render the same number of blanks.
+const BRANCH_COL_WIDTH: usize = 16;
+const SUMMARY_COL_WIDTH: usize = 50;
+const AUTHOR_COL_WIDTH: usize = 12;
 
 pub struct CommitRowSpec<'a> {
     pub commit: &'a CommitInfo,
@@ -82,21 +89,31 @@ pub fn render_commit_row<'a>(spec: &CommitRowSpec<'a>) -> Line<'a> {
         styles::hash_style(theme),
     ));
 
+    // Branch column: always BRANCH_COL_WIDTH cells. With a branch we render
+    // `[<name>]` padded out with trailing spaces; without one we render
+    // BRANCH_COL_WIDTH spaces so the summary column starts at the same x.
     if let Some(branch_name) = &spec.commit.branch_name {
+        let chip = format!("[{}]", truncate_str(branch_name, BRANCH_COL_WIDTH - 3));
         spans.push(Span::styled(
-            format!("[{}] ", truncate_str(branch_name, 20)),
+            truncate_or_pad(&chip, BRANCH_COL_WIDTH),
             styles::branch_style(theme),
         ));
+    } else {
+        spans.push(Span::raw(" ".repeat(BRANCH_COL_WIDTH)));
     }
 
     spans.push(Span::styled(
-        truncate_str(&spec.commit.summary, 50),
+        truncate_or_pad(&spec.commit.summary, SUMMARY_COL_WIDTH),
         row_text_style,
     ));
 
     let when = format_relative_short(&spec.commit.time);
     spans.push(Span::styled(
-        format!("  {} \u{00b7} {}", spec.commit.author, when),
+        format!(
+            "  {} \u{00b7} {}",
+            truncate_or_pad(&spec.commit.author, AUTHOR_COL_WIDTH),
+            when
+        ),
         Style::default().fg(theme.fg_secondary),
     ));
 

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -49,14 +49,7 @@ struct SideBySideContext<'a> {
 pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
-    let title = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
-        " Diff (Side-by-Side) \u{2014} Overview ".to_string()
-    } else {
-        format!(
-            " Diff (Side-by-Side) \u{2014} {} ",
-            app.current_file_path().unwrap().display()
-        )
-    };
+    let title = crate::ui::diff_view::diff_title(app, area.width);
 
     let block = Block::default()
         .title(title)

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -25,14 +25,7 @@ use crate::vcs::git::calculate_gap;
 pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
-    let title = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
-        " Diff (Unified) \u{2014} Overview ".to_string()
-    } else {
-        format!(
-            " Diff (Unified) \u{2014} {} ",
-            app.current_file_path().unwrap().display()
-        )
-    };
+    let title = crate::ui::diff_view::diff_title(app, area.width);
 
     let block = Block::default()
         .title(title)

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -22,6 +22,64 @@ pub(super) fn render_diff_view(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 }
 
+/// Build the diff view's left title: ` <path> ` when a file is in view, or
+/// ` Overview ` in overview mode. Long paths are prefix-truncated so the
+/// most-informative tail (closest to the filename) survives.
+pub(super) fn diff_title(app: &App, area_width: u16) -> String {
+    if app.is_cursor_in_overview() || app.current_file_path().is_none() {
+        return " Overview ".to_string();
+    }
+    let path = app
+        .current_file_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+
+    // Reserve room for the title's own spacing (` <path> `), the stats title
+    // on the right, and the two corner glyphs. We deliberately under-reserve
+    // — the precise stats width depends on the file's add/del counts, so the
+    // worst case is a few-char overshoot that ratatui will truncate cleanly.
+    let stats_reserve = 16; // ` +DDDD -DDDD ` plus padding
+    let chrome_reserve = 4; // corners + leading/trailing space around title
+    let max_path_width = (area_width as usize)
+        .saturating_sub(stats_reserve + chrome_reserve)
+        .max(8);
+
+    format!(" {} ", truncate_path_smart(&path, max_path_width))
+}
+
+/// Truncate `path` to fit within `max_width` cells by dropping leading path
+/// segments and prefixing with `…/`. Always keeps the basename intact; falls
+/// back to suffix-truncating the basename only when the basename alone is
+/// wider than `max_width`.
+pub(super) fn truncate_path_smart(path: &str, max_width: usize) -> String {
+    if path.chars().count() <= max_width {
+        return path.to_string();
+    }
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+    if segments.is_empty() {
+        return path.to_string();
+    }
+
+    for n in (1..segments.len()).rev() {
+        let tail = segments[segments.len() - n..].join("/");
+        let candidate = format!("\u{2026}/{tail}");
+        if candidate.chars().count() <= max_width {
+            return candidate;
+        }
+    }
+
+    let basename = *segments.last().unwrap();
+    let basename_w = basename.chars().count();
+    if basename_w <= max_width {
+        return basename.to_string();
+    }
+    // Basename alone is too wide: keep the leading chars + `…`.
+    let kept = max_width.saturating_sub(1);
+    let mut s: String = basename.chars().take(kept).collect();
+    s.push('\u{2026}');
+    s
+}
+
 /// Build a right-aligned title showing diff stats for the current scope.
 /// In overview: total stats across all files. In a file: that file's stats.
 pub(super) fn diff_stat_title(app: &App) -> Line<'static> {

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -1,7 +1,6 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem},
 };
@@ -12,11 +11,21 @@ use crate::app::{App, FileTreeItem, FocusedPanel};
 use crate::ui::diff_view::apply_horizontal_scroll;
 use crate::ui::styles;
 
+const EXPANDED_GLYPH: &str = "\u{25bc}"; // ▼
+const COLLAPSED_GLYPH: &str = "\u{25b6}"; // ▶
+const REVIEWED_BOX: &str = "\u{25a3}"; // ▣
+const UNREVIEWED_BOX: &str = "\u{25a2}"; // ▢
+
 pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::FileList;
 
+    let title = format!(
+        " Files \u{00b7} {}/{} ",
+        app.reviewed_count(),
+        app.file_count()
+    );
     let block = Block::default()
-        .title(" Files ")
+        .title(title)
         .borders(Borders::ALL)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
@@ -42,7 +51,7 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("?");
-                depth * 2 + 3 + 3 + filename.width()
+                depth * 2 + 4 + filename.width()
             }
         })
         .max()
@@ -78,95 +87,77 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     }
 
-    let selected_idx = app.file_list_state.selected();
-
     let items: Vec<ListItem> = visible_items
         .iter()
-        .enumerate()
-        .map(|(i, item)| {
-            let is_selected = i == selected_idx;
-
-            match item {
+        .map(|item| {
+            let line = match item {
                 FileTreeItem::Directory {
                     path,
                     depth,
                     expanded,
                 } => {
                     let indent = "  ".repeat(*depth);
-                    let icon = if *expanded { "▾" } else { "▸" };
+                    let icon = if *expanded {
+                        EXPANDED_GLYPH
+                    } else {
+                        COLLAPSED_GLYPH
+                    };
                     let dir_name = Path::new(path)
                         .file_name()
                         .and_then(|n| n.to_str())
                         .unwrap_or(path);
-
-                    let style = if is_selected {
-                        styles::selected_style(&app.theme).add_modifier(Modifier::UNDERLINED)
-                    } else {
-                        Style::default()
-                    };
-
-                    let line = Line::from(vec![
-                        Span::styled(indent, Style::default()),
+                    Line::from(vec![
+                        Span::raw(indent),
                         Span::styled(format!("{icon} "), styles::dir_icon_style(&app.theme)),
-                        Span::styled(format!("{dir_name}/"), style),
-                    ]);
-
-                    ListItem::new(apply_horizontal_scroll(line, scroll_x))
+                        Span::raw(format!("{dir_name}/")),
+                    ])
                 }
                 FileTreeItem::File { file_idx, depth } => {
                     let file = &app.diff_files[*file_idx];
                     let path = file.display_path();
                     let is_reviewed = app.session.is_file_reviewed(path);
-                    let review_mark = if is_reviewed { "✓" } else { " " };
-
-                    let style = if is_selected {
-                        styles::selected_style(&app.theme).add_modifier(Modifier::UNDERLINED)
+                    let checkbox = if is_reviewed {
+                        REVIEWED_BOX
                     } else {
-                        Style::default()
+                        UNREVIEWED_BOX
                     };
-
-                    let line = if file.is_commit_message {
+                    let checkbox_style = if is_reviewed {
+                        styles::reviewed_style(&app.theme)
+                    } else {
+                        styles::pending_style(&app.theme)
+                    };
+                    if file.is_commit_message {
                         Line::from(vec![
-                            Span::styled(
-                                format!("[{review_mark}]"),
-                                if is_reviewed {
-                                    styles::reviewed_style(&app.theme)
-                                } else {
-                                    styles::pending_style(&app.theme)
-                                },
-                            ),
-                            Span::styled("   Commit Message".to_string(), style),
+                            Span::styled(format!("{checkbox} "), checkbox_style),
+                            Span::raw("  Commit Message".to_string()),
                         ])
                     } else {
                         let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
                         let status = file.status.as_char();
                         let indent = "  ".repeat(*depth);
                         Line::from(vec![
-                            Span::styled(indent, Style::default()),
+                            Span::raw(indent),
+                            Span::styled(format!("{checkbox} "), checkbox_style),
                             Span::styled(
-                                format!("[{review_mark}]"),
-                                if is_reviewed {
-                                    styles::reviewed_style(&app.theme)
-                                } else {
-                                    styles::pending_style(&app.theme)
-                                },
-                            ),
-                            Span::styled(
-                                format!(" {status} "),
+                                format!("{status} "),
                                 styles::file_status_style(&app.theme, status),
                             ),
-                            Span::styled(filename.to_string(), style),
+                            Span::raw(filename.to_string()),
                         ])
-                    };
-
-                    ListItem::new(apply_horizontal_scroll(line, scroll_x))
+                    }
                 }
-            }
+            };
+
+            ListItem::new(apply_horizontal_scroll(line, scroll_x))
         })
         .collect();
 
+    // Full-row bg highlight on the selected row (no leading cursor glyph or
+    // underline modifier) — mirrors how the diff view highlights its cursor
+    // line.
     let list = List::new(items)
         .style(styles::panel_style(&app.theme))
+        .highlight_style(styles::selected_style(&app.theme))
         .block(block);
 
     frame.render_stateful_widget(list, area, &mut app.file_list_state.list_state);

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -11,7 +11,11 @@ use crate::ui::styles;
 
 pub fn render_help(frame: &mut Frame, app: &mut App) {
     let theme = &app.theme;
-    let area = centered_rect(60, 70, frame.area());
+    // Center over the diff pane (matches the submit-modal anchoring) so the
+    // file list doesn't tug the popup's visual centre off to one side. Fall
+    // back to the full frame when no diff area is laid out yet.
+    let anchor = app.diff_area.unwrap_or(frame.area());
+    let area = centered_rect(80, 90, anchor);
 
     // Clear the area behind the popup
     frame.render_widget(Clear, area);

--- a/src/ui/inline_commit_selector.rs
+++ b/src/ui/inline_commit_selector.rs
@@ -1,110 +1,52 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::Style,
-    text::{Line, Span},
+    text::Line,
     widgets::{Block, Borders, Paragraph},
 };
 
 use crate::app::{App, FocusedPanel};
+use crate::ui::commit_row::{CommitRowSpec, render_commit_row};
 use crate::ui::styles;
-use crate::ui::text_utils::truncate_str;
 
 pub(super) fn render_inline_commit_selector(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::CommitSelector;
+    let theme = &app.theme;
+
     let block = Block::default()
         .title(" Commits ")
         .borders(Borders::ALL)
-        .border_style(styles::border_style(&app.theme, focused));
+        .style(styles::panel_style(theme))
+        .border_style(styles::border_style(theme, focused));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    // Update viewport height for scroll
     app.commit_list_viewport_height = inner.height as usize;
     app.commit_list_inner_area = Some(inner);
 
-    {
-        let range = app.commit_selection_range;
-        let total_commits = app.review_commits.len();
-
-        let items: Vec<Line> = app
-            .review_commits
-            .iter()
-            .take(total_commits)
-            .enumerate()
-            .map(|(i, commit)| {
-                let is_selected = app.is_commit_selected(i);
-                let is_cursor = i == app.commit_list_cursor;
-
-                // Range boundary indicators
-                let range_marker = match range {
-                    Some((start, end)) if i == start && i == end => "\u{2500}",
-                    Some((start, _)) if i == start => "\u{250c}",
-                    Some((_, end)) if i == end => "\u{2514}",
-                    Some((start, end)) if i > start && i < end => "\u{2502}",
-                    _ => " ",
-                };
-
-                let checkbox = if is_selected { "[x]" } else { "[ ]" };
-
-                let style = if is_cursor {
-                    styles::selected_style(&app.theme)
-                } else if is_selected {
-                    Style::default().fg(app.theme.fg_secondary)
-                } else {
-                    Style::default()
-                };
-
-                let checkbox_style = if is_selected {
-                    styles::reviewed_style(&app.theme)
-                } else {
-                    styles::pending_style(&app.theme)
-                };
-
-                let range_style = if is_selected {
-                    styles::reviewed_style(&app.theme)
-                } else {
-                    Style::default().fg(app.theme.fg_secondary)
-                };
-
-                let pointer = if is_cursor { "> " } else { "  " };
-
-                let time_str = commit.time.format("%Y-%m-%d").to_string();
-                let mut spans = vec![
-                    Span::styled(pointer.to_string(), style),
-                    Span::styled(format!("{} ", range_marker), range_style),
-                    Span::styled(format!("{} ", checkbox), checkbox_style),
-                    Span::styled(
-                        format!("{} ", commit.short_id),
-                        styles::hash_style(&app.theme),
-                    ),
-                ];
-
-                if let Some(branch_name) = &commit.branch_name {
-                    spans.push(Span::styled(
-                        format!("[{}] ", truncate_str(branch_name, 20)),
-                        styles::branch_style(&app.theme),
-                    ));
-                }
-
-                spans.push(Span::styled(truncate_str(&commit.summary, 50), style));
-                spans.push(Span::styled(
-                    format!(" ({}, {})", commit.author, time_str),
-                    Style::default().fg(app.theme.fg_secondary),
-                ));
-
-                Line::from(spans)
+    let items: Vec<Line> = app
+        .review_commits
+        .iter()
+        .enumerate()
+        .map(|(i, commit)| {
+            render_commit_row(&CommitRowSpec {
+                commit,
+                is_cursor: i == app.commit_list_cursor,
+                is_selected: app.is_commit_selected(i),
+                theme,
             })
-            .collect();
+        })
+        .collect();
 
-        let visible_items: Vec<Line> = items
-            .into_iter()
-            .skip(app.commit_list_scroll_offset)
-            .take(inner.height as usize)
-            .collect();
+    let visible_items: Vec<Line> = items
+        .into_iter()
+        .skip(app.commit_list_scroll_offset)
+        .take(inner.height as usize)
+        .collect();
 
-        let paragraph = Paragraph::new(visible_items);
-        frame.render_widget(paragraph, inner);
-    }
+    frame.render_widget(
+        Paragraph::new(visible_items).style(styles::panel_style(theme)),
+        inner,
+    );
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 pub mod app_layout;
 pub mod comment_panel;
+pub mod commit_row;
 pub mod diff_side_by_side;
 pub mod diff_unified;
 pub mod diff_view;

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -8,95 +8,194 @@ use ratatui::{
 
 use crate::app::{App, TargetTab};
 use crate::forge::selector::{PrTabStatus, PrTabView};
+use crate::ui::commit_row::{
+    CURSOR_GLYPH, CommitRowSpec, format_relative_short, render_commit_row,
+};
 use crate::ui::status_bar;
 use crate::ui::styles;
 use crate::ui::text_utils::truncate_str;
 
+const TAB_LOCAL: &str = "Local";
+const TAB_PULL_REQUESTS: &str = "Pull Requests";
+
 pub(super) fn render_commit_select(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
+    // Layout: header, blank, tab strip (full-width bg, active tab is a
+    // brighter chip inside the strip), bordered body, footer.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // Header
-            Constraint::Length(1), // Tab strip
-            Constraint::Min(0),    // Active tab body
-            Constraint::Length(1), // Footer hints
+            Constraint::Length(1), // header
+            Constraint::Length(1), // blank
+            Constraint::Length(1), // tab strip
+            Constraint::Min(0),    // body block (full borders)
+            Constraint::Length(1), // footer
         ])
         .split(area);
 
-    // Header
-    let header = Paragraph::new(" Select a review target ")
-        .style(styles::header_style(&app.theme))
-        .block(Block::default().style(styles::panel_style(&app.theme)));
-    frame.render_widget(header, chunks[0]);
+    render_header_line(frame, app, chunks[0]);
+    render_tab_strip(frame, app, chunks[2]);
 
-    render_target_tab_strip(frame, app, chunks[1]);
+    let body_area = chunks[3];
+    let body_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(styles::border_style(&app.theme, true))
+        .style(styles::panel_style(&app.theme));
+    let inner = body_block.inner(body_area);
+    frame.render_widget(body_block, body_area);
 
     match app.target_tab {
-        TargetTab::Local => render_local_target_tab(frame, app, chunks[2]),
-        TargetTab::PullRequests => render_pull_requests_tab(frame, app, chunks[2]),
+        TargetTab::Local => render_local_target_tab(frame, app, inner),
+        TargetTab::PullRequests => render_pull_requests_tab(frame, app, inner),
     }
 
-    render_target_selector_footer(frame, app, chunks[3]);
+    render_target_selector_footer(frame, app, chunks[4]);
 }
 
-fn render_target_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
+fn render_header_line(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let vcs_type = &app.vcs_info.vcs_type;
+    let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
+
+    let brand = Span::styled(
+        " tuicr  ",
+        Style::default()
+            .fg(theme.fg_primary)
+            .add_modifier(Modifier::BOLD),
+    );
+    let action = Span::styled(
+        "select review target",
+        Style::default().fg(theme.fg_secondary),
+    );
+    let right = format!("{vcs_type}:{branch} ");
+    let right_width = right.len();
+    let right_span = Span::styled(right, Style::default().fg(theme.fg_secondary));
+
+    let left = vec![brand, action];
+    let left_width: usize = left.iter().map(|s| s.content.len()).sum();
+    let total_width = area.width as usize;
+    let pad = total_width.saturating_sub(left_width + right_width);
+
+    let mut spans = left;
+    spans.push(Span::raw(" ".repeat(pad)));
+    spans.push(right_span);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).style(styles::panel_style(theme)),
+        area,
+    );
+}
+
+/// Single-row tab strip filling the full terminal width with a subtle bg.
+/// The active tab renders as a brighter chip (`bg_highlight` + bold primary
+/// fg); inactive tab text sits flat on the strip bg in dim fg. The right
+/// slot carries the PR-tab status hint when that tab is active.
+fn render_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let active = app.target_tab;
-    let active_style = Style::default()
-        .fg(theme.fg_primary)
-        .add_modifier(Modifier::BOLD | Modifier::REVERSED);
-    let bracket_style = Style::default().fg(theme.fg_secondary);
-    let inactive_label_style = Style::default().fg(theme.fg_primary);
-
-    let mut spans: Vec<Span> = Vec::with_capacity(8);
-    spans.push(Span::raw(" "));
-
     let local_active = active == TargetTab::Local;
-    spans.push(Span::styled("[", bracket_style));
-    if local_active {
-        spans.push(Span::styled(" Local ", active_style));
-    } else {
-        spans.push(Span::styled(" Local ", inactive_label_style));
+    let pr_active = active == TargetTab::PullRequests;
+
+    let strip_bg = theme.status_bar_bg;
+    let strip_fg = theme.fg_dim;
+    let strip_style = Style::default().bg(strip_bg).fg(strip_fg);
+
+    let active_chip = Style::default()
+        .bg(theme.bg_highlight)
+        .fg(theme.fg_primary)
+        .add_modifier(Modifier::BOLD);
+    let inactive_chip = Style::default().bg(strip_bg).fg(theme.fg_dim);
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    spans.push(Span::styled(" ".to_string(), strip_style));
+    spans.push(Span::styled(
+        format!(" {TAB_LOCAL} "),
+        if local_active {
+            active_chip
+        } else {
+            inactive_chip
+        },
+    ));
+    spans.push(Span::styled(" ".to_string(), strip_style));
+    spans.push(Span::styled(
+        format!(" {TAB_PULL_REQUESTS} "),
+        if pr_active {
+            active_chip
+        } else {
+            inactive_chip
+        },
+    ));
+
+    let left_width: usize = spans.iter().map(|s| s.content.chars().count()).sum();
+
+    let (right_span, right_width) = match active {
+        TargetTab::PullRequests => pr_status_hint_span(app, strip_bg),
+        TargetTab::Local => (Span::raw(""), 0),
+    };
+
+    let total_width = area.width as usize;
+    let pad = total_width.saturating_sub(left_width + right_width);
+    spans.push(Span::styled(" ".repeat(pad), strip_style));
+    if right_width > 0 {
+        spans.push(right_span);
     }
-    spans.push(Span::styled("]", bracket_style));
 
-    spans.push(Span::raw("  "));
+    frame.render_widget(Paragraph::new(Line::from(spans)).style(strip_style), area);
+}
 
-    let prs_active = active == TargetTab::PullRequests;
-    spans.push(Span::styled("[", bracket_style));
-    if prs_active {
-        spans.push(Span::styled(" Pull Requests ", active_style));
-    } else {
-        spans.push(Span::styled(" Pull Requests ", inactive_label_style));
-    }
-    spans.push(Span::styled("]", bracket_style));
-
-    let line = Line::from(spans);
-    let strip = Paragraph::new(line).style(styles::panel_style(theme));
-    frame.render_widget(strip, area);
+/// Right-slot status hint for the PR tab. Idle ready states show
+/// `<count> loaded · /<filter>` (filter only when set). Loading shows a
+/// braille spinner + label. Error renders in error color. The caller
+/// supplies the strip bg so the hint blends with the tab strip's bar.
+fn pr_status_hint_span(app: &App, strip_bg: ratatui::style::Color) -> (Span<'static>, usize) {
+    let theme = &app.theme;
+    let view = app.pr_tab.view();
+    let base = Style::default().bg(strip_bg).fg(theme.fg_secondary);
+    let (content, style) = match &view.status {
+        PrTabStatus::Disabled(reason) => (format!("{reason} — Shift-Tab to go back "), base),
+        PrTabStatus::Idle => (" waiting… ".to_string(), base),
+        PrTabStatus::Loading => {
+            let glyph = pr_open_spinner_glyph(std::time::Duration::from_millis(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            ));
+            (format!("{glyph} loading… "), base)
+        }
+        PrTabStatus::LoadingMore => {
+            let glyph = pr_open_spinner_glyph(std::time::Duration::from_millis(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis() as u64)
+                    .unwrap_or(0),
+            ));
+            (format!("{glyph} loading more… "), base)
+        }
+        PrTabStatus::Error(msg) => (
+            format!("error \u{00b7} {msg} "),
+            styles::error_inline_style(theme).bg(strip_bg),
+        ),
+        PrTabStatus::Ready => {
+            let mut s = format!("{} loaded", view.rows.len());
+            if !view.filter.is_empty() {
+                s.push_str(&format!(" \u{00b7} /{}", view.filter));
+            }
+            s.push(' ');
+            (s, base)
+        }
+    };
+    let width = content.len();
+    (Span::styled(content, style), width)
 }
 
 fn render_local_target_tab(frame: &mut Frame, app: &mut App, area: Rect) {
-    let block = Block::default()
-        .title(" Recent Commits ")
-        .borders(Borders::ALL)
-        .style(styles::panel_style(&app.theme))
-        .border_style(styles::border_style(&app.theme, true));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-
     // Update viewport height for scroll calculations
-    app.commit_list_viewport_height = inner.height as usize;
-    app.commit_list_inner_area = Some(inner);
+    app.commit_list_viewport_height = area.height as usize;
+    app.commit_list_inner_area = Some(area);
     app.pr_list_inner_area = None;
 
-    // Get range info for visual indicators
-    let range = app.commit_selection_range;
-
-    // Determine commits to show
     let total_commits = app.commit_list.len();
     let visible_count = app.visible_commit_count.min(total_commits);
 
@@ -106,255 +205,57 @@ fn render_local_target_tab(frame: &mut Frame, app: &mut App, area: Rect) {
         .take(visible_count)
         .enumerate()
         .map(|(i, commit)| {
-            let is_selected = app.is_commit_selected(i);
-            let is_cursor = i == app.commit_list_cursor;
-
-            // Range boundary indicators
-            let range_marker = match range {
-                Some((start, end)) if i == start && i == end => "─",
-                Some((start, _)) if i == start => "┌",
-                Some((_, end)) if i == end => "└",
-                Some((start, end)) if i > start && i < end => "│",
-                _ => " ",
-            };
-
-            let checkbox = if is_selected { "[x]" } else { "[ ]" };
-            let pointer = if is_cursor { ">" } else { " " };
-
-            let style = if is_cursor {
-                styles::selected_style(&app.theme)
-            } else if is_selected {
-                Style::default().fg(app.theme.fg_secondary)
-            } else {
-                Style::default()
-            };
-
-            let checkbox_style = if is_selected {
-                styles::reviewed_style(&app.theme)
-            } else {
-                styles::pending_style(&app.theme)
-            };
-
-            let range_style = if is_selected {
-                styles::reviewed_style(&app.theme)
-            } else {
-                Style::default().fg(app.theme.fg_secondary)
-            };
-
-            // Format: > ┌ [x] abc1234  Commit message (author, date)
-            let time_str = commit.time.format("%Y-%m-%d").to_string();
-            let mut spans = vec![
-                Span::styled(format!("{pointer} "), style),
-                Span::styled(format!("{range_marker} "), range_style),
-                Span::styled(format!("{checkbox} "), checkbox_style),
-                Span::styled(
-                    format!("{} ", commit.short_id),
-                    styles::hash_style(&app.theme),
-                ),
-            ];
-
-            if commit.id == crate::app::STAGED_SELECTION_ID
-                || commit.id == crate::app::UNSTAGED_SELECTION_ID
-            {
-                spans.push(Span::styled(&commit.summary, style));
-                return Line::from(spans);
-            }
-
-            if let Some(branch_name) = &commit.branch_name {
-                spans.push(Span::styled(
-                    format!("[{}] ", truncate_str(branch_name, 20)),
-                    styles::branch_style(&app.theme),
-                ));
-            }
-
-            spans.push(Span::styled(truncate_str(&commit.summary, 50), style));
-            spans.push(Span::styled(
-                format!(" ({}, {})", commit.author, time_str),
-                Style::default().fg(app.theme.fg_secondary),
-            ));
-
-            Line::from(spans)
+            render_commit_row(&CommitRowSpec {
+                commit,
+                is_cursor: i == app.commit_list_cursor,
+                is_selected: app.is_commit_selected(i),
+                theme: &app.theme,
+            })
         })
         .collect();
 
-    // Show an expand row when commits are collapsed
     if app.can_show_more_commits() {
-        let is_cursor = app.commit_list_cursor == visible_count;
-
-        let style = if is_cursor {
-            styles::selected_style(&app.theme)
-        } else {
-            Style::default().fg(app.theme.fg_secondary)
-        };
-
-        items.push(Line::from(vec![
-            Span::styled(if is_cursor { "> " } else { "  " }, style),
-            Span::styled("       ... show more commits ...", style),
-        ]));
+        items.push(overflow_row(
+            &app.theme,
+            app.commit_list_cursor == visible_count,
+            "show more commits",
+        ));
     }
 
-    // Apply scroll offset and take only visible items
     let visible_items: Vec<Line> = items
         .into_iter()
         .skip(app.commit_list_scroll_offset)
-        .take(inner.height as usize)
+        .take(area.height as usize)
         .collect();
 
     let list = Paragraph::new(visible_items).style(styles::panel_style(&app.theme));
-    frame.render_widget(list, inner);
+    frame.render_widget(list, area);
+}
+
+fn overflow_row<'a>(theme: &crate::theme::Theme, is_cursor: bool, label: &'a str) -> Line<'a> {
+    let style = if is_cursor {
+        styles::selected_style(theme)
+    } else {
+        Style::default().fg(theme.fg_dim)
+    };
+    let pointer = if is_cursor {
+        format!("{CURSOR_GLYPH} ")
+    } else {
+        "  ".to_string()
+    };
+    Line::from(vec![
+        Span::styled(pointer, style),
+        Span::styled(format!("    \u{2026} {label}"), style),
+    ])
 }
 
 fn render_pull_requests_tab(frame: &mut Frame, app: &mut App, area: Rect) {
-    let title = match app.forge_repository.as_ref() {
-        Some(repo) => format!(" Pull Requests ({}) ", repo.display_name()),
-        None => " Pull Requests ".to_string(),
-    };
-    let block = Block::default()
-        .title(title)
-        .borders(Borders::ALL)
-        .style(styles::panel_style(&app.theme))
-        .border_style(styles::border_style(&app.theme, true));
-
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
     app.commit_list_inner_area = None;
-    app.pr_list_inner_area = Some(inner);
-    app.pr_list_viewport_height = inner.height.saturating_sub(1) as usize;
-
-    // Reserve one row at the top for the status / filter banner.
-    let body_chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Min(0)])
-        .split(inner);
-    let banner_area = body_chunks[0];
-    let list_area = body_chunks[1];
-    app.pr_list_viewport_height = list_area.height as usize;
+    app.pr_list_inner_area = Some(area);
+    app.pr_list_viewport_height = area.height as usize;
 
     let view = app.pr_tab.view();
-    render_pr_banner(frame, app, banner_area, &view);
-    render_pr_list(frame, app, list_area, &view);
-}
-
-fn render_pr_banner(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>) {
-    let theme = &app.theme;
-
-    if let Some(draft) = app.pr_filter_draft.as_ref() {
-        let prefix = Span::styled(" filter: ", Style::default().fg(theme.fg_secondary));
-        let value = Span::styled(format!("/{draft}"), Style::default().fg(theme.fg_primary));
-        let hint = Span::styled(
-            "   (Enter: apply  Esc: cancel)",
-            Style::default().fg(theme.fg_secondary),
-        );
-        let line = Line::from(vec![prefix, value, hint]);
-        let banner = Paragraph::new(line).style(styles::panel_style(theme));
-        frame.render_widget(banner, area);
-        return;
-    }
-
-    match &view.status {
-        PrTabStatus::Disabled(reason) => {
-            let line = Line::from(Span::styled(
-                format!(" {reason} — switch back with Shift-Tab "),
-                Style::default().fg(theme.fg_secondary),
-            ));
-            frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
-        }
-        PrTabStatus::Idle => {
-            let line = Line::from(Span::styled(
-                " Press Tab again or wait — loading…",
-                Style::default().fg(theme.fg_secondary),
-            ));
-            frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
-        }
-        PrTabStatus::Loading => {
-            render_pr_progress(frame, app, area, "Fetching pull requests from origin...");
-        }
-        PrTabStatus::LoadingMore => {
-            render_pr_progress(frame, app, area, "Loading more pull requests...");
-        }
-        PrTabStatus::Error(msg) => {
-            let line = Line::from(vec![
-                Span::styled(
-                    " error: ",
-                    Style::default()
-                        .fg(theme.message_error_fg)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                Span::styled((*msg).to_string(), Style::default().fg(theme.fg_primary)),
-            ]);
-            frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
-        }
-        PrTabStatus::Ready => {
-            let mut spans: Vec<Span> = vec![Span::styled(
-                format!(" {} loaded", view.rows.len()),
-                Style::default().fg(theme.fg_secondary),
-            )];
-            if !view.filter.is_empty() {
-                spans.push(Span::styled(
-                    format!("   filter: /{}", view.filter),
-                    Style::default().fg(theme.fg_primary),
-                ));
-                spans.push(Span::styled(
-                    "   ('/' to edit, Esc to clear)",
-                    Style::default().fg(theme.fg_secondary),
-                ));
-            } else {
-                spans.push(Span::styled(
-                    "   '/' to filter",
-                    Style::default().fg(theme.fg_secondary),
-                ));
-            }
-            frame.render_widget(
-                Paragraph::new(Line::from(spans)).style(styles::panel_style(theme)),
-                area,
-            );
-        }
-    }
-}
-
-fn render_pr_progress(frame: &mut Frame, app: &App, area: Rect, label: &str) {
-    let theme = &app.theme;
-    let width = area.width.saturating_sub(label.len() as u16 + 5).max(4) as usize;
-    // Indeterminate bar: a windowed block of ~width/3 that travels using
-    // wall-clock seconds, so the bar visibly moves between frames without
-    // requiring per-frame state on App.
-    let block_width = (width / 3).max(2);
-    let travel = (width + block_width).max(1);
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as usize)
-        .unwrap_or(0);
-    let position = (now / 80) % travel;
-    let mut bar = String::with_capacity(width);
-    for i in 0..width {
-        if position < block_width {
-            if i < position {
-                bar.push(' ');
-            } else if i < position + block_width && i < width {
-                bar.push('#');
-            } else {
-                bar.push(' ');
-            }
-        } else {
-            let start = position.saturating_sub(block_width);
-            if i >= start && i < position && i < width {
-                bar.push('#');
-            } else {
-                bar.push(' ');
-            }
-        }
-    }
-    let line = Line::from(vec![
-        Span::styled(
-            format!(" {label} "),
-            Style::default().fg(theme.fg_secondary),
-        ),
-        Span::styled(
-            format!("[{bar}]"),
-            Style::default().fg(theme.diff_hunk_header),
-        ),
-    ]);
-    frame.render_widget(Paragraph::new(line).style(styles::panel_style(theme)), area);
+    render_pr_list(frame, app, area, &view);
 }
 
 fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>) {
@@ -363,9 +264,37 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
         return;
     }
 
-    // Pre-compute the spinner glyph once per draw so it animates without
-    // per-row recalculation. Held outside the loop because Rust's borrow
-    // rules around `app` are simpler that way.
+    // The tab-strip right slot already surfaces loading / error / disabled
+    // hints concisely; the body only fills in when there's a useful action
+    // (idle → tap Tab again, error → retry guidance). Disabled / Loading /
+    // LoadingMore leave the body blank so we don't echo the same text twice.
+    match view.status {
+        PrTabStatus::Disabled(_) | PrTabStatus::Loading | PrTabStatus::LoadingMore => return,
+        PrTabStatus::Idle => {
+            let line = Line::from(Span::styled(
+                "  Press Tab again to load pull requests\u{2026}",
+                Style::default().fg(theme.fg_dim),
+            ));
+            frame.render_widget(
+                Paragraph::new(vec![line]).style(styles::panel_style(theme)),
+                area,
+            );
+            return;
+        }
+        PrTabStatus::Error(msg) => {
+            let line = Line::from(vec![
+                Span::styled("  error \u{00b7} ", styles::error_inline_style(theme)),
+                Span::styled(msg.to_string(), Style::default().fg(theme.fg_primary)),
+            ]);
+            frame.render_widget(
+                Paragraph::new(vec![line]).style(styles::panel_style(theme)),
+                area,
+            );
+            return;
+        }
+        PrTabStatus::Ready => {}
+    }
+
     let spinner = app
         .pr_open_state
         .as_ref()
@@ -378,13 +307,11 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
             (spinner, app.pr_open_state.as_ref()),
             (Some(_), Some(s)) if s.matches(&row.summary.repository, row.summary.number)
         );
-        // Spinner glyph replaces the cursor pointer (per design A): the
-        // row's leading character means "this is the active thing" in
-        // both the navigation and loading states.
+
         let pointer_str = if is_loading {
             format!("{} ", spinner.unwrap_or("⠋"))
         } else if is_cursor {
-            "> ".to_string()
+            format!("{CURSOR_GLYPH} ")
         } else {
             "  ".to_string()
         };
@@ -393,61 +320,50 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
         } else {
             Style::default().fg(theme.fg_secondary)
         };
+
+        // The PR list does not use the bordered-row range model; PRs are
+        // single-select. We still align with the commit-row column layout
+        // for visual consistency: leading cursor, a placeholder for the
+        // range column, and a leading number badge.
         let number = format!("#{:<5}", row.summary.number);
         let title = truncate_str(&row.summary.title, 60);
         let author = row.summary.author.as_deref().unwrap_or("?");
         let updated = row
             .summary
             .updated_at
-            .map(format_relative_time)
+            .as_ref()
+            .map(format_relative_short)
             .unwrap_or_else(|| "—".to_string());
         let draft = if row.summary.is_draft { " [draft]" } else { "" };
 
-        let line = Line::from(vec![
+        lines.push(Line::from(vec![
             Span::styled(pointer_str, pointer_style),
+            Span::styled("  ", Style::default()),
             Span::styled(number, styles::hash_style(theme)),
             Span::styled(" ", Style::default()),
             Span::styled(title, Style::default().fg(theme.fg_primary)),
             Span::styled(
-                format!("   @{author}"),
+                format!("  {} \u{00b7} {}{}", author, updated, draft),
                 Style::default().fg(theme.fg_secondary),
             ),
-            Span::styled(
-                format!("   updated {updated}{draft}"),
-                Style::default().fg(theme.fg_secondary),
-            ),
-        ]);
-        lines.push(line);
+        ]));
     }
 
     if view.has_load_more {
         let load_idx = view.rows.len();
         let is_cursor = view.cursor == load_idx;
-        let style = if is_cursor {
-            styles::selected_style(theme)
-        } else {
-            Style::default().fg(theme.fg_secondary)
-        };
-        let pointer = if is_cursor { "> " } else { "  " };
-        lines.push(Line::from(vec![
-            Span::styled(pointer, style),
-            Span::styled("... load more pull requests", style),
-        ]));
+        lines.push(overflow_row(theme, is_cursor, "load more pull requests"));
     }
 
     if lines.is_empty() {
-        // Empty state placeholder under the banner.
-        if !matches!(view.status, PrTabStatus::Ready) {
-            return;
-        }
         let msg = if view.filter.is_empty() {
-            " No open pull requests"
+            "  No open pull requests"
         } else {
-            " No pull requests match the filter"
+            "  No pull requests match the filter"
         };
         lines.push(Line::from(Span::styled(
             msg,
-            Style::default().fg(theme.fg_secondary),
+            Style::default().fg(theme.fg_dim),
         )));
     }
 
@@ -469,74 +385,84 @@ pub(crate) fn pr_open_spinner_glyph(elapsed: std::time::Duration) -> &'static st
     FRAMES[idx]
 }
 
-fn format_relative_time(time: chrono::DateTime<chrono::Utc>) -> String {
-    let now = chrono::Utc::now();
-    let delta = now.signed_duration_since(time);
-    if delta.num_seconds() < 0 {
-        return "just now".to_string();
-    }
-    let secs = delta.num_seconds();
-    if secs < 60 {
-        return "just now".to_string();
-    }
-    let mins = delta.num_minutes();
-    if mins < 60 {
-        return format!("{mins}m ago");
-    }
-    let hours = delta.num_hours();
-    if hours < 24 {
-        return format!("{hours}h ago");
-    }
-    let days = delta.num_days();
-    if days < 30 {
-        return format!("{days}d ago");
-    }
-    let months = days / 30;
-    if months < 12 {
-        return format!("{months}mo ago");
-    }
-    let years = days / 365;
-    format!("{years}y ago")
-}
-
 fn render_target_selector_footer(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
+
+    // While editing the PR filter, the footer becomes a vim-style input
+    // line: left slot carries `/<draft>|`, right slot the apply/cancel hint.
+    if let Some(draft) = app.pr_filter_draft.as_ref() {
+        let left = vec![Span::styled(
+            format!(" /{draft}"),
+            Style::default().fg(theme.fg_primary),
+        )];
+        let (message_span, message_width) =
+            status_bar::build_message_span(app.message.as_ref(), theme);
+        let right_span = if message_width > 0 {
+            message_span
+        } else {
+            Span::styled(
+                " enter apply \u{00b7} esc cancel ",
+                Style::default().fg(theme.fg_secondary),
+            )
+        };
+        let right_width = right_span.content.len();
+        let spans = status_bar::build_right_aligned_spans(
+            left,
+            right_span,
+            right_width,
+            area.width as usize,
+        );
+        let footer = Paragraph::new(Line::from(spans)).style(styles::status_bar_style(theme));
+        frame.render_widget(footer, area);
+
+        // Set the terminal cursor at the end of the filter buffer so users
+        // see where typing will land.
+        let cursor_x = area.x + 2 + draft.len() as u16;
+        let cursor_y = area.y;
+        frame.set_cursor_position(ratatui::layout::Position {
+            x: cursor_x.min(area.x + area.width.saturating_sub(1)),
+            y: cursor_y,
+        });
+        return;
+    }
+
     let mode_span = Span::styled(" SELECT ", styles::mode_style(theme));
 
     let hints = if app.message.is_some() {
         String::new()
-    } else if app.pr_filter_editing() {
-        " Enter:apply  Esc:cancel ".to_string()
     } else {
         match app.target_tab {
             TargetTab::Local => {
-                let selected_count = match app.commit_selection_range {
-                    Some((start, end)) => end - start + 1,
-                    None => 0,
-                };
-                let selection_info = if selected_count > 0 {
-                    format!(" ({selected_count} selected)")
-                } else {
-                    String::new()
-                };
-                format!(
-                    " Tab:tabs  j/k:navigate  Space:select range  Enter:confirm  q:quit{selection_info}"
-                )
+                "   j/k navigate \u{00b7} space range \u{00b7} \u{21b5} confirm \u{00b7} q quit"
+                    .to_string()
             }
             TargetTab::PullRequests => {
-                " Tab:tabs  j/k:navigate  Enter:open  /:filter  Esc/q:back ".to_string()
+                "   j/k navigate \u{00b7} \u{21b5} open \u{00b7} / filter \u{00b7} esc/q back"
+                    .to_string()
             }
         }
     };
     let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 
-    let left_spans = vec![mode_span, hints_span];
+    let selected_count = match app.commit_selection_range {
+        Some((start, end)) if app.target_tab == TargetTab::Local => end - start + 1,
+        _ => 0,
+    };
 
-    let (message_span, message_width) = status_bar::build_message_span(app.message.as_ref(), theme);
+    let (right_span, right_width) = if let (Some(_), _) = (&app.message, ()) {
+        status_bar::build_message_span(app.message.as_ref(), theme)
+    } else if selected_count > 0 {
+        let text = format!(" {selected_count} selected ");
+        let width = text.len();
+        (Span::styled(text, Style::default().fg(theme.fg_dim)), width)
+    } else {
+        (Span::raw(""), 0)
+    };
+
     let spans = status_bar::build_right_aligned_spans(
-        left_spans,
-        message_span,
-        message_width,
+        vec![mode_span, hints_span],
+        right_span,
+        right_width,
         area.width as usize,
     );
 
@@ -551,9 +477,7 @@ mod selector_render_snapshot_tests {
     //! Render-snapshot tests for the review-target selector. We drive the
     //! real `render` against ratatui's `TestBackend` and assert on the
     //! resulting character grid (plus a few style checks for the active
-    //! tab highlight). These tests caught a regression where the inactive
-    //! tab rendered as bare dim text with no bracket / cue, making the
-    //! Pull Requests tab functionally invisible.
+    //! tab highlight).
     use crate::app::{App, DiffSource, InputMode};
     use crate::error::Result as TuicrResult;
     use crate::error::TuicrError;
@@ -683,98 +607,105 @@ mod selector_render_snapshot_tests {
             .collect()
     }
 
-    /// True when at least one cell in [x_start, x_end) on row `y` carries the
-    /// REVERSED modifier — our visual marker for the active tab.
-    fn any_reversed_in_range(buffer: &Buffer, y: u16, x_start: u16, x_end: u16) -> bool {
-        (x_start..x_end.min(buffer.area.width)).any(|x| {
-            buffer[(x, y)]
-                .style()
-                .add_modifier
-                .contains(Modifier::REVERSED)
-        })
+    /// True when at least one cell in [x_start, x_end) on row `y` carries
+    /// the BOLD modifier — the active-label cue in the new flat design.
+    fn any_bold_in_range(buffer: &Buffer, y: u16, x_start: u16, x_end: u16) -> bool {
+        (x_start..x_end.min(buffer.area.width))
+            .any(|x| buffer[(x, y)].style().add_modifier.contains(Modifier::BOLD))
     }
 
     /// Locate the inclusive x-range of a substring on row `y`. Panics if
-    /// the substring is not present, with a helpful dump.
+    /// the substring is not present.
     fn locate(buffer: &Buffer, y: u16, needle: &str) -> (u16, u16) {
         let line = row_text(buffer, y);
         let byte_idx = line
             .find(needle)
             .unwrap_or_else(|| panic!("expected to find {needle:?} on row {y}, got {line:?}"));
-        // Symbols are ASCII in our render so byte index == column index.
         let start = byte_idx as u16;
         let end = start + needle.len() as u16;
         (start, end)
     }
 
+    const TAB_STRIP_ROW: u16 = 2;
+
+    /// True when at least one cell in [x_start, x_end) on row `y` carries
+    /// the given background color.
+    fn any_bg_in_range(
+        buffer: &Buffer,
+        y: u16,
+        x_start: u16,
+        x_end: u16,
+        bg: ratatui::style::Color,
+    ) -> bool {
+        (x_start..x_end.min(buffer.area.width)).any(|x| buffer[(x, y)].style().bg == Some(bg))
+    }
+
     #[test]
-    fn should_render_both_tabs_with_brackets_when_local_active_and_no_forge() {
-        // given — plain app with no GitHub remote
+    fn should_render_both_tab_labels_with_active_chip_bg_when_local_active() {
+        // given — plain app, Local is active by default
         let mut app = make_app(vec![commit(0), commit(1)]);
+        let highlight_bg = app.theme.bg_highlight;
         // when
         let buffer = draw(&mut app);
-        // then — tab strip has both bracketed labels
-        let strip = row_text(&buffer, 1);
+        // then — tab strip shows both labels in the single bg-filled row
+        let strip = row_text(&buffer, TAB_STRIP_ROW);
         assert!(
-            strip.contains("[ Local ]") && strip.contains("[ Pull Requests ]"),
-            "tab strip missing brackets: {strip:?}"
+            strip.contains("Local") && strip.contains("Pull Requests"),
+            "tab strip missing labels: {strip:?}"
         );
-        // and — the active "Local" label is REVERSED, inactive PR label is not
-        let (lo, hi) = locate(&buffer, 1, "Local");
+        // and — the active "Local" chip carries the highlight bg
+        let (lo, hi) = locate(&buffer, TAB_STRIP_ROW, "Local");
         assert!(
-            any_reversed_in_range(&buffer, 1, lo, hi),
-            "active Local label should be REVERSED"
+            any_bg_in_range(&buffer, TAB_STRIP_ROW, lo, hi, highlight_bg),
+            "active Local chip should carry bg_highlight"
         );
-        let (lo, hi) = locate(&buffer, 1, "Pull Requests");
+        // and the active label is BOLD
         assert!(
-            !any_reversed_in_range(&buffer, 1, lo, hi),
-            "inactive Pull Requests label should NOT be REVERSED"
+            any_bold_in_range(&buffer, TAB_STRIP_ROW, lo, hi),
+            "active Local label should be BOLD"
+        );
+        // inactive "Pull Requests" is NOT highlighted
+        let (lo, hi) = locate(&buffer, TAB_STRIP_ROW, "Pull Requests");
+        assert!(
+            !any_bg_in_range(&buffer, TAB_STRIP_ROW, lo, hi, highlight_bg),
+            "inactive Pull Requests chip should NOT carry bg_highlight"
         );
     }
 
     #[test]
-    fn should_show_disabled_banner_when_pr_tab_active_without_forge() {
+    fn should_show_disabled_hint_in_status_slot_when_pr_tab_active_without_forge() {
         // given
         let mut app = make_app(vec![commit(0)]);
         app.target_tab = crate::app::TargetTab::PullRequests;
         // when
         let buffer = draw(&mut app);
-        // then — banner spells out the reason
-        let body = (3..buffer.area.height)
-            .map(|y| row_text(&buffer, y))
-            .collect::<Vec<_>>()
-            .join("\n");
+        // then — tab strip carries the disabled reason in its right slot
+        let strip = row_text(&buffer, TAB_STRIP_ROW);
         assert!(
-            body.contains("No GitHub remote on this repo"),
-            "expected disabled banner, got body:\n{body}"
+            strip.contains("No GitHub remote on this repo"),
+            "expected disabled hint in tab strip, got: {strip:?}"
         );
     }
 
     #[test]
-    fn should_highlight_pr_tab_label_when_pr_tab_active() {
-        // given — forge repo configured, PR tab active in Idle state
+    fn should_bold_pr_tab_label_when_pr_tab_active() {
+        // given
         let mut app = make_app(vec![commit(0)]);
         app.forge_repository = Some(repo());
         app.pr_tab = PullRequestsTab::new(Some(repo()));
         app.target_tab = crate::app::TargetTab::PullRequests;
         // when
         let buffer = draw(&mut app);
-        // then — Pull Requests is the highlighted (REVERSED) label
-        let (lo, hi) = locate(&buffer, 1, "Pull Requests");
-        assert!(
-            any_reversed_in_range(&buffer, 1, lo, hi),
-            "active Pull Requests label should be REVERSED"
-        );
-        let (lo, hi) = locate(&buffer, 1, "Local");
-        assert!(
-            !any_reversed_in_range(&buffer, 1, lo, hi),
-            "inactive Local label should NOT be REVERSED"
-        );
+        // then
+        let (lo, hi) = locate(&buffer, TAB_STRIP_ROW, "Pull Requests");
+        assert!(any_bold_in_range(&buffer, TAB_STRIP_ROW, lo, hi));
+        let (lo, hi) = locate(&buffer, TAB_STRIP_ROW, "Local");
+        assert!(!any_bold_in_range(&buffer, TAB_STRIP_ROW, lo, hi));
     }
 
     #[test]
     fn should_render_loaded_pr_rows_with_number_title_author() {
-        // given — three loaded PRs, second with no author
+        // given — two loaded PRs
         let mut app = make_app(vec![commit(0)]);
         app.forge_repository = Some(repo());
         let mut tab = PullRequestsTab::new(Some(repo()));
@@ -790,8 +721,8 @@ mod selector_render_snapshot_tests {
         app.target_tab = crate::app::TargetTab::PullRequests;
         // when
         let buffer = draw(&mut app);
-        // then — both rows are present in the rendered body
-        let body = (3..buffer.area.height)
+        // then
+        let body = (4..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect::<Vec<_>>()
             .join("\n");
@@ -808,6 +739,29 @@ mod selector_render_snapshot_tests {
     }
 
     #[test]
+    fn should_show_loaded_count_in_tab_strip_status_slot_when_ready() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.forge_repository = Some(repo());
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        tab.start_initial_load();
+        tab.apply_initial_load(Ok((
+            vec![pr(1, "alpha", "a"), pr(2, "beta", "b"), pr(3, "gamma", "c")],
+            false,
+        )));
+        app.pr_tab = tab;
+        app.target_tab = crate::app::TargetTab::PullRequests;
+        // when
+        let buffer = draw(&mut app);
+        // then — `3 loaded` lives in the tab-strip right slot
+        let strip = row_text(&buffer, TAB_STRIP_ROW);
+        assert!(
+            strip.contains("3 loaded"),
+            "expected '3 loaded' in tab strip, got: {strip:?}"
+        );
+    }
+
+    #[test]
     fn should_show_load_more_row_when_has_more_and_no_filter() {
         // given
         let mut app = make_app(vec![commit(0)]);
@@ -820,7 +774,7 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (3..buffer.area.height)
+        let body = (4..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect::<Vec<_>>()
             .join("\n");
@@ -832,7 +786,7 @@ mod selector_render_snapshot_tests {
 
     #[test]
     fn should_hide_load_more_row_when_filter_active() {
-        // given — has_more is true but a filter is set
+        // given
         let mut app = make_app(vec![commit(0)]);
         app.forge_repository = Some(repo());
         let mut tab = PullRequestsTab::new(Some(repo()));
@@ -844,7 +798,7 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (3..buffer.area.height)
+        let body = (4..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect::<Vec<_>>()
             .join("\n");
@@ -855,7 +809,7 @@ mod selector_render_snapshot_tests {
     }
 
     #[test]
-    fn should_render_filter_draft_banner_when_editing_filter() {
+    fn should_render_filter_draft_input_in_footer_when_editing() {
         // given
         let mut app = make_app(vec![commit(0)]);
         app.forge_repository = Some(repo());
@@ -867,19 +821,20 @@ mod selector_render_snapshot_tests {
         app.pr_filter_draft = Some("alp".to_string());
         // when
         let buffer = draw(&mut app);
-        // then — the banner shows the in-progress filter expression
-        let body = (3..buffer.area.height)
-            .map(|y| row_text(&buffer, y))
-            .collect::<Vec<_>>()
-            .join("\n");
+        // then — footer (last row) carries `/alp` on the left and apply/cancel on the right
+        let footer = row_text(&buffer, buffer.area.height - 1);
         assert!(
-            body.contains("/alp") && body.contains("filter"),
-            "expected filter draft banner, got:\n{body}"
+            footer.contains("/alp"),
+            "expected filter draft in footer, got: {footer:?}"
+        );
+        assert!(
+            footer.contains("apply") && footer.contains("cancel"),
+            "expected apply/cancel hint in footer, got: {footer:?}"
         );
     }
 
     #[test]
-    fn should_render_error_banner_when_pr_load_failed() {
+    fn should_render_error_state_in_tab_strip_status_slot_when_pr_load_failed() {
         // given
         let mut app = make_app(vec![commit(0)]);
         app.forge_repository = Some(repo());
@@ -891,42 +846,35 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (3..buffer.area.height)
-            .map(|y| row_text(&buffer, y))
-            .collect::<Vec<_>>()
-            .join("\n");
+        let strip = row_text(&buffer, TAB_STRIP_ROW);
         assert!(
-            body.contains("error") && body.contains("network down"),
-            "expected error banner, got:\n{body}"
+            strip.contains("error") && strip.contains("network down"),
+            "expected error in tab-strip status slot, got: {strip:?}"
         );
     }
 
     #[test]
-    fn should_render_loading_banner_when_pr_load_in_flight() {
+    fn should_render_loading_state_in_tab_strip_status_slot_when_pr_load_in_flight() {
         // given
         let mut app = make_app(vec![commit(0)]);
         app.forge_repository = Some(repo());
         let mut tab = PullRequestsTab::new(Some(repo()));
         tab.start_initial_load();
-        // (stays in Loading until apply_initial_load)
         app.pr_tab = tab;
         app.target_tab = crate::app::TargetTab::PullRequests;
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (3..buffer.area.height)
-            .map(|y| row_text(&buffer, y))
-            .collect::<Vec<_>>()
-            .join("\n");
+        let strip = row_text(&buffer, TAB_STRIP_ROW);
         assert!(
-            body.contains("Fetching pull requests"),
-            "expected loading banner, got:\n{body}"
+            strip.contains("loading"),
+            "expected loading hint in tab strip, got: {strip:?}"
         );
     }
 
     #[test]
     fn should_render_spinner_glyph_in_place_of_cursor_for_loading_pr_row() {
-        // given — two PRs loaded, an open in-flight for #148
+        // given
         use crate::app::PrOpenRequest;
         use std::time::Instant;
         let mut app = make_app(vec![commit(0)]);
@@ -949,35 +897,24 @@ mod selector_render_snapshot_tests {
         });
         // when
         let buffer = draw(&mut app);
-        // then — the loading row leads with one of the braille spinner glyphs
+        // then
         let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-        let lines: Vec<String> = (3..buffer.area.height)
+        let lines: Vec<String> = (4..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect();
         let loading_row = lines
             .iter()
             .find(|l| l.contains("#148"))
             .expect("#148 row missing");
-        let non_loading_row = lines
-            .iter()
-            .find(|l| l.contains("#125"))
-            .expect("#125 row missing");
         assert!(
-            frames
-                .iter()
-                .any(|g| loading_row.starts_with(&format!(" {g}")) || loading_row.contains(g)),
+            frames.iter().any(|g| loading_row.contains(g)),
             "loading row should contain a spinner glyph: {loading_row:?}"
-        );
-        // The non-loading row should not have any spinner glyph at the front.
-        assert!(
-            !frames.iter().any(|g| non_loading_row.contains(g)),
-            "non-loading row should not contain a spinner glyph: {non_loading_row:?}"
         );
     }
 
     #[test]
     fn should_keep_cursor_pointer_on_other_rows_during_loading() {
-        // given — loading #148, cursor on #125
+        // given
         use crate::app::PrOpenRequest;
         use std::time::Instant;
         let mut app = make_app(vec![commit(0)]);
@@ -992,7 +929,7 @@ mod selector_render_snapshot_tests {
             false,
         )));
         if let PullRequestsTab::Loaded { cursor, .. } = &mut tab {
-            *cursor = 1; // cursor on #125
+            *cursor = 1;
         }
         app.pr_tab = tab;
         app.target_tab = crate::app::TargetTab::PullRequests;
@@ -1003,8 +940,8 @@ mod selector_render_snapshot_tests {
         });
         // when
         let buffer = draw(&mut app);
-        // then — #125 row keeps the `> ` cursor pointer (after the panel border)
-        let lines: Vec<String> = (3..buffer.area.height)
+        // then — #125 row keeps the cursor arrow
+        let lines: Vec<String> = (4..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect();
         let cursor_row = lines
@@ -1012,8 +949,8 @@ mod selector_render_snapshot_tests {
             .find(|l| l.contains("#125"))
             .expect("#125 row missing");
         assert!(
-            cursor_row.contains("> #125"),
-            "cursor row should contain `> #125`: {cursor_row:?}"
+            cursor_row.contains("\u{25b8}"),
+            "cursor row should contain ▸ glyph: {cursor_row:?}"
         );
     }
 }
@@ -1030,7 +967,6 @@ mod pr_open_spinner_tests {
         assert_eq!(pr_open_spinner_glyph(Duration::from_millis(99)), "⠋");
         assert_eq!(pr_open_spinner_glyph(Duration::from_millis(100)), "⠙");
         assert_eq!(pr_open_spinner_glyph(Duration::from_millis(900)), "⠏");
-        // Wraps after the 10th frame.
         assert_eq!(pr_open_spinner_glyph(Duration::from_millis(1000)), "⠋");
     }
 }

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -13,7 +13,7 @@ use crate::ui::commit_row::{
 };
 use crate::ui::status_bar;
 use crate::ui::styles;
-use crate::ui::text_utils::truncate_str;
+use crate::ui::text_utils::truncate_or_pad;
 
 const TAB_LOCAL: &str = "Local";
 const TAB_PULL_REQUESTS: &str = "Pull Requests";
@@ -21,23 +21,20 @@ const TAB_PULL_REQUESTS: &str = "Pull Requests";
 pub(super) fn render_commit_select(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
-    // Layout: header, blank, tab strip (full-width bg, active tab is a
-    // brighter chip inside the strip), bordered body, footer.
+    // Layout: top bar (brand + tabs + right-slot status), bordered body,
+    // footer. The tabs live INSIDE the top bar — no separate strip row.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // header
-            Constraint::Length(1), // blank
-            Constraint::Length(1), // tab strip
+            Constraint::Length(1), // top bar (brand + tabs + status)
             Constraint::Min(0),    // body block (full borders)
             Constraint::Length(1), // footer
         ])
         .split(area);
 
-    render_header_line(frame, app, chunks[0]);
-    render_tab_strip(frame, app, chunks[2]);
+    render_top_bar(frame, app, chunks[0]);
 
-    let body_area = chunks[3];
+    let body_area = chunks[1];
     let body_block = Block::default()
         .borders(Borders::ALL)
         .border_style(styles::border_style(&app.theme, true))
@@ -50,57 +47,25 @@ pub(super) fn render_commit_select(frame: &mut Frame, app: &mut App) {
         TargetTab::PullRequests => render_pull_requests_tab(frame, app, inner),
     }
 
-    render_target_selector_footer(frame, app, chunks[4]);
+    render_target_selector_footer(frame, app, chunks[2]);
 }
 
-fn render_header_line(frame: &mut Frame, app: &App, area: Rect) {
-    let theme = &app.theme;
-    let vcs_type = &app.vcs_info.vcs_type;
-    let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
-
-    let brand = Span::styled(
-        " tuicr  ",
-        Style::default()
-            .fg(theme.fg_primary)
-            .add_modifier(Modifier::BOLD),
-    );
-    let action = Span::styled(
-        "select review target",
-        Style::default().fg(theme.fg_secondary),
-    );
-    let right = format!("{vcs_type}:{branch} ");
-    let right_width = right.len();
-    let right_span = Span::styled(right, Style::default().fg(theme.fg_secondary));
-
-    let left = vec![brand, action];
-    let left_width: usize = left.iter().map(|s| s.content.len()).sum();
-    let total_width = area.width as usize;
-    let pad = total_width.saturating_sub(left_width + right_width);
-
-    let mut spans = left;
-    spans.push(Span::raw(" ".repeat(pad)));
-    spans.push(right_span);
-
-    frame.render_widget(
-        Paragraph::new(Line::from(spans)).style(styles::panel_style(theme)),
-        area,
-    );
-}
-
-/// Single-row tab strip filling the full terminal width with a subtle bg.
-/// The active tab renders as a brighter chip (`bg_highlight` + bold primary
-/// fg); inactive tab text sits flat on the strip bg in dim fg. The right
-/// slot carries the PR-tab status hint when that tab is active.
-fn render_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
+/// Combined top bar: brand on the left, tab chips, then a right slot
+/// carrying `git:<branch>` (Local tab) or the PR-tab status hint. The entire
+/// row uses `status_bar_bg` so the active tab's `bg_highlight` reads as a
+/// chip popping out of the strip.
+fn render_top_bar(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let active = app.target_tab;
     let local_active = active == TargetTab::Local;
     let pr_active = active == TargetTab::PullRequests;
 
     let strip_bg = theme.status_bar_bg;
-    let strip_fg = theme.fg_dim;
-    let strip_style = Style::default().bg(strip_bg).fg(strip_fg);
-
+    let strip_style = Style::default().bg(strip_bg).fg(theme.fg_dim);
+    let brand_style = Style::default()
+        .bg(strip_bg)
+        .fg(theme.fg_primary)
+        .add_modifier(Modifier::BOLD);
     let active_chip = Style::default()
         .bg(theme.bg_highlight)
         .fg(theme.fg_primary)
@@ -108,7 +73,7 @@ fn render_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
     let inactive_chip = Style::default().bg(strip_bg).fg(theme.fg_dim);
 
     let mut spans: Vec<Span<'static>> = Vec::new();
-    spans.push(Span::styled(" ".to_string(), strip_style));
+    spans.push(Span::styled(" tuicr  ", brand_style));
     spans.push(Span::styled(
         format!(" {TAB_LOCAL} "),
         if local_active {
@@ -131,7 +96,13 @@ fn render_tab_strip(frame: &mut Frame, app: &App, area: Rect) {
 
     let (right_span, right_width) = match active {
         TargetTab::PullRequests => pr_status_hint_span(app, strip_bg),
-        TargetTab::Local => (Span::raw(""), 0),
+        TargetTab::Local => {
+            let vcs_type = &app.vcs_info.vcs_type;
+            let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
+            let content = format!(" {vcs_type}:{branch} ");
+            let width = content.chars().count();
+            (Span::styled(content, strip_style), width)
+        }
     };
 
     let total_width = area.width as usize;
@@ -321,13 +292,13 @@ fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>
             Style::default().fg(theme.fg_secondary)
         };
 
-        // The PR list does not use the bordered-row range model; PRs are
-        // single-select. We still align with the commit-row column layout
-        // for visual consistency: leading cursor, a placeholder for the
-        // range column, and a leading number badge.
+        // PRs are single-select. Mirror the commit-row column layout for
+        // visual consistency (leading cursor + a placeholder column where
+        // the range bar lives on commit rows) and pad title/author so the
+        // date column lands at the same x across rows.
         let number = format!("#{:<5}", row.summary.number);
-        let title = truncate_str(&row.summary.title, 60);
-        let author = row.summary.author.as_deref().unwrap_or("?");
+        let title = truncate_or_pad(&row.summary.title, 60);
+        let author = truncate_or_pad(row.summary.author.as_deref().unwrap_or("?"), 12);
         let updated = row
             .summary
             .updated_at
@@ -626,7 +597,7 @@ mod selector_render_snapshot_tests {
         (start, end)
     }
 
-    const TAB_STRIP_ROW: u16 = 2;
+    const TAB_STRIP_ROW: u16 = 0;
 
     /// True when at least one cell in [x_start, x_end) on row `y` carries
     /// the given background color.
@@ -722,7 +693,7 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (4..buffer.area.height)
+        let body = (2..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect::<Vec<_>>()
             .join("\n");
@@ -774,7 +745,7 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (4..buffer.area.height)
+        let body = (2..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect::<Vec<_>>()
             .join("\n");
@@ -798,7 +769,7 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then
-        let body = (4..buffer.area.height)
+        let body = (2..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect::<Vec<_>>()
             .join("\n");
@@ -899,7 +870,7 @@ mod selector_render_snapshot_tests {
         let buffer = draw(&mut app);
         // then
         let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-        let lines: Vec<String> = (4..buffer.area.height)
+        let lines: Vec<String> = (2..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect();
         let loading_row = lines
@@ -941,7 +912,7 @@ mod selector_render_snapshot_tests {
         // when
         let buffer = draw(&mut app);
         // then — #125 row keeps the cursor arrow
-        let lines: Vec<String> = (4..buffer.area.height)
+        let lines: Vec<String> = (2..buffer.area.height)
             .map(|y| row_text(&buffer, y))
             .collect();
         let cursor_row = lines

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -52,152 +52,137 @@ pub fn build_right_aligned_spans<'a>(
 
 pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
-    let vcs_type = &app.vcs_info.vcs_type;
-    let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
-
     let in_pr_mode = matches!(app.diff_source, DiffSource::PullRequest(_));
 
-    let title = if in_pr_mode {
-        " tuicr - PR Review ".to_string()
+    let brand = Span::styled(
+        " tuicr ",
+        Style::default()
+            .fg(theme.fg_primary)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    // Right-cluster: source/context chunks, bullet-separated. PR mode leads
+    // with a `PR Mode` tag; otherwise we show `<vcs>:<branch> · <source>`.
+    let mut chunks: Vec<String> = Vec::new();
+    if in_pr_mode {
+        chunks.push("PR Mode".to_string());
     } else {
-        " tuicr - Code Review ".to_string()
-    };
-    let vcs_info = if in_pr_mode {
-        // PR mode header is anchored on the PR identity, not the local VCS.
+        let vcs_type = &app.vcs_info.vcs_type;
+        let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
+        chunks.push(format!("{vcs_type}:{branch}"));
+    }
+    if let Some(source) = header_source_chunk(app) {
+        chunks.push(source);
+    }
+    let source_text = if chunks.is_empty() {
         String::new()
     } else {
-        format!("[{vcs_type}:{branch}] ")
+        format!(" {} ", chunks.join(" \u{00b7} "))
+    };
+    let source_width = source_text.chars().count();
+    let source_span = Span::styled(source_text, Style::default().fg(theme.fg_secondary));
+
+    let (update_span, update_width) = match app.update_info.as_ref() {
+        Some(info) if info.update_available => {
+            let text = format!(" v{} available ", info.latest_version);
+            let width = text.chars().count();
+            (
+                Span::styled(
+                    text,
+                    Style::default()
+                        .fg(theme.update_badge_fg)
+                        .bg(theme.update_badge_bg)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                width,
+            )
+        }
+        Some(info) if info.is_ahead => {
+            let text = format!(" unreleased v{} ", info.current_version);
+            let width = text.chars().count();
+            (
+                Span::styled(
+                    text,
+                    Style::default()
+                        .fg(theme.update_badge_fg)
+                        .bg(theme.update_badge_bg)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                width,
+            )
+        }
+        _ => (Span::raw(""), 0),
     };
 
-    // Show diff source info
-    let source_info = match &app.diff_source {
-        DiffSource::WorkingTree => String::new(),
-        DiffSource::Staged => "[staged] ".to_string(),
-        DiffSource::Unstaged => "[unstaged] ".to_string(),
-        DiffSource::StagedAndUnstaged => "[staged + unstaged] ".to_string(),
+    let total_width = area.width as usize;
+    let brand_width = brand.content.chars().count();
+    let right_width = source_width + update_width;
+    let pad_width = total_width.saturating_sub(brand_width + right_width);
+
+    let mut spans = vec![brand, Span::raw(" ".repeat(pad_width)), source_span];
+    if update_width > 0 {
+        spans.push(update_span);
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).style(styles::status_bar_style(theme)),
+        area,
+    );
+}
+
+/// Short, lowercase description of the active review source. Returns `None`
+/// for plain working-tree review (no extra label needed beyond `vcs:branch`).
+fn header_source_chunk(app: &App) -> Option<String> {
+    match &app.diff_source {
+        DiffSource::WorkingTree => None,
+        DiffSource::Staged => Some("staged".to_string()),
+        DiffSource::Unstaged => Some("unstaged".to_string()),
+        DiffSource::StagedAndUnstaged => Some("staged + unstaged".to_string()),
         DiffSource::CommitRange(commits) => {
             if commits.len() == 1 {
-                format!("[commit {}] ", &commits[0][..7.min(commits[0].len())])
+                Some(format!("commit {}", &commits[0][..7.min(commits[0].len())]))
             } else {
                 match app.commit_selection_range {
-                    Some((start, end)) if end - start + 1 < app.review_commits.len() => {
-                        format!(
-                            "[{}/{} commits] ",
-                            end - start + 1,
-                            app.review_commits.len()
-                        )
-                    }
-                    _ => format!("[{} commits] ", commits.len()),
+                    Some((start, end)) if end - start + 1 < app.review_commits.len() => Some(
+                        format!("{}/{} commits", end - start + 1, app.review_commits.len()),
+                    ),
+                    _ => Some(format!("{} commits", commits.len())),
                 }
             }
         }
         DiffSource::StagedUnstagedAndCommits(commits) => {
             if commits.len() == 1 {
-                format!(
-                    "[staged + unstaged + commit {}] ",
+                Some(format!(
+                    "staged + unstaged + commit {}",
                     &commits[0][..7.min(commits[0].len())]
-                )
+                ))
             } else {
-                format!("[staged + unstaged + {} commits] ", commits.len())
+                Some(format!("staged + unstaged + {} commits", commits.len()))
             }
         }
         DiffSource::PullRequest(pr) => {
             let slug = pr.key.repository.display_name();
-            let trimmed_title = if pr.title.len() > 60 {
-                format!("{}…", &pr.title[..59])
+            let trimmed_title = if pr.title.chars().count() > 60 {
+                format!("{}\u{2026}", &pr.title[..59])
             } else {
                 pr.title.clone()
             };
-            let mut info = format!(
-                "[PR mode · {slug}#{number} · {trimmed_title}] ",
-                number = pr.key.number,
+            let mut s = format!(
+                "{slug}#{number} \u{00b7} {trimmed_title}",
+                number = pr.key.number
             );
-            if let Some(state) = pr.read_only_reason() {
-                info.push_str(&format!("[{state} — read only] "));
-            }
-            // Surface a strict-subset selection so the user can see at a
-            // glance that the diff is scoped to a narrower commit range
-            // than the full PR. Single-commit PRs (no selector) and
-            // full-range selection get no label.
             let total = app.pr_commits.len();
             if total > 1
                 && let Some((start, end)) = app.commit_selection_range
             {
                 let selected = end - start + 1;
                 if selected < total {
-                    info.push_str(&format!("[{selected} of {total} commits] "));
+                    s.push_str(&format!(" \u{00b7} {selected} of {total} commits"));
                 }
             }
-            info
+            Some(s)
         }
-    };
-
-    let progress = format!("{}/{} reviewed ", app.reviewed_count(), app.file_count());
-
-    let title_span = Span::styled(title, styles::header_style(theme));
-    let vcs_span = Span::styled(vcs_info, Style::default().fg(theme.fg_secondary));
-    let source_span = Span::styled(source_info, Style::default().fg(theme.diff_hunk_header));
-    let progress_span = Span::styled(
-        progress,
-        if app.reviewed_count() == app.file_count() {
-            styles::reviewed_style(theme)
-        } else {
-            styles::pending_style(theme)
-        },
-    );
-
-    let (update_span, update_width) = if let Some(ref info) = app.update_info {
-        if info.update_available {
-            let text = format!(" v{} available ", info.latest_version);
-            let width = text.len();
-            (
-                Span::styled(
-                    text,
-                    Style::default()
-                        .fg(theme.update_badge_fg)
-                        .bg(theme.update_badge_bg)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                width,
-            )
-        } else if info.is_ahead {
-            let text = format!(" unreleased v{} ", info.current_version);
-            let width = text.len();
-            (
-                Span::styled(
-                    text,
-                    Style::default()
-                        .fg(theme.update_badge_fg)
-                        .bg(theme.update_badge_bg)
-                        .add_modifier(Modifier::BOLD),
-                ),
-                width,
-            )
-        } else {
-            (Span::raw(""), 0)
-        }
-    } else {
-        (Span::raw(""), 0)
-    };
-
-    let left_spans = vec![title_span, vcs_span, source_span, progress_span];
-    let left_width: usize = left_spans.iter().map(|s| s.content.len()).sum();
-    let total_width = area.width as usize;
-    let padding_width = total_width.saturating_sub(left_width + update_width);
-
-    let mut spans = left_spans;
-    spans.push(Span::raw(" ".repeat(padding_width)));
-    if update_width > 0 {
-        spans.push(update_span);
     }
-
-    let line = Line::from(spans);
-
-    let header = Paragraph::new(line)
-        .style(styles::status_bar_style(theme))
-        .block(Block::default());
-
-    frame.render_widget(header, area);
 }
 
 pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
@@ -257,60 +242,43 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             Cow::Borrowed("")
         } else {
             match app.input_mode {
-                InputMode::Normal => Cow::Owned(format!(
-                    " j/k:scroll  {{/}}:file  r:reviewed  c:comment  {}c:review  V:visual  /:search  ?:help  :q:quit ",
-                    app.leader_key
-                )),
-                InputMode::Command => Cow::Borrowed(" Enter:execute  Esc:cancel "),
-                InputMode::Search => Cow::Borrowed(" Enter:search  Esc:cancel "),
-                InputMode::Comment => Cow::Borrowed(" Ctrl-S:save  Esc:cancel "),
-                InputMode::Help => Cow::Borrowed(" q/?/Esc:close "),
-                InputMode::Confirm => Cow::Borrowed(" y:yes  n:no "),
-                InputMode::CommitSelect => {
-                    Cow::Borrowed(" j/k:navigate  Space:select  Enter:confirm  Esc:back  q:quit ")
+                InputMode::Normal => Cow::Borrowed(
+                    "   j/k scroll \u{00b7} {/} file \u{00b7} r reviewed \u{00b7} c comment \u{00b7} ? help",
+                ),
+                InputMode::Command => Cow::Borrowed("   \u{21b5} execute \u{00b7} esc cancel"),
+                InputMode::Search => Cow::Borrowed("   \u{21b5} search \u{00b7} esc cancel"),
+                InputMode::Comment => Cow::Borrowed("   ctrl-s save \u{00b7} esc cancel"),
+                InputMode::Help => Cow::Borrowed("   q/?/esc close"),
+                InputMode::Confirm => Cow::Borrowed("   y yes \u{00b7} n no"),
+                InputMode::CommitSelect => Cow::Borrowed(
+                    "   j/k navigate \u{00b7} space select \u{00b7} \u{21b5} confirm \u{00b7} esc back",
+                ),
+                InputMode::VisualSelect => Cow::Borrowed(
+                    "   j/k extend \u{00b7} c/\u{21b5} comment \u{00b7} y yank \u{00b7} esc/V cancel",
+                ),
+                InputMode::SubmitResolver => Cow::Borrowed(
+                    "   j/k move \u{00b7} \u{21b5} toggle \u{00b7} s submit \u{00b7} esc cancel",
+                ),
+                InputMode::SubmitConfirm => {
+                    Cow::Borrowed("   y submit \u{00b7} n cancel \u{00b7} esc cancel")
                 }
-                InputMode::VisualSelect => {
-                    Cow::Borrowed(" j/k:extend  c/Enter:comment  y:yank  Esc/V:cancel ")
-                }
-                InputMode::SubmitResolver => {
-                    Cow::Borrowed(" j/k:move  Enter:toggle  s:submit  Esc:cancel ")
-                }
-                InputMode::SubmitConfirm => Cow::Borrowed(" y:submit  n:cancel  Esc:cancel "),
                 InputMode::SubmitActionPicker => {
-                    Cow::Borrowed(" j/k:move  Enter:submit  Esc:cancel ")
+                    Cow::Borrowed("   j/k move \u{00b7} \u{21b5} submit \u{00b7} esc cancel")
                 }
             }
         };
         let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
 
-        let dirty_indicator = if app.dirty {
-            Span::styled(" [modified] ", Style::default().fg(theme.pending))
-        } else {
-            Span::raw("")
-        };
-
-        // Inline hint while remote review threads are still loading in PR
-        // mode. The diff is already visible; this just tells the user that
-        // existing GitHub discussions are still on the way.
-        let remote_loading = if app.forge_review_threads_loading {
-            Span::styled(
-                " Loading remote comments… ",
-                Style::default().fg(theme.fg_dim),
-            )
-        } else {
-            Span::raw("")
-        };
-
-        vec![mode_span, hints_span, dirty_indicator, remote_loading]
+        vec![mode_span, hints_span]
     };
 
-    // Right-aligned slot: while `:e` is in flight we put the spinner
-    // there instead of any pending message, mirroring how messages are
-    // placed. The user sees one prominent right-aligned indicator at a
-    // time. After the reload lands, the success message takes the slot
-    // back. A range re-fetch (toggling commit selection in PR mode) takes
-    // the same slot but with its own label.
-    let (right_span, right_width) = if let Some(submit) = app.pr_submit_state.as_ref() {
+    // Right-aligned slot priority: active message > pr-flow spinners
+    // (submit/reload/range) > remote-comments loading hint > modified
+    // indicator. Surfaces the most important transient state without
+    // crowding the hints on the left.
+    let (right_span, right_width) = if app.message.is_some() {
+        build_message_span(app.message.as_ref(), theme)
+    } else if let Some(submit) = app.pr_submit_state.as_ref() {
         use crate::forge::submit::SubmitEvent;
         let glyph = crate::ui::selector::pr_open_spinner_glyph(submit.started_at.elapsed());
         let label = match submit.event {
@@ -318,7 +286,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             _ => "Submitting review…",
         };
         let content = format!(" {glyph} {label} ");
-        let width = content.len();
+        let width = content.chars().count();
         (
             Span::styled(
                 content,
@@ -332,7 +300,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     } else if let Some(reload) = app.pr_reload_state.as_ref() {
         let glyph = crate::ui::selector::pr_open_spinner_glyph(reload.started_at.elapsed());
         let content = format!(" {glyph} Reloading PR… ");
-        let width = content.len();
+        let width = content.chars().count();
         (
             Span::styled(
                 content,
@@ -346,7 +314,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     } else if let Some(range) = app.pr_range_reload_state.as_ref() {
         let glyph = crate::ui::selector::pr_open_spinner_glyph(range.started_at.elapsed());
         let content = format!(" {glyph} Loading range diff… ");
-        let width = content.len();
+        let width = content.chars().count();
         (
             Span::styled(
                 content,
@@ -357,8 +325,22 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
             ),
             width,
         )
+    } else if app.forge_review_threads_loading {
+        let content = " loading remote comments\u{2026} ".to_string();
+        let width = content.chars().count();
+        (
+            Span::styled(content, Style::default().fg(theme.fg_dim)),
+            width,
+        )
+    } else if app.dirty {
+        let content = " \u{2022} modified ".to_string();
+        let width = content.chars().count();
+        (
+            Span::styled(content, Style::default().fg(theme.pending)),
+            width,
+        )
     } else {
-        build_message_span(app.message.as_ref(), theme)
+        (Span::raw(""), 0)
     };
     let total_width = area.width as usize;
     let spans = build_right_aligned_spans(left_spans, right_span, right_width, total_width);
@@ -535,34 +517,44 @@ mod pr_header_snapshot_tests {
         let app = build_pr_app(pr_source(false, false));
         // when
         let buffer = draw_header(&app);
-        // then
+        // then — brand on the left, then bullet-separated PR Mode tag,
+        // slug#number, and title in the right cluster.
         let line = row_text(&buffer, 0);
-        assert!(line.contains("tuicr - PR Review"), "got: {line:?}");
-        assert!(line.contains("PR mode"), "got: {line:?}");
+        assert!(line.contains("tuicr"), "got: {line:?}");
+        assert!(line.contains("PR Mode"), "got: {line:?}");
         assert!(line.contains("agavra/tuicr#125"), "got: {line:?}");
         assert!(line.contains("Add forge-backed PR review"), "got: {line:?}");
     }
 
+    // Read-only badges are no longer shown in the header: the `PR Mode`
+    // tag itself signals the user is on a forge-managed review; whether
+    // the PR is open/closed/merged is left to the submit flow to surface
+    // (the submit action errors with a clear message). These tests now
+    // assert the simpler invariant: closed/merged still show `PR Mode`
+    // but don't add a `read only` chip.
+
     #[test]
-    fn should_render_read_only_badge_for_closed_pr() {
+    fn should_not_show_read_only_badge_for_closed_pr() {
         // given a closed PR
         let app = build_pr_app(pr_source(true, false));
         // when
         let buffer = draw_header(&app);
         // then
         let line = row_text(&buffer, 0);
-        assert!(line.contains("closed — read only"), "got: {line:?}");
+        assert!(line.contains("PR Mode"), "got: {line:?}");
+        assert!(!line.contains("read only"), "got: {line:?}");
     }
 
     #[test]
-    fn should_render_read_only_badge_for_merged_pr() {
+    fn should_not_show_read_only_badge_for_merged_pr() {
         // given a merged PR
         let app = build_pr_app(pr_source(false, true));
         // when
         let buffer = draw_header(&app);
         // then
         let line = row_text(&buffer, 0);
-        assert!(line.contains("merged — read only"), "got: {line:?}");
+        assert!(line.contains("PR Mode"), "got: {line:?}");
+        assert!(!line.contains("read only"), "got: {line:?}");
     }
 
     #[test]
@@ -615,9 +607,9 @@ mod pr_header_snapshot_tests {
         app.commit_selection_range = Some((0, 2));
         // when
         let buffer = draw_header(&app);
-        // then
+        // then — no `N of M commits` subset label since the full range is selected
         let line = row_text(&buffer, 0);
-        assert!(!line.contains("commits]"), "got: {line:?}");
+        assert!(!line.contains(" of 3 commits"), "got: {line:?}");
     }
 
     #[test]
@@ -630,6 +622,6 @@ mod pr_header_snapshot_tests {
         let buffer = draw_header(&app);
         // then
         let line = row_text(&buffer, 0);
-        assert!(!line.contains("of"), "got: {line:?}");
+        assert!(!line.contains(" of "), "got: {line:?}");
     }
 }

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -127,3 +127,17 @@ pub fn visual_selection_style(theme: &Theme) -> Style {
 pub fn help_indicator_style(theme: &Theme) -> Style {
     Style::default().fg(theme.help_indicator).bg(theme.panel_bg)
 }
+
+pub fn range_bar_style(theme: &Theme) -> Style {
+    Style::default().fg(theme.border_focused)
+}
+
+pub fn error_inline_style(theme: &Theme) -> Style {
+    Style::default()
+        .fg(theme.message_error_fg)
+        .add_modifier(Modifier::BOLD)
+}
+
+pub fn pseudo_commit_tag_style(theme: &Theme) -> Style {
+    Style::default().fg(theme.file_modified)
+}

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -2,13 +2,6 @@ use ratatui::style::{Color, Modifier, Style};
 
 use crate::theme::Theme;
 
-pub fn header_style(theme: &Theme) -> Style {
-    Style::default()
-        .bg(theme.panel_bg)
-        .fg(theme.fg_primary)
-        .add_modifier(Modifier::BOLD)
-}
-
 pub fn selected_style(theme: &Theme) -> Style {
     Style::default().bg(theme.bg_highlight).fg(theme.fg_primary)
 }


### PR DESCRIPTION
## Summary
- Commit/PR selector: top bar holds the brand + tab chips + status hint on a single bg-tinted row; bordered body for the list; tabular row spacing so author/date columns align
- Main review frame: brand-left + info-right header (dropped subtitle, `PR Mode` tag replaces read-only badge); `Files · N/M` title carries reviewed progress; diff title drops `Diff (Unified) — ` prefix and gets smart path prefix-truncation; status bar trimmed to 5 essential bullet-separated hints with modified/loading moved to the right slot
- Shared `▣`/`▢` checkbox + `▸` cursor row pattern across commit rows and file rows; full-row bg highlight on selected file rows
- Help popup centers over the diff pane (matches the submit modals)

## Test plan
- [ ] Open the commit selector (`tuicr`) and verify the top bar shows brand, active Local chip, and `git:<branch>` on the right
- [ ] Tab to Pull Requests, verify the active chip moves and the status slot shows `loading…` / `N loaded` / `error · …` as appropriate
- [ ] Verify commit rows show `▸ ▌ ▣ <hash> [branch] <summary>   <author> · <date>` with author/date aligned across rows
- [ ] Press `/` in the PR tab to start filtering, verify the footer becomes the vim-style `/foo|` input
- [ ] Pick a target and verify the main header is `tuicr   ...   git:<branch> · <source> · [v0.13 available]` (or `PR Mode · <slug>#<num>` in PR mode)
- [ ] Verify the file list title shows `Files · 0/12` and the selected row gets full-width bg highlight (no cursor glyph)
- [ ] Open a deeply nested file and verify the diff title truncates as `…/middleware/auth/session.rs`
- [ ] Toggle the file list (`F` or `:set nocommits`) and confirm the reviewed count is no longer displayed anywhere
- [ ] Press `?` to open help — it should center over the diff pane, not the whole frame
- [ ] Edit a comment to make the buffer dirty, verify `• modified` appears in the status bar's right slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)