### PR TITLE
add expand after end of diff

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -51,11 +51,18 @@ fn char_slice(s: &str, lo_char: usize, hi_char: Option<usize>) -> &str {
     &s[lo_byte..hi_byte]
 }
 
-fn gap_annotation_line_count(is_top_of_file: bool, remaining: usize) -> usize {
+fn gap_annotation_line_count(
+    is_top_of_file: bool,
+    is_end_of_file: bool,
+    remaining: usize,
+) -> usize {
     if remaining == 0 {
         0
     } else if is_top_of_file {
         // ↑ expander, plus a HiddenLines line when remaining > batch
+        if remaining > GAP_EXPAND_BATCH { 2 } else { 1 }
+    } else if is_end_of_file {
+        // ↓ expander, plus a HiddenLines line when remaining > batch
         if remaining > GAP_EXPAND_BATCH { 2 } else { 1 }
     } else {
         // Between hunks: ↓ + HiddenLines + ↑ when >= batch, else single ↕
@@ -896,6 +903,8 @@ pub struct App {
     pub expanded_top: HashMap<GapId, Vec<DiffLine>>,
     /// Stores lines expanded upward from the lower boundary of each gap (in ascending line order)
     pub expanded_bottom: HashMap<GapId, Vec<DiffLine>>,
+    /// Cached file line counts (keyed by file_idx) to avoid repeated disk reads
+    pub file_line_count_cache: HashMap<usize, u32>,
     /// Cached annotations describing what each rendered line represents
     pub line_annotations: Vec<AnnotatedLine>,
     /// Output to stdout instead of clipboard when exporting
@@ -1539,6 +1548,7 @@ impl App {
             expanded_dirs: HashSet::new(),
             expanded_top: HashMap::new(),
             expanded_bottom: HashMap::new(),
+            file_line_count_cache: HashMap::new(),
             line_annotations: Vec::new(),
             output_to_stdout,
             pending_stdout_output: None,
@@ -1564,6 +1574,7 @@ impl App {
         }
         app.sort_files_by_directory(true);
         app.expand_all_dirs();
+        app.populate_file_line_count_cache();
         app.rebuild_annotations();
         app.detect_forge_repository();
         Ok(app)
@@ -3105,6 +3116,7 @@ impl App {
         self.clear_expanded_gaps();
 
         self.sort_files_by_directory(false);
+        self.populate_file_line_count_cache();
         self.expand_all_dirs();
 
         if self.diff_files.is_empty() {
@@ -3642,16 +3654,29 @@ impl App {
 
     fn gap_size(&self, gap_id: &GapId) -> Option<u32> {
         let file = self.diff_files.get(gap_id.file_idx)?;
-        let hunk = file.hunks.get(gap_id.hunk_idx)?;
-        let prev_hunk = if gap_id.hunk_idx > 0 {
-            file.hunks.get(gap_id.hunk_idx - 1)
+
+        if gap_id.hunk_idx == file.hunks.len() {
+            // End-of-file gap
+            let last_hunk = file.hunks.last()?;
+            let start = last_hunk.new_start + last_hunk.new_count;
+            let end = *self.file_line_count_cache.get(&gap_id.file_idx)?;
+            if start > end {
+                Some(0)
+            } else {
+                Some(end - start + 1)
+            }
         } else {
-            None
-        };
-        Some(calculate_gap(
-            prev_hunk.map(|h| (&h.new_start, &h.new_count)),
-            hunk.new_start,
-        ))
+            let hunk = file.hunks.get(gap_id.hunk_idx)?;
+            let prev_hunk = if gap_id.hunk_idx > 0 {
+                file.hunks.get(gap_id.hunk_idx - 1)
+            } else {
+                None
+            };
+            Some(calculate_gap(
+                prev_hunk.map(|h| (&h.new_start, &h.new_count)),
+                hunk.new_start,
+            ))
+        }
     }
 
     pub fn center_cursor(&mut self) {
@@ -3822,6 +3847,29 @@ impl App {
                 return Some(GapId { file_idx, hunk_idx });
             }
         }
+
+        // Check the EOF gap (after the last hunk).
+        if let Some(last) = file.hunks.last()
+            && let Some(&total) = self.file_line_count_cache.get(&file_idx)
+        {
+            let (start, end) = match side {
+                LineSide::New => (last.new_start + last.new_count, total),
+                LineSide::Old => {
+                    let delta = (last.new_start + last.new_count) as i64
+                        - (last.old_start + last.old_count) as i64;
+                    let new_start = last.new_start + last.new_count;
+                    let old_start = (new_start as i64 - delta) as u32;
+                    let old_end = (total as i64 - delta) as u32;
+                    (old_start, old_end)
+                }
+            };
+            if start <= end && target_lineno >= start && target_lineno <= end {
+                return Some(GapId {
+                    file_idx,
+                    hunk_idx: file.hunks.len(),
+                });
+            }
+        }
         None
     }
 
@@ -3843,9 +3891,26 @@ impl App {
         let Some(file) = self.diff_files.get(gap_id.file_idx) else {
             return (ExpandDirection::Both, None);
         };
-        let Some(hunk) = file.hunks.get(gap_id.hunk_idx) else {
-            return (ExpandDirection::Both, None);
-        };
+        // EOF gap: no next hunk, only expand downward from the last hunk.
+        let is_eof_gap = gap_id.hunk_idx == file.hunks.len();
+        if is_eof_gap {
+            let Some(last) = file.hunks.last() else {
+                return (ExpandDirection::Both, None);
+            };
+            let gap_start_new = last.new_start + last.new_count;
+            let offset_new_minus_old =
+                (last.new_start + last.new_count) as i64 - (last.old_start + last.old_count) as i64;
+            let target_new = match side {
+                LineSide::New => target_lineno as i64,
+                LineSide::Old => target_lineno as i64 + offset_new_minus_old,
+            };
+            let top_len = self.expanded_top.get(gap_id).map_or(0, |v| v.len()) as i64;
+            let inner_start = gap_start_new as i64 + top_len;
+            let limit = (target_new - inner_start + 1).max(0) as usize;
+            return (ExpandDirection::Down, Some(limit));
+        }
+
+        let hunk = &file.hunks[gap_id.hunk_idx];
         let prev_hunk = if gap_id.hunk_idx > 0 {
             Some(&file.hunks[gap_id.hunk_idx - 1])
         } else {
@@ -4421,7 +4486,7 @@ impl App {
                     let bot_len = self.expanded_bottom.get(&gap_id).map_or(0, |v| v.len());
                     let remaining = (gap as usize).saturating_sub(top_len + bot_len);
                     content_lines += top_len + bot_len;
-                    content_lines += gap_annotation_line_count(hunk_idx == 0, remaining);
+                    content_lines += gap_annotation_line_count(hunk_idx == 0, false, remaining);
                 }
 
                 // Hunk header + diff lines
@@ -4558,6 +4623,27 @@ impl App {
                             }
                         }
                     }
+                }
+            }
+
+            // End-of-file gap (not for deleted files)
+            if file.status != FileStatus::Deleted
+                && let Some(last_hunk) = file.hunks.last()
+            {
+                let eof_start = last_hunk.new_start + last_hunk.new_count;
+                if let Some(&total) = self.file_line_count_cache.get(&file_idx)
+                    && eof_start <= total
+                {
+                    let gap = (total - eof_start + 1) as usize;
+                    let eof_gap_id = GapId {
+                        file_idx,
+                        hunk_idx: file.hunks.len(),
+                    };
+                    let top_len = self.expanded_top.get(&eof_gap_id).map_or(0, |v| v.len());
+                    let bot_len = self.expanded_bottom.get(&eof_gap_id).map_or(0, |v| v.len());
+                    let remaining = gap.saturating_sub(top_len + bot_len);
+                    content_lines += top_len + bot_len;
+                    content_lines += gap_annotation_line_count(false, true, remaining);
                 }
             }
         }
@@ -6957,6 +7043,8 @@ impl App {
         use std::collections::BTreeMap;
         use std::path::Path;
 
+        self.file_line_count_cache.clear();
+
         let current_path = if !reset_position {
             self.current_file_path().cloned()
         } else {
@@ -7042,23 +7130,36 @@ impl App {
     /// Get the line boundaries (start_line, end_line) of a gap.
     fn gap_boundaries(&self, gap_id: &GapId) -> Option<(u32, u32)> {
         let file = self.diff_files.get(gap_id.file_idx)?;
-        let hunk = file.hunks.get(gap_id.hunk_idx)?;
-        let prev_hunk = if gap_id.hunk_idx > 0 {
-            file.hunks.get(gap_id.hunk_idx - 1)
+
+        if gap_id.hunk_idx == file.hunks.len() {
+            // End-of-file gap: starts after last hunk, ends at file end
+            let last_hunk = file.hunks.last()?;
+            let start = last_hunk.new_start + last_hunk.new_count;
+            let end = *self.file_line_count_cache.get(&gap_id.file_idx)?;
+            if start > end {
+                None
+            } else {
+                Some((start, end))
+            }
         } else {
-            None
-        };
-        let (start, end) = match prev_hunk {
-            None => (1, hunk.new_start.saturating_sub(1)),
-            Some(prev) => (
-                prev.new_start + prev.new_count,
-                hunk.new_start.saturating_sub(1),
-            ),
-        };
-        if start > end {
-            None
-        } else {
-            Some((start, end))
+            let hunk = file.hunks.get(gap_id.hunk_idx)?;
+            let prev_hunk = if gap_id.hunk_idx > 0 {
+                file.hunks.get(gap_id.hunk_idx - 1)
+            } else {
+                None
+            };
+            let (start, end) = match prev_hunk {
+                None => (1, hunk.new_start.saturating_sub(1)),
+                Some(prev) => (
+                    prev.new_start + prev.new_count,
+                    hunk.new_start.saturating_sub(1),
+                ),
+            };
+            if start > end {
+                None
+            } else {
+                Some((start, end))
+            }
         }
     }
 
@@ -7081,6 +7182,9 @@ impl App {
         direction: ExpandDirection,
         limit: Option<usize>,
     ) -> Result<()> {
+        // Ensure file line count is cached for EOF gaps
+        self.ensure_file_line_count_cached(gap_id.file_idx);
+
         let (gap_start, gap_end) = self
             .gap_boundaries(&gap_id)
             .ok_or_else(|| TuicrError::CorruptedSession(format!("Invalid gap: {:?}", gap_id)))?;
@@ -7101,14 +7205,35 @@ impl App {
             return Ok(()); // Fully expanded
         }
 
+        // Compute the delta between new-side and old-side line numbers for this
+        // gap. Expanded context is fetched in new-side coordinates; the old-side
+        // number is `new_lineno - delta`.
+        let delta = {
+            let file = &self.diff_files[gap_id.file_idx];
+            if gap_id.hunk_idx == 0 {
+                0i64
+            } else {
+                let prev = &file.hunks[gap_id.hunk_idx - 1];
+                let old_end = prev.old_start as i64 + prev.old_count as i64;
+                let new_end = prev.new_start as i64 + prev.new_count as i64;
+                new_end - old_end
+            }
+        };
+
         let fetch = |start: u32, end: u32| -> Result<Vec<DiffLine>> {
-            self.context_provider().fetch_context_lines(
+            let mut lines = self.context_provider().fetch_context_lines(
                 old_path.as_ref(),
                 new_path.as_ref(),
                 file_status,
                 start,
                 end,
-            )
+            )?;
+            for line in &mut lines {
+                if let Some(n) = line.new_lineno {
+                    line.old_lineno = Some((n as i64 - delta) as u32);
+                }
+            }
+            Ok(lines)
         };
 
         match direction {
@@ -7148,6 +7273,25 @@ impl App {
     /// Resolve the right `ContextProvider` for the current diff source.
     /// In PR mode (with a forge backend present), expansion goes through the
     /// forge; otherwise it goes through the local VCS backend.
+    fn ref_commit(&self) -> Option<&str> {
+        match &self.diff_source {
+            DiffSource::CommitRange(commits) => {
+                // When the inline commit selector narrows to a subrange,
+                // review_commits is newest-first so index `start` is the
+                // newest selected commit — that's the snapshot to read from.
+                if let Some((start, _)) = self.commit_selection_range {
+                    self.review_commits
+                        .get(start)
+                        .map(|c| c.id.as_str())
+                        .or_else(|| commits.last().map(|s| s.as_str()))
+                } else {
+                    commits.last().map(|s| s.as_str())
+                }
+            }
+            _ => None,
+        }
+    }
+
     fn context_provider(&self) -> Box<dyn ContextProvider + '_> {
         if let (DiffSource::PullRequest(pr), Some(backend)) =
             (&self.diff_source, self.forge_backend.as_ref())
@@ -7161,6 +7305,7 @@ impl App {
         } else {
             Box::new(VcsContextProvider {
                 vcs: self.vcs.as_ref(),
+                ref_commit: self.ref_commit().map(|s| s.to_string()),
             })
         }
     }
@@ -7176,6 +7321,50 @@ impl App {
     pub fn clear_expanded_gaps(&mut self) {
         self.expanded_top.clear();
         self.expanded_bottom.clear();
+        self.file_line_count_cache.clear();
+    }
+
+    fn eof_gap_enabled(&self) -> bool {
+        matches!(
+            self.diff_source,
+            DiffSource::WorkingTree
+                | DiffSource::Unstaged
+                | DiffSource::StagedAndUnstaged
+                | DiffSource::StagedUnstagedAndCommits(_)
+                | DiffSource::CommitRange(_)
+        )
+    }
+
+    /// Ensure the file line count cache is populated for a given file.
+    fn ensure_file_line_count_cached(&mut self, file_idx: usize) {
+        if !self.eof_gap_enabled() || self.file_line_count_cache.contains_key(&file_idx) {
+            return;
+        }
+        if let Some(file) = self.diff_files.get(file_idx) {
+            let path = file.display_path().clone();
+            let status = file.status;
+            let ref_commit = self.ref_commit().map(|s| s.to_string());
+            if let Ok(count) = self
+                .vcs
+                .file_line_count(&path, status, ref_commit.as_deref())
+            {
+                self.file_line_count_cache.insert(file_idx, count);
+            }
+        }
+    }
+
+    /// Populate the file line count cache for all eligible files.
+    /// Only enabled for diff sources where the worktree/index is the correct snapshot.
+    fn populate_file_line_count_cache(&mut self) {
+        self.file_line_count_cache.clear();
+        if self.eof_gap_enabled() {
+            for file_idx in 0..self.diff_files.len() {
+                let file = &self.diff_files[file_idx];
+                if !file.hunks.is_empty() && file.status != FileStatus::Deleted {
+                    self.ensure_file_line_count_cached(file_idx);
+                }
+            }
+        }
     }
 
     /// Rebuild the line annotations cache. Call this when:
@@ -7184,6 +7373,10 @@ impl App {
     /// - Comments are added/removed
     /// - Diff view mode changes
     pub fn rebuild_annotations(&mut self) {
+        if self.file_line_count_cache.is_empty() {
+            self.populate_file_line_count_cache();
+        }
+
         self.line_annotations.clear();
 
         // Pre-index remote threads by (path, line, side) for quick lookup
@@ -7348,6 +7541,60 @@ impl App {
                                 &self.forge_review_threads,
                                 &remote_index,
                             );
+                        }
+                    }
+                }
+
+                // End-of-file gap (after all hunks, not for deleted files)
+                if file.status != FileStatus::Deleted
+                    && let Some(last_hunk) = file.hunks.last()
+                {
+                    let eof_start = last_hunk.new_start + last_hunk.new_count;
+                    if let Some(&total) = self.file_line_count_cache.get(&file_idx)
+                        && eof_start <= total
+                    {
+                        let gap = (total - eof_start + 1) as usize;
+                        let eof_gap_id = GapId {
+                            file_idx,
+                            hunk_idx: file.hunks.len(),
+                        };
+
+                        let top_len = self.expanded_top.get(&eof_gap_id).map_or(0, |v| v.len());
+                        let bot_len = self.expanded_bottom.get(&eof_gap_id).map_or(0, |v| v.len());
+                        let remaining = gap.saturating_sub(top_len + bot_len);
+
+                        let mut ctx_idx = 0;
+
+                        // Top expanded lines (↓ direction)
+                        for _ in 0..top_len {
+                            self.line_annotations.push(AnnotatedLine::ExpandedContext {
+                                gap_id: eof_gap_id.clone(),
+                                line_idx: ctx_idx,
+                            });
+                            ctx_idx += 1;
+                        }
+
+                        // Expanders / hidden lines
+                        if remaining > 0 {
+                            self.line_annotations.push(AnnotatedLine::Expander {
+                                gap_id: eof_gap_id.clone(),
+                                direction: ExpandDirection::Down,
+                            });
+                            if remaining > GAP_EXPAND_BATCH {
+                                self.line_annotations.push(AnnotatedLine::HiddenLines {
+                                    gap_id: eof_gap_id.clone(),
+                                    count: remaining,
+                                });
+                            }
+                        }
+
+                        // Bottom expanded lines (↑ direction)
+                        for _ in 0..bot_len {
+                            self.line_annotations.push(AnnotatedLine::ExpandedContext {
+                                gap_id: eof_gap_id.clone(),
+                                line_idx: ctx_idx,
+                            });
+                            ctx_idx += 1;
                         }
                     }
                 }
@@ -8005,10 +8252,20 @@ mod commit_selection_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> Result<Vec<DiffLine>> {
             Ok(Vec::new())
+        }
+
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> Result<u32> {
+            Ok(0)
         }
     }
 
@@ -8133,6 +8390,7 @@ mod target_selector_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> Result<Vec<DiffLine>> {
@@ -8154,6 +8412,15 @@ mod target_selector_tests {
                 .take(limit)
                 .cloned()
                 .collect())
+        }
+
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> Result<u32> {
+            Ok(0)
         }
     }
 
@@ -9328,10 +9595,20 @@ mod scroll_behavior_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> Result<Vec<DiffLine>> {
             Ok(Vec::new())
+        }
+
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> Result<u32> {
+            Ok(0)
         }
     }
 
@@ -9977,10 +10254,20 @@ mod change_status_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> Result<Vec<DiffLine>> {
             Ok(Vec::new())
+        }
+
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> Result<u32> {
+            Ok(0)
         }
     }
 
@@ -10090,6 +10377,7 @@ mod expand_gap_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             start_line: u32,
             end_line: u32,
         ) -> Result<Vec<DiffLine>> {
@@ -10104,6 +10392,15 @@ mod expand_gap_tests {
                 });
             }
             Ok(result)
+        }
+
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> Result<u32> {
+            Ok(self.total_lines)
         }
     }
 
@@ -10696,6 +10993,194 @@ mod expand_gap_tests {
             "remaining hidden lines need an `↑` expander"
         );
     }
+
+    #[test]
+    fn should_show_end_of_file_expander() {
+        // given: file with hunk at lines 1-5 and total 100 lines (95 lines after hunk)
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 5)]);
+        let app = build_app_with_files(vec![file], 100);
+        let eof_gap_id = GapId {
+            file_idx: 0,
+            hunk_idx: 1, // hunks.len() == 1
+        };
+
+        // then: should have ↓ expander for end-of-file gap
+        let expander_count = app
+            .line_annotations
+            .iter()
+            .filter(|a| matches!(a, AnnotatedLine::Expander { gap_id: g, direction: ExpandDirection::Down } if *g == eof_gap_id))
+            .count();
+        assert_eq!(expander_count, 1, "should show ↓ expander at end of file");
+
+        // and: should have HiddenLines (95 lines > 20)
+        let hidden_count = app
+            .line_annotations
+            .iter()
+            .filter(|a| matches!(a, AnnotatedLine::HiddenLines { gap_id: g, count } if *g == eof_gap_id && *count == 95))
+            .count();
+        assert_eq!(hidden_count, 1, "should show hidden lines count");
+
+        // and: total_lines() must match line_annotations.len()
+        assert_eq!(
+            app.total_lines(),
+            app.line_annotations.len(),
+            "file_render_height sum must match annotation count"
+        );
+    }
+
+    #[test]
+    fn should_expand_down_at_end_of_file() {
+        // given: file with hunk at lines 1-5, total 100 lines
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 5)]);
+        let mut app = build_app_with_files(vec![file], 100);
+        let eof_gap_id = GapId {
+            file_idx: 0,
+            hunk_idx: 1,
+        };
+
+        // when: expand Down 20 lines
+        app.expand_gap(eof_gap_id.clone(), ExpandDirection::Down, Some(20))
+            .unwrap();
+
+        // then: 20 lines expanded from start of EOF gap (lines 6-25)
+        let content = app.expanded_top.get(&eof_gap_id).unwrap();
+        assert_eq!(content.len(), 20);
+        assert_eq!(content[0].new_lineno, Some(6));
+        assert_eq!(content[19].new_lineno, Some(25));
+    }
+
+    #[test]
+    fn should_not_show_eof_gap_when_hunk_ends_at_file_end() {
+        // given: file with hunk at lines 1-100 and total 100 lines (no gap)
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 100)]);
+        let app = build_app_with_files(vec![file], 100);
+        let eof_gap_id = GapId {
+            file_idx: 0,
+            hunk_idx: 1,
+        };
+
+        // then: no expander for end-of-file
+        let expander_count = app
+            .line_annotations
+            .iter()
+            .filter(|a| matches!(a, AnnotatedLine::Expander { gap_id: g, .. } if *g == eof_gap_id))
+            .count();
+        assert_eq!(
+            expander_count, 0,
+            "no EOF expander when hunk covers entire file"
+        );
+    }
+
+    #[test]
+    fn should_handle_subsequent_eof_expansions() {
+        // given: file with hunk at lines 1-5, total 50 lines, already expanded 20
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 5)]);
+        let mut app = build_app_with_files(vec![file], 50);
+        let eof_gap_id = GapId {
+            file_idx: 0,
+            hunk_idx: 1,
+        };
+        app.expand_gap(eof_gap_id.clone(), ExpandDirection::Down, Some(20))
+            .unwrap();
+
+        // when: expand Down 20 more
+        app.expand_gap(eof_gap_id.clone(), ExpandDirection::Down, Some(20))
+            .unwrap();
+
+        // then: 40 lines total (lines 6-45)
+        let content = app.expanded_top.get(&eof_gap_id).unwrap();
+        assert_eq!(content.len(), 40);
+        assert_eq!(content[0].new_lineno, Some(6));
+        assert_eq!(content[39].new_lineno, Some(45));
+    }
+
+    #[test]
+    fn should_show_small_eof_gap_expander_without_hidden_lines() {
+        // given: file with hunk at lines 1-90 and total 100 lines (10-line gap)
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 90)]);
+        let app = build_app_with_files(vec![file], 100);
+        let eof_gap_id = GapId {
+            file_idx: 0,
+            hunk_idx: 1,
+        };
+
+        // then: should have ↓ expander
+        let expander_count = app
+            .line_annotations
+            .iter()
+            .filter(|a| matches!(a, AnnotatedLine::Expander { gap_id: g, direction: ExpandDirection::Down } if *g == eof_gap_id))
+            .count();
+        assert_eq!(expander_count, 1);
+
+        // and: should NOT have HiddenLines (10 <= 20)
+        let hidden_count = app
+            .line_annotations
+            .iter()
+            .filter(
+                |a| matches!(a, AnnotatedLine::HiddenLines { gap_id: g, .. } if *g == eof_gap_id),
+            )
+            .count();
+        assert_eq!(
+            hidden_count, 0,
+            "small EOF gap should not show hidden lines"
+        );
+    }
+
+    #[test]
+    fn total_lines_must_match_annotations_with_eof_gaps() {
+        // Multiple files, each with EOF gaps of different sizes
+        let files = vec![
+            make_file_with_hunks("a.rs", vec![make_hunk(10, 5)]), // gap before (9) + gap after
+            make_file_with_hunks("b.rs", vec![make_hunk(1, 5), make_hunk(30, 5)]), // between gap + EOF gap
+            make_file_with_hunks("c.rs", vec![make_hunk(1, 100)]), // no EOF gap (hunk covers all)
+        ];
+        let app = build_app_with_files(files, 100);
+
+        assert_eq!(
+            app.total_lines(),
+            app.line_annotations.len(),
+            "total_lines() must equal line_annotations.len()\n\
+             total_lines={}, annotations={}",
+            app.total_lines(),
+            app.line_annotations.len()
+        );
+    }
+
+    #[test]
+    fn should_not_show_eof_gap_for_deleted_files() {
+        // given: a deleted file with hunks (old-side content)
+        let hunks = vec![make_hunk(1, 5)];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        let file = DiffFile {
+            old_path: Some(PathBuf::from("deleted.rs")),
+            new_path: None,
+            status: FileStatus::Deleted,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        };
+        let app = build_app_with_files(vec![file], 100);
+        let eof_gap_id = GapId {
+            file_idx: 0,
+            hunk_idx: 1,
+        };
+
+        // then: no EOF expander for deleted files
+        let expander_count = app
+            .line_annotations
+            .iter()
+            .filter(|a| matches!(a, AnnotatedLine::Expander { gap_id: g, .. } if *g == eof_gap_id))
+            .count();
+        assert_eq!(
+            expander_count, 0,
+            "deleted files should not have EOF expander"
+        );
+
+        // and: total_lines must match annotations
+        assert_eq!(app.total_lines(), app.line_annotations.len());
+    }
 }
 
 #[cfg(test)]
@@ -10778,6 +11263,7 @@ mod submit_flow_tests {
             &self,
             _p: &Path,
             _s: FileStatus,
+            _ref_commit: Option<&str>,
             _start: u32,
             _end: u32,
         ) -> Result<Vec<DiffLine>> {
@@ -10788,6 +11274,14 @@ mod submit_flow_tests {
                 staged: false,
                 unstaged: false,
             })
+        }
+        fn file_line_count(
+            &self,
+            _p: &Path,
+            _s: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> Result<u32> {
+            Ok(0)
         }
     }
 

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -38,6 +38,7 @@ pub trait ContextProvider {
 /// the head side, old on the base side) and forwards to the backend.
 pub struct VcsContextProvider<'a> {
     pub vcs: &'a dyn VcsBackend,
+    pub ref_commit: Option<String>,
 }
 
 impl ContextProvider for VcsContextProvider<'_> {
@@ -56,8 +57,13 @@ impl ContextProvider for VcsContextProvider<'_> {
             Some(p) => p.as_path(),
             None => return Ok(Vec::new()),
         };
-        self.vcs
-            .fetch_context_lines(path, file_status, start_line, end_line)
+        self.vcs.fetch_context_lines(
+            path,
+            file_status,
+            self.ref_commit.as_deref(),
+            start_line,
+            end_line,
+        )
     }
 }
 

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -7,8 +7,10 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, ExpandDirection, FocusedPanel, GAP_EXPAND_BATCH, GapId, InputMode};
-use crate::model::{LineOrigin, LineRange, LineSide};
+use crate::app::{
+    App, DiffSource, ExpandDirection, FocusedPanel, GAP_EXPAND_BATCH, GapId, InputMode,
+};
+use crate::model::{FileStatus, LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_view::{
@@ -486,6 +488,84 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             }
         }
 
+        // End-of-file gap (after all hunks, not for deleted files)
+        if file.status != FileStatus::Deleted
+            && matches!(
+                app.diff_source,
+                DiffSource::WorkingTree
+                    | DiffSource::Unstaged
+                    | DiffSource::StagedAndUnstaged
+                    | DiffSource::StagedUnstagedAndCommits(_)
+                    | DiffSource::CommitRange(_)
+            )
+            && let Some(last_hunk) = file.hunks.last()
+        {
+            let eof_start = last_hunk.new_start + last_hunk.new_count;
+            if let Some(&total) = app.file_line_count_cache.get(&file_idx)
+                && eof_start <= total
+            {
+                let gap = (total - eof_start + 1) as usize;
+                let eof_gap_id = GapId {
+                    file_idx,
+                    hunk_idx: file.hunks.len(),
+                };
+                let top_lines = app.expanded_top.get(&eof_gap_id);
+                let bot_lines = app.expanded_bottom.get(&eof_gap_id);
+                let top_len = top_lines.map_or(0, |v| v.len());
+                let bot_len = bot_lines.map_or(0, |v| v.len());
+                let remaining = gap.saturating_sub(top_len + bot_len);
+
+                // Render top expanded lines (↓ direction)
+                if let Some(top) = top_lines {
+                    for expanded_line in top {
+                        render_sbs_expanded_context_line(
+                            &mut lines,
+                            &mut line_idx,
+                            ctx.current_line_idx,
+                            expanded_line,
+                            ctx.content_width,
+                            &app.theme,
+                        );
+                    }
+                }
+
+                // Expander / hidden lines
+                if remaining > 0 {
+                    render_expander_line(
+                        &mut lines,
+                        &mut line_idx,
+                        ctx.current_line_idx,
+                        ExpandDirection::Down,
+                        remaining,
+                        &app.theme,
+                    );
+                    if remaining > GAP_EXPAND_BATCH {
+                        render_hidden_lines(
+                            &mut lines,
+                            &mut line_idx,
+                            ctx.current_line_idx,
+                            remaining,
+                            &app.theme,
+                        );
+                    }
+                }
+
+                // Render bottom expanded lines
+                if let Some(bot) = bot_lines {
+                    for expanded_line in bot {
+                        render_sbs_expanded_context_line(
+                            &mut lines,
+                            &mut line_idx,
+                            ctx.current_line_idx,
+                            expanded_line,
+                            ctx.content_width,
+                            &app.theme,
+                        );
+                    }
+                }
+            }
+        }
+
         // Spacing between files
         let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
         lines.push(Line::from(Span::styled(
@@ -665,20 +745,24 @@ fn render_sbs_expanded_context_line(
     theme: &Theme,
 ) {
     let indicator = cursor_indicator(*line_idx, current_line_idx);
-    let line_num = expanded_line
+    let old_line_num = expanded_line
+        .old_lineno
+        .map(|n| format!("{n:>4} "))
+        .unwrap_or_else(|| "     ".to_string());
+    let new_line_num = expanded_line
         .new_lineno
         .map(|n| format!("{n:>4} "))
         .unwrap_or_else(|| "     ".to_string());
     let line_spans = vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
-        Span::styled(line_num.clone(), styles::expanded_context_style(theme)),
+        Span::styled(old_line_num, styles::expanded_context_style(theme)),
         Span::styled(" ", styles::expanded_context_style(theme)),
         Span::styled(
             truncate_or_pad(&expanded_line.content, content_width),
             styles::expanded_context_style(theme),
         ),
         Span::styled(" │ ", styles::dim_style(theme)),
-        Span::styled(line_num, styles::expanded_context_style(theme)),
+        Span::styled(new_line_num, styles::expanded_context_style(theme)),
         Span::styled(" ", styles::expanded_context_style(theme)),
         Span::styled(
             truncate_or_pad(&expanded_line.content, content_width),
@@ -768,9 +852,12 @@ fn render_context_line_side_by_side(
     mut line_idx: usize,
     lines: &mut Vec<Line>,
 ) -> (usize, Option<SideBySideCursorInfo>) {
-    let line_num = diff_line
+    let old_line_num = diff_line
         .old_lineno
-        .or(diff_line.new_lineno)
+        .map(|n| format!("{n:>4}"))
+        .unwrap_or_else(|| "    ".to_string());
+    let new_line_num = diff_line
+        .new_lineno
         .map(|n| format!("{n:>4}"))
         .unwrap_or_else(|| "    ".to_string());
 
@@ -778,7 +865,7 @@ fn render_context_line_side_by_side(
 
     let mut spans = vec![
         Span::styled(indicator, styles::current_line_indicator_style(ctx.theme)),
-        Span::styled(format!("{line_num} "), styles::dim_style(ctx.theme)),
+        Span::styled(format!("{old_line_num} "), styles::dim_style(ctx.theme)),
         Span::styled(" ".to_string(), styles::diff_context_style(ctx.theme)),
     ];
 
@@ -798,7 +885,7 @@ fn render_context_line_side_by_side(
     // Separator
     spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
     spans.push(Span::styled(
-        format!("{line_num} "),
+        format!("{new_line_num} "),
         styles::dim_style(ctx.theme),
     ));
     spans.push(Span::styled(
@@ -1339,6 +1426,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> TuicrResult<Vec<DiffLine>> {
@@ -1349,6 +1437,14 @@ mod remote_comments_side_by_side_snapshot_tests {
                 staged: false,
                 unstaged: false,
             })
+        }
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> TuicrResult<u32> {
+            Ok(0)
         }
     }
 

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -7,9 +7,11 @@ use ratatui::{
 };
 use unicode_width::UnicodeWidthStr;
 
-use crate::app::{App, ExpandDirection, FocusedPanel, GAP_EXPAND_BATCH, GapId, InputMode};
+use crate::app::{
+    App, DiffSource, ExpandDirection, FocusedPanel, GAP_EXPAND_BATCH, GapId, InputMode,
+};
 use crate::forge::remote_comments::PrCommentsVisibility;
-use crate::model::{LineOrigin, LineRange, LineSide};
+use crate::model::{FileStatus, LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_view::{
@@ -814,6 +816,82 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             }
         }
 
+        // End-of-file gap (after all hunks, not for deleted files)
+        if file.status != FileStatus::Deleted
+            && matches!(
+                app.diff_source,
+                DiffSource::WorkingTree
+                    | DiffSource::Unstaged
+                    | DiffSource::StagedAndUnstaged
+                    | DiffSource::StagedUnstagedAndCommits(_)
+                    | DiffSource::CommitRange(_)
+            )
+            && let Some(last_hunk) = file.hunks.last()
+        {
+            let eof_start = last_hunk.new_start + last_hunk.new_count;
+            if let Some(&total) = app.file_line_count_cache.get(&file_idx)
+                && eof_start <= total
+            {
+                let gap = (total - eof_start + 1) as usize;
+                let eof_gap_id = GapId {
+                    file_idx,
+                    hunk_idx: file.hunks.len(),
+                };
+                let top_lines = app.expanded_top.get(&eof_gap_id);
+                let bot_lines = app.expanded_bottom.get(&eof_gap_id);
+                let top_len = top_lines.map_or(0, |v| v.len());
+                let bot_len = bot_lines.map_or(0, |v| v.len());
+                let remaining = gap.saturating_sub(top_len + bot_len);
+
+                // Render top expanded lines (↓ direction)
+                if let Some(top) = top_lines {
+                    for expanded_line in top {
+                        render_expanded_context_line(
+                            &mut lines,
+                            &mut line_idx,
+                            current_line_idx,
+                            expanded_line,
+                            &app.theme,
+                        );
+                    }
+                }
+
+                // Expander / hidden lines
+                if remaining > 0 {
+                    render_expander_line(
+                        &mut lines,
+                        &mut line_idx,
+                        current_line_idx,
+                        ExpandDirection::Down,
+                        remaining,
+                        &app.theme,
+                    );
+                    if remaining > GAP_EXPAND_BATCH {
+                        render_hidden_lines(
+                            &mut lines,
+                            &mut line_idx,
+                            current_line_idx,
+                            remaining,
+                            &app.theme,
+                        );
+                    }
+                }
+
+                // Render bottom expanded lines
+                if let Some(bot) = bot_lines {
+                    for expanded_line in bot {
+                        render_expanded_context_line(
+                            &mut lines,
+                            &mut line_idx,
+                            current_line_idx,
+                            expanded_line,
+                            &app.theme,
+                        );
+                    }
+                }
+            }
+        }
+
         // Spacing between files
         let indicator = cursor_indicator(line_idx, current_line_idx);
         lines.push(Line::from(Span::styled(
@@ -1138,6 +1216,7 @@ mod remote_comments_snapshot_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> TuicrResult<Vec<DiffLine>> {
@@ -1148,6 +1227,14 @@ mod remote_comments_snapshot_tests {
                 staged: false,
                 unstaged: false,
             })
+        }
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> TuicrResult<u32> {
+            Ok(0)
         }
     }
 

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -487,6 +487,7 @@ mod selector_render_snapshot_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> TuicrResult<Vec<DiffLine>> {
@@ -498,6 +499,15 @@ mod selector_render_snapshot_tests {
                 staged: false,
                 unstaged: false,
             })
+        }
+
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> TuicrResult<u32> {
+            Ok(0)
         }
     }
 

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -454,10 +454,19 @@ mod pr_header_snapshot_tests {
             &self,
             _file_path: &Path,
             _file_status: FileStatus,
+            _ref_commit: Option<&str>,
             _start_line: u32,
             _end_line: u32,
         ) -> TuicrResult<Vec<DiffLine>> {
             Ok(Vec::new())
+        }
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> TuicrResult<u32> {
+            Ok(0)
         }
     }
 

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -317,6 +317,7 @@ mod tests {
             &self,
             _p: &Path,
             _s: FileStatus,
+            _ref_commit: Option<&str>,
             _start: u32,
             _end: u32,
         ) -> TuicrResult<Vec<DiffLine>> {
@@ -327,6 +328,14 @@ mod tests {
                 staged: false,
                 unstaged: false,
             })
+        }
+        fn file_line_count(
+            &self,
+            _p: &Path,
+            _s: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> TuicrResult<u32> {
+            Ok(0)
         }
     }
 

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -303,6 +303,7 @@ impl VcsBackend for FileBackend {
         &self,
         file_path: &Path,
         _file_status: FileStatus,
+        _ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
@@ -345,6 +346,17 @@ impl VcsBackend for FileBackend {
         }
 
         Ok(result)
+    }
+
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        let abs_path = self.info.root_path.join(file_path);
+        let content = std::fs::read_to_string(&abs_path)?;
+        Ok(content.lines().count() as u32)
     }
 }
 

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -544,7 +544,7 @@ mod tests {
         let backend = FileBackend::new_pristine(vec![path_a, path_b], root).unwrap();
 
         let lines = backend
-            .fetch_context_lines(Path::new("b.txt"), FileStatus::Modified, 1, 3)
+            .fetch_context_lines(Path::new("b.txt"), FileStatus::Modified, None, 1, 3)
             .unwrap();
 
         assert_eq!(lines.len(), 3);
@@ -568,7 +568,7 @@ mod tests {
 
         let backend = FileBackend::new_pristine(vec![kept], repo.clone()).unwrap();
         let lines = backend
-            .fetch_context_lines(Path::new("../secret.txt"), FileStatus::Modified, 1, 1)
+            .fetch_context_lines(Path::new("../secret.txt"), FileStatus::Modified, None, 1, 1)
             .unwrap();
         assert!(
             lines.is_empty(),

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -128,6 +128,26 @@ impl GitCliBackend {
         );
         Ok(files)
     }
+
+    fn read_file_content(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<String> {
+        let path_str = file_path.to_string_lossy();
+        if let Some(commit) = ref_commit {
+            read_git_object(&self.root_path, &format!("{commit}:{path_str}")).ok_or_else(|| {
+                TuicrError::VcsCommand(format!("failed to read {path_str} at {commit}"))
+            })
+        } else if file_status == FileStatus::Deleted {
+            read_git_object(&self.root_path, &format!("HEAD:{path_str}")).ok_or_else(|| {
+                TuicrError::VcsCommand("failed to read deleted file from HEAD".into())
+            })
+        } else {
+            Ok(fs::read_to_string(self.root_path.join(file_path))?)
+        }
+    }
 }
 
 impl VcsBackend for GitCliBackend {
@@ -217,6 +237,7 @@ impl VcsBackend for GitCliBackend {
         &self,
         file_path: &Path,
         file_status: FileStatus,
+        ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
@@ -224,16 +245,7 @@ impl VcsBackend for GitCliBackend {
             return Ok(Vec::new());
         }
 
-        let content = match file_status {
-            FileStatus::Deleted => read_git_object(
-                &self.root_path,
-                &format!("HEAD:{}", file_path.to_string_lossy()),
-            )
-            .ok_or_else(|| {
-                TuicrError::VcsCommand("failed to read deleted file from HEAD".into())
-            })?,
-            _ => fs::read_to_string(self.root_path.join(file_path))?,
-        };
+        let content = self.read_file_content(file_path, file_status, ref_commit)?;
 
         let lines: Vec<&str> = content.lines().collect();
         let mut result = Vec::new();
@@ -250,6 +262,16 @@ impl VcsBackend for GitCliBackend {
             }
         }
         Ok(result)
+    }
+
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        let content = self.read_file_content(file_path, file_status, ref_commit)?;
+        Ok(content.lines().count() as u32)
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {

--- a/src/vcs/git/context.rs
+++ b/src/vcs/git/context.rs
@@ -6,12 +6,13 @@ use crate::model::{DiffLine, FileStatus, LineOrigin};
 
 /// Fetch context lines from a file for gap expansion.
 ///
-/// For Added/Modified files: reads from working tree
-/// For Deleted files: reads from HEAD blob
+/// When `ref_commit` is `Some`, reads from that commit's tree.
+/// Otherwise: working tree for non-deleted, HEAD blob for deleted.
 pub fn fetch_context_lines(
     repo: &Repository,
     file_path: &Path,
     file_status: FileStatus,
+    ref_commit: Option<&str>,
     start_line: u32,
     end_line: u32,
 ) -> Result<Vec<DiffLine>> {
@@ -19,18 +20,7 @@ pub fn fetch_context_lines(
         return Ok(Vec::new());
     }
 
-    let content = match file_status {
-        FileStatus::Deleted => {
-            // Read from HEAD blob for deleted files
-            fetch_blob_content(repo, file_path)?
-        }
-        _ => {
-            // Read from working tree for all other statuses
-            let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
-            let full_path = workdir.join(file_path);
-            std::fs::read_to_string(&full_path)?
-        }
-    };
+    let content = read_file_content(repo, file_path, file_status, ref_commit)?;
 
     let lines: Vec<&str> = content.lines().collect();
     let mut result = Vec::new();
@@ -51,10 +41,52 @@ pub fn fetch_context_lines(
     Ok(result)
 }
 
-/// Fetch content from a git blob (for deleted files)
+/// Get the total number of lines in a file.
+pub fn file_line_count(
+    repo: &Repository,
+    file_path: &Path,
+    file_status: FileStatus,
+    ref_commit: Option<&str>,
+) -> Result<u32> {
+    let content = read_file_content(repo, file_path, file_status, ref_commit)?;
+    Ok(content.lines().count() as u32)
+}
+
+fn read_file_content(
+    repo: &Repository,
+    file_path: &Path,
+    file_status: FileStatus,
+    ref_commit: Option<&str>,
+) -> Result<String> {
+    if let Some(commit) = ref_commit {
+        fetch_commit_blob_content(repo, commit, file_path)
+    } else if file_status == FileStatus::Deleted {
+        fetch_blob_content(repo, file_path)
+    } else {
+        let workdir = repo.workdir().ok_or(TuicrError::NotARepository)?;
+        Ok(std::fs::read_to_string(workdir.join(file_path))?)
+    }
+}
+
+/// Fetch content from HEAD blob (for deleted files without a ref_commit).
 fn fetch_blob_content(repo: &Repository, file_path: &Path) -> Result<String> {
     let head = repo.head()?.peel_to_tree()?;
     let entry = head.get_path(file_path)?;
+    let blob = repo.find_blob(entry.id())?;
+    let content = std::str::from_utf8(blob.content())
+        .map_err(|e| TuicrError::CorruptedSession(format!("Invalid UTF-8 in file: {e}")))?;
+    Ok(content.to_string())
+}
+
+/// Fetch content from an arbitrary commit's tree.
+fn fetch_commit_blob_content(
+    repo: &Repository,
+    commit_spec: &str,
+    file_path: &Path,
+) -> Result<String> {
+    let obj = repo.revparse_single(commit_spec)?;
+    let tree = obj.peel_to_tree()?;
+    let entry = tree.get_path(file_path)?;
     let blob = repo.find_blob(entry.id())?;
     let content = std::str::from_utf8(blob.content())
         .map_err(|e| TuicrError::CorruptedSession(format!("Invalid UTF-8 in file: {e}")))?;

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -108,10 +108,27 @@ impl VcsBackend for Libgit2Backend {
         &self,
         file_path: &Path,
         file_status: FileStatus,
+        ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
-        context::fetch_context_lines(&self.repo, file_path, file_status, start_line, end_line)
+        context::fetch_context_lines(
+            &self.repo,
+            file_path,
+            file_status,
+            ref_commit,
+            start_line,
+            end_line,
+        )
+    }
+
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        context::file_line_count(&self.repo, file_path, file_status, ref_commit)
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -203,16 +203,37 @@ impl VcsBackend for GitBackend {
         &self,
         file_path: &Path,
         file_status: FileStatus,
+        ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
         match self {
-            Self::Libgit2(backend) => {
-                backend.fetch_context_lines(file_path, file_status, start_line, end_line)
-            }
-            Self::Cli(backend) => {
-                backend.fetch_context_lines(file_path, file_status, start_line, end_line)
-            }
+            Self::Libgit2(backend) => backend.fetch_context_lines(
+                file_path,
+                file_status,
+                ref_commit,
+                start_line,
+                end_line,
+            ),
+            Self::Cli(backend) => backend.fetch_context_lines(
+                file_path,
+                file_status,
+                ref_commit,
+                start_line,
+                end_line,
+            ),
+        }
+    }
+
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        match self {
+            Self::Libgit2(backend) => backend.file_line_count(file_path, file_status, ref_commit),
+            Self::Cli(backend) => backend.file_line_count(file_path, file_status, ref_commit),
         }
     }
 

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -104,6 +104,7 @@ impl VcsBackend for HgBackend {
         &self,
         file_path: &Path,
         file_status: FileStatus,
+        ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
@@ -111,19 +112,13 @@ impl VcsBackend for HgBackend {
             return Ok(Vec::new());
         }
 
-        let content = match file_status {
-            FileStatus::Deleted => {
-                // Read from hg cat (last committed version)
-                run_hg_command(
-                    &self.info.root_path,
-                    &["cat", "-r", ".", &file_path.to_string_lossy()],
-                )?
-            }
-            _ => {
-                // Read from working tree
-                let full_path = self.info.root_path.join(file_path);
-                std::fs::read_to_string(&full_path)?
-            }
+        let path_str = file_path.to_string_lossy();
+        let content = if let Some(commit) = ref_commit {
+            run_hg_command(&self.info.root_path, &["cat", "-r", commit, &path_str])?
+        } else if file_status == FileStatus::Deleted {
+            run_hg_command(&self.info.root_path, &["cat", "-r", ".", &path_str])?
+        } else {
+            std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
 
         let lines: Vec<&str> = content.lines().collect();
@@ -143,6 +138,23 @@ impl VcsBackend for HgBackend {
         }
 
         Ok(result)
+    }
+
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        let path_str = file_path.to_string_lossy();
+        let content = if let Some(commit) = ref_commit {
+            run_hg_command(&self.info.root_path, &["cat", "-r", commit, &path_str])?
+        } else if file_status == FileStatus::Deleted {
+            run_hg_command(&self.info.root_path, &["cat", "-r", ".", &path_str])?
+        } else {
+            std::fs::read_to_string(self.info.root_path.join(file_path))?
+        };
+        Ok(content.lines().count() as u32)
     }
 
     fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
@@ -585,7 +597,7 @@ mod tests {
 
         // Fetch context lines from working tree (modified file)
         let lines = backend
-            .fetch_context_lines(Path::new("hello.txt"), FileStatus::Modified, 1, 2)
+            .fetch_context_lines(Path::new("hello.txt"), FileStatus::Modified, None, 1, 2)
             .expect("Failed to fetch context lines");
 
         assert_eq!(lines.len(), 2);

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -142,6 +142,7 @@ impl VcsBackend for JjBackend {
         &self,
         file_path: &Path,
         file_status: FileStatus,
+        ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>> {
@@ -149,19 +150,19 @@ impl VcsBackend for JjBackend {
             return Ok(Vec::new());
         }
 
-        let content = match file_status {
-            FileStatus::Deleted => {
-                // Read from jj show (parent revision)
-                run_jj_command(
-                    &self.info.root_path,
-                    &["file", "show", "-r", "@-", &file_path.to_string_lossy()],
-                )?
-            }
-            _ => {
-                // Read from working tree
-                let full_path = self.info.root_path.join(file_path);
-                std::fs::read_to_string(&full_path)?
-            }
+        let path_str = file_path.to_string_lossy();
+        let content = if let Some(commit) = ref_commit {
+            run_jj_command(
+                &self.info.root_path,
+                &["file", "show", "-r", commit, &path_str],
+            )?
+        } else if file_status == FileStatus::Deleted {
+            run_jj_command(
+                &self.info.root_path,
+                &["file", "show", "-r", "@-", &path_str],
+            )?
+        } else {
+            std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
 
         let lines: Vec<&str> = content.lines().collect();
@@ -181,6 +182,29 @@ impl VcsBackend for JjBackend {
         }
 
         Ok(result)
+    }
+
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        let path_str = file_path.to_string_lossy();
+        let content = if let Some(commit) = ref_commit {
+            run_jj_command(
+                &self.info.root_path,
+                &["file", "show", "-r", commit, &path_str],
+            )?
+        } else if file_status == FileStatus::Deleted {
+            run_jj_command(
+                &self.info.root_path,
+                &["file", "show", "-r", "@-", &path_str],
+            )?
+        } else {
+            std::fs::read_to_string(self.info.root_path.join(file_path))?
+        };
+        Ok(content.lines().count() as u32)
     }
 
     fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
@@ -573,7 +597,7 @@ mod tests {
 
         // Fetch context lines from working tree (modified file)
         let lines = backend
-            .fetch_context_lines(Path::new("hello.txt"), FileStatus::Modified, 1, 2)
+            .fetch_context_lines(Path::new("hello.txt"), FileStatus::Modified, None, 1, 2)
             .expect("Failed to fetch context lines");
 
         assert_eq!(lines.len(), 2);

--- a/src/vcs/pr_noop.rs
+++ b/src/vcs/pr_noop.rs
@@ -42,6 +42,7 @@ impl VcsBackend for PrNoopVcs {
         &self,
         _file_path: &Path,
         _file_status: FileStatus,
+        _ref_commit: Option<&str>,
         _start_line: u32,
         _end_line: u32,
     ) -> Result<Vec<DiffLine>> {
@@ -49,6 +50,17 @@ impl VcsBackend for PrNoopVcs {
         // If anything reaches this backend, it's a routing bug — return an
         // empty result rather than panicking so the UI degrades gracefully.
         Ok(Vec::new())
+    }
+
+    fn file_line_count(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        Err(TuicrError::UnsupportedOperation(
+            "PR mode does not read from the local working tree".to_string(),
+        ))
     }
 }
 
@@ -73,7 +85,7 @@ mod tests {
         let vcs = PrNoopVcs::new(info());
         // when
         let lines = vcs
-            .fetch_context_lines(&PathBuf::from("x"), FileStatus::Modified, 1, 5)
+            .fetch_context_lines(&PathBuf::from("x"), FileStatus::Modified, None, 1, 5)
             .unwrap();
         // then
         assert!(lines.is_empty());

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -99,14 +99,26 @@ pub trait VcsBackend: Send {
     }
 
     /// Fetch context lines for gap expansion.
-    /// For deleted files, reads from VCS; otherwise from working tree.
+    /// When `ref_commit` is `Some`, reads from that commit; otherwise reads
+    /// from the working tree (or VCS HEAD for deleted files).
     fn fetch_context_lines(
         &self,
         file_path: &Path,
         file_status: FileStatus,
+        ref_commit: Option<&str>,
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>>;
+
+    /// Get the total number of lines in a file.
+    /// When `ref_commit` is `Some`, reads from that commit; otherwise reads
+    /// from the working tree (or VCS HEAD for deleted files).
+    fn file_line_count(
+        &self,
+        file_path: &Path,
+        file_status: FileStatus,
+        ref_commit: Option<&str>,
+    ) -> Result<u32>;
 
     /// Get recent commits for commit selection UI.
     /// Returns empty vec if not supported (default).


### PR DESCRIPTION
I found myself needing context after the end of the diff frequently.
This PR adds support to expand the file source at the end of the diff.

This wound up being a great deal more involved than anticipated. Included is a subtle bug fix where the expanded chunks on the before/removed diff pane would use line #'s from the added diff side.

Written up via Claude. Lots of manual QA as well as several rounds of Codex reviews.

screenshot w/ expand options:
<img width="2814" height="2064" alt="Screenshot 2026-05-18 at 4 14 06 PM" src="https://github.com/user-attachments/assets/458c97b5-9c42-4749-8674-3bce88879ff0" />
screenshot w/ expanded diff:
<img width="2811" height="2067" alt="Screenshot 2026-05-18 at 4 14 20 PM" src="https://github.com/user-attachments/assets/466c1edb-a537-4ce2-8576-5263e3d039c3" />
