### PR TITLE
fix(config): honour `wrap = false`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -259,8 +259,8 @@ fn main() -> anyhow::Result<()> {
         if cfg.diff_view.as_deref() == Some("side-by-side") {
             app.diff_view_mode = app::DiffViewMode::SideBySide;
         }
-        if cfg.wrap == Some(true) {
-            app.set_diff_wrap(true);
+        if let Some(wrap) = cfg.wrap {
+            app.diff_state.wrap_lines = wrap;
         }
         if cfg.export_legend == Some(false) {
             app.export_legend = false;


### PR DESCRIPTION

`DiffState` defaults to `wrap_lines = true`, and the config loader only handled `Some(true)`:

```rust
if cfg.wrap == Some(true) {
    app.set_diff_wrap(true);
}
```

so `wrap = false` in `~/.config/tuicr/config.toml` was a no-op — the only way to start with wrapping off was `:set nowrap` at runtime.

Set `app.diff_state.wrap_lines` directly so both values take effect. This also avoids `set_diff_wrap()`, which prints the "Diff wrapping: on/off" status message — not wanted on startup.
