### PR TITLE
fix: pre-wrap comment box content to prevent border overflow

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4297,7 +4297,7 @@ impl App {
     fn review_comments_render_height(&self) -> usize {
         let mut height = 1; // Header line
         for comment in &self.session.review_comments {
-            height += Self::comment_display_lines(comment);
+            height += Self::comment_display_lines(comment, self.diff_state.viewport_width);
         }
         if self.input_mode == InputMode::Comment
             && self.comment_is_review_level
@@ -4324,7 +4324,7 @@ impl App {
 
         if let Some(review) = self.session.files.get(path) {
             for comment in &review.file_comments {
-                comment_lines += Self::comment_display_lines(comment);
+                comment_lines += Self::comment_display_lines(comment, self.diff_state.viewport_width);
             }
         }
 
@@ -4370,7 +4370,7 @@ impl App {
                                 {
                                     for comment in comments {
                                         if comment.side == Some(LineSide::Old) {
-                                            comment_lines += Self::comment_display_lines(comment);
+                                            comment_lines += Self::comment_display_lines(comment, self.diff_state.viewport_width);
                                         }
                                     }
                                 }
@@ -4380,7 +4380,7 @@ impl App {
                                 {
                                     for comment in comments {
                                         if comment.side != Some(LineSide::Old) {
-                                            comment_lines += Self::comment_display_lines(comment);
+                                            comment_lines += Self::comment_display_lines(comment, self.diff_state.viewport_width);
                                         }
                                     }
                                 }
@@ -4407,7 +4407,7 @@ impl App {
                                         for comment in comments {
                                             if comment.side != Some(LineSide::Old) {
                                                 comment_lines +=
-                                                    Self::comment_display_lines(comment);
+                                                    Self::comment_display_lines(comment, self.diff_state.viewport_width);
                                             }
                                         }
                                     }
@@ -4446,7 +4446,7 @@ impl App {
                                                 for comment in comments {
                                                     if comment.side == Some(LineSide::Old) {
                                                         comment_lines +=
-                                                            Self::comment_display_lines(comment);
+                                                            Self::comment_display_lines(comment, self.diff_state.viewport_width);
                                                     }
                                                 }
                                             }
@@ -4459,7 +4459,7 @@ impl App {
                                                 for comment in comments {
                                                     if comment.side != Some(LineSide::Old) {
                                                         comment_lines +=
-                                                            Self::comment_display_lines(comment);
+                                                            Self::comment_display_lines(comment, self.diff_state.viewport_width);
                                                     }
                                                 }
                                             }
@@ -4479,7 +4479,7 @@ impl App {
                                         for comment in comments {
                                             if comment.side != Some(LineSide::Old) {
                                                 comment_lines +=
-                                                    Self::comment_display_lines(comment);
+                                                    Self::comment_display_lines(comment, self.diff_state.viewport_width);
                                             }
                                         }
                                     }
@@ -4550,10 +4550,29 @@ impl App {
         self.total_lines().saturating_sub(1)
     }
 
-    /// Calculate the number of display lines a comment takes (header + content + footer)
-    fn comment_display_lines(comment: &Comment) -> usize {
-        let content_lines = comment.content.split('\n').count();
-        2 + content_lines // header + content lines + footer
+    /// Calculate the number of display lines a comment takes (header + content + footer).
+    /// Uses viewport_width to account for pre-wrapped visual segments so the
+    /// annotation count stays in sync with what format_comment_lines renders.
+    pub(crate) fn comment_display_lines(comment: &Comment, viewport_width: usize) -> usize {
+        // Mirrors the content_area calculation in format_comment_lines:
+        // indicator(1) + border_prefix(7) + safety_margin(2) = 10
+        let content_area = viewport_width.saturating_sub(10);
+        let visual_lines: usize = comment
+            .content
+            .split('\n')
+            .map(|line| crate::ui::comment_panel::wrap_segments(line, content_area).len())
+            .sum();
+        2 + visual_lines // top border + visual segments + bottom border
+    }
+
+    /// Update viewport_width and trigger annotation rebuild if it changed.
+    /// Called from render functions when inner.width is computed — keeps
+    /// line_annotations.len() in sync with the rendered Vec<Line>.
+    pub fn sync_viewport_width(&mut self, new_width: usize) {
+        if self.diff_state.viewport_width != new_width {
+            self.diff_state.viewport_width = new_width;
+            self.rebuild_annotations();
+        }
     }
 
     /// Returns the source line number and side at the current cursor position, if on a diff line
@@ -7119,7 +7138,7 @@ impl App {
         self.line_annotations
             .push(AnnotatedLine::ReviewCommentsHeader);
         for (comment_idx, comment) in self.session.review_comments.iter().enumerate() {
-            let comment_lines = Self::comment_display_lines(comment);
+            let comment_lines = Self::comment_display_lines(comment, self.diff_state.viewport_width);
             for _ in 0..comment_lines {
                 self.line_annotations
                     .push(AnnotatedLine::ReviewComment { comment_idx });
@@ -7141,7 +7160,7 @@ impl App {
             // File comments
             if let Some(review) = self.session.files.get(path) {
                 for (comment_idx, comment) in review.file_comments.iter().enumerate() {
-                    let comment_lines = Self::comment_display_lines(comment);
+                    let comment_lines = Self::comment_display_lines(comment, self.diff_state.viewport_width);
                     for _ in 0..comment_lines {
                         self.line_annotations.push(AnnotatedLine::FileComment {
                             file_idx,
@@ -7259,6 +7278,7 @@ impl App {
                                 path,
                                 &self.forge_review_threads,
                                 &remote_index,
+                                self.diff_state.viewport_width,
                             );
                         }
                         DiffViewMode::SideBySide => {
@@ -7271,6 +7291,7 @@ impl App {
                                 path,
                                 &self.forge_review_threads,
                                 &remote_index,
+                                self.diff_state.viewport_width,
                             );
                         }
                     }
@@ -7288,6 +7309,7 @@ impl App {
         line_no: Option<u32>,
         line_comments: &std::collections::HashMap<u32, Vec<crate::model::Comment>>,
         side: LineSide,
+        viewport_width: usize,
     ) {
         let Some(ln) = line_no else {
             return;
@@ -7305,7 +7327,7 @@ impl App {
                 continue;
             }
 
-            let comment_lines = Self::comment_display_lines(comment);
+            let comment_lines = Self::comment_display_lines(comment, viewport_width);
             for _ in 0..comment_lines {
                 annotations.push(AnnotatedLine::LineComment {
                     file_idx,
@@ -7385,6 +7407,7 @@ impl App {
         path: &std::path::Path,
         remote_threads: &[crate::forge::remote_comments::RemoteReviewThread],
         remote_index: &RemoteThreadIndex,
+        viewport_width: usize,
     ) {
         for (line_idx, diff_line) in lines.iter().enumerate() {
             annotations.push(AnnotatedLine::DiffLine {
@@ -7403,6 +7426,7 @@ impl App {
                     Some(old_ln),
                     line_comments,
                     LineSide::Old,
+                    viewport_width,
                 );
                 Self::push_remote_threads(
                     annotations,
@@ -7422,6 +7446,7 @@ impl App {
                     Some(new_ln),
                     line_comments,
                     LineSide::New,
+                    viewport_width,
                 );
                 Self::push_remote_threads(
                     annotations,
@@ -7446,6 +7471,7 @@ impl App {
         path: &std::path::Path,
         remote_threads: &[crate::forge::remote_comments::RemoteReviewThread],
         remote_index: &RemoteThreadIndex,
+        viewport_width: usize,
     ) {
         let mut i = 0;
         while i < lines.len() {
@@ -7468,6 +7494,7 @@ impl App {
                         diff_line.new_lineno,
                         line_comments,
                         LineSide::New,
+                        viewport_width,
                     );
                     if let Some(new_ln) = diff_line.new_lineno {
                         Self::push_remote_threads(
@@ -7532,6 +7559,7 @@ impl App {
                             old_lineno,
                             line_comments,
                             LineSide::Old,
+                            viewport_width,
                         );
                         if let Some(old_ln) = old_lineno {
                             Self::push_remote_threads(
@@ -7549,6 +7577,7 @@ impl App {
                             new_lineno,
                             line_comments,
                             LineSide::New,
+                            viewport_width,
                         );
                         if let Some(new_ln) = new_lineno {
                             Self::push_remote_threads(
@@ -7580,6 +7609,7 @@ impl App {
                         diff_line.new_lineno,
                         line_comments,
                         LineSide::New,
+                        viewport_width,
                     );
                     if let Some(new_ln) = diff_line.new_lineno {
                         Self::push_remote_threads(

--- a/src/app.rs
+++ b/src/app.rs
@@ -4324,7 +4324,8 @@ impl App {
 
         if let Some(review) = self.session.files.get(path) {
             for comment in &review.file_comments {
-                comment_lines += Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                comment_lines +=
+                    Self::comment_display_lines(comment, self.diff_state.viewport_width);
             }
         }
 
@@ -4370,7 +4371,10 @@ impl App {
                                 {
                                     for comment in comments {
                                         if comment.side == Some(LineSide::Old) {
-                                            comment_lines += Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                                            comment_lines += Self::comment_display_lines(
+                                                comment,
+                                                self.diff_state.viewport_width,
+                                            );
                                         }
                                     }
                                 }
@@ -4380,7 +4384,10 @@ impl App {
                                 {
                                     for comment in comments {
                                         if comment.side != Some(LineSide::Old) {
-                                            comment_lines += Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                                            comment_lines += Self::comment_display_lines(
+                                                comment,
+                                                self.diff_state.viewport_width,
+                                            );
                                         }
                                     }
                                 }
@@ -4406,8 +4413,10 @@ impl App {
                                     {
                                         for comment in comments {
                                             if comment.side != Some(LineSide::Old) {
-                                                comment_lines +=
-                                                    Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                                                comment_lines += Self::comment_display_lines(
+                                                    comment,
+                                                    self.diff_state.viewport_width,
+                                                );
                                             }
                                         }
                                     }
@@ -4446,7 +4455,10 @@ impl App {
                                                 for comment in comments {
                                                     if comment.side == Some(LineSide::Old) {
                                                         comment_lines +=
-                                                            Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                                                            Self::comment_display_lines(
+                                                                comment,
+                                                                self.diff_state.viewport_width,
+                                                            );
                                                     }
                                                 }
                                             }
@@ -4459,7 +4471,10 @@ impl App {
                                                 for comment in comments {
                                                     if comment.side != Some(LineSide::Old) {
                                                         comment_lines +=
-                                                            Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                                                            Self::comment_display_lines(
+                                                                comment,
+                                                                self.diff_state.viewport_width,
+                                                            );
                                                     }
                                                 }
                                             }
@@ -4478,8 +4493,10 @@ impl App {
                                     {
                                         for comment in comments {
                                             if comment.side != Some(LineSide::Old) {
-                                                comment_lines +=
-                                                    Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                                                comment_lines += Self::comment_display_lines(
+                                                    comment,
+                                                    self.diff_state.viewport_width,
+                                                );
                                             }
                                         }
                                     }
@@ -7138,7 +7155,8 @@ impl App {
         self.line_annotations
             .push(AnnotatedLine::ReviewCommentsHeader);
         for (comment_idx, comment) in self.session.review_comments.iter().enumerate() {
-            let comment_lines = Self::comment_display_lines(comment, self.diff_state.viewport_width);
+            let comment_lines =
+                Self::comment_display_lines(comment, self.diff_state.viewport_width);
             for _ in 0..comment_lines {
                 self.line_annotations
                     .push(AnnotatedLine::ReviewComment { comment_idx });
@@ -7160,7 +7178,8 @@ impl App {
             // File comments
             if let Some(review) = self.session.files.get(path) {
                 for (comment_idx, comment) in review.file_comments.iter().enumerate() {
-                    let comment_lines = Self::comment_display_lines(comment, self.diff_state.viewport_width);
+                    let comment_lines =
+                        Self::comment_display_lines(comment, self.diff_state.viewport_width);
                     for _ in 0..comment_lines {
                         self.line_annotations.push(AnnotatedLine::FileComment {
                             file_idx,

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -1,9 +1,9 @@
 use ratatui::{
+    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
-    Frame,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -5,12 +5,69 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::App;
 use crate::model::LineRange;
 use crate::theme::Theme;
 use crate::ui::styles;
+
+/// Content prefix used on every comment-body line. 4 pad chars + `│` + 2 spaces.
+/// The 4-char left pad lets the bar painter draw `│` up through diff lines
+/// without colliding with the col-6 `▌` add/del prefix.
+const BORDER_PREFIX: &str = "    │  ";
+const BORDER_PREFIX_WIDTH: usize = 7;
+
+/// Split `text` into segments whose display width each fits within `content_area`.
+/// Returns a single-element vec when the text already fits. The returned slices
+/// borrow from `text`, so the caller must keep `text` alive while iterating.
+fn wrap_segments(text: &str, content_area: usize) -> Vec<&str> {
+    if content_area == 0 || text.width() <= content_area {
+        return vec![text];
+    }
+    let mut segments = Vec::new();
+    let mut remaining = text;
+    while !remaining.is_empty() {
+        let mut take_bytes = 0usize;
+        let mut taken_width = 0usize;
+        for c in remaining.chars() {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if taken_width + cw > content_area {
+                break;
+            }
+            taken_width += cw;
+            take_bytes += c.len_utf8();
+        }
+        // Single character wider than content_area — emit it anyway so we don't loop forever
+        if take_bytes == 0 {
+            take_bytes = remaining.chars().next().map_or(0, |c| c.len_utf8());
+        }
+        let (seg, rest) = remaining.split_at(take_bytes);
+        segments.push(seg);
+        remaining = rest;
+    }
+    segments
+}
+
+/// Push spans for a text segment containing the cursor. The cursor is rendered
+/// as a styled span on the character at the split point, or a trailing space
+/// when the cursor is at end-of-segment.
+fn push_cursor_spans(
+    spans: &mut Vec<Span<'static>>,
+    before: &str,
+    after: &str,
+    cursor_style: Style,
+) {
+    spans.push(Span::raw(before.to_string()));
+    let mut chars = after.chars();
+    match chars.next() {
+        Some(cursor_char) => {
+            spans.push(Span::styled(cursor_char.to_string(), cursor_style));
+            spans.push(Span::raw(chars.as_str().to_string()));
+        }
+        None => spans.push(Span::styled(" ", cursor_style)),
+    }
+}
 
 /// Information about where the cursor should be positioned within comment input
 #[derive(Debug, Clone)]
@@ -35,6 +92,7 @@ pub struct CommentTypePresentation {
 ///
 /// Returns a tuple of (lines, cursor_info) where cursor_info contains the position
 /// of the cursor within the formatted output for IME positioning.
+#[allow(clippy::too_many_arguments)]
 pub fn format_comment_input_lines(
     theme: &Theme,
     comment_type: CommentTypePresentation,
@@ -43,6 +101,7 @@ pub fn format_comment_input_lines(
     line_range: Option<LineRange>,
     is_editing: bool,
     supports_keyboard_enhancement: bool,
+    width: usize,
 ) -> (Vec<Line<'static>>, CommentCursorInfo) {
     let type_style = styles::comment_type_style(theme, comment_type.color);
     let border_style = styles::comment_border_style(theme, comment_type.color);
@@ -63,14 +122,12 @@ pub fn format_comment_input_lines(
         "Ctrl-J"
     };
 
+    // "    │  " is the per-line content prefix; everything past that is content.
+    let content_area = width.saturating_sub(BORDER_PREFIX_WIDTH);
+
     let mut result = Vec::new();
-    // Box left edge sits at col 5 (after the 1-col cursor indicator + 4 pad
-    // chars) so the bar painter can extend a `│` up through the diff lines
-    // the comment covers without colliding with the col-6 `▌` add/del prefix.
-    let border_prefix = "    │  ";
-    let border_width = border_prefix.width() as u16;
     let mut cursor_line_offset: usize = 1;
-    let mut cursor_column: u16 = border_width;
+    let mut cursor_column: u16 = BORDER_PREFIX_WIDTH as u16;
 
     // Top-left corner becomes `├` when a line range is present — the bar
     // painter then draws `│` going up through the range and a `╭` at the
@@ -97,64 +154,67 @@ pub fn format_comment_input_lines(
     if buffer.is_empty() {
         // Show placeholder with cursor at start
         result.push(Line::from(vec![
-            Span::styled(border_prefix, border_style),
+            Span::styled(BORDER_PREFIX, border_style),
             Span::styled(" ", cursor_style),
             Span::styled("Type your comment...", styles::dim_style(theme)),
         ]));
         // cursor_line_offset is already 1 (first content line)
-        // cursor_column is already border_width (cursor at start of content)
+        // cursor_column is already BORDER_PREFIX_WIDTH (cursor at start of content)
     } else {
-        // Split buffer into lines and render with cursor
         let buffer_lines: Vec<&str> = buffer.split('\n').collect();
-        let mut char_offset = 0;
+        let mut byte_offset = 0;
+        // Tracks how many visual lines have been pushed so far (not counting the header).
+        let mut total_visual_lines: usize = 0;
 
         for (line_idx, text) in buffer_lines.iter().enumerate() {
-            let line_start = char_offset;
-            let line_end = char_offset + text.len();
+            let line_start = byte_offset;
+            let line_end = byte_offset + text.len();
+            let is_last_logical = line_idx + 1 == buffer_lines.len();
 
             // Check if cursor is on this line
             let cursor_on_this_line = cursor_pos >= line_start
-                && (cursor_pos <= line_end
-                    || (line_idx == buffer_lines.len() - 1 && cursor_pos == buffer.len()));
+                && (cursor_pos <= line_end || (is_last_logical && cursor_pos == buffer.len()));
 
-            let mut line_spans = vec![Span::styled(border_prefix, border_style)];
+            // Pre-wrap this logical line into segments so ratatui never wraps it.
+            // Short lines come back as a single-element vec.
+            let segments = wrap_segments(text, content_area);
+            let mut seg_byte_start = 0usize;
 
-            if cursor_on_this_line {
-                let cursor_pos_in_line = cursor_pos - line_start;
-                let cursor_pos_in_line = cursor_pos_in_line.min(text.len());
-                let (before_cursor, after_cursor) = text.split_at(cursor_pos_in_line);
+            for (seg_idx, seg) in segments.iter().enumerate() {
+                let seg_start = line_start + seg_byte_start;
+                let seg_end = seg_start + seg.len();
+                let is_last_seg = seg_idx + 1 == segments.len();
+                let cursor_in_seg = cursor_on_this_line
+                    && cursor_pos >= seg_start
+                    && (cursor_pos < seg_end || is_last_seg);
 
-                // Track cursor position for IME
-                // line_offset: header (1) + current content line index
-                cursor_line_offset = 1 + line_idx;
-                // column: border width + display width of text before cursor
-                cursor_column = border_width + before_cursor.width() as u16;
+                let mut line_spans = vec![Span::styled(BORDER_PREFIX, border_style)];
 
-                if after_cursor.is_empty() {
-                    line_spans.push(Span::raw(before_cursor.to_string()));
-                    line_spans.push(Span::styled(" ", cursor_style));
+                if cursor_in_seg {
+                    let cursor_pos_in_seg = (cursor_pos - seg_start).min(seg.len());
+                    let (before, after) = seg.split_at(cursor_pos_in_seg);
+
+                    // Track cursor position for IME
+                    cursor_line_offset = 1 + total_visual_lines;
+                    cursor_column = BORDER_PREFIX_WIDTH as u16 + before.width() as u16;
+                    push_cursor_spans(&mut line_spans, before, after, cursor_style);
                 } else {
-                    let mut chars = after_cursor.chars();
-                    let cursor_char = chars.next().unwrap();
-                    let remaining = chars.as_str();
-                    line_spans.push(Span::raw(before_cursor.to_string()));
-                    line_spans.push(Span::styled(cursor_char.to_string(), cursor_style));
-                    line_spans.push(Span::raw(remaining.to_string()));
+                    line_spans.push(Span::raw(seg.to_string()));
                 }
-            } else {
-                line_spans.push(Span::raw(text.to_string()));
+
+                result.push(Line::from(line_spans));
+                total_visual_lines += 1;
+                seg_byte_start += seg.len();
             }
 
-            result.push(Line::from(line_spans));
-
             // Account for newline character (except for last line)
-            char_offset = line_end + 1;
+            byte_offset = line_end + 1;
         }
     }
 
-    // Bottom border
+    // Bottom border — "    ╰" = 5 chars, fill to width
     result.push(Line::from(vec![Span::styled(
-        "    ╰".to_string() + &"─".repeat(39),
+        "    ╰".to_string() + &"─".repeat(width.saturating_sub(5)),
         border_style,
     )]));
 
@@ -254,6 +314,7 @@ pub fn format_comment_lines(
     comment_type: CommentTypePresentation,
     content: &str,
     line_range: Option<LineRange>,
+    width: usize,
 ) -> Vec<Line<'static>> {
     let type_style = styles::comment_type_style(theme, comment_type.color);
     let border_style = styles::comment_border_style(theme, comment_type.color);
@@ -263,6 +324,10 @@ pub fn format_comment_lines(
         Some(range) => format!("L{}-L{} ", range.start, range.end),
         None => String::new(),
     };
+
+    // "    │  " is the per-line content prefix; everything past that is content.
+    let content_area = width.saturating_sub(BORDER_PREFIX_WIDTH);
+
     let content_lines: Vec<&str> = content.split('\n').collect();
 
     let mut result = Vec::new();
@@ -270,25 +335,29 @@ pub fn format_comment_lines(
     let top_corner = if line_range.is_some() { '├' } else { '╭' };
     let top_prefix = format!("    {top_corner}── ");
 
-    // Top border with type label
+    // Top border — fill dynamically so total line = width.
+    // top_prefix = 8, "[LABEL] " = label.len()+3, line_info = variable
+    let top_fill = width.saturating_sub(8 + comment_type.label.len() + 3 + line_info.width());
     result.push(Line::from(vec![
         Span::styled(top_prefix, border_style),
         Span::styled(format!("[{}] ", comment_type.label), type_style),
         Span::styled(line_info, styles::dim_style(theme)),
-        Span::styled("─".repeat(30), border_style),
+        Span::styled("─".repeat(top_fill), border_style),
     ]));
 
-    // Content lines
+    // Content lines — pre-wrap at content_area so ratatui never wraps them
     for line in &content_lines {
-        result.push(Line::from(vec![
-            Span::styled("    │  ", border_style),
-            Span::raw(line.to_string()),
-        ]));
+        for seg in wrap_segments(line, content_area) {
+            result.push(Line::from(vec![
+                Span::styled(BORDER_PREFIX, border_style),
+                Span::raw(seg.to_string()),
+            ]));
+        }
     }
 
-    // Bottom border
+    // Bottom border — "    ╰" = 5 chars, fill to width
     result.push(Line::from(vec![Span::styled(
-        "    ╰".to_string() + &"─".repeat(39),
+        "    ╰".to_string() + &"─".repeat(width.saturating_sub(5)),
         border_style,
     )]));
 
@@ -346,6 +415,106 @@ mod tests {
         Theme::default()
     }
 
+    // -- wrap_segments tests --
+
+    #[test]
+    fn wrap_segments_returns_single_segment_when_text_fits() {
+        // given
+        let text = "hello";
+
+        // when
+        let segments = wrap_segments(text, 80);
+
+        // then
+        assert_eq!(segments, vec!["hello"]);
+    }
+
+    #[test]
+    fn wrap_segments_returns_single_segment_for_empty_text() {
+        // given
+        let text = "";
+
+        // when
+        let segments = wrap_segments(text, 80);
+
+        // then
+        assert_eq!(segments, vec![""]);
+    }
+
+    #[test]
+    fn wrap_segments_returns_text_unchanged_when_content_area_is_zero() {
+        // given
+        let text = "anything";
+
+        // when
+        let segments = wrap_segments(text, 0);
+
+        // then
+        assert_eq!(segments, vec!["anything"]);
+    }
+
+    #[test]
+    fn wrap_segments_splits_long_ascii_at_content_area() {
+        // given
+        let text = "hello world";
+
+        // when - content_area=5 means each segment is at most 5 display cols
+        let segments = wrap_segments(text, 5);
+
+        // then
+        assert_eq!(segments, vec!["hello", " worl", "d"]);
+    }
+
+    #[test]
+    fn wrap_segments_respects_cjk_display_width() {
+        // given - each CJK char is 2 display cols, total = 8 cols, 12 bytes
+        let text = "中文测试";
+
+        // when - content_area=4 fits exactly 2 CJK chars per segment
+        let segments = wrap_segments(text, 4);
+
+        // then
+        assert_eq!(segments, vec!["中文", "测试"]);
+    }
+
+    #[test]
+    fn wrap_segments_handles_mixed_ascii_and_cjk() {
+        // given - 'a'(1) + '中'(2) + 'b'(1) + '文'(2) = 6 display cols
+        let text = "a中b文";
+
+        // when - content_area=3 fits "a中" (1+2=3), then "b文" (1+2=3)
+        let segments = wrap_segments(text, 3);
+
+        // then
+        assert_eq!(segments, vec!["a中", "b文"]);
+    }
+
+    #[test]
+    fn wrap_segments_emits_oversized_char_to_avoid_infinite_loop() {
+        // given - '中' is 2 cols wide but content_area only allows 1
+        let text = "中a";
+
+        // when
+        let segments = wrap_segments(text, 1);
+
+        // then - '中' is emitted even though it exceeds content_area
+        assert_eq!(segments, vec!["中", "a"]);
+    }
+
+    #[test]
+    fn wrap_segments_handles_exact_width_boundary() {
+        // given - text exactly fills content_area
+        let text = "12345";
+
+        // when
+        let segments = wrap_segments(text, 5);
+
+        // then - single segment, no spurious empty trailing segment
+        assert_eq!(segments, vec!["12345"]);
+    }
+
+    // -- format_comment_input_lines tests --
+
     #[test]
     fn should_return_cursor_at_start_for_empty_buffer() {
         // given
@@ -363,6 +532,7 @@ mod tests {
             None,
             false,
             false,
+            80,
         );
 
         // then
@@ -390,6 +560,7 @@ mod tests {
             None,
             false,
             false,
+            80,
         );
 
         // then
@@ -416,6 +587,7 @@ mod tests {
             None,
             false,
             false,
+            80,
         );
 
         // then
@@ -443,6 +615,7 @@ mod tests {
             None,
             false,
             false,
+            80,
         );
 
         // then
@@ -469,6 +642,7 @@ mod tests {
             None,
             false,
             false,
+            80,
         );
 
         // then
@@ -496,6 +670,7 @@ mod tests {
             None,
             false,
             false,
+            80,
         );
 
         // then

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -21,7 +21,7 @@ const BORDER_PREFIX_WIDTH: usize = 7;
 /// Split `text` into segments whose display width each fits within `content_area`.
 /// Returns a single-element vec when the text already fits. The returned slices
 /// borrow from `text`, so the caller must keep `text` alive while iterating.
-fn wrap_segments(text: &str, content_area: usize) -> Vec<&str> {
+pub(crate) fn wrap_segments(text: &str, content_area: usize) -> Vec<&str> {
     if content_area == 0 || text.width() <= content_area {
         return vec![text];
     }
@@ -59,13 +59,13 @@ fn push_cursor_spans(
     cursor_style: Style,
 ) {
     spans.push(Span::raw(before.to_string()));
+    // Cursor at end-of-segment: no trailing space so the line stays within
+    // bounds. The terminal cursor (set_cursor_position) handles the visible
+    // position without needing an extra styled space.
     let mut chars = after.chars();
-    match chars.next() {
-        Some(cursor_char) => {
-            spans.push(Span::styled(cursor_char.to_string(), cursor_style));
-            spans.push(Span::raw(chars.as_str().to_string()));
-        }
-        None => spans.push(Span::styled(" ", cursor_style)),
+    if let Some(cursor_char) = chars.next() {
+        spans.push(Span::styled(cursor_char.to_string(), cursor_style));
+        spans.push(Span::raw(chars.as_str().to_string()));
     }
 }
 
@@ -123,7 +123,9 @@ pub fn format_comment_input_lines(
     };
 
     // "    │  " is the per-line content prefix; everything past that is content.
-    let content_area = width.saturating_sub(BORDER_PREFIX_WIDTH);
+    // Subtract two extra: one so ratatui never wraps an exact-fit line, and
+    // one so the terminal cursor at end-of-segment stays clear of the border.
+    let content_area = width.saturating_sub(BORDER_PREFIX_WIDTH + 2);
 
     let mut result = Vec::new();
     let mut cursor_line_offset: usize = 1;
@@ -326,7 +328,9 @@ pub fn format_comment_lines(
     };
 
     // "    │  " is the per-line content prefix; everything past that is content.
-    let content_area = width.saturating_sub(BORDER_PREFIX_WIDTH);
+    // Subtract two extra: one so ratatui never wraps an exact-fit line, and
+    // one so the terminal cursor at end-of-segment stays clear of the border.
+    let content_area = width.saturating_sub(BORDER_PREFIX_WIDTH + 2);
 
     let content_lines: Vec<&str> = content.split('\n').collect();
 

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -30,6 +30,7 @@ struct SideBySideContext<'a> {
     app: &'a App,
     theme: &'a Theme,
     content_width: usize,
+    panel_width: usize,
     current_line_idx: usize,
     // Comment input state for inline editing
     comment_input_mode: bool,
@@ -81,6 +82,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         app,
         theme: &app.theme,
         content_width,
+        panel_width: inner.width as usize,
         current_line_idx: app.diff_state.cursor_line,
         comment_input_mode,
         comment_line: app.comment_line,
@@ -136,6 +138,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 None,
                 true,
                 app.supports_keyboard_enhancement,
+                ctx.panel_width.saturating_sub(1),
             );
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
             comment_cursor_column = 1 + cursor_info.column;
@@ -159,6 +162,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 comment_type_presentation(app, &comment.comment_type),
                 &comment.content,
                 None,
+                ctx.panel_width.saturating_sub(1),
             );
             for mut comment_line in comment_lines {
                 let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
@@ -181,6 +185,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             None,
             false,
             app.supports_keyboard_enhancement,
+            ctx.panel_width.saturating_sub(1),
         );
         comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
         comment_cursor_column = 1 + cursor_info.column;
@@ -247,6 +252,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                         None,
                         true,
                         app.supports_keyboard_enhancement,
+                        ctx.panel_width.saturating_sub(1),
                     );
                     comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
                     comment_cursor_column = 1 + cursor_info.column;
@@ -273,6 +279,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                         comment_type_presentation(app, &comment.comment_type),
                         &comment.content,
                         None,
+                        ctx.panel_width.saturating_sub(1),
                     );
                     for mut comment_line in comment_lines {
                         let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
@@ -300,6 +307,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 None,
                 false,
                 app.supports_keyboard_enhancement,
+                ctx.panel_width.saturating_sub(1),
             );
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
             comment_cursor_column = 1 + cursor_info.column;
@@ -1192,6 +1200,7 @@ fn add_comments_to_line(
                         line_range,
                         true,
                         ctx.supports_keyboard_enhancement,
+                        ctx.panel_width.saturating_sub(1),
                     );
                     let box_top_row = line_idx;
                     let box_end = line_idx + input_lines.len().saturating_sub(1);
@@ -1230,6 +1239,7 @@ fn add_comments_to_line(
                         comment_type_presentation(ctx.app, &comment.comment_type),
                         &comment.content,
                         line_range,
+                        ctx.panel_width.saturating_sub(1),
                     );
                     let box_top_row = line_idx;
                     for mut comment_line in comment_lines {
@@ -1267,6 +1277,7 @@ fn add_comments_to_line(
             line_range,
             false,
             ctx.supports_keyboard_enhancement,
+            ctx.panel_width.saturating_sub(1),
         );
         let box_top_row = line_idx;
         let box_end = line_idx + input_lines.len().saturating_sub(1);

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -258,7 +258,8 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                     comment_cursor_column = 1 + cursor_info.column;
                     comment_input_box_range =
                         Some((line_idx, line_idx + input_lines.len().saturating_sub(1)));
-                    let annotations_replaced = App::comment_display_lines(comment, inner.width as usize);
+                    let annotations_replaced =
+                        App::comment_display_lines(comment, inner.width as usize);
                     annotation_offset = Some((line_idx, input_lines.len(), annotations_replaced));
 
                     for mut input_line in input_lines {

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -144,7 +144,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             comment_cursor_column = 1 + cursor_info.column;
             comment_input_box_range =
                 Some((line_idx, line_idx + input_lines.len().saturating_sub(1)));
-            let annotations_replaced = 2 + comment.content.split('\n').count();
+            let annotations_replaced = App::comment_display_lines(comment, inner.width as usize);
             annotation_offset = Some((line_idx, input_lines.len(), annotations_replaced));
 
             for mut input_line in input_lines {
@@ -258,7 +258,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                     comment_cursor_column = 1 + cursor_info.column;
                     comment_input_box_range =
                         Some((line_idx, line_idx + input_lines.len().saturating_sub(1)));
-                    let annotations_replaced = 2 + comment.content.split('\n').count();
+                    let annotations_replaced = App::comment_display_lines(comment, inner.width as usize);
                     annotation_offset = Some((line_idx, input_lines.len(), annotations_replaced));
 
                     for mut input_line in input_lines {
@@ -538,7 +538,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
 
     let max_content_width = line_widths.iter().copied().max().unwrap_or(0);
 
-    app.diff_state.viewport_width = inner.width as usize;
+    app.sync_viewport_width(inner.width as usize);
     app.diff_state.max_content_width = max_content_width;
 
     let scroll_offset = app.diff_state.scroll_offset;
@@ -1204,7 +1204,7 @@ fn add_comments_to_line(
                     );
                     let box_top_row = line_idx;
                     let box_end = line_idx + input_lines.len().saturating_sub(1);
-                    let annotations_replaced = 2 + comment.content.split('\n').count();
+                    let annotations_replaced = App::comment_display_lines(comment, ctx.panel_width);
                     cursor_info_out = Some((
                         line_idx + cursor_info.line_offset,
                         1 + cursor_info.column,

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -35,6 +35,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         .border_style(styles::border_style(&app.theme, focused));
 
     let inner = block.inner(area);
+    let comment_width = inner.width.saturating_sub(1) as usize;
     frame.render_widget(block, area);
 
     // Update viewport height for scroll calculations
@@ -91,6 +92,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 None,
                 true,
                 app.supports_keyboard_enhancement,
+                comment_width,
             );
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
             comment_cursor_column = 1 + cursor_info.column;
@@ -115,6 +117,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 comment_type_presentation(app, &comment.comment_type),
                 &comment.content,
                 None,
+                comment_width,
             );
             for mut comment_line in comment_lines {
                 let indicator = cursor_indicator(line_idx, current_line_idx);
@@ -137,6 +140,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             None,
             false,
             app.supports_keyboard_enhancement,
+            comment_width,
         );
         comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
         comment_cursor_column = 1 + cursor_info.column;
@@ -204,6 +208,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         None,
                         true,
                         app.supports_keyboard_enhancement,
+                        comment_width,
                     );
                     // Track cursor position: logical line = current line_idx + cursor offset within input
                     comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
@@ -233,6 +238,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         comment_type_presentation(app, &comment.comment_type),
                         &comment.content,
                         None,
+                        comment_width,
                     );
                     for mut comment_line in comment_lines {
                         let indicator = cursor_indicator(line_idx, current_line_idx);
@@ -260,6 +266,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 None,
                 false,
                 app.supports_keyboard_enhancement,
+                comment_width,
             );
             // Track cursor position
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
@@ -528,6 +535,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                                 line_range,
                                                 true,
                                                 app.supports_keyboard_enhancement,
+                                                comment_width,
                                             );
                                         comment_cursor_logical_line =
                                             Some(line_idx + cursor_info.line_offset);
@@ -574,6 +582,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             comment_type_presentation(app, &comment.comment_type),
                                             &comment.content,
                                             line_range,
+                                            comment_width,
                                         );
                                         let box_top_row = line_idx;
                                         for mut comment_line in comment_lines {
@@ -628,6 +637,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                     line_range,
                                     false,
                                     app.supports_keyboard_enhancement,
+                                    comment_width,
                                 );
                             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
                             comment_cursor_column = 1 + cursor_info.column;
@@ -682,6 +692,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                                 line_range,
                                                 true,
                                                 app.supports_keyboard_enhancement,
+                                                comment_width,
                                             );
                                         comment_cursor_logical_line =
                                             Some(line_idx + cursor_info.line_offset);
@@ -728,6 +739,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             comment_type_presentation(app, &comment.comment_type),
                                             &comment.content,
                                             line_range,
+                                            comment_width,
                                         );
                                         let box_top_row = line_idx;
                                         for mut comment_line in comment_lines {
@@ -782,6 +794,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                     line_range,
                                     false,
                                     app.supports_keyboard_enhancement,
+                                    comment_width,
                                 );
                             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
                             comment_cursor_column = 1 + cursor_info.column;

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -98,7 +98,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             comment_cursor_column = 1 + cursor_info.column;
             comment_input_box_range =
                 Some((line_idx, line_idx + input_lines.len().saturating_sub(1)));
-            let annotations_replaced = 2 + comment.content.split('\n').count();
+            let annotations_replaced = App::comment_display_lines(comment, inner.width as usize);
             app.comment_input_annotation_offset =
                 Some((line_idx, input_lines.len(), annotations_replaced));
 
@@ -216,7 +216,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                     comment_cursor_column = 1 + cursor_info.column;
                     comment_input_box_range =
                         Some((line_idx, line_idx + input_lines.len().saturating_sub(1)));
-                    let annotations_replaced = 2 + comment.content.split('\n').count();
+                    let annotations_replaced = App::comment_display_lines(comment, inner.width as usize);
                     app.comment_input_annotation_offset =
                         Some((line_idx, input_lines.len(), annotations_replaced));
 
@@ -546,7 +546,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             line_idx + input_lines.len().saturating_sub(1),
                                         ));
                                         let annotations_replaced =
-                                            2 + comment.content.split('\n').count();
+                                            App::comment_display_lines(comment, inner.width as usize);
                                         app.comment_input_annotation_offset = Some((
                                             line_idx,
                                             input_lines.len(),
@@ -703,7 +703,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             line_idx + input_lines.len().saturating_sub(1),
                                         ));
                                         let annotations_replaced =
-                                            2 + comment.content.split('\n').count();
+                                            App::comment_display_lines(comment, inner.width as usize);
                                         app.comment_input_annotation_offset = Some((
                                             line_idx,
                                             input_lines.len(),
@@ -862,7 +862,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
     let max_content_width = line_widths.iter().copied().max().unwrap_or(0);
 
-    app.diff_state.viewport_width = inner.width as usize;
+    app.sync_viewport_width(inner.width as usize);
     app.diff_state.max_content_width = max_content_width;
 
     let scroll_offset = app.diff_state.scroll_offset;

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -216,7 +216,8 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                     comment_cursor_column = 1 + cursor_info.column;
                     comment_input_box_range =
                         Some((line_idx, line_idx + input_lines.len().saturating_sub(1)));
-                    let annotations_replaced = App::comment_display_lines(comment, inner.width as usize);
+                    let annotations_replaced =
+                        App::comment_display_lines(comment, inner.width as usize);
                     app.comment_input_annotation_offset =
                         Some((line_idx, input_lines.len(), annotations_replaced));
 
@@ -545,8 +546,10 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             line_idx,
                                             line_idx + input_lines.len().saturating_sub(1),
                                         ));
-                                        let annotations_replaced =
-                                            App::comment_display_lines(comment, inner.width as usize);
+                                        let annotations_replaced = App::comment_display_lines(
+                                            comment,
+                                            inner.width as usize,
+                                        );
                                         app.comment_input_annotation_offset = Some((
                                             line_idx,
                                             input_lines.len(),
@@ -702,8 +705,10 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             line_idx,
                                             line_idx + input_lines.len().saturating_sub(1),
                                         ));
-                                        let annotations_replaced =
-                                            App::comment_display_lines(comment, inner.width as usize);
+                                        let annotations_replaced = App::comment_display_lines(
+                                            comment,
+                                            inner.width as usize,
+                                        );
                                         app.comment_input_annotation_offset = Some((
                                             line_idx,
                                             input_lines.len(),


### PR DESCRIPTION
## Summary

Fixes #205 — multi-line comment text was breaking out of the annotation box border when ratatui wrapped a long content line; the wrapped continuation had no `│` prefix.

Both the **display** and **input** variants of the comment box now pre-wrap content at the available panel width so ratatui never wraps a line itself. The borders are also dynamic — they always match the panel width instead
of being hardcoded.

The wrap logic is factored into a shared `wrap_segments` helper used by both `format_comment_lines` and `format_comment_input_lines`. Cursor tracking across wrapped visual segments keeps IME screen position correct
when typing past the wrap boundary.

## Test plan

- Open a diff and add a comment with content longer than ~40 chars → comment box border stays intact across multiple visual rows
- Repeat in side-by-side mode (`:diff`)
- Toggle wrap off (`:set wrap!`) — comment box still intact
- Resize terminal narrower while a multi-line comment is visible → border re-flows correctly
- Type a long CJK / Pinyin comment → wraps at correct display width (each CJK char is 2 cols)
- Edit an existing multi-line comment → cursor lands on the correct visual row when navigating

## Out of scope / follow-up

While testing IME input, I noticed that selecting many CJK characters in succession feels slightly slower than typing ASCII. I prototyped a per-line cache that keeps the wrap calc bounded, but the surrounding diff still rebuilds on every keystroke (only made a small difference). Happy to file a separate issue or open a follow-up PR if there's interest.