### PR TITLE
feat: allow --file to accept a directory for codebase review

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1097,8 +1097,11 @@ impl App {
                 None, // no path_filter
             )?;
 
-            // Hide file list since there's only one file
-            app.show_file_list = false;
+            // Hide the file list only when reviewing a single file; in
+            // directory mode the user needs the list to navigate.
+            if app.diff_files.len() == 1 {
+                app.show_file_list = false;
+            }
             app.focused_panel = FocusedPanel::Diff;
 
             return Ok(app);

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -52,10 +52,7 @@ impl FileBackend {
         let metadata = std::fs::metadata(&canonical)?;
 
         let (root_path, files) = if metadata.is_file() {
-            let root = canonical
-                .parent()
-                .unwrap_or(Path::new("/"))
-                .to_path_buf();
+            let root = canonical.parent().unwrap_or(Path::new("/")).to_path_buf();
             (root, vec![(canonical, metadata.len())])
         } else if metadata.is_dir() {
             let files = collect_text_files(&canonical);
@@ -309,13 +306,7 @@ mod tests {
 
         let names: Vec<_> = diffs
             .iter()
-            .map(|d| {
-                d.new_path
-                    .as_ref()
-                    .unwrap()
-                    .to_string_lossy()
-                    .into_owned()
-            })
+            .map(|d| d.new_path.as_ref().unwrap().to_string_lossy().into_owned())
             .collect();
 
         assert_eq!(names, vec!["kept.txt"]);

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -1,4 +1,7 @@
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+use ignore::WalkBuilder;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
@@ -6,37 +9,66 @@ use crate::syntax::SyntaxHighlighter;
 
 use super::traits::{VcsBackend, VcsInfo, VcsType};
 
-/// A backend for reviewing a single file without a VCS repository.
+/// A backend for reviewing files outside of a VCS repository.
 ///
-/// All lines are presented as additions (like a new-file diff), allowing the
-/// user to annotate any file without needing git, hg, or jj.
+/// Accepts either a single file path or a directory. In directory mode the
+/// tree is walked with `ignore::WalkBuilder`:
+///
+/// - `.gitignore`, `.tuicrignore`, and the user's global git excludes
+///   (e.g. `~/.config/git/ignore`) are honored
+/// - hidden entries (dot-files and `.git`/`.hg`/`.jj`) are skipped
+/// - symlinks are not followed
+/// - binary and unreadable files are skipped silently
+///
+/// Every remaining text file is surfaced as a new-file diff so the user can
+/// annotate an entire codebase without git, hg, or jj.
 pub struct FileBackend {
     info: VcsInfo,
-    /// Absolute path to the file being reviewed
-    file_path: PathBuf,
+    /// Absolute paths of every file the user can review, paired with the
+    /// file size recorded at discovery time so `build_diff_file_for_path`
+    /// does not need to re-stat each entry.
+    files: Vec<(PathBuf, u64)>,
 }
 
+/// Files larger than this are added to the diff list as `is_too_large` so the
+/// UI can show a placeholder instead of loading them. Matches
+/// `MAX_UNTRACKED_FILE_SIZE` in `vcs/git/diff.rs` so behavior is consistent
+/// across backends.
+const MAX_FILE_BYTES: u64 = 10 * 1_024 * 1_024;
+
+/// Bytes inspected when classifying a file as text vs. binary.
+const BINARY_SNIFF_BYTES: usize = 8192;
+
 impl FileBackend {
-    /// Create a new `FileBackend` for the given file path.
-    ///
-    /// The path is resolved to an absolute path. The file must exist and be
-    /// readable.
+    /// Create a new `FileBackend` for the given file or directory path.
     pub fn new(path: &str) -> Result<Self> {
-        let file_path = std::fs::canonicalize(path).map_err(|e| {
+        let canonical = std::fs::canonicalize(path).map_err(|e| {
             TuicrError::Io(std::io::Error::new(
                 e.kind(),
-                format!("Cannot open file '{}': {}", path, e),
+                format!("Cannot open '{}': {}", path, e),
             ))
         })?;
 
-        if !file_path.is_file() {
+        let metadata = std::fs::metadata(&canonical)?;
+
+        let (root_path, files) = if metadata.is_file() {
+            let root = canonical
+                .parent()
+                .unwrap_or(Path::new("/"))
+                .to_path_buf();
+            (root, vec![(canonical, metadata.len())])
+        } else if metadata.is_dir() {
+            let files = collect_text_files(&canonical);
+            if files.is_empty() {
+                return Err(TuicrError::NoChanges);
+            }
+            (canonical, files)
+        } else {
             return Err(TuicrError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
-                format!("'{}' is not a file", path),
+                format!("'{}' is not a file or directory", path),
             )));
-        }
-
-        let root_path = file_path.parent().unwrap_or(Path::new("/")).to_path_buf();
+        };
 
         let info = VcsInfo {
             root_path,
@@ -45,21 +77,47 @@ impl FileBackend {
             vcs_type: VcsType::File,
         };
 
-        Ok(Self { info, file_path })
-    }
-}
-
-impl VcsBackend for FileBackend {
-    fn info(&self) -> &VcsInfo {
-        &self.info
+        Ok(Self { info, files })
     }
 
-    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        let content = std::fs::read_to_string(&self.file_path)?;
+    fn build_diff_file_for_path(
+        &self,
+        highlighter: &SyntaxHighlighter,
+        abs_path: &Path,
+        file_size: u64,
+    ) -> Option<DiffFile> {
+        // Binary check first so a too-large binary is skipped (not surfaced
+        // as a misleading is_too_large text placeholder), and so single-file
+        // mode (which never went through `collect_text_files`) is also guarded.
+        if is_probably_binary(abs_path) {
+            return None;
+        }
+
+        // Relative path from root (just the filename in single-file mode)
+        let rel_path = abs_path
+            .strip_prefix(&self.info.root_path)
+            .unwrap_or(abs_path)
+            .to_path_buf();
+
+        if file_size > MAX_FILE_BYTES {
+            let hunks: Vec<DiffHunk> = Vec::new();
+            let content_hash = DiffFile::compute_content_hash(&hunks);
+            return Some(DiffFile {
+                old_path: None,
+                new_path: Some(rel_path),
+                status: FileStatus::Added,
+                hunks,
+                is_binary: false,
+                is_too_large: true,
+                is_commit_message: false,
+                content_hash,
+            });
+        }
+
+        let content = std::fs::read_to_string(abs_path).ok()?;
         let lines: Vec<&str> = content.lines().collect();
-
         if lines.is_empty() {
-            return Err(TuicrError::NoChanges);
+            return None;
         }
 
         // Build line contents and origins for syntax highlighting
@@ -70,7 +128,7 @@ impl VcsBackend for FileBackend {
         let highlight_sequences =
             SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
         let new_highlighted_lines =
-            highlighter.highlight_file_lines(&self.file_path, &highlight_sequences.new_lines);
+            highlighter.highlight_file_lines(abs_path, &highlight_sequences.new_lines);
 
         // Build DiffLines
         let mut diff_lines = Vec::with_capacity(lines.len());
@@ -95,14 +153,6 @@ impl VcsBackend for FileBackend {
         }
 
         let total_lines = lines.len() as u32;
-
-        // Relative path from root (just the filename)
-        let rel_path = self
-            .file_path
-            .file_name()
-            .map(PathBuf::from)
-            .unwrap_or_else(|| self.file_path.clone());
-
         let hunk = DiffHunk {
             header: format!("@@ -0,0 +1,{} @@", total_lines),
             lines: diff_lines,
@@ -114,7 +164,7 @@ impl VcsBackend for FileBackend {
 
         let hunks = vec![hunk];
         let content_hash = DiffFile::compute_content_hash(&hunks);
-        let file = DiffFile {
+        Some(DiffFile {
             old_path: None,
             new_path: Some(rel_path),
             status: FileStatus::Added,
@@ -123,14 +173,32 @@ impl VcsBackend for FileBackend {
             is_too_large: false,
             is_commit_message: false,
             content_hash,
-        };
+        })
+    }
+}
 
-        Ok(vec![file])
+impl VcsBackend for FileBackend {
+    fn info(&self) -> &VcsInfo {
+        &self.info
+    }
+
+    fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        let diff_files: Vec<DiffFile> = self
+            .files
+            .iter()
+            .filter_map(|(p, size)| self.build_diff_file_for_path(highlighter, p, *size))
+            .collect();
+
+        if diff_files.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        Ok(diff_files)
     }
 
     fn fetch_context_lines(
         &self,
-        _file_path: &Path,
+        file_path: &Path,
         _file_status: FileStatus,
         start_line: u32,
         end_line: u32,
@@ -139,7 +207,12 @@ impl VcsBackend for FileBackend {
             return Ok(Vec::new());
         }
 
-        let content = std::fs::read_to_string(&self.file_path)?;
+        let abs_path = self.info.root_path.join(file_path);
+        if !abs_path.is_file() {
+            return Ok(Vec::new());
+        }
+
+        let content = std::fs::read_to_string(&abs_path)?;
         let lines: Vec<&str> = content.lines().collect();
         let mut result = Vec::new();
 
@@ -157,5 +230,120 @@ impl VcsBackend for FileBackend {
         }
 
         Ok(result)
+    }
+}
+
+fn collect_text_files(root: &Path) -> Vec<(PathBuf, u64)> {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .require_git(false)
+        .add_custom_ignore_filename(".tuicrignore");
+
+    let mut files: Vec<(PathBuf, u64)> = builder
+        .build()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_some_and(|ft| ft.is_file()))
+        .filter_map(|entry| {
+            let size = entry.metadata().ok()?.len();
+            let path = entry.into_path();
+            if is_probably_binary(&path) {
+                return None;
+            }
+            Some((path, size))
+        })
+        .collect();
+
+    files.sort();
+    files
+}
+
+fn is_probably_binary(path: &Path) -> bool {
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return true;
+    };
+    let mut buf = [0u8; BINARY_SNIFF_BYTES];
+    let n = match file.read(&mut buf) {
+        Ok(n) => n,
+        Err(_) => return true,
+    };
+    buf[..n].contains(&0)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+    use crate::syntax::SyntaxHighlighter;
+
+    fn highlighter() -> SyntaxHighlighter {
+        SyntaxHighlighter::default()
+    }
+
+    #[test]
+    fn single_file_mode_returns_one_diff_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        fs::write(&path, "alpha\nbeta\n").unwrap();
+
+        let backend = FileBackend::new(path.to_str().unwrap()).unwrap();
+        let diffs = backend.get_working_tree_diff(&highlighter()).unwrap();
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].new_path.as_deref().unwrap(),
+            Path::new("hello.txt")
+        );
+        assert_eq!(diffs[0].hunks[0].lines.len(), 2);
+    }
+
+    #[test]
+    fn directory_mode_walks_and_respects_gitignore() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::write(dir.path().join("kept.txt"), "hello\n").unwrap();
+        fs::write(dir.path().join("ignored.txt"), "skip me\n").unwrap();
+
+        let backend = FileBackend::new(dir.path().to_str().unwrap()).unwrap();
+        let diffs = backend.get_working_tree_diff(&highlighter()).unwrap();
+
+        let names: Vec<_> = diffs
+            .iter()
+            .map(|d| {
+                d.new_path
+                    .as_ref()
+                    .unwrap()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect();
+
+        assert_eq!(names, vec!["kept.txt"]);
+    }
+
+    #[test]
+    fn directory_mode_skips_binary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("binary.bin"), [0u8, 1, 2, 3, 0, 4]).unwrap();
+
+        let result = FileBackend::new(dir.path().to_str().unwrap());
+        assert!(matches!(result, Err(TuicrError::NoChanges)));
+    }
+
+    #[test]
+    fn directory_mode_preserves_relative_paths_for_nested_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let sub = dir.path().join("nested");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("inner.txt"), "x\n").unwrap();
+
+        let backend = FileBackend::new(dir.path().to_str().unwrap()).unwrap();
+        let diffs = backend.get_working_tree_diff(&highlighter()).unwrap();
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].new_path.as_deref().unwrap(),
+            Path::new("nested/inner.txt")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Reviewing a whole codebase previously meant relaunching `tuicr` once per file, which is impractical for anything beyond a quick spot-check. The minimal way to unlock multi-file review without inventing a new flag is to relax `--file`: the rest of the app already iterates `Vec<DiffFile>`, so a directory just needs to populate that vector.

Directory mode walks the tree with `ignore::WalkBuilder` so `.gitignore`, `.tuicrignore`, and global git excludes are honored the same way users already expect from the git backend. Binary files are skipped silently and oversized files reuse `is_too_large` with the same 10 MiB threshold as the git backend, keeping the UI's rendering branches uniform across modes.

## Test plan

- `tuicr --file <single-file>` still works as before
- `tuicr --file <directory>` lists all eligible files in the directory tree
- Ignored files (`.gitignore`, `.tuicrignore`, global excludes) are skipped
- Binary files are skipped
- Files over 10 MiB are handled the same way as in git backend mod

## Dog Food
In addition to the integrated tests I've manually ran this against a small-ish and a large repository. It can take a moment to load all files, but that's a problem the other VCS integrations have as well. A large diff touching many files shows the same startup delay. Loading the diff/files asynchronously is out of scope for this PR.