### PR TITLE
fix(vcs): open worktrees from bare clones, and don't crash on unborn HEAD

### DIFF
--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -253,6 +253,13 @@ impl VcsBackend for GitCliBackend {
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
+        // Unborn HEAD (fresh `git init` / `git clone` of an empty remote):
+        // `git log` returns 128 with "does not have any commits yet". Detect
+        // that up-front and return an empty list so startup can fall through
+        // to the staged/unstaged paths.
+        if run_git_command(&self.root_path, &["rev-parse", "--verify", "HEAD"]).is_err() {
+            return Ok(Vec::new());
+        }
         let branch_tip_names = get_branch_tip_names(&self.root_path);
         let output = run_git_command_args(
             &self.root_path,

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -10,19 +10,25 @@ pub fn get_working_tree_diff(
     repo: &Repository,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    let head = repo.head()?.peel_to_tree()?;
+    // Unborn HEAD (fresh `git init` / `git clone` of an empty remote) has no
+    // tree to compare against; diff against an empty baseline so freshly
+    // staged/added files still surface in the working-tree review.
+    let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
 
     let mut opts = DiffOptions::new();
     opts.include_untracked(true);
     opts.show_untracked_content(true);
     opts.recurse_untracked_dirs(true);
 
-    let diff = repo.diff_tree_to_workdir_with_index(Some(&head), Some(&mut opts))?;
+    let diff = repo.diff_tree_to_workdir_with_index(head.as_ref(), Some(&mut opts))?;
     let mut files = parse_diff(&diff, highlighter)?;
     enhance_with_full_file_highlight(
         &mut files,
         highlighter,
-        |path| read_path_from_tree(repo, &head, path),
+        |path| {
+            head.as_ref()
+                .and_then(|tree| read_path_from_tree(repo, tree, path))
+        },
         |path| read_path_from_workdir(repo, path),
     );
     Ok(files)
@@ -444,5 +450,27 @@ mod tests {
             get_unstaged_diff(&repo, &highlighter),
             Err(TuicrError::NoChanges)
         ));
+    }
+
+    #[test]
+    fn should_surface_staged_files_on_unborn_head() {
+        // given a freshly initialised repo with a staged file but no commits
+        // (the "naked clone" / `git init` state — HEAD is unborn)
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+        fs::write(temp_dir.path().join("file.txt"), "hello\n").expect("write file");
+        let mut index = repo.index().expect("open index");
+        index.add_path(Path::new("file.txt")).expect("stage file");
+        index.write().expect("write index");
+
+        // when
+        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
+            .expect("unborn HEAD should produce a diff against an empty tree");
+
+        // then the staged file shows up as an addition rather than crashing
+        // with `reference 'refs/heads/main' not found`
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].display_path(), Path::new("file.txt"));
+        assert!(matches!(files[0].status, FileStatus::Added));
     }
 }

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -1,5 +1,6 @@
 use git2::Repository;
 use std::path::Path;
+use std::sync::Once;
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
@@ -14,8 +15,28 @@ pub struct Libgit2Backend {
     info: VcsInfo,
 }
 
+/// Declare libgit2 extensions tuicr understands so discovery doesn't refuse
+/// repos that opt into newer git on-disk features.
+///
+/// Currently: `relativeworktrees` (git 2.48+ `worktree.useRelativePaths`).
+/// Without this declaration libgit2 refuses to open a worktree created from a
+/// bare clone with that setting — tuicr would surface as "Not a repository"
+/// while plain `git status` works fine. Path resolution for relative
+/// `gitdir:` pointers already works in libgit2; only the safety gate refuses.
+fn register_supported_extensions() {
+    static REGISTER: Once = Once::new();
+    REGISTER.call_once(|| {
+        // SAFETY: libgit2 stores extensions in a process-wide static. We call
+        // this exactly once, before any `Repository::discover`, via `Once`.
+        unsafe {
+            let _ = git2::opts::set_extensions(&["relativeworktrees"]);
+        }
+    });
+}
+
 impl Libgit2Backend {
     pub(super) fn discover_from(cwd: &Path) -> Result<Self> {
+        register_supported_extensions();
         let repo = Repository::discover(cwd).map_err(|_| TuicrError::NotARepository)?;
 
         let root_path = repo
@@ -147,5 +168,80 @@ impl VcsBackend for Libgit2Backend {
 
     fn stage_file(&self, path: &Path) -> Result<()> {
         staging::stage_file(&self.repo, path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+
+    fn git(workdir: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(workdir)
+            .args(args)
+            .output()
+            .expect("failed to run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn should_discover_worktree_with_relativeworktrees_extension() {
+        // given: a bare clone with `extensions.relativeworktrees = true` set
+        // and a worktree linked to it. This is the on-disk state git 2.48+
+        // produces with `worktree.useRelativePaths`. Without
+        // `set_extensions(["relativeworktrees"])` libgit2 refuses to open the
+        // worktree at all, surfacing as "Not a repository" in tuicr.
+        let temp = tempfile::tempdir().expect("temp dir");
+        let source = temp.path().join("source");
+        let bare = temp.path().join("bare.git");
+        let worktree = temp.path().join("wt");
+
+        fs::create_dir_all(&source).unwrap();
+        git(&source, &["init", "-q", "-b", "main"]);
+        git(&source, &["config", "user.email", "test@example.com"]);
+        git(&source, &["config", "user.name", "Test User"]);
+        fs::write(source.join("README"), "hello\n").unwrap();
+        git(&source, &["add", "README"]);
+        git(&source, &["commit", "-q", "-m", "init"]);
+
+        git(
+            temp.path(),
+            &[
+                "clone",
+                "--bare",
+                "-q",
+                source.to_str().unwrap(),
+                bare.to_str().unwrap(),
+            ],
+        );
+        // The extension declaration is the gate libgit2 enforces. Setting
+        // this alone reproduces the failure regardless of the local git
+        // version — `worktree.useRelativePaths` (git 2.48+) is what writes
+        // this in real-world setups. `core.repositoryFormatVersion = 1` is
+        // required to opt into the `extensions.*` namespace at all.
+        git(&bare, &["config", "core.repositoryFormatVersion", "1"]);
+        git(&bare, &["config", "extensions.relativeworktrees", "true"]);
+        git(
+            &bare,
+            &["worktree", "add", "-q", worktree.to_str().unwrap()],
+        );
+
+        // when
+        let backend = Libgit2Backend::discover_from(&worktree)
+            .expect("worktree with relativeworktrees extension should open");
+
+        // then
+        assert_eq!(backend.info().vcs_type, VcsType::Git);
+        assert!(
+            backend.repo.workdir().is_some(),
+            "worktree must report a workdir"
+        );
     }
 }

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -30,13 +30,26 @@ impl Libgit2Backend {
             .map(|c| c.id().to_string())
             .unwrap_or_else(|| "HEAD".to_string());
 
-        let branch_name = repo.head().ok().and_then(|h| {
-            if h.is_branch() {
-                h.shorthand().map(|s| s.to_string())
-            } else {
-                None
-            }
-        });
+        // For unborn HEAD (fresh `git init` / `git clone` of an empty remote),
+        // `repo.head()` errors, so fall back to reading HEAD's symbolic target
+        // directly. That way the status bar still shows e.g. `git:main` instead
+        // of `git:detached` before the first commit lands.
+        let branch_name = repo
+            .head()
+            .ok()
+            .and_then(|h| {
+                if h.is_branch() {
+                    h.shorthand().map(|s| s.to_string())
+                } else {
+                    None
+                }
+            })
+            .or_else(|| {
+                repo.find_reference("HEAD")
+                    .ok()
+                    .and_then(|r| r.symbolic_target().map(str::to_string))
+                    .and_then(|t| t.strip_prefix("refs/heads/").map(str::to_string))
+            });
 
         let info = VcsInfo {
             root_path,

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -65,6 +65,18 @@ pub fn get_recent_commits(
     offset: usize,
     limit: usize,
 ) -> Result<Vec<CommitInfo>> {
+    // Unborn HEAD (fresh `git init` / `git clone` of an empty remote): the
+    // branch ref does not point at a commit yet, so there is nothing to walk.
+    // Probe with `repo.head()` — `revwalk.push_head()` rewraps the underlying
+    // "reference not found" error with a generic code, which would slip past
+    // an `ErrorCode::UnbornBranch` check. Treat unborn HEAD as zero commits
+    // so App startup falls through to the staged/unstaged paths.
+    if matches!(
+        repo.head().map_err(|e| e.code()),
+        Err(git2::ErrorCode::UnbornBranch | git2::ErrorCode::NotFound)
+    ) {
+        return Ok(Vec::new());
+    }
     let mut revwalk = repo.revwalk()?;
     revwalk.push_head()?;
     let branch_tip_names = get_branch_tip_names(repo);
@@ -187,4 +199,24 @@ pub fn resolve_revisions(repo: &Repository, revisions: &str) -> Result<Vec<Strin
     // revwalk outputs newest first; reverse so oldest is first
     commit_ids.reverse();
     Ok(commit_ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_return_empty_recent_commits_for_unborn_head() {
+        // given a fresh `git init` repo (HEAD points at refs/heads/main but
+        // the ref does not exist yet — the "naked clone" state)
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        // when
+        let result = get_recent_commits(&repo, 0, 50);
+
+        // then unborn HEAD is treated as zero commits, not an error
+        let commits = result.expect("unborn HEAD should yield an empty list");
+        assert!(commits.is_empty(), "unborn HEAD has no commits to walk");
+    }
 }


### PR DESCRIPTION
## Summary
Two independent libgit2-backend fixes for repos that aren't a typical "cloned repo with commits and a working tree":

- **Worktree from a bare clone with relative paths** (issue #274). Git 2.48+ writes `extensions.relativeworktrees = true` into the bare repo's config when `worktree.useRelativePaths` is on. libgit2 doesn't recognise the extension yet, so per the git extension protocol it refuses to open the worktree at all — tuicr surfaced as `Not a repository` while plain `git status` worked. Fix: declare the extension via `git2::opts::set_extensions` once at startup. libgit2's path resolution already handles the on-disk format; only the safety gate refuses.
- **Unborn HEAD** (fresh `git init` or `git clone` of an empty remote). Three call sites (`get_recent_commits` in both backends, `get_working_tree_diff` in libgit2) assumed `repo.head()` resolves to a commit and propagated the error. Result: tuicr crashed with `reference 'refs/heads/main' not found` even when there were staged files to review. Fix: return an empty list / diff against an empty baseline when HEAD is unborn, mirroring what `get_staged_diff` already did. The libgit2 backend also reads HEAD's symbolic target directly so the status bar shows `git:main` instead of `git:detached`.

Each fix is its own commit.

## Test plan
- [x] `cargo test --bin tuicr` — 684 pass (3 new regression tests across the two fixes).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] Manual: `git clone --bare <repo>` + `git -C bare config worktree.useRelativePaths true` + `git -C bare worktree add ../wt` — tuicr now opens the commit selector in `../wt`.
- [x] Manual: `mkdir x && cd x && git init && touch f && git add f && tuicr` — now shows the staged file in the selector instead of erroring.
- [x] Manual: regression-check normal clones (this repo, fresh Hello-World clone) — commit selector still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)