### PR TITLE
fix split diff gutter sizing in 10k+ line files

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -123,13 +123,40 @@ pub enum ExpandDirection {
     Both,
 }
 
-/// Unified diff gutter: 1 (cursor indicator) + 5 (line_num + space) + 2 (prefix + space).
-pub const UNIFIED_GUTTER: u16 = 8;
-/// Side-by-side leading width before Old content: indicator(1) + lineno(4) + space(1) + prefix(1).
-pub const SBS_LEFT_GUTTER: u16 = 7;
-/// Side-by-side fixed overhead (both gutters + " │ " divider). The two content
-/// panes share what's left of the inner width equally.
-pub const SBS_OVERHEAD: u16 = 16;
+/// Minimum line-number column width (covers files up to 9 999 lines).
+const MIN_LINENO_WIDTH: usize = 4;
+
+/// Number of characters needed to display `n` in decimal, minimum `MIN_LINENO_WIDTH`.
+pub fn lineno_width(max_lineno: u32) -> usize {
+    if max_lineno == 0 {
+        return MIN_LINENO_WIDTH;
+    }
+    let mut digits = 0;
+    let mut n = max_lineno;
+    while n > 0 {
+        digits += 1;
+        n /= 10;
+    }
+    digits.max(MIN_LINENO_WIDTH)
+}
+
+/// Unified diff gutter: indicator(1) + lineno(w) + space(1) + prefix(1) + space(1).
+pub fn unified_gutter(w: usize) -> u16 {
+    (w + 4) as u16
+}
+
+/// Side-by-side leading width before Old content: indicator(1) + lineno(w) + space(1) + prefix(1).
+pub fn sbs_left_gutter(w: usize) -> u16 {
+    (w + 3) as u16
+}
+
+/// Side-by-side fixed overhead (both gutters + " │ " divider).
+/// Left: indicator(1) + lineno(w) + space(1) + prefix(1)
+/// Right: lineno(w) + space(1) + prefix(1)
+/// Divider: 3
+pub fn sbs_overhead(w: usize) -> u16 {
+    (2 * w + 8) as u16
+}
 
 /// X-coords of one diff content pane. SBS has Old and New; Unified has one.
 #[derive(Debug, Clone, Copy)]
@@ -4158,26 +4185,46 @@ impl App {
         Ok(count)
     }
 
+    pub fn lineno_width(&self) -> usize {
+        let hunk_max = self
+            .diff_files
+            .iter()
+            .map(|f| f.max_lineno())
+            .max()
+            .unwrap_or(0);
+        let cache_max = self
+            .file_line_count_cache
+            .values()
+            .copied()
+            .max()
+            .unwrap_or(0);
+        lineno_width(hunk_max.max(cache_max))
+    }
+
     pub fn pane_geometry(&self, inner: ratatui::layout::Rect, side: LineSide) -> PaneGeom {
+        let w = self.lineno_width();
         match self.diff_view_mode {
             DiffViewMode::Unified => {
-                let content_width = (inner.width as usize).saturating_sub(UNIFIED_GUTTER as usize);
+                let gutter = unified_gutter(w);
+                let content_width = (inner.width as usize).saturating_sub(gutter as usize);
                 PaneGeom {
-                    content_x_start: inner.x + UNIFIED_GUTTER,
+                    content_x_start: inner.x + gutter,
                     content_x_end: inner.x + inner.width,
                     content_width,
                 }
             }
             DiffViewMode::SideBySide => {
-                let half_w = (inner.width.saturating_sub(SBS_OVERHEAD) / 2) as usize;
+                let overhead = sbs_overhead(w);
+                let left_gutter = sbs_left_gutter(w);
+                let half_w = (inner.width.saturating_sub(overhead) / 2) as usize;
                 match side {
                     LineSide::Old => PaneGeom {
-                        content_x_start: inner.x + SBS_LEFT_GUTTER,
-                        content_x_end: inner.x + SBS_LEFT_GUTTER + half_w as u16,
+                        content_x_start: inner.x + left_gutter,
+                        content_x_end: inner.x + left_gutter + half_w as u16,
                         content_width: half_w,
                     },
                     LineSide::New => {
-                        let start = inner.x + SBS_OVERHEAD + half_w as u16;
+                        let start = inner.x + overhead + half_w as u16;
                         PaneGeom {
                             content_x_start: start,
                             content_x_end: start + half_w as u16,
@@ -4195,11 +4242,12 @@ impl App {
         x: u16,
         ann_default: LineSide,
     ) -> LineSide {
+        let w = self.lineno_width();
         match self.diff_view_mode {
             DiffViewMode::Unified => ann_default,
             DiffViewMode::SideBySide => {
-                let half_w = inner.width.saturating_sub(SBS_OVERHEAD) / 2;
-                let divider = inner.x + SBS_LEFT_GUTTER + half_w;
+                let half_w = inner.width.saturating_sub(sbs_overhead(w)) / 2;
+                let divider = inner.x + sbs_left_gutter(w) + half_w;
                 if x < divider {
                     LineSide::Old
                 } else {

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -91,6 +91,17 @@ impl DiffFile {
         hasher.finish()
     }
 
+    /// Highest line number reachable from hunk headers (old or new side).
+    /// Used to size the gutter; expanded context beyond hunks is covered
+    /// separately via `file_line_count_cache`.
+    pub fn max_lineno(&self) -> u32 {
+        self.hunks
+            .iter()
+            .map(|h| (h.old_start + h.old_count).max(h.new_start + h.new_count))
+            .max()
+            .unwrap_or(0)
+    }
+
     pub fn display_path(&self) -> &PathBuf {
         self.new_path
             .as_ref()

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -34,6 +34,7 @@ struct SideBySideContext<'a> {
     content_width: usize,
     panel_width: usize,
     current_line_idx: usize,
+    lineno_width: usize,
     // Comment input state for inline editing
     comment_input_mode: bool,
     comment_line: Option<(u32, LineSide)>,
@@ -71,8 +72,8 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     // Reset comment input annotation offset (will be set if a comment input box is rendered)
     app.comment_input_annotation_offset = None;
 
-    // Layout: indicator(1) + linenum(4) + space(1) + prefix(1) + content + " │ "(3) + linenum(4) + space(1) + prefix(1) + content
-    let available_width = inner.width.saturating_sub(crate::app::SBS_OVERHEAD) as usize;
+    let lw = app.lineno_width();
+    let available_width = inner.width.saturating_sub(crate::app::sbs_overhead(lw)) as usize;
     let content_width = available_width / 2;
 
     // Determine if we're in line comment mode (not file-level)
@@ -86,6 +87,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         content_width,
         panel_width: inner.width as usize,
         current_line_idx: app.diff_state.cursor_line,
+        lineno_width: lw,
         comment_input_mode,
         comment_line: app.comment_line,
         comment_type: app.comment_type.clone(),
@@ -391,6 +393,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                                 expanded_line,
                                 ctx.content_width,
                                 &app.theme,
+                                lw,
                             );
                         }
                     }
@@ -461,6 +464,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                                 expanded_line,
                                 ctx.content_width,
                                 &app.theme,
+                                lw,
                             );
                         }
                     }
@@ -534,6 +538,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                             expanded_line,
                             ctx.content_width,
                             &app.theme,
+                            lw,
                         );
                     }
                 }
@@ -569,6 +574,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                             expanded_line,
                             ctx.content_width,
                             &app.theme,
+                            lw,
                         );
                     }
                 }
@@ -752,16 +758,17 @@ fn render_sbs_expanded_context_line(
     expanded_line: &crate::model::DiffLine,
     content_width: usize,
     theme: &Theme,
+    lw: usize,
 ) {
     let indicator = cursor_indicator(*line_idx, current_line_idx);
     let old_line_num = expanded_line
         .old_lineno
-        .map(|n| format!("{n:>4} "))
-        .unwrap_or_else(|| "     ".to_string());
+        .map(|n| format!("{n:>lw$} "))
+        .unwrap_or_else(|| " ".repeat(lw + 1));
     let new_line_num = expanded_line
         .new_lineno
-        .map(|n| format!("{n:>4} "))
-        .unwrap_or_else(|| "     ".to_string());
+        .map(|n| format!("{n:>lw$} "))
+        .unwrap_or_else(|| " ".repeat(lw + 1));
     let line_spans = vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
         Span::styled(old_line_num, styles::expanded_context_style(theme)),
@@ -861,14 +868,15 @@ fn render_context_line_side_by_side(
     mut line_idx: usize,
     lines: &mut Vec<Line>,
 ) -> (usize, Option<SideBySideCursorInfo>) {
+    let w = ctx.lineno_width;
     let old_line_num = diff_line
         .old_lineno
-        .map(|n| format!("{n:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
+        .map(|n| format!("{n:>w$}"))
+        .unwrap_or_else(|| " ".repeat(w));
     let new_line_num = diff_line
         .new_lineno
-        .map(|n| format!("{n:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
+        .map(|n| format!("{n:>w$}"))
+        .unwrap_or_else(|| " ".repeat(w));
 
     let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
 
@@ -988,9 +996,15 @@ fn render_deletion_addition_pair_side_by_side(
         // Left side (deletion)
         if offset < del_count {
             let del_line = &hunk_lines[start_idx + offset];
-            add_deletion_spans(ctx.theme, &mut spans, del_line, ctx.content_width);
+            add_deletion_spans(
+                ctx.theme,
+                &mut spans,
+                del_line,
+                ctx.content_width,
+                ctx.lineno_width,
+            );
         } else {
-            add_empty_column_spans(&mut spans, ctx.content_width);
+            add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
         }
 
         spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
@@ -998,9 +1012,15 @@ fn render_deletion_addition_pair_side_by_side(
         // Right side (addition)
         if offset < add_count {
             let add_line = &hunk_lines[add_start + offset];
-            add_addition_spans(ctx.theme, &mut spans, add_line, ctx.content_width);
+            add_addition_spans(
+                ctx.theme,
+                &mut spans,
+                add_line,
+                ctx.content_width,
+                ctx.lineno_width,
+            );
         } else {
-            add_empty_column_spans(&mut spans, ctx.content_width);
+            add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
         }
 
         lines.push(Line::from(spans));
@@ -1086,9 +1106,15 @@ fn render_standalone_addition_side_by_side(
         indicator,
         styles::current_line_indicator_style(ctx.theme),
     )];
-    add_empty_column_spans(&mut spans, ctx.content_width);
+    add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
     spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
-    add_addition_spans(ctx.theme, &mut spans, diff_line, ctx.content_width);
+    add_addition_spans(
+        ctx.theme,
+        &mut spans,
+        diff_line,
+        ctx.content_width,
+        ctx.lineno_width,
+    );
 
     lines.push(Line::from(spans));
     line_idx += 1;
@@ -1128,11 +1154,12 @@ fn add_deletion_spans(
     spans: &mut Vec<Span>,
     diff_line: &crate::model::DiffLine,
     content_width: usize,
+    lw: usize,
 ) {
     let line_num = diff_line
         .old_lineno
-        .map(|n| format!("{n:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
+        .map(|n| format!("{n:>lw$}"))
+        .unwrap_or_else(|| " ".repeat(lw));
 
     spans.push(Span::styled(
         format!("{line_num} "),
@@ -1158,11 +1185,12 @@ fn add_addition_spans(
     spans: &mut Vec<Span>,
     diff_line: &crate::model::DiffLine,
     content_width: usize,
+    lw: usize,
 ) {
     let line_num = diff_line
         .new_lineno
-        .map(|n| format!("{n:>4}"))
-        .unwrap_or_else(|| "    ".to_string());
+        .map(|n| format!("{n:>lw$}"))
+        .unwrap_or_else(|| " ".repeat(lw));
 
     spans.push(Span::styled(
         format!("{line_num} "),
@@ -1183,10 +1211,10 @@ fn add_addition_spans(
 }
 
 /// Add empty column spans (for when one side has no content)
-fn add_empty_column_spans(spans: &mut Vec<Span>, content_width: usize) {
-    // line_num(4) + space(1) + prefix(1) + content
+fn add_empty_column_spans(spans: &mut Vec<Span>, content_width: usize, lw: usize) {
+    // line_num(lw) + space(1) + prefix(1) + content
     spans.push(Span::styled(
-        " ".repeat(5 + 1 + content_width),
+        " ".repeat(lw + 1 + 1 + content_width),
         Style::default(),
     ));
 }

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -47,6 +47,8 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     // Reset comment input annotation offset (will be set if a comment input box is rendered)
     app.comment_input_annotation_offset = None;
 
+    let lw = app.lineno_width();
+
     // Build all diff lines for infinite scroll
     // Track line index to mark the current line (cursor position)
     let mut lines: Vec<Line> = Vec::new();
@@ -355,6 +357,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                 current_line_idx,
                                 expanded_line,
                                 &app.theme,
+                                lw,
                             );
                         }
                     }
@@ -424,6 +427,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                 current_line_idx,
                                 expanded_line,
                                 &app.theme,
+                                lw,
                             );
                         }
                     }
@@ -450,20 +454,21 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
                     let style = base_style;
 
+                    let blank = " ".repeat(lw + 1);
                     let line_num_str = match diff_line.origin {
                         LineOrigin::Addition => diff_line
                             .new_lineno
-                            .map(|n| format!("{n:>4} "))
-                            .unwrap_or_else(|| "     ".to_string()),
+                            .map(|n| format!("{n:>lw$} "))
+                            .unwrap_or_else(|| blank.clone()),
                         LineOrigin::Deletion => diff_line
                             .old_lineno
-                            .map(|n| format!("{n:>4} "))
-                            .unwrap_or_else(|| "     ".to_string()),
+                            .map(|n| format!("{n:>lw$} "))
+                            .unwrap_or_else(|| blank.clone()),
                         _ => diff_line
                             .new_lineno
                             .or(diff_line.old_lineno)
-                            .map(|n| format!("{n:>4} "))
-                            .unwrap_or_else(|| "     ".to_string()),
+                            .map(|n| format!("{n:>lw$} "))
+                            .unwrap_or_else(|| blank),
                     };
 
                     let indicator = cursor_indicator(line_idx, current_line_idx);
@@ -870,6 +875,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                             current_line_idx,
                             expanded_line,
                             &app.theme,
+                            lw,
                         );
                     }
                 }
@@ -904,6 +910,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                             current_line_idx,
                             expanded_line,
                             &app.theme,
+                            lw,
                         );
                     }
                 }
@@ -1173,12 +1180,13 @@ fn render_expanded_context_line(
     current_line_idx: usize,
     expanded_line: &crate::model::DiffLine,
     theme: &Theme,
+    lw: usize,
 ) {
     let indicator = cursor_indicator(*line_idx, current_line_idx);
     let line_num = expanded_line
         .new_lineno
-        .map(|n| format!("{n:>4} "))
-        .unwrap_or_else(|| "     ".to_string());
+        .map(|n| format!("{n:>lw$} "))
+        .unwrap_or_else(|| " ".repeat(lw + 1));
     let line_spans = vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
         Span::styled(line_num, styles::expanded_context_style(theme)),


### PR DESCRIPTION
As `app.rs` has grown, it now exceeds 10k lines. This can break down rendering in the git diff if you have changed content with a line number exceeding 4 digits.
This issue did not seem to be present in the unified view, but I did not debug the differences.

before:
<img width="2409" height="1424" alt="Screenshot 2026-05-19 at 1 07 37 PM" src="https://github.com/user-attachments/assets/c5e1ef0c-85cc-484e-b12f-7a9b7558955c" />

after:
<img width="2412" height="1431" alt="Screenshot 2026-05-19 at 1 08 29 PM" src="https://github.com/user-attachments/assets/3d8a1dc2-ffeb-430d-8868-d45e22dd1815" />
