### PR TITLE
feat: --all-files for whole-repo annotation

### DIFF
--- a/docs/decisions/FEAT-0010 All-Files Pristine View.md
+++ b/docs/decisions/FEAT-0010 All-Files Pristine View.md
@@ -1,0 +1,72 @@
+---
+title: All-Files Pristine View Mode
+description: Add `tuicr --all-files` for whole-repo annotation distinct from `--file` directory mode
+type: adr
+status: proposed
+created: 2026-05-18
+---
+
+# FEAT-0010 All-Files Pristine View Mode
+
+## Context and Problem Statement
+
+tuicr is diff-first: working tree, commit range, GitHub PR. The only non-diff entry point is `--file <path>`, which after #321 also accepts a directory and walks it with `ignore::WalkBuilder`, rendering every line as a new-file addition.
+
+That mode serves "annotate a folder I don't control" workflows, but it doesn't fit whole-repo annotation for a tracked codebase. The walker can include untracked build artifacts when no `.gitignore` is present, and the green `+` gutter on every line implies "review these changes" when the goal is to annotate code that hasn't been touched. Coding agents like Claude Code, Codex, and Cursor want a surface that says "here's the entire codebase, comment on any line, hand the comments back" — a peer to diff modes, not a workaround inside one.
+
+This feature is inspired by [revdiff][REVDIFF]'s `--all-files` mode (umputun's Go-based TUI), which solves the same "annotate every tracked file and feed it to a coding agent" problem in a separate tool. The shape and ergonomics borrow from revdiff; the implementation reuses tuicr's existing review primitives so the new mode composes with vim navigation, comment types, themes, the clipboard export format, and session persistence without changes.
+
+## Decision Drivers
+
+- The clipboard export pipeline (`y` / `:clip` structured markdown) is already what agents consume; the new mode must plug into it unchanged.
+- File enumeration should reflect what is under version control, not a filesystem snapshot.
+- Rendering must signal "no diff here" so reviewers don't mistake context lines for additions.
+- Session persistence must survive a HEAD advance mid-review (e.g. `git pull`) without orphaning comments.
+- Scope of this ADR: ship the surface; defer cross-VCS support and structural cleanups to separate ADRs.
+
+## Considered Options
+
+### 1. Extend `--file <dir>` with VCS-aware enumeration
+
+Promote the existing directory walk in `FileBackend` to call `git ls-files` when inside a repo and fall back to `WalkBuilder` otherwise. One flag, two enumeration modes selected at runtime.
+
+Rejected: silently changes the behavior shipped in #321 for users already running `tuicr --file .`, and bundles two different filtering semantics (filesystem vs VCS-tracked) into one backend whose contract is no longer self-evident.
+
+### 2. New `--all-files` flag with new `DiffSource::Pristine` variant
+
+Introduce a first-class `DiffSource::Pristine { included: Vec<PathBuf> }` variant alongside `WorkingTree`, `CommitRange`, and `PullRequest`. Add `VcsBackend::list_tracked_files(&self) -> Result<Vec<PathBuf>>` to the trait, with per-backend implementations.
+
+Rejected for this PR: touches the trait, the enum, persistence, status bar dispatch, and every backend at once. Correct end state, but pairs poorly with shipping the user-visible feature in a reviewable PR.
+
+### 3. New `--all-files` flag, FileBackend extension, deferred structural cleanup
+
+Add `--all-files` / `-A` as a sibling flag. Reuse `FileBackend` with a new `FileMode { Single, Directory, Pristine }` enum and a `new_pristine(paths, root)` constructor. A small helper `vcs::pristine::collect_tracked_paths` shells out to `git ls-files -z`. Session keying piggybacks on the existing `base_commit: String` field via a `"pristine:{HEAD or none}:{path_hash:016x}"` prefix; the persistence layer prefix-matches on reload so an advancing HEAD does not orphan comments.
+
+## Decision Outcome
+
+Chosen: option 3.
+
+`--all-files` / `-A` is mutually exclusive with `-r`, `-w`, `--file`. File enumeration is git-only; non-git invocation returns `NotARepository` with a tailored hint. Every file renders with `LineOrigin::Context` and `@@ -1,N +1,N @@` hunk headers; status badges (`M`/`A`/`D`) are suppressed in the file list and per-file diff headers, since the files are not changed. Side-by-side view is suppressed in pristine mode because it would render identical panes; the `:diff` command no-ops with a status message in pristine mode. The status bar gains a `PRISTINE · <short-sha> · N files` chip so reviewers always know which mode they are in and which HEAD their comments are anchored against. The clipboard export format is unchanged.
+
+The `.tuicrignore` filter is applied after enumeration, matching every other mode's behavior, so users can elide tracked-but-noisy files (lockfiles, generated docs) from the view surface without affecting git's view of the tracked set.
+
+Pristine session keys reuse the existing `base_commit: String` field with a `pristine:<head>:<path_hash>` prefix; the persistence layer prefix-matches on reload, ignoring the head segment so an advancing HEAD still resolves to the same session. Two pristine sessions over different path subsets (different `<path_hash>`) persist independently. The single-file `--file` mode keeps its existing `"file"` sentinel and does not collide.
+
+## Consequences
+
+- [+] Whole-repo annotation is a first-class mode. The previous workaround — synthesizing a diff against git's empty tree via `commit-tree 4b825dc6...` and `tuicr -r <empty>..HEAD` — is no longer needed.
+- [+] Every existing feature composes for free: vim navigation, comment types, clipboard export, theme rendering, session persistence, file-tree expansion.
+- [+] Coexists with the merged `--file <dir>` mode from #321. Users keep both surfaces and pick based on intent.
+- [-] jj and Mercurial users see "pristine mode requires a git repository." Cross-VCS support is a separate decision; a hard error is preferable to silently producing a different file set.
+- [-] One additional `git ls-files` subprocess on startup. Negligible cost for repos up to ~10k tracked files; larger repos may want async enumeration in a follow-up.
+
+## Future Considerations
+
+Candidate follow-up ADRs. Each decision boundary is independent and any subset can land in any order.
+
+- Promote pristine to a typed `DiffSource::Pristine { included: Vec<PathBuf> }` variant with a dedicated `SessionDiffSource::Pristine` payload. Migrates the prefix-matched string keys on load and lets `header_source_chunk` dispatch on the variant instead of the `is_pristine_mode` flag.
+- Hoist enumeration into a `VcsBackend::list_tracked_files(&self) -> Result<Vec<PathBuf>>` trait method so `--all-files` works on jj (`jj file list`) and any future backend. Mercurial stays explicit `UnsupportedOperation` until the maintainers decide whether `hg manifest` should drive it.
+- Extract pristine rendering into a shared renderer so `--include <prefix>` / `--exclude <prefix>` filters compose without duplicating render code.
+- Measure single-file focus mode for large codebases. tuicr renders every file into one continuous scroll today; whether that holds up for pristine views of >100-file repos is an empirical question worth investigating before adding a focus toggle.
+
+[REVDIFF]: https://github.com/umputun/revdiff "umputun/revdiff -- TUI for reviewing diffs, files, and documents with inline annotations"

--- a/src/app.rs
+++ b/src/app.rs
@@ -872,6 +872,10 @@ pub struct App {
     pub pending_confirm: Option<ConfirmAction>,
     pub supports_keyboard_enhancement: bool,
     pub show_file_list: bool,
+    /// `true` when the session was opened via `--all-files`. Drives the
+    /// `PRISTINE · N files` chip in the status bar and prevents that chip
+    /// from showing in the regular `--file <dir>` directory mode.
+    pub is_pristine_mode: bool,
     pub cursor_line_highlight: bool,
     pub leader_key: char,
     pub scroll_offset: usize,
@@ -1055,6 +1059,9 @@ pub struct AppStartupOptions<'a> {
     pub working_tree: bool,
     pub path_filter: Option<&'a str>,
     pub file_path: Option<&'a str>,
+    /// Whole-repo annotation mode (`--all-files`). Mutually exclusive with
+    /// the other selectors; the binary validates that before reaching here.
+    pub all_files: bool,
     pub git_backend_preference: GitBackendPreference,
     /// Direct PR target (`tuicr pr <target>`). Mutually exclusive with the
     /// other selectors above; the binary validates that before reaching here.
@@ -1103,6 +1110,64 @@ impl App {
                 app.show_file_list = false;
             }
             app.focused_panel = FocusedPanel::Diff;
+
+            return Ok(app);
+        }
+
+        // --all-files mode: enumerate every tracked file via `git ls-files`
+        // and render in context-only mode for whole-repo annotation. Git-only
+        // for MVP; non-git invocation surfaces as `NotARepository`.
+        if options.all_files {
+            let cwd = std::env::current_dir()
+                .map_err(|_| TuicrError::NotARepository)?
+                .canonicalize()
+                .map_err(|_| TuicrError::NotARepository)?;
+            let paths = crate::vcs::pristine::collect_tracked_paths(&cwd)?;
+
+            let mut joined = Vec::new();
+            for path in &paths {
+                joined.extend_from_slice(path.as_os_str().as_encoded_bytes());
+                joined.push(b'\n');
+            }
+            let path_hash = crate::hash::fnv1a_64(&joined);
+            let head_or_none = crate::vcs::pristine::head_short_sha(&cwd);
+            let base_commit = format!("pristine:{head_or_none}:{path_hash:016x}");
+
+            let vcs = Box::new(FileBackend::new_pristine(paths, cwd.clone())?);
+            let mut vcs_info = vcs.info().clone();
+            vcs_info.head_commit = base_commit;
+            let highlighter = theme.syntax_highlighter();
+            let diff_files = vcs.get_working_tree_diff(highlighter)?;
+            // `git ls-files` already honors `.gitignore`, but `.tuicrignore`
+            // is tuicr-specific and not known to git. Run the same post-VCS
+            // filter every other mode uses so users can elide tracked-but-
+            // boring files (lockfiles, generated docs) from the review surface.
+            let diff_files = Self::filter_ignored_diff_files(&cwd, diff_files);
+            if diff_files.is_empty() {
+                return Err(TuicrError::NoChanges);
+            }
+            let session = Self::load_or_create_session(&vcs_info, SessionDiffSource::Pristine);
+
+            let mut app = Self::build(
+                vcs,
+                vcs_info,
+                theme,
+                comment_type_configs,
+                output_to_stdout,
+                diff_files,
+                session,
+                DiffSource::WorkingTree,
+                InputMode::Normal,
+                Vec::new(),
+                None, // no path_filter
+            )?;
+
+            app.is_pristine_mode = true;
+            app.focused_panel = FocusedPanel::Diff;
+            // Force unified view: pristine mode has no diff, so side-by-side
+            // would render two identical panes. The `:diff` command is gated
+            // separately so the user cannot toggle back.
+            app.diff_view_mode = DiffViewMode::Unified;
 
             return Ok(app);
         }
@@ -1461,6 +1526,7 @@ impl App {
             pending_confirm: None,
             supports_keyboard_enhancement: false,
             show_file_list: true,
+            is_pristine_mode: false,
             cursor_line_highlight: true,
             leader_key: crate::config::DEFAULT_LEADER_KEY,
             scroll_offset: 0,
@@ -6280,6 +6346,13 @@ impl App {
     }
 
     pub fn toggle_diff_view_mode(&mut self) {
+        if self.is_pristine_mode {
+            // Side-by-side has nothing to show in pristine mode: there is no
+            // diff, so the two panes would render identical content. Keep
+            // the view unified and tell the user why the toggle did nothing.
+            self.set_message("side-by-side not available in pristine mode");
+            return;
+        }
         self.diff_view_mode = match self.diff_view_mode {
             DiffViewMode::Unified => DiffViewMode::SideBySide,
             DiffViewMode::SideBySide => DiffViewMode::Unified,

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> anyhow::Result<()> {
         matches!(supports_keyboard_enhancement(), Ok(true))
     };
 
-    // --file is mutually exclusive with --path, -r, and -w
+    // --file is mutually exclusive with --path, -r, -w, and --all-files
     if cli_args.file_path.is_some() {
         if cli_args.path_filter.is_some() {
             eprintln!("Error: --file cannot be combined with --path");
@@ -93,6 +93,27 @@ fn main() -> anyhow::Result<()> {
         }
         if cli_args.working_tree {
             eprintln!("Error: --file cannot be combined with -w/--working-tree");
+            std::process::exit(2);
+        }
+        if cli_args.all_files {
+            eprintln!("Error: --file cannot be combined with -A/--all-files");
+            std::process::exit(2);
+        }
+    }
+
+    // --all-files is mutually exclusive with --path, -r, and -w (--file
+    // already covered above)
+    if cli_args.all_files {
+        if cli_args.path_filter.is_some() {
+            eprintln!("Error: --all-files cannot be combined with --path");
+            std::process::exit(2);
+        }
+        if cli_args.revisions.is_some() {
+            eprintln!("Error: --all-files cannot be combined with -r/--revisions");
+            std::process::exit(2);
+        }
+        if cli_args.working_tree {
+            eprintln!("Error: --all-files cannot be combined with -w/--working-tree");
             std::process::exit(2);
         }
     }
@@ -183,6 +204,7 @@ fn main() -> anyhow::Result<()> {
                 working_tree: cli_args.working_tree,
                 path_filter: cli_args.path_filter.as_deref(),
                 file_path: cli_args.file_path.as_deref(),
+                all_files: cli_args.all_files,
                 git_backend_preference,
                 pr_target: cli_args.pr_target.as_deref(),
             },
@@ -208,9 +230,15 @@ fn main() -> anyhow::Result<()> {
             // startup errors — `tuicr pr <bad-url>`, forge auth issues,
             // missing PR, `--file <missing-path>` — the hint is wrong.
             if matches!(e, crate::error::TuicrError::NotARepository) {
-                eprintln!(
-                    "\nMake sure you're in a git, jujutsu, or mercurial repository with commits or staged/unstaged changes."
-                );
+                if cli_args.all_files {
+                    eprintln!(
+                        "\ntuicr --all-files requires a git repository with tracked files. Run `git init && git add -A` to bootstrap one."
+                    );
+                } else {
+                    eprintln!(
+                        "\nMake sure you're in a git, jujutsu, or mercurial repository with commits or staged/unstaged changes."
+                    );
+                }
             }
             std::process::exit(1);
         }
@@ -256,7 +284,9 @@ fn main() -> anyhow::Result<()> {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
-        if cfg.diff_view.as_deref() == Some("side-by-side") {
+        // Pristine mode has no diff, so side-by-side would render two
+        // identical panes. Honor the config for every other mode.
+        if cfg.diff_view.as_deref() == Some("side-by-side") && !app.is_pristine_mode {
             app.diff_view_mode = app::DiffViewMode::SideBySide;
         }
         if let Some(wrap) = cfg.wrap {

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -66,6 +66,11 @@ pub enum SessionDiffSource {
     /// `ReviewSession::pr_session_key`; this variant is a discriminator so
     /// the persistence layer can route to PR-specific filename construction.
     PullRequest,
+    /// Whole-repo annotation surface. Every tracked file is shown in
+    /// context-only rendering, sourced from `git ls-files`. The persisted
+    /// `base_commit` for these sessions starts with `"pristine:"` so the
+    /// reload path can match by prefix instead of exact HEAD.
+    Pristine,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -171,6 +171,7 @@ fn session_filename(session: &ReviewSession) -> String {
         SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
         SessionDiffSource::StagedUnstagedAndCommits => "staged_unstaged_and_commits",
         SessionDiffSource::PullRequest => "pr",
+        SessionDiffSource::Pristine => "pristine",
     };
 
     let timestamp = session.created_at.format("%Y%m%d_%H%M%S");
@@ -259,6 +260,7 @@ pub fn load_latest_session_for_context(
         SessionDiffSource::CommitRange => "commits",
         SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
         SessionDiffSource::StagedUnstagedAndCommits => "staged_unstaged_and_commits",
+        SessionDiffSource::Pristine => "pristine",
         // PR sessions are looked up via `load_pr_session`. If a caller asks
         // for the local-session loader with this diff source, return nothing.
         SessionDiffSource::PullRequest => return Ok(None),
@@ -361,8 +363,19 @@ pub fn load_latest_session_for_context(
 
         let session_branch = session.branch_name.as_deref();
         if session_branch == branch_name {
-            if branch_name.is_none() && session.base_commit != head_commit {
-                continue;
+            if branch_name.is_none() {
+                // Pristine sessions key on the path-list hash, not the HEAD
+                // sha, so an advancing HEAD after `git pull` still reloads
+                // the same comments. Other branch-less sessions fall back to
+                // exact head_commit comparison.
+                let exact_match = if matches!(diff_source, SessionDiffSource::Pristine) {
+                    pristine_keys_match(&session.base_commit, head_commit)
+                } else {
+                    session.base_commit == head_commit
+                };
+                if !exact_match {
+                    continue;
+                }
             }
 
             return Ok(Some((path, session)));
@@ -379,6 +392,26 @@ pub fn load_latest_session_for_context(
     }
 
     Ok(legacy_candidate)
+}
+
+/// Match two pristine session keys by their path-hash suffix.
+///
+/// Pristine `base_commit` values have the shape `"pristine:<head>:<hash>"`.
+/// Two sessions belong to the same review if they share the same path-list
+/// hash, regardless of HEAD; the prefix and trailing hash must both match.
+fn pristine_keys_match(a: &str, b: &str) -> bool {
+    let Some(a_hash) = pristine_key_hash(a) else {
+        return false;
+    };
+    let Some(b_hash) = pristine_key_hash(b) else {
+        return false;
+    };
+    a_hash == b_hash
+}
+
+fn pristine_key_hash(key: &str) -> Option<&str> {
+    let rest = key.strip_prefix("pristine:")?;
+    rest.rsplit_once(':').map(|(_, hash)| hash)
 }
 
 #[cfg(test)]
@@ -1085,5 +1118,136 @@ mod tests {
         // then each load returns its matching PR
         assert_eq!(loaded_a.1.pr_session_key.as_ref(), Some(&key_a));
         assert_eq!(loaded_b.1.pr_session_key.as_ref(), Some(&key_b));
+    }
+
+    // ---------- Pristine session key tests ----------
+
+    #[test]
+    fn pristine_key_hash_extracts_trailing_segment() {
+        assert_eq!(pristine_key_hash("pristine:abc1234:9f0a"), Some("9f0a"));
+        assert_eq!(pristine_key_hash("pristine:none:0000"), Some("0000"));
+        assert_eq!(pristine_key_hash("worktree:abc1234"), None);
+        assert_eq!(pristine_key_hash("pristine:no-trailing-hash"), None);
+    }
+
+    #[test]
+    fn pristine_keys_match_when_path_hash_equal_even_if_head_changed() {
+        assert!(pristine_keys_match(
+            "pristine:abc1234:9f0a",
+            "pristine:def5678:9f0a"
+        ));
+        assert!(!pristine_keys_match(
+            "pristine:abc1234:9f0a",
+            "pristine:def5678:beef"
+        ));
+        assert!(!pristine_keys_match(
+            "pristine:abc1234:9f0a",
+            "worktree:abc1234"
+        ));
+    }
+
+    #[test]
+    fn pristine_session_reloads_after_head_advance() {
+        let _guard = with_test_reviews_dir();
+        let repo_path =
+            std::env::temp_dir().join(format!("tuicr-pristine-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&repo_path).unwrap();
+
+        let session = create_session(
+            repo_path.clone(),
+            "pristine:abc1234:9f0a",
+            None,
+            SessionDiffSource::Pristine,
+            None,
+        );
+        let saved_path = save_session(&session).unwrap();
+
+        // HEAD advanced; the new key shares the same path hash suffix.
+        let loaded = load_latest_session_for_context(
+            &repo_path,
+            None,
+            "pristine:def5678:9f0a",
+            SessionDiffSource::Pristine,
+            None,
+        )
+        .unwrap();
+        assert!(
+            loaded.is_some(),
+            "advanced HEAD must still find the session"
+        );
+        assert_eq!(loaded.unwrap().0, saved_path);
+    }
+
+    #[test]
+    fn pristine_session_does_not_reload_when_path_hash_differs() {
+        let _guard = with_test_reviews_dir();
+        let repo_path =
+            std::env::temp_dir().join(format!("tuicr-pristine-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&repo_path).unwrap();
+
+        let session = create_session(
+            repo_path.clone(),
+            "pristine:abc1234:aaaa",
+            None,
+            SessionDiffSource::Pristine,
+            None,
+        );
+        save_session(&session).unwrap();
+
+        let loaded = load_latest_session_for_context(
+            &repo_path,
+            None,
+            "pristine:abc1234:bbbb",
+            SessionDiffSource::Pristine,
+            None,
+        )
+        .unwrap();
+        assert!(
+            loaded.is_none(),
+            "different path-hash must NOT match a stored pristine session"
+        );
+    }
+
+    #[test]
+    fn pristine_session_does_not_collide_with_single_file_session() {
+        let _guard = with_test_reviews_dir();
+        let repo_path =
+            std::env::temp_dir().join(format!("tuicr-pristine-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&repo_path).unwrap();
+
+        // Single-file `--file` session at the same root_path uses base_commit "file".
+        let single = create_session(
+            repo_path.clone(),
+            "file",
+            None,
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        save_session(&single).unwrap();
+
+        // Pristine session at the same root_path uses base_commit "pristine:...".
+        let pristine = create_session(
+            repo_path.clone(),
+            "pristine:abc1234:9f0a",
+            None,
+            SessionDiffSource::Pristine,
+            None,
+        );
+        let pristine_path = save_session(&pristine).unwrap();
+
+        let loaded = load_latest_session_for_context(
+            &repo_path,
+            None,
+            "pristine:abc1234:9f0a",
+            SessionDiffSource::Pristine,
+            None,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            loaded.0, pristine_path,
+            "pristine loader must return the pristine session, not the --file one"
+        );
+        assert_eq!(loaded.1.diff_source, SessionDiffSource::Pristine);
     }
 }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1510,8 +1510,11 @@ pub struct CliArgs {
     pub working_tree: bool,
     /// Filter diff to a specific file or directory path
     pub path_filter: Option<String>,
-    /// Open a single file for annotation (no VCS required)
+    /// Open a single file or directory for annotation (no VCS required)
     pub file_path: Option<String>,
+    /// Whole-repo annotation mode (`--all-files` / `-A`). Lists every tracked
+    /// file via `git ls-files` and renders them in context-only mode.
+    pub all_files: bool,
     /// Direct pull request target from `tuicr pr <target>`.
     pub pr_target: Option<String>,
 }
@@ -1897,7 +1900,8 @@ Options:
   -p, --path <PATH>     Filter diff to a specific file or directory
   -w, --working-tree     Include uncommitted changes (skip commit selector when used alone,
                          combine with commits when used with -r)
-  --file <PATH>          Open a file for annotation (no VCS required)
+  --file <PATH>          Open a file or directory for annotation (no VCS required)
+  -A, --all-files        Review every tracked file in the cwd's git repo
   --stdout               Output to stdout instead of clipboard when exporting
   --no-update-check      Skip checking for updates on startup
   -V, --version          Print version
@@ -2059,6 +2063,11 @@ fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
                 return Err("--file requires a file path".to_string());
             }
             cli_args.file_path = Some(value.to_string());
+        }
+
+        // Handle --all-files / -A
+        if args[i] == "--all-files" || args[i] == "-A" {
+            cli_args.all_files = true;
         }
 
         // Handle -r / --revisions value

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -167,6 +167,10 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
         let header_text = if file.is_commit_message {
             format!("═══ {}Commit Message ", review_mark)
+        } else if app.is_pristine_mode {
+            // Pristine mode reviews unchanged code; the M/A/D badge would
+            // mislead. Render the header without it.
+            format!("═══ {}{} ", review_mark, path.display())
         } else {
             format!("═══ {}{} [{}] ", review_mark, path.display(), status)
         };

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -133,17 +133,23 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                         ])
                     } else {
                         let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
-                        let status = file.status.as_char();
                         let indent = "  ".repeat(*depth);
-                        Line::from(vec![
+                        let mut spans = vec![
                             Span::raw(indent),
                             Span::styled(format!("{checkbox} "), checkbox_style),
-                            Span::styled(
+                        ];
+                        // Pristine mode reviews unchanged code; the M/A/D
+                        // badge would lie. Suppress it and leave the row as
+                        // checkbox + filename.
+                        if !app.is_pristine_mode {
+                            let status = file.status.as_char();
+                            spans.push(Span::styled(
                                 format!("{status} "),
                                 styles::file_status_style(&app.theme, status),
-                            ),
-                            Span::raw(filename.to_string()),
-                        ])
+                            ));
+                        }
+                        spans.push(Span::raw(filename.to_string()));
+                        Line::from(spans)
                     }
                 }
             };

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -74,6 +74,24 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     if let Some(source) = header_source_chunk(app) {
         chunks.push(source);
     }
+    if app.is_pristine_mode {
+        // The pristine session key has shape `pristine:<head_or_none>:<hash>`,
+        // so the middle segment is the short SHA of the HEAD we're reviewing.
+        // "none" renders as `uncommitted` so empty repos read sensibly. A
+        // missing prefix falls back to `?` rather than crashing the chip.
+        let head_label = app
+            .vcs_info
+            .head_commit
+            .strip_prefix("pristine:")
+            .and_then(|rest| rest.split(':').next())
+            .map(|raw| if raw == "none" { "uncommitted" } else { raw })
+            .unwrap_or("?");
+        chunks.push(format!(
+            "PRISTINE \u{00b7} {} \u{00b7} {} files",
+            head_label,
+            app.diff_files.len()
+        ));
+    }
     let source_text = if chunks.is_empty() {
         String::new()
     } else {

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -9,25 +9,43 @@ use crate::syntax::SyntaxHighlighter;
 
 use super::traits::{VcsBackend, VcsInfo, VcsType};
 
-/// A backend for reviewing files outside of a VCS repository.
+/// A backend for reviewing files outside of a VCS repository (`--file`)
+/// and for the whole-repo `--all-files` mode.
 ///
-/// Accepts either a single file path or a directory. In directory mode the
-/// tree is walked with `ignore::WalkBuilder`:
+/// `Single` and `Directory` modes render each line with
+/// `LineOrigin::Addition` and a `@@ -0,0 +1,N @@` hunk header (new-file
+/// diff shape). `Pristine` mode renders each line with
+/// `LineOrigin::Context` and a `@@ -1,N +1,N @@` hunk header.
 ///
-/// - `.gitignore`, `.tuicrignore`, and the user's global git excludes
-///   (e.g. `~/.config/git/ignore`) are honored
-/// - hidden entries (dot-files and `.git`/`.hg`/`.jj`) are skipped
-/// - symlinks are not followed
-/// - binary and unreadable files are skipped silently
-///
-/// Every remaining text file is surfaced as a new-file diff so the user can
-/// annotate an entire codebase without git, hg, or jj.
+/// Directory mode walks the tree with `ignore::WalkBuilder`, honoring
+/// `.gitignore`, `.tuicrignore`, the user's global git excludes, hidden
+/// entries, and symlink boundaries. Binary and unreadable files are
+/// skipped silently. Pristine mode skips the walker and accepts a
+/// pre-enumerated path list (typically from `git ls-files`).
 pub struct FileBackend {
     info: VcsInfo,
     /// Absolute paths of every file the user can review, paired with the
     /// file size recorded at discovery time so `build_diff_file_for_path`
     /// does not need to re-stat each entry.
     files: Vec<(PathBuf, u64)>,
+    /// Which entry point built this backend. Controls per-line rendering
+    /// (addition coloring vs context) and the hunk-header math.
+    mode: FileMode,
+}
+
+/// How a [`FileBackend`] was constructed. Determines rendering semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileMode {
+    /// Single file passed via `--file <path>`. Renders as a new-file
+    /// addition diff (`@@ -0,0 +1,N @@`, `LineOrigin::Addition`).
+    Single,
+    /// Directory walked via `ignore::WalkBuilder` from `--file <dir>`.
+    /// Same rendering as `Single`; only the entry point differs.
+    Directory,
+    /// Whole-repo annotation surface from `--all-files`. Renders as
+    /// context (`@@ -1,N +1,N @@`, `LineOrigin::Context`) so the user
+    /// reads pristine source instead of a synthetic addition diff.
+    Pristine,
 }
 
 /// Files larger than this are added to the diff list as `is_too_large` so the
@@ -40,7 +58,15 @@ const MAX_FILE_BYTES: u64 = 10 * 1_024 * 1_024;
 const BINARY_SNIFF_BYTES: usize = 8192;
 
 impl FileBackend {
-    /// Create a new `FileBackend` for the given file or directory path.
+    /// Create a new `FileBackend` for the given file or directory path
+    /// (the `--file <path>` entry point).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuicrError::Io`] if `path` cannot be canonicalized or is
+    /// neither a file nor a directory. Returns [`TuicrError::NoChanges`]
+    /// when a directory walk surfaces zero text files after binary
+    /// filtering.
     pub fn new(path: &str) -> Result<Self> {
         let canonical = std::fs::canonicalize(path).map_err(|e| {
             TuicrError::Io(std::io::Error::new(
@@ -51,15 +77,15 @@ impl FileBackend {
 
         let metadata = std::fs::metadata(&canonical)?;
 
-        let (root_path, files) = if metadata.is_file() {
+        let (root_path, files, mode) = if metadata.is_file() {
             let root = canonical.parent().unwrap_or(Path::new("/")).to_path_buf();
-            (root, vec![(canonical, metadata.len())])
+            (root, vec![(canonical, metadata.len())], FileMode::Single)
         } else if metadata.is_dir() {
             let files = collect_text_files(&canonical);
             if files.is_empty() {
                 return Err(TuicrError::NoChanges);
             }
-            (canonical, files)
+            (canonical, files, FileMode::Directory)
         } else {
             return Err(TuicrError::Io(std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
@@ -74,7 +100,58 @@ impl FileBackend {
             vcs_type: VcsType::File,
         };
 
-        Ok(Self { info, files })
+        Ok(Self { info, files, mode })
+    }
+
+    /// Create a [`FileBackend`] in pristine mode from a pre-enumerated
+    /// list of absolute paths under `root` (the `--all-files` entry
+    /// point).
+    ///
+    /// Skips the `ignore::WalkBuilder` step entirely: the caller has
+    /// already decided what should be included (typically from
+    /// `git ls-files`). Each path is `stat`-ed for its size, binary files
+    /// are dropped via [`is_probably_binary`], and the remaining set is
+    /// stored sorted. The session keying happens upstream, so this
+    /// constructor only handles the backend state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TuicrError::NoChanges`] when every path was filtered
+    /// out (all binary, all unreadable, or the input list was empty).
+    /// Returns [`TuicrError::Io`] when a non-recoverable filesystem
+    /// error occurs while stat-ing a path that the caller claimed
+    /// exists.
+    pub fn new_pristine(paths: Vec<PathBuf>, root: PathBuf) -> Result<Self> {
+        let mut files: Vec<(PathBuf, u64)> = Vec::with_capacity(paths.len());
+        for path in paths {
+            if is_probably_binary(&path) {
+                continue;
+            }
+            let size = match std::fs::metadata(&path) {
+                Ok(meta) => meta.len(),
+                Err(_) => continue,
+            };
+            files.push((path, size));
+        }
+
+        if files.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        files.sort();
+
+        let info = VcsInfo {
+            root_path: root,
+            head_commit: "file".to_string(),
+            branch_name: None,
+            vcs_type: VcsType::File,
+        };
+
+        Ok(Self {
+            info,
+            files,
+            mode: FileMode::Pristine,
+        })
     }
 
     fn build_diff_file_for_path(
@@ -117,9 +194,14 @@ impl FileBackend {
             return None;
         }
 
+        let render_origin = match self.mode {
+            FileMode::Pristine => LineOrigin::Context,
+            FileMode::Single | FileMode::Directory => LineOrigin::Addition,
+        };
+
         // Build line contents and origins for syntax highlighting
         let line_contents: Vec<String> = lines.iter().map(|l| super::tabify(l)).collect();
-        let line_origins: Vec<LineOrigin> = vec![LineOrigin::Addition; line_contents.len()];
+        let line_origins: Vec<LineOrigin> = vec![render_origin; line_contents.len()];
 
         // Apply syntax highlighting
         let highlight_sequences =
@@ -137,24 +219,48 @@ impl FileBackend {
                 new_highlighted_lines.as_deref(),
                 None,
                 highlight_sequences.new_line_indices[i],
-                LineOrigin::Addition,
+                render_origin,
             );
 
+            // Pristine context lines need both old_lineno and new_lineno
+            // populated so the side-by-side and unified renderers walk the
+            // gutter math correctly.
+            let old_lineno = match self.mode {
+                FileMode::Pristine => Some(line_num),
+                FileMode::Single | FileMode::Directory => None,
+            };
+
             diff_lines.push(DiffLine {
-                origin: LineOrigin::Addition,
+                origin: render_origin,
                 content: content.clone(),
-                old_lineno: None,
+                old_lineno,
                 new_lineno: Some(line_num),
                 highlighted_spans,
             });
         }
 
         let total_lines = lines.len() as u32;
+        let (hunk_header, old_start, old_count) = match self.mode {
+            FileMode::Pristine => (
+                format!("@@ -1,{0} +1,{0} @@", total_lines),
+                1u32,
+                total_lines,
+            ),
+            FileMode::Single | FileMode::Directory => {
+                (format!("@@ -0,0 +1,{} @@", total_lines), 0u32, 0u32)
+            }
+        };
+
+        let file_status = match self.mode {
+            FileMode::Pristine => FileStatus::Modified,
+            FileMode::Single | FileMode::Directory => FileStatus::Added,
+        };
+
         let hunk = DiffHunk {
-            header: format!("@@ -0,0 +1,{} @@", total_lines),
+            header: hunk_header,
             lines: diff_lines,
-            old_start: 0,
-            old_count: 0,
+            old_start,
+            old_count,
             new_start: 1,
             new_count: total_lines,
         };
@@ -164,7 +270,7 @@ impl FileBackend {
         Some(DiffFile {
             old_path: None,
             new_path: Some(rel_path),
-            status: FileStatus::Added,
+            status: file_status,
             hunks,
             is_binary: false,
             is_too_large: false,
@@ -204,12 +310,24 @@ impl VcsBackend for FileBackend {
             return Ok(Vec::new());
         }
 
-        let abs_path = self.info.root_path.join(file_path);
-        if !abs_path.is_file() {
+        // Canonicalize the joined path and confine it to root_path.
+        // Without this guard a malformed session pointing at `../../etc/passwd`
+        // (or a renamed repo where a stored path now escapes the new root)
+        // could read arbitrary files. Pristine mode is multi-file, so the
+        // attack surface is genuinely larger here than in single-file mode.
+        let joined = self.info.root_path.join(file_path);
+        let canonical = match std::fs::canonicalize(&joined) {
+            Ok(p) => p,
+            Err(_) => return Ok(Vec::new()),
+        };
+        if !canonical.starts_with(&self.info.root_path) {
+            return Ok(Vec::new());
+        }
+        if !canonical.is_file() {
             return Ok(Vec::new());
         }
 
-        let content = std::fs::read_to_string(&abs_path)?;
+        let content = std::fs::read_to_string(&canonical)?;
         let lines: Vec<&str> = content.lines().collect();
         let mut result = Vec::new();
 
@@ -336,5 +454,171 @@ mod tests {
             diffs[0].new_path.as_deref().unwrap(),
             Path::new("nested/inner.txt")
         );
+    }
+
+    // ---------- Pristine-mode regression tests ----------
+
+    #[test]
+    fn pristine_diff_uses_context_origin_and_one_indexed_hunk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("hello.rs").canonicalize_lazy(dir.path());
+        fs::write(
+            &path,
+            "fn main() {}\nlet x = 1;\nlet y = 2;\nlet z = 3;\nlet w = 4;\n",
+        )
+        .unwrap();
+        let root = dir.path().canonicalize().unwrap();
+        let backend = FileBackend::new_pristine(vec![path.clone()], root).unwrap();
+        let diffs = backend.get_working_tree_diff(&highlighter()).unwrap();
+
+        assert_eq!(diffs.len(), 1);
+        let hunk = &diffs[0].hunks[0];
+        assert_eq!(hunk.header, "@@ -1,5 +1,5 @@");
+        assert_eq!(hunk.old_start, 1);
+        assert_eq!(hunk.old_count, 5);
+        assert_eq!(hunk.new_start, 1);
+        assert_eq!(hunk.new_count, 5);
+        assert!(hunk.lines.iter().all(|l| l.origin == LineOrigin::Context));
+        assert!(hunk.lines.iter().all(|l| l.old_lineno.is_some()));
+        assert!(hunk.lines.iter().all(|l| l.new_lineno.is_some()));
+        assert_eq!(diffs[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn directory_mode_still_uses_addition_origin() {
+        // Regression: pristine mode must not bleed back into the existing
+        // `--file <dir>` directory-mode rendering.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("a.txt"), "alpha\nbeta\n").unwrap();
+
+        let backend = FileBackend::new(dir.path().to_str().unwrap()).unwrap();
+        let diffs = backend.get_working_tree_diff(&highlighter()).unwrap();
+
+        assert_eq!(diffs.len(), 1);
+        let hunk = &diffs[0].hunks[0];
+        assert_eq!(hunk.header, "@@ -0,0 +1,2 @@");
+        assert!(hunk.lines.iter().all(|l| l.origin == LineOrigin::Addition));
+        assert!(hunk.lines.iter().all(|l| l.old_lineno.is_none()));
+        assert_eq!(diffs[0].status, FileStatus::Added);
+    }
+
+    #[test]
+    fn pristine_filters_binary_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let text_path = dir.path().join("text.txt").canonicalize_lazy(dir.path());
+        let bin_path = dir.path().join("bin.bin").canonicalize_lazy(dir.path());
+        fs::write(&text_path, "hello\n").unwrap();
+        fs::write(&bin_path, [0u8, 1, 2, 3, 0, 4]).unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        let backend = FileBackend::new_pristine(vec![text_path.clone(), bin_path], root).unwrap();
+        let diffs = backend.get_working_tree_diff(&highlighter()).unwrap();
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].new_path.as_deref().unwrap(), Path::new("text.txt"));
+    }
+
+    #[test]
+    fn pristine_fetch_context_resolves_per_file() {
+        use crate::model::FileStatus;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path_a = dir.path().join("a.txt").canonicalize_lazy(dir.path());
+        let path_b = dir.path().join("b.txt").canonicalize_lazy(dir.path());
+        fs::write(&path_a, "alpha-1\nalpha-2\nalpha-3\n").unwrap();
+        fs::write(&path_b, "beta-1\nbeta-2\nbeta-3\n").unwrap();
+
+        let root = dir.path().canonicalize().unwrap();
+        let backend = FileBackend::new_pristine(vec![path_a, path_b], root).unwrap();
+
+        let lines = backend
+            .fetch_context_lines(Path::new("b.txt"), FileStatus::Modified, 1, 3)
+            .unwrap();
+
+        assert_eq!(lines.len(), 3);
+        assert!(lines.iter().all(|l| l.content.starts_with("beta-")));
+        assert!(lines.iter().all(|l| l.origin == LineOrigin::Context));
+    }
+
+    #[test]
+    fn pristine_fetch_context_rejects_path_escape() {
+        use crate::model::FileStatus;
+
+        let outer = tempfile::tempdir().unwrap();
+        let outer_canon = outer.path().canonicalize().unwrap();
+        let secret = outer_canon.join("secret.txt");
+        fs::write(&secret, "TOP_SECRET\n").unwrap();
+
+        let repo = outer_canon.join("repo");
+        fs::create_dir(&repo).unwrap();
+        let kept = repo.join("kept.txt");
+        fs::write(&kept, "ok\n").unwrap();
+
+        let backend = FileBackend::new_pristine(vec![kept], repo.clone()).unwrap();
+        let lines = backend
+            .fetch_context_lines(Path::new("../secret.txt"), FileStatus::Modified, 1, 1)
+            .unwrap();
+        assert!(
+            lines.is_empty(),
+            "fetch_context_lines must not read files outside the configured root"
+        );
+    }
+
+    // ---------- Property test for is_probably_binary ----------
+
+    #[test]
+    fn is_probably_binary_detects_any_null_in_sniff_window() {
+        for trial in [0usize, 1, 100, 8000, BINARY_SNIFF_BYTES, 16_384] {
+            // No nulls anywhere within sniff window -> text.
+            let dir = tempfile::tempdir().unwrap();
+            let text = dir.path().join(format!("text-{trial}.bin"));
+            fs::write(&text, vec![b'a'; trial]).unwrap();
+            assert!(
+                !is_probably_binary(&text) || trial == 0 && text.metadata().unwrap().len() == 0,
+                "no-null content of length {trial} must be classified text (got binary)"
+            );
+        }
+
+        // A null at any position within the sniff window classifies as binary.
+        for null_at in [0usize, 1, 100, BINARY_SNIFF_BYTES - 1] {
+            let dir = tempfile::tempdir().unwrap();
+            let bin = dir.path().join(format!("null-at-{null_at}.bin"));
+            let mut content = vec![b'a'; BINARY_SNIFF_BYTES];
+            content[null_at] = 0;
+            fs::write(&bin, &content).unwrap();
+            assert!(
+                is_probably_binary(&bin),
+                "null at offset {null_at} must classify as binary"
+            );
+        }
+
+        // A null AFTER the sniff window is NOT detected (by design).
+        let dir = tempfile::tempdir().unwrap();
+        let bin_after = dir.path().join("null-after-window.bin");
+        let mut content = vec![b'a'; BINARY_SNIFF_BYTES + 10];
+        content[BINARY_SNIFF_BYTES + 5] = 0;
+        fs::write(&bin_after, &content).unwrap();
+        assert!(
+            !is_probably_binary(&bin_after),
+            "null past the {BINARY_SNIFF_BYTES}-byte sniff window must NOT be detected"
+        );
+    }
+
+    // Small helper: turn `dir/foo.txt` into its post-create canonical form,
+    // since `new_pristine` expects absolute paths.
+    trait CanonicalizeLazy {
+        fn canonicalize_lazy(self, base: &Path) -> PathBuf;
+    }
+    impl CanonicalizeLazy for PathBuf {
+        fn canonicalize_lazy(self, base: &Path) -> PathBuf {
+            // create parent + file if missing so canonicalize succeeds
+            if !self.exists() {
+                if let Some(parent) = self.parent() {
+                    let _ = fs::create_dir_all(parent);
+                }
+                let _ = fs::write(&self, "");
+            }
+            self.canonicalize().unwrap_or_else(|_| base.join(self))
+        }
     }
 }

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -17,6 +17,7 @@ pub mod git;
 mod hg;
 mod jj;
 pub mod pr_noop;
+pub mod pristine;
 pub(crate) mod traits;
 
 pub use file::FileBackend;

--- a/src/vcs/pristine.rs
+++ b/src/vcs/pristine.rs
@@ -1,0 +1,202 @@
+//! Pristine review path enumeration.
+//!
+//! Whole-repo review mode (`tuicr --all-files`) needs a list of every file
+//! the user can annotate. This module shells out to `git ls-files -z` to
+//! enumerate the tracked set, so untracked build artifacts (`target/`,
+//! `node_modules/`, etc.) are excluded without having to maintain a
+//! deny-list and without depending on the absence of a `.gitignore`.
+//!
+//! The MVP is git-only; jj and mercurial support is deferred to a future
+//! follow-up that hoists this responsibility into the `VcsBackend` trait.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::{Result, TuicrError};
+
+/// The literal used in place of a HEAD SHA when the repository has no
+/// commits yet. Keeps the `pristine:HEAD:hash` session key well-formed in
+/// the empty-repo case.
+const NO_HEAD_SENTINEL: &str = "none";
+
+/// Enumerate every tracked file in the git repository rooted at `repo_root`,
+/// returning absolute paths.
+///
+/// The list is taken from `git ls-files -z`, so it reflects exactly what
+/// git considers tracked (post-`.gitignore`, post-`.git/info/exclude`,
+/// untracked files excluded). Deleted-but-tracked entries are filtered out
+/// at the boundary: a path that no longer exists on disk is dropped.
+///
+/// # Errors
+///
+/// Returns [`TuicrError::NotARepository`] if `git ls-files` cannot find a
+/// repository at `repo_root` (or git is not on `PATH`). Returns
+/// [`TuicrError::NoChanges`] when the repository exists but has no tracked
+/// files on disk.
+pub fn collect_tracked_paths(repo_root: &Path) -> Result<Vec<PathBuf>> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .arg("ls-files")
+        .arg("-z")
+        .output()
+        .map_err(|_| TuicrError::NotARepository)?;
+
+    if !output.status.success() {
+        return Err(TuicrError::NotARepository);
+    }
+
+    let mut paths: Vec<PathBuf> = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            repo_root.join(std::path::Path::new(
+                std::str::from_utf8(part).unwrap_or(""),
+            ))
+        })
+        .filter(|path| path.is_file())
+        .collect();
+
+    paths.sort();
+
+    if paths.is_empty() {
+        return Err(TuicrError::NoChanges);
+    }
+
+    Ok(paths)
+}
+
+/// Return the short SHA of HEAD for the git repo at `repo_root`, or the
+/// `"none"` sentinel if HEAD is unborn (e.g. a freshly-initialized repo
+/// with no commits) or any subprocess error occurs.
+///
+/// The result is used as a component of pristine session keys; an
+/// advancing HEAD changes the key but the persistence-layer prefix-match
+/// keeps comments attached across `git pull`.
+#[must_use]
+pub fn head_short_sha(repo_root: &Path) -> String {
+    let output = match Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+    {
+        Ok(out) if out.status.success() => out,
+        _ => return NO_HEAD_SENTINEL.to_string(),
+    };
+    let trimmed = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if trimmed.is_empty() {
+        NO_HEAD_SENTINEL.to_string()
+    } else {
+        trimmed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::process::Command;
+
+    use super::*;
+
+    fn init_git_repo(dir: &Path) {
+        Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .arg("init")
+            .arg("-q")
+            .output()
+            .expect("git init");
+        Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["config", "user.email", "tester@example.com"])
+            .output()
+            .expect("git config email");
+        Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["config", "user.name", "Tester"])
+            .output()
+            .expect("git config name");
+    }
+
+    fn git_add_commit(dir: &Path) {
+        Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["add", "-A"])
+            .output()
+            .expect("git add");
+        Command::new("git")
+            .args(["-C"])
+            .arg(dir)
+            .args(["commit", "-q", "-m", "init"])
+            .output()
+            .expect("git commit");
+    }
+
+    #[test]
+    fn errors_when_not_a_git_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = collect_tracked_paths(dir.path());
+        assert!(matches!(result, Err(TuicrError::NotARepository)));
+    }
+
+    #[test]
+    fn errors_when_repo_has_no_tracked_files() {
+        let dir = tempfile::tempdir().unwrap();
+        init_git_repo(dir.path());
+        let result = collect_tracked_paths(dir.path());
+        assert!(matches!(result, Err(TuicrError::NoChanges)));
+    }
+
+    #[test]
+    fn lists_only_tracked_files() {
+        let dir = tempfile::tempdir().unwrap();
+        init_git_repo(dir.path());
+        fs::write(dir.path().join("kept.txt"), "hello\n").unwrap();
+        fs::write(dir.path().join(".gitignore"), "ignored.txt\n").unwrap();
+        fs::write(dir.path().join("ignored.txt"), "skip me\n").unwrap();
+        git_add_commit(dir.path());
+        // Add an untracked file after the commit -- must NOT appear.
+        fs::write(dir.path().join("untracked.txt"), "untracked\n").unwrap();
+
+        let paths = collect_tracked_paths(dir.path()).unwrap();
+        let names: Vec<String> = paths
+            .iter()
+            .map(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("")
+                    .to_string()
+            })
+            .collect();
+
+        assert!(names.contains(&"kept.txt".to_string()));
+        assert!(names.contains(&".gitignore".to_string()));
+        assert!(!names.contains(&"ignored.txt".to_string()));
+        assert!(!names.contains(&"untracked.txt".to_string()));
+    }
+
+    #[test]
+    fn drops_deleted_but_tracked_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        init_git_repo(dir.path());
+        fs::write(dir.path().join("kept.txt"), "k\n").unwrap();
+        fs::write(dir.path().join("removed.txt"), "r\n").unwrap();
+        git_add_commit(dir.path());
+        // Remove from disk but keep in the index by skipping `git rm`.
+        fs::remove_file(dir.path().join("removed.txt")).unwrap();
+
+        let paths = collect_tracked_paths(dir.path()).unwrap();
+        let names: Vec<String> = paths
+            .iter()
+            .filter_map(|p| p.file_name()?.to_str().map(str::to_string))
+            .collect();
+
+        assert!(names.contains(&"kept.txt".to_string()));
+        assert!(!names.contains(&"removed.txt".to_string()));
+    }
+}


### PR DESCRIPTION
Adds `tuicr --all-files` (or `-A`) that lists every git-tracked file in the cwd's repo so one can comment on any line. Same clipboard format as the other modes.

Builds on the directory mode from #321 by @davenonymous. Switches to `git ls-files` so build artefacts don't sneak in, and renders as context instead of additions because nothing is actually changing.

Inspired by revdiff's `--all-files` (https://github.com/umputun/revdiff). Design notes in `docs/decisions/FEAT-0010 All-Files Pristine View.md`.

Notes:
- Mutex with `-r`, `-w`, `--file`. Operates on cwd.
- Non-git invocation errors with a hint.
- Status badges (M/A/D) and side-by-side view are suppressed in this mode — they don't mean anything when nothing's changed.
- Top header chip shows: `PRISTINE · <short-sha> · N files`.
- Session keys are `pristine:<head>:<path_hash>`; loader prefix-matches the hash so a `git pull` mid-review doesn't drop your comments.
- `.tuicrignore` is honored.

Testing:
- `cargo fmt`, clippy clean, `cargo test --bin tuicr` clean
- 15 new tests across `vcs::pristine`, `vcs::file`, `persistence::storage`
- Round-tripped through Claude Code with anchors resolved. `--file .` still renders as additions.

Deferred: `--include`/`--exclude` filters, jj/hg, see the ADR.