### PR TITLE
feat(forge): remove the "Reviewed with tuicr" review-body footer

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,16 +24,12 @@ pub struct ForgeConfig {
     /// reader can see the comment classification at a glance. Defaults to
     /// `true`; set to `false` to send the raw comment body.
     pub comment_type_prefix: bool,
-    /// Append the `<sub>Reviewed with tuicr…</sub>` footer to the GitHub
-    /// review body on submit. Defaults to `true`.
-    pub review_footer: bool,
 }
 
 impl Default for ForgeConfig {
     fn default() -> Self {
         Self {
             comment_type_prefix: true,
-            review_footer: true,
         }
     }
 }
@@ -83,7 +79,7 @@ const KNOWN_KEYS: &[&str] = &[
     "forge",
 ];
 
-const FORGE_KNOWN_KEYS: &[&str] = &["comment_type_prefix", "review_footer"];
+const FORGE_KNOWN_KEYS: &[&str] = &["comment_type_prefix"];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ConfigLoadOutcome {
@@ -306,10 +302,6 @@ fn parse_forge(value: &Value, warnings: &mut Vec<String>) -> Option<ForgeConfig>
 
     if let Some(v) = read_forge_bool(table, "comment_type_prefix", warnings) {
         cfg.comment_type_prefix = v;
-        any_override = true;
-    }
-    if let Some(v) = read_forge_bool(table, "review_footer", warnings) {
-        cfg.review_footer = v;
         any_override = true;
     }
 
@@ -982,7 +974,6 @@ mod tests {
         let outcome = parse_config(
             r#"[forge]
 comment_type_prefix = false
-review_footer = false
 "#,
         );
         let forge = outcome
@@ -991,7 +982,6 @@ review_footer = false
             .and_then(|cfg| cfg.forge.clone())
             .expect("forge section should parse");
         assert!(!forge.comment_type_prefix);
-        assert!(!forge.review_footer);
         assert!(outcome.warnings.is_empty());
     }
 
@@ -1011,7 +1001,7 @@ review_footer = false
     fn should_warn_on_unknown_forge_keys() {
         let outcome = parse_config(
             r#"[forge]
-review_footer = true
+comment_type_prefix = false
 foo = "bar"
 "#,
         );
@@ -1020,8 +1010,7 @@ foo = "bar"
             .as_ref()
             .and_then(|cfg| cfg.forge.clone())
             .expect("forge section should parse");
-        assert!(forge.review_footer);
-        assert!(forge.comment_type_prefix);
+        assert!(!forge.comment_type_prefix);
         assert_eq!(outcome.warnings.len(), 1);
         assert_eq!(
             outcome.warnings[0],
@@ -1070,12 +1059,9 @@ comment_type_prefix = "yes"
     }
 
     #[test]
-    fn forge_defaults_are_both_true() {
-        // Guard against silent changes to public defaults — both knobs ship
-        // enabled per the spec.
+    fn forge_defaults_enable_comment_type_prefix() {
         let cfg = ForgeConfig::default();
         assert!(cfg.comment_type_prefix);
-        assert!(cfg.review_footer);
     }
 
     #[test]

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -432,18 +432,8 @@ pub fn build_review_body(
         sections.push(block);
     }
 
-    if config.review_footer {
-        sections.push(REVIEW_FOOTER.to_string());
-    }
-
     sections.join("\n\n")
 }
-
-/// Footer appended to every tuicr-authored GitHub review body (when
-/// `forge.review_footer` is enabled). Kept as a constant so it's trivial to
-/// snapshot-test in the body builder.
-pub const REVIEW_FOOTER: &str =
-    "<sub>Reviewed with [tuicr](https://github.com/agavra/tuicr).</sub>";
 
 #[cfg(test)]
 mod tests {
@@ -779,7 +769,6 @@ mod tests {
         let comment = comment_with_line(LineSide::New, Some(11), None);
         let cfg = ForgeConfig {
             comment_type_prefix: false,
-            review_footer: true,
         };
         let mapped = map_comment(&comment, anchor_from(&comment), &typical_file(), &cfg);
         match mapped {
@@ -798,31 +787,20 @@ mod tests {
     }
 
     #[test]
-    fn should_return_empty_body_when_no_inputs_and_footer_disabled() {
-        let cfg = ForgeConfig {
-            comment_type_prefix: true,
-            review_footer: false,
-        };
-        let body = build_review_body(&[], &[], &cfg);
-        assert_eq!(body, "");
-    }
-
-    #[test]
-    fn should_return_footer_only_when_no_review_comments_and_no_summary() {
+    fn should_return_empty_body_when_no_inputs() {
         let body = build_review_body(&[], &[], &default_config());
-        assert_eq!(body, REVIEW_FOOTER);
+        assert_eq!(body, "");
     }
 
     #[test]
     fn should_render_review_level_comments_with_type_prefix() {
         let comments = vec![note("first"), note("second")];
         let body = build_review_body(&comments, &[], &default_config());
-        assert!(body.starts_with("[NOTE] first\n\n[NOTE] second"));
-        assert!(body.ends_with(REVIEW_FOOTER));
+        assert_eq!(body, "[NOTE] first\n\n[NOTE] second");
     }
 
     #[test]
-    fn should_render_unplaced_comments_section_before_footer() {
+    fn should_render_unplaced_comments_section() {
         let item = MovedToSummaryItem {
             comment: Comment::new("kaboom".to_string(), CommentType::Issue, None),
             file: PathBuf::from("src/lib.rs"),
@@ -830,11 +808,10 @@ mod tests {
         let body = build_review_body(&[], &[item], &default_config());
         assert!(body.contains("## Unplaced comments"));
         assert!(body.contains("- [ISSUE] src/lib.rs: kaboom"));
-        assert!(body.ends_with(REVIEW_FOOTER));
     }
 
     #[test]
-    fn should_render_all_three_sections_in_order() {
+    fn should_render_review_level_above_unplaced_section() {
         let review = vec![note("top")];
         let summary = vec![MovedToSummaryItem {
             comment: Comment::new("middle".to_string(), CommentType::Note, None),
@@ -843,15 +820,13 @@ mod tests {
         let body = build_review_body(&review, &summary, &default_config());
         let top = body.find("[NOTE] top").expect("review comment");
         let middle = body.find("## Unplaced comments").expect("unplaced section");
-        let bottom = body.find(REVIEW_FOOTER).expect("footer");
-        assert!(top < middle && middle < bottom, "section ordering: {body}");
+        assert!(top < middle, "section ordering: {body}");
     }
 
     #[test]
     fn should_omit_type_prefix_in_body_when_disabled() {
         let cfg = ForgeConfig {
             comment_type_prefix: false,
-            review_footer: false,
         };
         let comments = vec![note("just text")];
         let body = build_review_body(&comments, &[], &cfg);

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -228,12 +228,11 @@ fn describe_row(item: &UnmappableItem) -> String {
 
 fn body_summary_label(app: &App, moved_count: usize) -> String {
     let review_level = app.session.review_comments.len();
-    match (review_level, moved_count, app.forge_config.review_footer) {
-        (0, 0, false) => "empty".to_string(),
-        (0, 0, true) => "footer only".to_string(),
-        (n, 0, _) => format!("{n} review comment{s}", s = plural(n)),
-        (0, m, _) => format!("{m} unplaced comment{s}", s = plural(m)),
-        (n, m, _) => format!("{n} review comment{sn} + {m} unplaced", sn = plural(n)),
+    match (review_level, moved_count) {
+        (0, 0) => "empty".to_string(),
+        (n, 0) => format!("{n} review comment{s}", s = plural(n)),
+        (0, m) => format!("{m} unplaced comment{s}", s = plural(m)),
+        (n, m) => format!("{n} review comment{sn} + {m} unplaced", sn = plural(n)),
     }
 }
 


### PR DESCRIPTION
## Summary

- Drop the `<sub>Reviewed with [tuicr]…</sub>` footer that was appended to every GitHub review body on `:submit`.
- Remove the `forge.review_footer` config knob, the `REVIEW_FOOTER` constant, and the `body_summary_label` branch that reported "footer only" when there was nothing else in the body.

## Test plan

- [x] `cargo test` (715 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt`
- [ ] Manual: `:submit` against a PR and confirm the GitHub review body no longer ends with the tuicr footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)