### PR TITLE
feat: add no_update_check config option

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,6 +25,7 @@ wrap = false
 cursor_line = true
 transparent_background = true
 scroll_offset = 5
+no_update_check = false
 
 backend = "libgit2"
 
@@ -53,6 +54,7 @@ comment_types = [
 | `cursor_line` | `true` | Highlight the current cursor line and visual selection. |
 | `transparent_background` | `true` | Let the terminal background show through panels. `false` paints the theme's `panel_bg`. |
 | `scroll_offset` | `0` | Minimum lines visible above and below the cursor when scrolling (like Vim's `scrolloff`). |
+| `no_update_check` | `false` | Skip startup update check when `true`. |
 | `backend` | `libgit2` | Git backend: `libgit2` or `cli`. Sparse-checkout repos auto-route to `cli`. |
 | `comment_types` | (built-in) | Comment categories. See [Comment types](#comment-types). |
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -56,6 +56,7 @@ pub struct AppConfig {
     pub leader: Option<char>,
     pub transparent_background: Option<bool>,
     pub scroll_offset: Option<usize>,
+    pub no_update_check: Option<bool>,
     /// `[forge]` section settings. Always present; `None` means "no override"
     /// and downstream code should treat it as `ForgeConfig::default()`.
     pub forge: Option<ForgeConfig>,
@@ -78,6 +79,7 @@ const KNOWN_KEYS: &[&str] = &[
     "leader",
     "transparent_background",
     "scroll_offset",
+    "no_update_check",
     "forge",
 ];
 
@@ -263,6 +265,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         leader: read_leader(table, &mut warnings),
         transparent_background: read_bool(table, "transparent_background", &mut warnings),
         scroll_offset: read_usize(table, "scroll_offset", &mut warnings),
+        no_update_check: read_bool(table, "no_update_check", &mut warnings),
         forge: table
             .get("forge")
             .and_then(|v| parse_forge(v, &mut warnings)),
@@ -821,6 +824,52 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'leader' must be a string; ignoring value"
+        );
+    }
+
+    // no_update_check
+
+    #[test]
+    fn should_parse_no_update_check_true() {
+        let outcome = parse_config("no_update_check = true\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.no_update_check),
+            Some(true)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_no_update_check_false() {
+        let outcome = parse_config("no_update_check = false\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.no_update_check),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_default_no_update_check_to_none() {
+        let outcome = parse_config("\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.no_update_check),
+            None
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_no_update_check_with_invalid_type() {
+        let outcome = parse_config("no_update_check = \"yes\"\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.no_update_check),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'no_update_check' must be a boolean; ignoring value"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,15 @@ fn main() -> anyhow::Result<()> {
         theme.panel_bg = ratatui::style::Color::Reset;
     }
 
+    let no_update_check = cli_args.no_update_check
+        || config_outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.no_update_check)
+            .unwrap_or(false);
+
     // Start update check in background (non-blocking)
-    let update_rx = if !cli_args.no_update_check {
+    let update_rx = if !no_update_check {
         let (tx, rx) = mpsc::channel();
         std::thread::spawn(move || {
             let result = update::check_for_updates();


### PR DESCRIPTION
Add a config-file equivalent of the --no-update-check CLI flag so users can persistently skip the startup update check without passing a flag every time.

- Config field: no_update_check: Option<bool> (defaults to None/false)
- CLI flag takes priority via || merge with config value
- Docs updated in CONFIG.md

I dogfooded this by setting the flag in my config then ran `nono learn -- cargo run` and comparing the observed network access against `nono learn -- tuicr`, my global install. The global install did not recognize the flag and so it hit the network to check for updates. The `cargo run` version did recognize the config and did not hit the network.