### PR TITLE
feat: deterministic slug-addressed sessions for agent discovery

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1658,6 +1658,16 @@ impl App {
         Ok(app)
     }
 
+    /// Slug for the currently active session, derived from the session's
+    /// embedded fields. Returns `None` if derivation fails (e.g., a local
+    /// session pointing at a non-existent path). The slug is cheap to derive
+    /// from PR sessions (no I/O) and a few stat calls for local sessions.
+    pub fn session_slug(&self) -> Option<String> {
+        crate::persistence::storage::slug_for_session(&self.session)
+            .ok()
+            .map(|s| s.to_string())
+    }
+
     /// Detect a GitHub forge repository from the local checkout, if any.
     /// Lazily called during startup — running this synchronously is fine
     /// because it only reads local config, never the network.

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -7,7 +7,7 @@ use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::submit::SubmitEvent;
 use crate::model::{DiffLine, FileStatus};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ForgeKind {
     GitHub,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -177,6 +177,7 @@ fn handle_left_click(app: &mut App, pos: Position) {
 /// Export review: either to clipboard or set pending stdout output based on app.output_to_stdout.
 /// When output_to_stdout is true, stores the content and sets should_quit.
 fn handle_export(app: &mut App) {
+    let slug = app.session_slug();
     if app.output_to_stdout {
         match generate_export_content(
             &app.session,
@@ -184,6 +185,7 @@ fn handle_export(app: &mut App) {
             &app.comment_types,
             app.export_legend,
             &app.forge_review_threads,
+            slug.as_deref(),
         ) {
             Ok(content) => {
                 app.pending_stdout_output = Some(content);
@@ -198,6 +200,7 @@ fn handle_export(app: &mut App) {
             &app.comment_types,
             app.export_legend,
             &app.forge_review_threads,
+            slug.as_deref(),
         ) {
             Ok(msg) => app.set_message(msg),
             Err(e) => app.set_warning(format!("{e}")),
@@ -632,6 +635,7 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
     match action {
         Action::ConfirmYes => {
             if let Some(app::ConfirmAction::CopyAndQuit) = app.pending_confirm {
+                let slug = app.session_slug();
                 if app.output_to_stdout {
                     match generate_export_content(
                         &app.session,
@@ -639,6 +643,7 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
                         &app.comment_types,
                         app.export_legend,
                         &app.forge_review_threads,
+                        slug.as_deref(),
                     ) {
                         Ok(content) => app.pending_stdout_output = Some(content),
                         Err(e) => app.set_warning(format!("{e}")),
@@ -650,6 +655,7 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
                         &app.comment_types,
                         app.export_legend,
                         &app.forge_review_threads,
+                        slug.as_deref(),
                     ) {
                         Ok(msg) => app.set_message(msg),
                         Err(e) => app.set_warning(format!("{e}")),

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod output;
 mod persistence;
 mod process;
 mod profile;
+mod slug;
 mod syntax;
 mod text_edit;
 mod theme;
@@ -243,6 +244,14 @@ fn main() -> anyhow::Result<()> {
             std::process::exit(1);
         }
     };
+
+    // Announce the slug for the active session so agents and wrapper scripts
+    // can discover it without parsing the markdown export. This is emitted to
+    // stderr before the alt-screen swap so the line stays on the user's
+    // scrollback after tuicr exits.
+    if let Some(slug) = app.session_slug() {
+        eprintln!("tuicr-session: {slug}");
+    }
 
     // Setup terminal
     // When --stdout is used, render TUI to /dev/tty so stdout is free for export output

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -23,6 +23,7 @@ pub fn generate_export_content(
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
     remote_threads: &[RemoteReviewThread],
+    session_slug: Option<&str>,
 ) -> Result<String> {
     // In PR mode it's still useful to export PR identity + remote
     // discussions even if the user has no local drafts. Outside PR mode
@@ -38,6 +39,7 @@ pub fn generate_export_content(
         comment_types,
         show_legend,
         remote_threads,
+        session_slug,
     ))
 }
 
@@ -47,6 +49,7 @@ pub fn export_to_clipboard(
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
     remote_threads: &[RemoteReviewThread],
+    session_slug: Option<&str>,
 ) -> Result<String> {
     let content = generate_export_content(
         session,
@@ -54,6 +57,7 @@ pub fn export_to_clipboard(
         comment_types,
         show_legend,
         remote_threads,
+        session_slug,
     )?;
     let via_terminal = copy_text_to_clipboard(&content)?;
     Ok(if via_terminal {
@@ -172,8 +176,14 @@ fn generate_markdown(
     comment_types: &[CommentTypeDefinition],
     show_legend: bool,
     remote_threads: &[RemoteReviewThread],
+    session_slug: Option<&str>,
 ) -> String {
     let mut md = String::new();
+
+    if let Some(slug) = session_slug {
+        let _ = writeln!(md, "## Session: {slug}");
+        let _ = writeln!(md);
+    }
 
     // Intro for agents
     let _ = writeln!(
@@ -513,13 +523,43 @@ mod tests {
     }
 
     #[test]
+    fn should_include_session_slug_header_when_provided() {
+        let session = create_test_session();
+        let diff_source = DiffSource::WorkingTree;
+
+        let markdown = generate_markdown(
+            &session,
+            &diff_source,
+            &comment_types(),
+            true,
+            &[],
+            Some("agavra/tuicr@main/worktree"),
+        );
+
+        assert!(
+            markdown.contains("## Session: agavra/tuicr@main/worktree"),
+            "expected slug header in:\n{markdown}"
+        );
+    }
+
+    #[test]
+    fn should_omit_session_slug_header_when_absent() {
+        let session = create_test_session();
+        let diff_source = DiffSource::WorkingTree;
+
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
+
+        assert!(!markdown.contains("## Session:"));
+    }
+
+    #[test]
     fn should_generate_valid_markdown() {
         // given
         let session = create_test_session();
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("I reviewed your code and have the following comments"));
@@ -560,8 +600,14 @@ mod tests {
             color: None,
         }];
 
-        let markdown =
-            generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true, &[]);
+        let markdown = generate_markdown(
+            &session,
+            &DiffSource::WorkingTree,
+            &custom_types,
+            true,
+            &[],
+            None,
+        );
 
         assert!(markdown.contains("Comment types: QUESTION (ask for clarification)"));
         assert!(markdown.contains("**[QUESTION]**"));
@@ -574,7 +620,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         // Should have 2 numbered comments
@@ -597,6 +643,7 @@ mod tests {
             &comment_types(),
             true,
             &[],
+            None,
         );
 
         assert!(markdown
@@ -618,6 +665,7 @@ mod tests {
             &comment_types(),
             true,
             &[],
+            None,
         );
 
         assert!(markdown.contains(
@@ -637,7 +685,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = export_to_clipboard(&session, &diff_source, &comment_types(), true, &[]);
+        let result = export_to_clipboard(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(result.is_err());
@@ -651,7 +699,8 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = generate_export_content(&session, &diff_source, &comment_types(), true, &[]);
+        let result =
+            generate_export_content(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(result.is_ok());
@@ -673,7 +722,8 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let result = generate_export_content(&session, &diff_source, &comment_types(), true, &[]);
+        let result =
+            generate_export_content(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(result.is_err());
@@ -690,7 +740,7 @@ mod tests {
         ]);
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("Reviewing commits: abc1234, def4567"));
@@ -703,7 +753,7 @@ mod tests {
         let diff_source = DiffSource::CommitRange(vec!["abc1234567890".to_string()]);
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("Reviewing commit: abc1234"));
@@ -764,7 +814,7 @@ mod tests {
         // given - simulate what would be copied during export
         let session = create_test_session();
         let diff_source = DiffSource::WorkingTree;
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
         let mut buffer: Vec<u8> = Vec::new();
 
         // when
@@ -806,7 +856,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("`src/main.rs:42`"));
@@ -839,7 +889,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("`src/main.rs:10-15`"));
@@ -872,7 +922,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("`src/main.rs:~20-~25`"));
@@ -904,7 +954,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("`src/main.rs:~30`"));
@@ -936,7 +986,7 @@ mod tests {
         let diff_source = DiffSource::WorkingTree;
 
         // when
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
 
         // then
         assert!(markdown.contains("`src/main.rs:50`"));
@@ -947,7 +997,8 @@ mod tests {
         let session = create_test_session();
         let diff_source = DiffSource::WorkingTree;
 
-        let markdown = generate_markdown(&session, &diff_source, &comment_types(), false, &[]);
+        let markdown =
+            generate_markdown(&session, &diff_source, &comment_types(), false, &[], None);
 
         assert!(!markdown.contains("Comment types:"));
         assert!(markdown.contains("[SUGGESTION]"));
@@ -977,6 +1028,7 @@ mod tests {
             &comment_types(),
             true,
             &[],
+            None,
         );
 
         assert!(markdown.contains("Comment types: PRAISE (positive feedback)"));
@@ -1064,6 +1116,7 @@ mod tests {
             &comment_types(),
             true,
             &threads,
+            None,
         );
 
         // then
@@ -1098,6 +1151,7 @@ mod tests {
             &comment_types(),
             true,
             &threads,
+            None,
         );
 
         // then — export succeeds even with no local comments
@@ -1131,6 +1185,7 @@ mod tests {
             &comment_types(),
             true,
             &threads,
+            None,
         );
 
         // then — the section is omitted in non-PR modes
@@ -1169,8 +1224,14 @@ mod tests {
             },
         ];
 
-        let markdown =
-            generate_markdown(&session, &DiffSource::WorkingTree, &custom_types, true, &[]);
+        let markdown = generate_markdown(
+            &session,
+            &DiffSource::WorkingTree,
+            &custom_types,
+            true,
+            &[],
+            None,
+        );
 
         assert!(markdown.contains("Comment types: QUESTION (ask for clarification)"));
         assert!(!markdown.contains("ISSUE"));

--- a/src/persistence/manifest.rs
+++ b/src/persistence/manifest.rs
@@ -1,0 +1,591 @@
+//! Manifest of saved review sessions.
+//!
+//! The manifest is the source of truth for slug -> session-file lookups. It
+//! lives at `<reviews_dir>/index.json` and carries enough denormalized
+//! metadata to drive `session list` without opening every session JSON. Each
+//! session file remains self-describing, so the manifest can always be
+//! rebuilt by walking the reviews directory.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Result, TuicrError};
+use crate::model::ReviewSession;
+use crate::model::review::SessionDiffSource;
+
+pub const MANIFEST_FILENAME: &str = "index.json";
+const MANIFEST_VERSION: &str = "1.0";
+
+/// A slug may map to more than one [`ManifestEntry`] when two local checkouts
+/// of the same repo are both under review (same slug, different canonical
+/// paths). PR slugs always have at most one entry — the current head's
+/// session. Lookups disambiguate by canonical path (local) or kind (PR).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Manifest {
+    pub version: String,
+    pub entries: HashMap<String, Vec<ManifestEntry>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestEntry {
+    /// Path to the session JSON, relative to the reviews directory.
+    pub path: PathBuf,
+    pub kind: ManifestKind,
+    pub updated_at: DateTime<Utc>,
+    /// Canonical path of the local checkout this session belongs to. `None`
+    /// for PR sessions. Lets `session list` disambiguate two checkouts of
+    /// the same repo when their slugs collide.
+    #[serde(default)]
+    pub canonical_repo_path: Option<PathBuf>,
+    pub display: DisplayMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ManifestKind {
+    Local,
+    Pr { number: u64, head_sha: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct DisplayMetadata {
+    pub comment_count: usize,
+    pub reviewed_count: usize,
+    pub file_count: usize,
+    /// Slug anchor segment as it appears in the slug (branch name or short
+    /// SHA). Cached so listings don't need to re-parse the slug.
+    pub anchor: String,
+}
+
+impl Manifest {
+    pub fn new() -> Self {
+        Self {
+            version: MANIFEST_VERSION.to_string(),
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Find the local entry for `slug` that matches `canonical_repo_path`.
+    pub fn get_local(&self, slug: &str, canonical_repo_path: &Path) -> Option<&ManifestEntry> {
+        self.entries.get(slug)?.iter().find(|e| {
+            matches!(e.kind, ManifestKind::Local)
+                && e.canonical_repo_path.as_deref() == Some(canonical_repo_path)
+        })
+    }
+
+    /// Find the PR entry for `slug` (PR entries are singletons per slug).
+    pub fn get_pr(&self, slug: &str) -> Option<&ManifestEntry> {
+        self.entries
+            .get(slug)?
+            .iter()
+            .find(|e| matches!(e.kind, ManifestKind::Pr { .. }))
+    }
+
+    /// Insert or replace an entry. For local entries the matching key is
+    /// `(slug, canonical_repo_path)`; for PR entries the slug alone suffices
+    /// because each PR slug holds at most one entry.
+    pub fn upsert(&mut self, slug: String, entry: ManifestEntry) {
+        let bucket = self.entries.entry(slug).or_default();
+        let idx = bucket
+            .iter()
+            .position(|existing| match (&existing.kind, &entry.kind) {
+                (ManifestKind::Pr { .. }, ManifestKind::Pr { .. }) => true,
+                (ManifestKind::Local, ManifestKind::Local) => {
+                    existing.canonical_repo_path == entry.canonical_repo_path
+                }
+                _ => false,
+            });
+        match idx {
+            Some(i) => bucket[i] = entry,
+            None => bucket.push(entry),
+        }
+    }
+
+    /// Remove all entries for `slug`. Returns the removed entries (empty if
+    /// no slug match).
+    pub fn remove_all(&mut self, slug: &str) -> Vec<ManifestEntry> {
+        self.entries.remove(slug).unwrap_or_default()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &ManifestEntry)> {
+        self.entries
+            .iter()
+            .flat_map(|(slug, bucket)| bucket.iter().map(move |e| (slug, e)))
+    }
+
+    /// Total entry count across all slugs (a slug with two local entries
+    /// counts twice).
+    pub fn len(&self) -> usize {
+        self.entries.values().map(|v| v.len()).sum()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.values().all(|v| v.is_empty())
+    }
+}
+
+/// Load the manifest from `<reviews_dir>/index.json`. Returns an empty
+/// manifest if the file does not exist; returns a corruption error when the
+/// file exists but cannot be parsed (callers may choose to recover by
+/// rebuilding from session files).
+pub fn load_manifest(reviews_dir: &Path) -> Result<Manifest> {
+    let path = reviews_dir.join(MANIFEST_FILENAME);
+    match fs::read_to_string(&path) {
+        Ok(contents) => serde_json::from_str(&contents)
+            .map_err(|e| TuicrError::CorruptedSession(format!("manifest parse error: {e}"))),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Manifest::new()),
+        Err(e) => Err(TuicrError::Io(e)),
+    }
+}
+
+/// Save the manifest atomically: write to a sibling temp file, then rename.
+/// A concurrent reader sees either the old version or the new version, never
+/// a partial write.
+pub fn save_manifest(reviews_dir: &Path, manifest: &Manifest) -> Result<()> {
+    fs::create_dir_all(reviews_dir)?;
+    let final_path = reviews_dir.join(MANIFEST_FILENAME);
+    let tmp_path = reviews_dir.join(format!("{MANIFEST_FILENAME}.tmp"));
+
+    let json = serde_json::to_string_pretty(manifest)?;
+    {
+        let mut tmp = fs::File::create(&tmp_path)?;
+        tmp.write_all(json.as_bytes())?;
+        tmp.sync_all().ok();
+    }
+    fs::rename(&tmp_path, &final_path)?;
+    Ok(())
+}
+
+/// Build a manifest entry from a loaded session and the session file's path
+/// relative to the reviews directory. The caller is responsible for
+/// determining the slug (it is the manifest key) and for passing the correct
+/// relative path.
+pub fn entry_from_session(
+    session: &ReviewSession,
+    relative_path: PathBuf,
+    anchor: String,
+) -> ManifestEntry {
+    let kind = match session.pr_session_key.as_ref() {
+        Some(key) => ManifestKind::Pr {
+            number: key.number,
+            head_sha: key.head_sha.clone(),
+        },
+        None => ManifestKind::Local,
+    };
+
+    let canonical_repo_path = if matches!(kind, ManifestKind::Local) {
+        fs::canonicalize(&session.repo_path)
+            .ok()
+            .or_else(|| Some(session.repo_path.clone()))
+    } else {
+        None
+    };
+
+    let comment_count = session.review_comments.len()
+        + session
+            .files
+            .values()
+            .map(|f| f.comment_count())
+            .sum::<usize>();
+    let reviewed_count = session.reviewed_count();
+    let file_count = session.files.len();
+
+    ManifestEntry {
+        path: relative_path,
+        kind,
+        updated_at: session.updated_at,
+        canonical_repo_path,
+        display: DisplayMetadata {
+            comment_count,
+            reviewed_count,
+            file_count,
+            anchor,
+        },
+    }
+}
+
+/// Walk every `.json` file under `reviews_dir` and invoke `extract` to build
+/// a `(slug, ManifestEntry)` pair. Returns the rebuilt manifest. Files that
+/// `extract` cannot map are skipped. Ignores the manifest file itself.
+pub fn rebuild_from_files<F>(reviews_dir: &Path, mut extract: F) -> Result<Manifest>
+where
+    F: FnMut(&Path) -> Option<(String, ManifestEntry)>,
+{
+    let mut manifest = Manifest::new();
+    if !reviews_dir.exists() {
+        return Ok(manifest);
+    }
+    walk_json(reviews_dir, &mut |path| {
+        if let Some((slug, entry)) = extract(path) {
+            manifest.upsert(slug, entry);
+        }
+    })?;
+    Ok(manifest)
+}
+
+fn walk_json(dir: &Path, visit: &mut impl FnMut(&Path)) -> Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            walk_json(&path, visit)?;
+            continue;
+        }
+        if !file_type.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == MANIFEST_FILENAME {
+            continue;
+        }
+        if !name.ends_with(".json") {
+            continue;
+        }
+        visit(&path);
+    }
+    Ok(())
+}
+
+/// Diff-source label used by the manifest's display metadata when no other
+/// label is available. Kept as a free function so callers can derive an
+/// anchor before constructing an entry.
+pub fn diff_source_label(diff_source: SessionDiffSource) -> &'static str {
+    match diff_source {
+        SessionDiffSource::WorkingTree => "worktree",
+        SessionDiffSource::Staged => "staged",
+        SessionDiffSource::Unstaged => "unstaged",
+        SessionDiffSource::StagedAndUnstaged => "staged-and-unstaged",
+        SessionDiffSource::CommitRange => "commits",
+        SessionDiffSource::WorkingTreeAndCommits => "worktree-and-commits",
+        SessionDiffSource::StagedUnstagedAndCommits => "staged-and-unstaged-and-commits",
+        SessionDiffSource::PullRequest => "pr",
+        SessionDiffSource::Pristine => "pristine",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::FileStatus;
+    use std::path::PathBuf;
+
+    fn entry(updated_at: DateTime<Utc>, anchor: &str) -> ManifestEntry {
+        ManifestEntry {
+            path: PathBuf::from("local/abcd/agavra/tuicr/main/worktree.json"),
+            kind: ManifestKind::Local,
+            updated_at,
+            canonical_repo_path: Some(PathBuf::from("/Users/agavra/dev/tuicr")),
+            display: DisplayMetadata {
+                comment_count: 3,
+                reviewed_count: 1,
+                file_count: 4,
+                anchor: anchor.to_string(),
+            },
+        }
+    }
+
+    fn pr_entry(updated_at: DateTime<Utc>, number: u64, head_sha: &str) -> ManifestEntry {
+        ManifestEntry {
+            path: PathBuf::from(format!("gh/agavra/tuicr/pr/{number}/{head_sha}.json")),
+            kind: ManifestKind::Pr {
+                number,
+                head_sha: head_sha.to_string(),
+            },
+            updated_at,
+            canonical_repo_path: None,
+            display: DisplayMetadata {
+                comment_count: 0,
+                reviewed_count: 0,
+                file_count: 0,
+                anchor: format!("pr/{number}"),
+            },
+        }
+    }
+
+    fn repo(name: &str) -> PathBuf {
+        PathBuf::from(format!("/Users/agavra/{name}"))
+    }
+
+    #[test]
+    fn should_start_empty() {
+        let manifest = Manifest::new();
+        assert!(manifest.is_empty());
+        assert_eq!(manifest.len(), 0);
+    }
+
+    #[test]
+    fn should_insert_and_retrieve_local_entry() {
+        let mut manifest = Manifest::new();
+        let mut e = entry(Utc::now(), "main");
+        e.canonical_repo_path = Some(repo("tuicr"));
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), e.clone());
+
+        assert_eq!(manifest.len(), 1);
+        assert_eq!(
+            manifest.get_local("agavra/tuicr@main/worktree", &repo("tuicr")),
+            Some(&e),
+        );
+        assert!(
+            manifest
+                .get_local("agavra/tuicr@main/worktree", &repo("other-checkout"))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn should_replace_local_entry_with_same_canonical_path() {
+        let mut manifest = Manifest::new();
+        let mut first = entry(Utc::now(), "main");
+        first.canonical_repo_path = Some(repo("tuicr"));
+        let mut second = first.clone();
+        second.display.comment_count = 99;
+
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), first);
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), second);
+
+        assert_eq!(manifest.len(), 1);
+        assert_eq!(
+            manifest
+                .get_local("agavra/tuicr@main/worktree", &repo("tuicr"))
+                .unwrap()
+                .display
+                .comment_count,
+            99,
+        );
+    }
+
+    #[test]
+    fn should_store_multiple_local_entries_for_same_slug_different_checkouts() {
+        let mut manifest = Manifest::new();
+        let mut work = entry(Utc::now(), "main");
+        work.canonical_repo_path = Some(repo("work/tuicr"));
+        let mut oss = entry(Utc::now(), "main");
+        oss.canonical_repo_path = Some(repo("oss/tuicr"));
+
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), work);
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), oss);
+
+        assert_eq!(manifest.len(), 2);
+        assert!(
+            manifest
+                .get_local("agavra/tuicr@main/worktree", &repo("work/tuicr"))
+                .is_some()
+        );
+        assert!(
+            manifest
+                .get_local("agavra/tuicr@main/worktree", &repo("oss/tuicr"))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn should_remove_all_entries_for_slug() {
+        let mut manifest = Manifest::new();
+        let mut a = entry(Utc::now(), "main");
+        a.canonical_repo_path = Some(repo("a"));
+        let mut b = entry(Utc::now(), "main");
+        b.canonical_repo_path = Some(repo("b"));
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), a);
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), b);
+
+        let removed = manifest.remove_all("agavra/tuicr@main/worktree");
+        assert_eq!(removed.len(), 2);
+        assert!(manifest.is_empty());
+    }
+
+    #[test]
+    fn should_replace_pr_entry_when_head_advances() {
+        let mut manifest = Manifest::new();
+        manifest.upsert(
+            "gh:agavra/tuicr/pr/125".to_string(),
+            pr_entry(Utc::now(), 125, "abc12345"),
+        );
+        manifest.upsert(
+            "gh:agavra/tuicr/pr/125".to_string(),
+            pr_entry(Utc::now(), 125, "def67890"),
+        );
+
+        assert_eq!(manifest.len(), 1);
+        let entry = manifest.get_pr("gh:agavra/tuicr/pr/125").unwrap();
+        match &entry.kind {
+            ManifestKind::Pr { head_sha, .. } => assert_eq!(head_sha, "def67890"),
+            _ => panic!("expected Pr"),
+        }
+    }
+
+    #[test]
+    fn should_return_empty_manifest_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = load_manifest(dir.path()).unwrap();
+        assert!(manifest.is_empty());
+    }
+
+    #[test]
+    fn should_roundtrip_manifest_through_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = Manifest::new();
+        let mut local = entry(Utc::now(), "main");
+        local.canonical_repo_path = Some(repo("tuicr"));
+        manifest.upsert("agavra/tuicr@main/worktree".to_string(), local.clone());
+        manifest.upsert(
+            "gh:agavra/tuicr/pr/125".to_string(),
+            pr_entry(Utc::now(), 125, "abc12345"),
+        );
+
+        save_manifest(dir.path(), &manifest).unwrap();
+        let loaded = load_manifest(dir.path()).unwrap();
+
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(
+            loaded.get_local("agavra/tuicr@main/worktree", &repo("tuicr")),
+            Some(&local),
+        );
+        assert!(loaded.get_pr("gh:agavra/tuicr/pr/125").is_some());
+    }
+
+    #[test]
+    fn should_overwrite_manifest_atomically() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut first = Manifest::new();
+        first.upsert("a".to_string(), entry(Utc::now(), "main"));
+        save_manifest(dir.path(), &first).unwrap();
+
+        let mut second = Manifest::new();
+        second.upsert("a".to_string(), entry(Utc::now(), "main"));
+        second.upsert("b".to_string(), entry(Utc::now(), "feature"));
+        save_manifest(dir.path(), &second).unwrap();
+
+        let loaded = load_manifest(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+
+        let tmp = dir.path().join(format!("{MANIFEST_FILENAME}.tmp"));
+        assert!(!tmp.exists(), "tmp file should be cleaned up after rename");
+    }
+
+    #[test]
+    fn should_surface_corrupted_manifest_as_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest_path = dir.path().join(MANIFEST_FILENAME);
+        fs::write(&manifest_path, "not json {").unwrap();
+
+        let err = load_manifest(dir.path()).unwrap_err();
+        assert!(matches!(err, TuicrError::CorruptedSession(_)));
+    }
+
+    #[test]
+    fn should_walk_only_json_files_excluding_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("local").join("abcd")).unwrap();
+        fs::write(root.join("local/abcd/a.json"), "{}").unwrap();
+        fs::write(root.join("local/abcd/b.txt"), "ignored").unwrap();
+        fs::write(root.join(MANIFEST_FILENAME), "{}").unwrap();
+
+        let mut visited: Vec<String> = Vec::new();
+        walk_json(root, &mut |path| {
+            visited.push(path.file_name().unwrap().to_string_lossy().to_string());
+        })
+        .unwrap();
+
+        assert_eq!(visited, vec!["a.json".to_string()]);
+    }
+
+    #[test]
+    fn should_rebuild_manifest_via_extractor() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("local").join("abcd")).unwrap();
+        fs::write(root.join("local/abcd/a.json"), "{}").unwrap();
+        fs::write(root.join("local/abcd/b.json"), "{}").unwrap();
+
+        let manifest = rebuild_from_files(root, |path| {
+            let name = path.file_stem()?.to_str()?.to_string();
+            let mut e = entry(Utc::now(), &name);
+            e.canonical_repo_path = Some(repo(&name));
+            Some((format!("repo@{name}/worktree"), e))
+        })
+        .unwrap();
+
+        assert_eq!(manifest.len(), 2);
+        assert!(manifest.get_local("repo@a/worktree", &repo("a")).is_some());
+        assert!(manifest.get_local("repo@b/worktree", &repo("b")).is_some());
+    }
+
+    #[test]
+    fn should_rebuild_empty_manifest_when_dir_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let nonexistent = dir.path().join("does-not-exist");
+        let manifest =
+            rebuild_from_files(&nonexistent, |_| panic!("should not be called")).unwrap();
+        assert!(manifest.is_empty());
+    }
+
+    // ---- entry_from_session ----
+
+    #[test]
+    fn should_extract_metadata_from_local_session() {
+        let mut session = ReviewSession::new(
+            PathBuf::from("/tmp/test-repo"),
+            "abc1234def".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::WorkingTree,
+        );
+        session.add_file(PathBuf::from("src/a.rs"), FileStatus::Modified, 0);
+        session.add_file(PathBuf::from("src/b.rs"), FileStatus::Modified, 0);
+        session
+            .get_file_mut(&PathBuf::from("src/a.rs"))
+            .unwrap()
+            .reviewed = true;
+
+        let relative = PathBuf::from("local/abcd/foo/bar/main/worktree.json");
+        let entry = entry_from_session(&session, relative.clone(), "main".to_string());
+
+        assert_eq!(entry.path, relative);
+        assert!(matches!(entry.kind, ManifestKind::Local));
+        assert_eq!(entry.updated_at, session.updated_at);
+        assert_eq!(entry.display.file_count, 2);
+        assert_eq!(entry.display.reviewed_count, 1);
+        assert_eq!(entry.display.comment_count, 0);
+        assert_eq!(entry.display.anchor, "main");
+    }
+
+    #[test]
+    fn should_extract_metadata_from_pr_session() {
+        use crate::forge::traits::{ForgeRepository, PrSessionKey};
+        let mut session = ReviewSession::new(
+            PathBuf::from("forge:github.com/agavra/tuicr"),
+            "abcdef0123456789".to_string(),
+            Some("reviews".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.pr_session_key = Some(PrSessionKey::new(
+            ForgeRepository::github("github.com", "agavra", "tuicr"),
+            125,
+            "abcdef0123456789".to_string(),
+        ));
+
+        let entry = entry_from_session(
+            &session,
+            PathBuf::from("gh/agavra/tuicr/pr/125/abcdef01.json"),
+            "pr/125".to_string(),
+        );
+
+        match &entry.kind {
+            ManifestKind::Pr { number, head_sha } => {
+                assert_eq!(*number, 125);
+                assert_eq!(head_sha, "abcdef0123456789");
+            }
+            _ => panic!("expected Pr kind, got {:?}", entry.kind),
+        }
+        assert_eq!(entry.canonical_repo_path, None);
+    }
+}

--- a/src/persistence/manifest.rs
+++ b/src/persistence/manifest.rs
@@ -20,7 +20,11 @@ use crate::model::ReviewSession;
 use crate::model::review::SessionDiffSource;
 
 pub const MANIFEST_FILENAME: &str = "index.json";
-const MANIFEST_VERSION: &str = "1.0";
+pub const MANIFEST_VERSION: &str = "2.0";
+/// Subdirectory inside `reviews/` where session JSON files live under the
+/// flat layout. The presence of this directory signals "current layout" to
+/// the migration check.
+pub const SESSIONS_DIRNAME: &str = "sessions";
 
 /// A slug may map to more than one [`ManifestEntry`] when two local checkouts
 /// of the same repo are both under review (same slug, different canonical

--- a/src/persistence/mod.rs
+++ b/src/persistence/mod.rs
@@ -1,3 +1,4 @@
+pub mod manifest;
 pub mod storage;
 
 pub use storage::{load_latest_session_for_context, load_pr_session, save_session};

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -1,248 +1,74 @@
-use directories::ProjectDirs;
+//! Slug-addressed storage layer for review sessions.
+//!
+//! Layout under `~/.local/share/tuicr/reviews/`:
+//!
+//! ```text
+//! reviews/
+//!   index.json                          # manifest, source of truth for lookups
+//!   local/<fp>/<owner>/<repo>/<ref>/<source>.json
+//!   local/<fp>/<repo>/<ref>/<source>.json        # no-owner fallback
+//!   gh/<owner>/<repo>/pr/<number>/<head_sha>.json
+//! ```
+//!
+//! Every save writes a session JSON file and updates the manifest. Every load
+//! is a manifest lookup keyed by the slug derived from the caller's context.
+//! Per-session JSON files are self-describing so the manifest can be rebuilt
+//! by walking the tree if it gets lost or corrupted.
+
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
+
+#[cfg(not(test))]
+use directories::ProjectDirs;
 
 use crate::error::{Result, TuicrError};
 use crate::forge::traits::PrSessionKey;
 use crate::hash::fnv1a_64;
 use crate::model::ReviewSession;
 use crate::model::review::SessionDiffSource;
+use crate::persistence::manifest::{self, MANIFEST_FILENAME, ManifestKind};
+use crate::slug::{self, LocalSlug, Slug, SlugAnchor, SlugSource};
 
-const SESSION_MAX_AGE_DAYS: u64 = 7;
-const SESSION_FILENAME_MIN_PARTS: usize = 6;
-const SESSION_FILENAME_SUFFIX_PARTS: usize = 4;
-const SESSION_FILENAME_DATE_LEN: usize = 8;
-const SESSION_FILENAME_TIME_LEN: usize = 6;
 const FINGERPRINT_HEX_LEN: usize = 8;
 
-struct SessionFilenameParts {
-    repo_fingerprints: Vec<String>,
-    diff_source: String,
-}
+// ---------- Public API ----------
 
-fn parse_session_filename(filename: &str) -> Option<SessionFilenameParts> {
-    // PR sessions use a different layout; never treat them as local session
-    // candidates here.
-    if filename.starts_with("pr_github_") {
-        return None;
-    }
-    let stem = filename.strip_suffix(".json")?;
-    let parts: Vec<&str> = stem.split('_').collect();
-
-    if parts.len() < SESSION_FILENAME_MIN_PARTS {
-        return None;
-    }
-
-    let diff_source_idx = parts.len().checked_sub(SESSION_FILENAME_SUFFIX_PARTS)?;
-    let date_idx = parts.len().checked_sub(SESSION_FILENAME_SUFFIX_PARTS - 1)?;
-    let time_idx = parts.len().checked_sub(SESSION_FILENAME_SUFFIX_PARTS - 2)?;
-    let diff_source = parts.get(diff_source_idx)?;
-    let date_part = parts.get(date_idx)?;
-    let time_part = parts.get(time_idx)?;
-
-    if !matches!(
-        *diff_source,
-        "worktree" | "commits" | "worktree_and_commits"
-    ) {
-        return None;
-    }
-
-    if !is_timestamp_part(date_part, SESSION_FILENAME_DATE_LEN)
-        || !is_timestamp_part(time_part, SESSION_FILENAME_TIME_LEN)
-    {
-        return None;
-    }
-
-    let mut fingerprints = Vec::new();
-    for part in &parts[..diff_source_idx] {
-        if is_hex_fingerprint(part) && !fingerprints.iter().any(|candidate| candidate == part) {
-            fingerprints.push((*part).to_string());
-        }
-    }
-
-    if fingerprints.is_empty() {
-        return None;
-    }
-
-    Some(SessionFilenameParts {
-        repo_fingerprints: fingerprints,
-        diff_source: diff_source.to_string(),
-    })
-}
-
-fn is_timestamp_part(part: &str, len: usize) -> bool {
-    part.len() == len && part.chars().all(|ch| ch.is_ascii_digit())
-}
-
-fn is_hex_fingerprint(part: &str) -> bool {
-    part.len() == FINGERPRINT_HEX_LEN && part.chars().all(|ch| ch.is_ascii_hexdigit())
-}
-
-fn get_reviews_dir() -> Result<PathBuf> {
-    #[cfg(test)]
-    if let Some(dir) = std::env::var_os("TUICR_REVIEWS_DIR") {
-        let path = PathBuf::from(dir);
-        fs::create_dir_all(&path)?;
-        return Ok(path);
-    }
-
-    let proj_dirs = ProjectDirs::from("", "", "tuicr").ok_or_else(|| {
-        TuicrError::Io(std::io::Error::other("Could not determine data directory"))
-    })?;
-
-    let data_dir = proj_dirs.data_dir().join("reviews");
-    fs::create_dir_all(&data_dir)?;
-    Ok(data_dir)
-}
-
-const MAX_FILENAME_COMPONENT_LEN: usize = 64;
-
-fn sanitize_filename_component(value: &str) -> String {
-    let mut sanitized = String::with_capacity(value.len().min(MAX_FILENAME_COMPONENT_LEN));
-    for ch in value.chars() {
-        if sanitized.len() >= MAX_FILENAME_COMPONENT_LEN {
-            break;
-        }
-        let ok = ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.');
-        sanitized.push(if ok { ch } else { '-' });
-    }
-
-    let sanitized = sanitized.trim_matches('-');
-    if sanitized.is_empty() {
-        "unknown".to_string()
-    } else {
-        sanitized.to_string()
-    }
-}
-
-fn repo_path_fingerprint(repo_path: &Path) -> String {
-    let normalized = normalize_repo_path(repo_path);
-    let hash = fnv1a_64(normalized.as_bytes());
-    let hex = format!("{hash:016x}");
-    hex[..FINGERPRINT_HEX_LEN].to_string()
-}
-
-fn normalize_repo_path(repo_path: &Path) -> String {
-    let canonical = fs::canonicalize(repo_path).unwrap_or_else(|_| repo_path.to_path_buf());
-    let normalized = canonical.to_string_lossy().to_string();
-
-    if cfg!(windows) {
-        normalized.to_lowercase()
-    } else {
-        normalized
-    }
-}
-
-fn session_filename(session: &ReviewSession) -> String {
-    // PR sessions key by forge identity + PR number + head SHA so multiple
-    // PR opens of the same repo land in distinct files, and reopening the
-    // same PR at the same head reuses the same session.
-    if let Some(key) = session.pr_session_key.as_ref() {
-        let host = sanitize_filename_component(&key.repository.host);
-        let owner = sanitize_filename_component(&key.repository.owner);
-        let repo = sanitize_filename_component(&key.repository.name);
-        let short = sanitize_filename_component(&key.short_head());
-        let id_fragment = session.id.split('-').next().unwrap_or(&session.id);
-        return format!(
-            "pr_github_{}_{}_{}_{}_{}_{}.json",
-            host, owner, repo, key.number, short, id_fragment,
-        );
-    }
-
-    let repo_name = session
-        .repo_path
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("unknown");
-
-    let repo_name = sanitize_filename_component(repo_name);
-    let repo_fingerprint = repo_path_fingerprint(&session.repo_path);
-
-    let branch = session.branch_name.as_deref().unwrap_or("detached");
-    let branch = sanitize_filename_component(branch);
-
-    let diff_source = match session.diff_source {
-        SessionDiffSource::WorkingTree => "worktree",
-        SessionDiffSource::Staged => "staged",
-        SessionDiffSource::Unstaged => "unstaged",
-        SessionDiffSource::StagedAndUnstaged => "staged_and_unstaged",
-        SessionDiffSource::CommitRange => "commits",
-        SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
-        SessionDiffSource::StagedUnstagedAndCommits => "staged_unstaged_and_commits",
-        SessionDiffSource::PullRequest => "pr",
-        SessionDiffSource::Pristine => "pristine",
-    };
-
-    let timestamp = session.created_at.format("%Y%m%d_%H%M%S");
-    let id_fragment = session.id.split('-').next().unwrap_or(&session.id);
-
-    format!(
-        "{}_{}_{}_{}_{}_{}.json",
-        repo_name, repo_fingerprint, branch, diff_source, timestamp, id_fragment
-    )
-}
-
+/// Save a session to disk and update the manifest. The on-disk path is
+/// derived from the session's slug; the slug is computed from the session's
+/// fields at save time.
 pub fn save_session(session: &ReviewSession) -> Result<PathBuf> {
     let reviews_dir = get_reviews_dir()?;
-    let filename = session_filename(session);
-    let path = reviews_dir.join(&filename);
+    maybe_migrate(&reviews_dir)?;
 
-    let json = serde_json::to_string_pretty(session)?;
-    fs::write(&path, json)?;
+    let slug = slug_for_session(session)?;
+    let relative = relative_path_for_slug(&slug, session)?;
+    let full_path = reviews_dir.join(&relative);
 
-    Ok(path)
-}
-
-pub fn load_session(path: &PathBuf) -> Result<ReviewSession> {
-    let contents = fs::read_to_string(path)?;
-    let session: ReviewSession =
-        serde_json::from_str(&contents).map_err(|e| TuicrError::CorruptedSession(e.to_string()))?;
-    Ok(session)
-}
-
-/// Look up the most recent persisted session for a PR keyed by forge identity,
-/// PR number, and head SHA. Returns `None` when no matching session exists.
-///
-/// PR sessions key only by identity; we deliberately do not consult mtime or
-/// other filename fields because reopening the same PR at the same head must
-/// restore the exact session that was last persisted for it.
-pub fn load_pr_session(key: &PrSessionKey) -> Result<Option<(PathBuf, ReviewSession)>> {
-    let reviews_dir = get_reviews_dir()?;
-    let entries = match fs::read_dir(&reviews_dir) {
-        Ok(entries) => entries,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => return Err(TuicrError::Io(e)),
-    };
-
-    let mut best: Option<(PathBuf, ReviewSession)> = None;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let Some(filename) = path.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-        if !filename.starts_with("pr_github_") || !filename.ends_with(".json") {
-            continue;
-        }
-        let Ok(session) = load_session(&path) else {
-            continue;
-        };
-        if session.pr_session_key.as_ref() == Some(key) {
-            // Keep the most recently updated entry when more than one exists
-            // (e.g. multiple draft saves in flight before cleanup).
-            let candidate_updated = session.updated_at;
-            let prefer_new = match best.as_ref() {
-                Some((_, current)) => candidate_updated > current.updated_at,
-                None => true,
-            };
-            if prefer_new {
-                best = Some((path, session));
-            }
-        }
+    if let Some(parent) = full_path.parent() {
+        fs::create_dir_all(parent)?;
     }
-    Ok(best)
+    let json = serde_json::to_string_pretty(session)?;
+    fs::write(&full_path, json)?;
+
+    let mut manifest = manifest::load_manifest(&reviews_dir).unwrap_or_default();
+    let anchor = manifest_anchor_for(&slug);
+    let entry = manifest::entry_from_session(session, relative, anchor);
+    manifest.upsert(slug.to_string(), entry);
+    manifest::save_manifest(&reviews_dir, &manifest)?;
+
+    Ok(full_path)
 }
 
+/// Load a session JSON file from an absolute path.
+pub fn load_session(path: &Path) -> Result<ReviewSession> {
+    let contents = fs::read_to_string(path)?;
+    serde_json::from_str(&contents).map_err(|e| TuicrError::CorruptedSession(e.to_string()))
+}
+
+/// Look up the persisted local session that matches the requested context.
+/// Returns `None` if no matching slug is in the manifest, or if a manifest
+/// entry exists but belongs to a different canonical checkout (same slug,
+/// different path on disk).
 pub fn load_latest_session_for_context(
     repo_path: &Path,
     branch_name: Option<&str>,
@@ -250,786 +76,360 @@ pub fn load_latest_session_for_context(
     diff_source: SessionDiffSource,
     commit_range: Option<&[String]>,
 ) -> Result<Option<(PathBuf, ReviewSession)>> {
-    let current_repo_path = normalize_repo_path(repo_path);
-    let current_fingerprint = repo_path_fingerprint(repo_path);
-    let current_diff_source = match diff_source {
-        SessionDiffSource::WorkingTree => "worktree",
-        SessionDiffSource::Staged => "staged",
-        SessionDiffSource::Unstaged => "unstaged",
-        SessionDiffSource::StagedAndUnstaged => "staged_and_unstaged",
-        SessionDiffSource::CommitRange => "commits",
-        SessionDiffSource::WorkingTreeAndCommits => "worktree_and_commits",
-        SessionDiffSource::StagedUnstagedAndCommits => "staged_unstaged_and_commits",
-        SessionDiffSource::Pristine => "pristine",
-        // PR sessions are looked up via `load_pr_session`. If a caller asks
-        // for the local-session loader with this diff source, return nothing.
-        SessionDiffSource::PullRequest => return Ok(None),
-    };
-
-    let reviews_dir = get_reviews_dir()?;
-    let now = SystemTime::now();
-    let max_age = Duration::from_secs(SESSION_MAX_AGE_DAYS * 24 * 60 * 60);
-
-    let mut session_files: Vec<_> = fs::read_dir(&reviews_dir)?
-        .filter_map(|entry| entry.ok())
-        .filter(|entry| {
-            let path = entry.path();
-
-            if !path
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("json"))
-            {
-                return false;
-            }
-
-            // Delete sessions older than 7 days
-            if let Ok(metadata) = entry.metadata()
-                && let Ok(modified) = metadata.modified()
-                && let Ok(age) = now.duration_since(modified)
-                && age > max_age
-            {
-                let _ = fs::remove_file(&path);
-                return false;
-            }
-
-            let Some(filename) = path.file_name().and_then(|f| f.to_str()) else {
-                return false;
-            };
-
-            let Some(parts) = parse_session_filename(filename) else {
-                return true;
-            };
-
-            if !parts
-                .repo_fingerprints
-                .iter()
-                .any(|fingerprint| fingerprint == &current_fingerprint)
-            {
-                return false;
-            }
-
-            if parts.diff_source != current_diff_source {
-                return false;
-            }
-
-            true
-        })
-        .collect();
-
-    session_files.sort_by(|a, b| {
-        let a_modified = a
-            .metadata()
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-        let b_modified = b
-            .metadata()
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .unwrap_or(SystemTime::UNIX_EPOCH);
-
-        b_modified
-            .cmp(&a_modified)
-            .then_with(|| a.file_name().cmp(&b.file_name()))
-    });
-
-    let mut legacy_candidate = None;
-
-    for entry in session_files {
-        let path = entry.path();
-        let Ok(session) = load_session(&path) else {
-            continue;
-        };
-
-        if normalize_repo_path(&session.repo_path) != current_repo_path {
-            continue;
-        }
-
-        if session.diff_source != diff_source {
-            continue;
-        }
-
-        if matches!(
-            diff_source,
-            SessionDiffSource::CommitRange
-                | SessionDiffSource::WorkingTreeAndCommits
-                | SessionDiffSource::StagedUnstagedAndCommits
-        ) && let Some(expected_range) = commit_range
-            && session.commit_range.as_deref() != Some(expected_range)
-        {
-            continue;
-        }
-
-        let session_branch = session.branch_name.as_deref();
-        if session_branch == branch_name {
-            if branch_name.is_none() {
-                // Pristine sessions key on the path-list hash, not the HEAD
-                // sha, so an advancing HEAD after `git pull` still reloads
-                // the same comments. Other branch-less sessions fall back to
-                // exact head_commit comparison.
-                let exact_match = if matches!(diff_source, SessionDiffSource::Pristine) {
-                    pristine_keys_match(&session.base_commit, head_commit)
-                } else {
-                    session.base_commit == head_commit
-                };
-                if !exact_match {
-                    continue;
-                }
-            }
-
-            return Ok(Some((path, session)));
-        }
-
-        let eligible_legacy = branch_name.is_some()
-            && legacy_candidate.is_none()
-            && commit_range.is_none()
-            && session_branch.is_none()
-            && session.base_commit == head_commit;
-        if eligible_legacy {
-            legacy_candidate = Some((path, session));
-        }
+    // PR sessions are resolved via `load_pr_session`. Mirror the old behavior
+    // so callers that pass `PullRequest` here get `None` rather than an error.
+    if matches!(diff_source, SessionDiffSource::PullRequest) {
+        return Ok(None);
     }
 
-    Ok(legacy_candidate)
+    let reviews_dir = get_reviews_dir()?;
+    maybe_migrate(&reviews_dir)?;
+
+    let owner_repo = slug::resolve_owner_repo(repo_path)
+        .map_err(|e| TuicrError::CorruptedSession(format!("slug derive: {e}")))?;
+    let local = slug::build_local_slug(
+        owner_repo,
+        branch_name,
+        head_commit,
+        diff_source,
+        commit_range,
+    )
+    .map_err(|e| TuicrError::CorruptedSession(format!("slug build: {e}")))?;
+    let slug = Slug::Local(local);
+
+    let manifest = manifest::load_manifest(&reviews_dir).unwrap_or_default();
+    let canonical = fs::canonicalize(repo_path).unwrap_or_else(|_| repo_path.to_path_buf());
+    let Some(entry) = manifest.get_local(&slug.to_string(), &canonical) else {
+        return Ok(None);
+    };
+
+    let full_path = reviews_dir.join(&entry.path);
+    let session = load_session(&full_path)?;
+    Ok(Some((full_path, session)))
 }
 
-/// Match two pristine session keys by their path-hash suffix.
-///
-/// Pristine `base_commit` values have the shape `"pristine:<head>:<hash>"`.
-/// Two sessions belong to the same review if they share the same path-list
-/// hash, regardless of HEAD; the prefix and trailing hash must both match.
-fn pristine_keys_match(a: &str, b: &str) -> bool {
-    let Some(a_hash) = pristine_key_hash(a) else {
-        return false;
+/// Look up the persisted PR session for a key. Returns `None` if no entry
+/// exists for the slug, or if the manifest's current head differs from the
+/// requested head (the old head's file may still be on disk but is not
+/// surfaced).
+pub fn load_pr_session(key: &PrSessionKey) -> Result<Option<(PathBuf, ReviewSession)>> {
+    let reviews_dir = get_reviews_dir()?;
+    maybe_migrate(&reviews_dir)?;
+
+    let slug: Slug = key.into();
+    let manifest = manifest::load_manifest(&reviews_dir).unwrap_or_default();
+    let Some(entry) = manifest.get_pr(&slug.to_string()) else {
+        return Ok(None);
     };
-    let Some(b_hash) = pristine_key_hash(b) else {
-        return false;
-    };
-    a_hash == b_hash
+
+    match &entry.kind {
+        ManifestKind::Pr { head_sha, .. } if head_sha == &key.head_sha => {
+            let full_path = reviews_dir.join(&entry.path);
+            let session = load_session(&full_path)?;
+            Ok(Some((full_path, session)))
+        }
+        _ => Ok(None),
+    }
 }
 
-fn pristine_key_hash(key: &str) -> Option<&str> {
-    let rest = key.strip_prefix("pristine:")?;
-    rest.rsplit_once(':').map(|(_, hash)| hash)
+/// Derive the slug for a session from its embedded fields. Local sessions
+/// require resolving the repo's `origin` remote (I/O); PR sessions are
+/// derived purely from the embedded `pr_session_key`.
+pub fn slug_for_session(session: &ReviewSession) -> Result<Slug> {
+    if let Some(key) = session.pr_session_key.as_ref() {
+        return Ok(key.into());
+    }
+    let owner_repo = slug::resolve_owner_repo(&session.repo_path)
+        .map_err(|e| TuicrError::CorruptedSession(format!("slug derive: {e}")))?;
+    let local = slug::build_local_slug(
+        owner_repo,
+        session.branch_name.as_deref(),
+        &session.base_commit,
+        session.diff_source,
+        session.commit_range.as_deref(),
+    )
+    .map_err(|e| TuicrError::CorruptedSession(format!("slug build: {e}")))?;
+    Ok(Slug::Local(local))
+}
+
+// ---------- Internals ----------
+
+#[cfg(test)]
+thread_local! {
+    static TEST_REVIEWS_DIR: std::cell::RefCell<Option<PathBuf>> = const {
+        std::cell::RefCell::new(None)
+    };
 }
 
 #[cfg(test)]
-fn delete_session(path: &PathBuf) -> Result<()> {
-    fs::remove_file(path)?;
+pub(crate) fn set_test_reviews_dir(path: Option<PathBuf>) {
+    TEST_REVIEWS_DIR.with(|cell| *cell.borrow_mut() = path);
+}
+
+fn get_reviews_dir() -> Result<PathBuf> {
+    #[cfg(test)]
+    {
+        // In tests, the reviews dir is a thread-local so that two parallel
+        // tests never share state through it. Tests that touch storage and
+        // care about isolation set the thread-local via
+        // `set_test_reviews_dir`; tests that hit storage incidentally (e.g.,
+        // App tests that toggle save markers) fall back to a per-thread
+        // temp dir. The real `~/.local/share/tuicr/reviews` is never used in
+        // test mode.
+        let configured = TEST_REVIEWS_DIR.with(|cell| cell.borrow().clone());
+        if let Some(path) = configured {
+            fs::create_dir_all(&path)?;
+            return Ok(path);
+        }
+        let thread_id = std::thread::current().id();
+        let path = std::env::temp_dir().join(format!(
+            "tuicr-test-thread-{:?}-{}",
+            thread_id,
+            std::process::id()
+        ));
+        fs::create_dir_all(&path)?;
+        Ok(path)
+    }
+
+    #[cfg(not(test))]
+    {
+        let proj_dirs = ProjectDirs::from("", "", "tuicr").ok_or_else(|| {
+            TuicrError::Io(std::io::Error::other("Could not determine data directory"))
+        })?;
+
+        let data_dir = proj_dirs.data_dir().join("reviews");
+        fs::create_dir_all(&data_dir)?;
+        Ok(data_dir)
+    }
+}
+
+/// On first run under the new layout, move any old flat-layout sessions out
+/// of the reviews dir. The new layout is identified by the presence of the
+/// manifest file. If the reviews dir contains top-level `.json` session files
+/// (old layout), rename it to `<reviews>.v1` and start fresh.
+fn maybe_migrate(reviews_dir: &Path) -> Result<()> {
+    if !reviews_dir.exists() {
+        return Ok(());
+    }
+    if reviews_dir.join(MANIFEST_FILENAME).exists() {
+        return Ok(());
+    }
+
+    let mut has_top_level_json = false;
+    for entry in fs::read_dir(reviews_dir)? {
+        let entry = entry?;
+        let ft = entry.file_type()?;
+        if !ft.is_file() {
+            continue;
+        }
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|n| n.ends_with(".json"))
+        {
+            has_top_level_json = true;
+            break;
+        }
+    }
+
+    if !has_top_level_json {
+        return Ok(());
+    }
+
+    let parent = reviews_dir
+        .parent()
+        .ok_or_else(|| TuicrError::Io(std::io::Error::other("reviews dir has no parent")))?;
+    let stem = reviews_dir
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| TuicrError::Io(std::io::Error::other("reviews dir has no name")))?;
+    let mut backup = parent.join(format!("{stem}.v1"));
+    let mut suffix = 1u32;
+    while backup.exists() {
+        suffix += 1;
+        backup = parent.join(format!("{stem}.v{suffix}"));
+    }
+
+    fs::rename(reviews_dir, &backup)?;
+    fs::create_dir_all(reviews_dir)?;
+    eprintln!(
+        "[tuicr] migrating reviews to new layout; previous reviews moved to {}",
+        backup.display()
+    );
     Ok(())
 }
+
+fn relative_path_for_slug(slug: &Slug, session: &ReviewSession) -> Result<PathBuf> {
+    match slug {
+        Slug::Local(local) => Ok(local_relative_path(local, &session.repo_path)),
+        Slug::Pr(_) => {
+            let key = session.pr_session_key.as_ref().ok_or_else(|| {
+                TuicrError::CorruptedSession(
+                    "PR slug requires session.pr_session_key to be populated".to_string(),
+                )
+            })?;
+            Ok(pr_relative_path(key))
+        }
+    }
+}
+
+fn local_relative_path(local: &LocalSlug, repo_path: &Path) -> PathBuf {
+    let fp = repo_path_fingerprint(repo_path);
+    let mut path = PathBuf::from("local").join(&fp);
+    if let Some(owner) = &local.owner {
+        path = path.join(sanitize_path_segment(owner));
+    }
+    path = path
+        .join(sanitize_path_segment(&local.repo))
+        .join(sanitize_path_segment(&anchor_segment(&local.anchor)));
+    for segment in source_segments(&local.source) {
+        path = path.join(sanitize_path_segment(&segment));
+    }
+    path.with_extension("json")
+}
+
+fn pr_relative_path(key: &PrSessionKey) -> PathBuf {
+    PathBuf::from("gh")
+        .join(sanitize_path_segment(&key.repository.owner))
+        .join(sanitize_path_segment(&key.repository.name))
+        .join("pr")
+        .join(key.number.to_string())
+        .join(format!("{}.json", sanitize_path_segment(&key.head_sha)))
+}
+
+fn anchor_segment(anchor: &SlugAnchor) -> String {
+    match anchor {
+        SlugAnchor::Branch(name) => name.clone(),
+        SlugAnchor::Anonymous(sha) => format!("~{sha}"),
+    }
+}
+
+fn source_segments(source: &SlugSource) -> Vec<String> {
+    match source {
+        SlugSource::Worktree => vec!["worktree".to_string()],
+        SlugSource::Staged => vec!["staged".to_string()],
+        SlugSource::Unstaged => vec!["unstaged".to_string()],
+        SlugSource::StagedAndUnstaged => vec!["staged-and-unstaged".to_string()],
+        SlugSource::Pristine => vec!["pristine".to_string()],
+        SlugSource::Commits(r) => vec!["commits".to_string(), format!("{}..{}", r.base, r.head)],
+        SlugSource::WorktreeAndCommits(r) => vec![
+            "worktree-and-commits".to_string(),
+            format!("{}..{}", r.base, r.head),
+        ],
+        SlugSource::StagedUnstagedAndCommits(r) => vec![
+            "staged-and-unstaged-and-commits".to_string(),
+            format!("{}..{}", r.base, r.head),
+        ],
+    }
+}
+
+/// Filenames must not contain path separators or otherwise-illegal characters.
+/// Slugs are already constrained but path segments may receive raw input
+/// (e.g., owner names with `.`) — be defensive.
+fn sanitize_path_segment(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~' | '+') {
+            out.push(ch);
+        } else {
+            out.push('-');
+        }
+    }
+    if out.is_empty() {
+        "unknown".to_string()
+    } else {
+        out
+    }
+}
+
+fn repo_path_fingerprint(repo_path: &Path) -> String {
+    let canonical = fs::canonicalize(repo_path).unwrap_or_else(|_| repo_path.to_path_buf());
+    let normalized = canonical.to_string_lossy().to_string();
+    let normalized = if cfg!(windows) {
+        normalized.to_lowercase()
+    } else {
+        normalized
+    };
+    let hash = fnv1a_64(normalized.as_bytes());
+    let hex = format!("{hash:016x}");
+    hex[..FINGERPRINT_HEX_LEN].to_string()
+}
+
+fn manifest_anchor_for(slug: &Slug) -> String {
+    match slug {
+        Slug::Local(local) => anchor_segment(&local.anchor),
+        Slug::Pr(pr) => format!("pr/{}", pr.number),
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn manifest_path_for(reviews_dir: &Path) -> PathBuf {
+    reviews_dir.join(MANIFEST_FILENAME)
+}
+
+// ---------- Tests ----------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
     use crate::model::FileStatus;
+    use crate::persistence::manifest::Manifest;
     use std::path::PathBuf;
-    use std::sync::{Mutex, OnceLock};
-    use std::time::Duration;
 
-    const TEST_MTIME_RETRIES: usize = 40;
-    const TEST_MTIME_SLEEP_MS: u64 = 100;
-
-    fn create_test_session() -> ReviewSession {
-        let mut session = ReviewSession::new(
-            PathBuf::from("/tmp/test-repo"),
-            "abc1234def".to_string(),
-            Some("main".to_string()),
-            SessionDiffSource::WorkingTree,
-        );
-        session.add_file(PathBuf::from("src/main.rs"), FileStatus::Modified, 0);
-        session
-    }
-
-    static TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-
-    struct TestReviewsDirGuard<'a> {
-        _lock: std::sync::MutexGuard<'a, ()>,
+    struct TestReviewsDirGuard {
         path: PathBuf,
     }
 
-    impl Drop for TestReviewsDirGuard<'_> {
+    impl Drop for TestReviewsDirGuard {
         fn drop(&mut self) {
-            unsafe {
-                std::env::remove_var("TUICR_REVIEWS_DIR");
-            }
+            set_test_reviews_dir(None);
             let _ = fs::remove_dir_all(&self.path);
         }
     }
 
-    fn with_test_reviews_dir() -> TestReviewsDirGuard<'static> {
-        let lock = TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    fn with_test_reviews_dir() -> TestReviewsDirGuard {
         let path =
             std::env::temp_dir().join(format!("tuicr-reviews-test-{}", uuid::Uuid::new_v4()));
         fs::create_dir_all(&path).unwrap();
-        unsafe {
-            std::env::set_var("TUICR_REVIEWS_DIR", path.as_os_str());
-        }
-
-        TestReviewsDirGuard { _lock: lock, path }
+        set_test_reviews_dir(Some(path.clone()));
+        TestReviewsDirGuard { path }
     }
 
-    fn create_session(
+    fn make_repo() -> PathBuf {
+        let repo = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&repo).unwrap();
+        repo
+    }
+
+    fn make_local_session(
         repo_path: PathBuf,
         base_commit: &str,
         branch_name: Option<&str>,
         diff_source: SessionDiffSource,
         commit_range: Option<Vec<String>>,
     ) -> ReviewSession {
-        let mut session = ReviewSession::new(
+        let mut s = ReviewSession::new(
             repo_path,
             base_commit.to_string(),
-            branch_name.map(|s| s.to_string()),
+            branch_name.map(|b| b.to_string()),
             diff_source,
         );
-        session.commit_range = commit_range;
-        session.add_file(PathBuf::from("src/main.rs"), FileStatus::Modified, 0);
-        session
+        s.commit_range = commit_range;
+        s.add_file(PathBuf::from("src/main.rs"), FileStatus::Modified, 0);
+        s
     }
 
-    fn save_legacy_session(reviews_dir: &Path, session: &ReviewSession) -> PathBuf {
-        let mut value = serde_json::to_value(session).unwrap();
-        let obj = value.as_object_mut().unwrap();
-        obj.remove("branch_name");
-        obj.remove("diff_source");
-        obj.remove("commit_range");
-        obj.insert(
-            "version".to_string(),
-            serde_json::Value::String("1.0".to_string()),
-        );
-
-        let id_fragment = session.id.split('-').next().unwrap_or(&session.id);
-        let path = reviews_dir.join(format!("legacy_{id_fragment}.json"));
-        fs::write(&path, serde_json::to_string_pretty(&value).unwrap()).unwrap();
-        path
-    }
-
-    fn ensure_newer_mtime(newer: &Path, older: &Path) {
-        let older_time = fs::metadata(older)
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-        for _ in 0..TEST_MTIME_RETRIES {
-            let newer_time = fs::metadata(newer)
-                .ok()
-                .and_then(|m| m.modified().ok())
-                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-            if newer_time > older_time {
-                return;
-            }
-
-            std::thread::sleep(Duration::from_millis(TEST_MTIME_SLEEP_MS));
-            let contents = fs::read_to_string(newer).unwrap();
-            fs::write(newer, contents).unwrap();
-        }
-
-        let newer_time = fs::metadata(newer)
-            .ok()
-            .and_then(|m| m.modified().ok())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-        assert!(
-            newer_time > older_time,
-            "failed to produce newer mtime for {}",
-            newer.display()
-        );
-    }
-
-    #[test]
-    fn should_generate_correct_filename() {
-        let session = create_test_session();
-        let filename = session_filename(&session);
-        assert!(filename.starts_with("test-repo_"));
-        assert!(filename.contains("_main_worktree_"));
-        assert!(filename.ends_with(".json"));
-    }
-
-    #[test]
-    fn should_generate_filename_for_staged_unstaged() {
-        let session = create_session(
-            PathBuf::from("/tmp/test-repo"),
-            "abc1234def",
-            Some("main"),
-            SessionDiffSource::StagedAndUnstaged,
-            None,
-        );
-        let filename = session_filename(&session);
-        assert!(filename.contains("_staged_and_unstaged_"));
-    }
-
-    #[test]
-    fn should_roundtrip_session() {
-        let _guard = with_test_reviews_dir();
-        let session = create_test_session();
-        let path = save_session(&session).unwrap();
-        let loaded = load_session(&path).unwrap();
-        assert_eq!(session.id, loaded.id);
-        assert_eq!(session.base_commit, loaded.base_commit);
-        assert_eq!(session.branch_name, loaded.branch_name);
-        assert_eq!(session.diff_source, loaded.diff_source);
-        assert_eq!(session.files.len(), loaded.files.len());
-        let _ = delete_session(&path);
-    }
-
-    #[test]
-    fn should_sanitize_branch_name_in_filename() {
-        let session = create_session(
-            PathBuf::from("/tmp/test-repo"),
-            "abc1234def",
-            Some("feature/login"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let filename = session_filename(&session);
-        assert!(!filename.contains('/'));
-        assert!(filename.contains("feature-login"));
-    }
-
-    #[test]
-    fn should_select_latest_session_for_branch() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session1 = create_session(
-            repo_path.clone(),
-            "commit-1",
-            Some("main"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let path1 = save_session(&session1).unwrap();
-
-        let session2 = create_session(
-            repo_path.clone(),
-            "commit-2",
-            Some("main"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let path2 = save_session(&session2).unwrap();
-        ensure_newer_mtime(&path2, &path1);
-        let (selected_path, selected) = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "head-does-not-matter-for-branch",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(selected_path, path2);
-        assert_ne!(selected_path, path1);
-        assert_eq!(selected.base_commit, "commit-2");
-    }
-
-    #[test]
-    fn should_match_branch_even_when_head_commit_differs() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session = create_session(
-            repo_path.clone(),
-            "old-head",
-            Some("main"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _ = save_session(&session).unwrap();
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "new-head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        assert!(loaded.is_some());
-    }
-
-    #[test]
-    fn should_load_session_with_underscore_branch_name() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session = create_session(
-            repo_path.clone(),
-            "head-commit",
-            Some("feature/with_underscores"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _ = save_session(&session).unwrap();
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            Some("feature/with_underscores"),
-            "new-head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        assert!(loaded.is_some());
-    }
-
-    #[test]
-    fn should_load_session_with_hex_like_branch_segment() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session = create_session(
-            repo_path.clone(),
-            "head-commit",
-            Some("feature/deadbeef_fix"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _ = save_session(&session).unwrap();
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            Some("feature/deadbeef_fix"),
-            "new-head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        assert!(loaded.is_some());
-    }
-
-    #[test]
-    fn should_prefer_branch_match_over_legacy_candidate() {
-        let guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let branch_session = create_session(
-            repo_path.clone(),
-            "branch-base",
-            Some("main"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let branch_path = save_session(&branch_session).unwrap();
-
-        let legacy_source = create_session(
-            repo_path.clone(),
-            "head-commit",
-            None,
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let legacy_path = save_legacy_session(&guard.path, &legacy_source);
-        let (selected_path, _selected) = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "head-commit",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(selected_path, branch_path);
-        assert_ne!(selected_path, legacy_path);
-    }
-
-    #[test]
-    fn should_fallback_to_legacy_session_when_no_branch_session_exists() {
-        let guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let legacy_source = create_session(
-            repo_path.clone(),
-            "head-commit",
-            None,
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let legacy_path = save_legacy_session(&guard.path, &legacy_source);
-        let (selected_path, selected) = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "head-commit",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(selected_path, legacy_path);
-        assert_eq!(selected.branch_name, None);
-        assert_eq!(selected.diff_source, SessionDiffSource::WorkingTree);
-    }
-
-    #[test]
-    fn should_not_select_legacy_session_when_head_commit_differs() {
-        let guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let legacy_source = create_session(
-            repo_path.clone(),
-            "old-head",
-            None,
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _legacy_path = save_legacy_session(&guard.path, &legacy_source);
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "new-head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        assert!(loaded.is_none());
-    }
-
-    #[test]
-    fn should_require_commit_match_in_detached_head() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session = create_session(
-            repo_path.clone(),
-            "detached-head",
-            None,
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _ = save_session(&session).unwrap();
-        let mismatch = load_latest_session_for_context(
-            &repo_path,
-            None,
-            "different-head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        let match_ = load_latest_session_for_context(
-            &repo_path,
-            None,
-            "detached-head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        assert!(mismatch.is_none());
-        assert!(match_.is_some());
-    }
-
-    #[test]
-    fn should_ignore_sessions_with_different_diff_source() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let commit_range = vec!["commit-2".to_string(), "commit-1".to_string()];
-        let commits_session = create_session(
-            repo_path.clone(),
-            "commit-2",
-            Some("main"),
-            SessionDiffSource::CommitRange,
-            Some(commit_range.clone()),
-        );
-        let _ = save_session(&commits_session).unwrap();
-        let worktree = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap();
-        let commits = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "head",
-            SessionDiffSource::CommitRange,
-            Some(commit_range.as_slice()),
-        )
-        .unwrap();
-        assert!(worktree.is_none());
-        assert!(commits.is_some());
-    }
-
-    #[test]
-    fn should_match_commit_range_session() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let commit_range_a = vec!["commit-a2".to_string(), "commit-a1".to_string()];
-        let commit_range_b = vec!["commit-b2".to_string(), "commit-b1".to_string()];
-
-        let session_a = create_session(
-            repo_path.clone(),
-            "commit-a2",
-            Some("main"),
-            SessionDiffSource::CommitRange,
-            Some(commit_range_a.clone()),
-        );
-        let path_a = save_session(&session_a).unwrap();
-
-        let session_b = create_session(
-            repo_path.clone(),
-            "commit-b2",
-            Some("main"),
-            SessionDiffSource::CommitRange,
-            Some(commit_range_b.clone()),
-        );
-        let path_b = save_session(&session_b).unwrap();
-        let (selected_path, selected) = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "commit-b2",
-            SessionDiffSource::CommitRange,
-            Some(commit_range_b.as_slice()),
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(selected_path, path_b);
-        assert_ne!(selected_path, path_a);
-        assert_eq!(
-            selected.commit_range.as_deref(),
-            Some(commit_range_b.as_slice())
-        );
-    }
-
-    #[test]
-    fn should_roundtrip_commit_range_session() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let commit_range = vec!["commit-2".to_string(), "commit-1".to_string()];
-        let session = create_session(
-            repo_path,
-            "commit-2",
-            Some("main"),
-            SessionDiffSource::CommitRange,
-            Some(commit_range.clone()),
-        );
-        let path = save_session(&session).unwrap();
-        let loaded = load_session(&path).unwrap();
-        assert_eq!(loaded.commit_range, Some(commit_range));
-        assert_eq!(loaded.diff_source, SessionDiffSource::CommitRange);
-        let _ = delete_session(&path);
-    }
-
-    #[test]
-    fn should_require_commit_range_order_match() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let commit_range = vec!["commit-2".to_string(), "commit-1".to_string()];
-        let reversed_range = vec!["commit-1".to_string(), "commit-2".to_string()];
-
-        let session = create_session(
-            repo_path.clone(),
-            "commit-2",
-            Some("main"),
-            SessionDiffSource::CommitRange,
-            Some(commit_range),
-        );
-        let _ = save_session(&session).unwrap();
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "commit-2",
-            SessionDiffSource::CommitRange,
-            Some(reversed_range.as_slice()),
-        )
-        .unwrap();
-        assert!(loaded.is_none());
-    }
-
-    #[test]
-    fn should_skip_commit_sessions_without_range_match() {
-        let _guard = with_test_reviews_dir();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let commit_range = vec!["commit-2".to_string(), "commit-1".to_string()];
-
-        let session = create_session(
-            repo_path.clone(),
-            "commit-2",
-            Some("main"),
-            SessionDiffSource::CommitRange,
-            None,
-        );
-        let _ = save_session(&session).unwrap();
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            Some("main"),
-            "commit-2",
-            SessionDiffSource::CommitRange,
-            Some(commit_range.as_slice()),
-        )
-        .unwrap();
-        assert!(loaded.is_none());
-    }
-
-    #[test]
-    fn should_disambiguate_repos_with_same_folder_name() {
-        let _guard = with_test_reviews_dir();
-        let base = std::env::temp_dir().join(format!("tuicr-repos-{}", uuid::Uuid::new_v4()));
-        let repo_a = base.join("a").join("same-repo");
-        let repo_b = base.join("b").join("same-repo");
-        fs::create_dir_all(&repo_a).unwrap();
-        fs::create_dir_all(&repo_b).unwrap();
-
-        let session_a = create_session(
-            repo_a.clone(),
-            "head-a",
-            Some("main"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _ = save_session(&session_a).unwrap();
-
-        let session_b = create_session(
-            repo_b.clone(),
-            "head-b",
-            Some("main"),
-            SessionDiffSource::WorkingTree,
-            None,
-        );
-        let _ = save_session(&session_b).unwrap();
-        let (_path, selected) = load_latest_session_for_context(
-            &repo_a,
-            Some("main"),
-            "head",
-            SessionDiffSource::WorkingTree,
-            None,
-        )
-        .unwrap()
-        .unwrap();
-        assert_eq!(selected.base_commit, "head-a");
-        assert_eq!(
-            normalize_repo_path(&selected.repo_path),
-            normalize_repo_path(&repo_a)
-        );
-    }
-
-    fn pr_key(number: u64, head_sha: &str) -> PrSessionKey {
+    fn make_pr_key(number: u64, head_sha: &str) -> PrSessionKey {
         PrSessionKey::new(
-            crate::forge::traits::ForgeRepository::github("github.com", "agavra", "tuicr"),
+            ForgeRepository::github("github.com", "agavra", "tuicr"),
             number,
             head_sha.to_string(),
         )
     }
 
-    fn pr_session(key: &PrSessionKey) -> ReviewSession {
-        let mut session = ReviewSession::new(
+    fn make_pr_session(key: &PrSessionKey) -> ReviewSession {
+        let mut s = ReviewSession::new(
             PathBuf::from(format!(
                 "forge:{}/{}/{}",
                 key.repository.host, key.repository.owner, key.repository.name
@@ -1038,216 +438,386 @@ mod tests {
             Some("reviews".to_string()),
             SessionDiffSource::PullRequest,
         );
-        session.pr_session_key = Some(key.clone());
-        session
+        s.pr_session_key = Some(key.clone());
+        s
     }
 
-    #[test]
-    fn should_generate_pr_session_filename_keyed_by_identity_and_head() {
-        // given a PR session
-        let key = pr_key(125, "abcdef0123456789");
-        let session = pr_session(&key);
-        // when
-        let filename = session_filename(&session);
-        // then
-        assert!(filename.starts_with("pr_github_github.com_agavra_tuicr_125_abcdef01_"));
-        assert!(filename.ends_with(".json"));
-    }
+    // ---- Save/load round trips ----
 
     #[test]
-    fn should_round_trip_pr_session_via_storage() {
-        let _guard = with_test_reviews_dir();
-        // given
-        let key = pr_key(125, "abcdef0123456789");
-        let session = pr_session(&key);
-        // when
+    fn should_roundtrip_local_session() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
         let path = save_session(&session).unwrap();
-        let (loaded_path, loaded) = load_pr_session(&key).unwrap().unwrap();
-        // then
-        assert_eq!(loaded_path, path);
-        assert_eq!(loaded.pr_session_key.as_ref(), Some(&key));
-        assert_eq!(loaded.diff_source, SessionDiffSource::PullRequest);
-        let _ = delete_session(&path);
+        let loaded = load_session(&path).unwrap();
+        assert_eq!(session.id, loaded.id);
+        assert_eq!(session.base_commit, loaded.base_commit);
     }
 
     #[test]
-    fn should_return_none_when_no_session_matches_head_sha() {
-        let _guard = with_test_reviews_dir();
-        // given a session at old head
-        let old_key = pr_key(125, "abcdef0123456789");
-        let _ = save_session(&pr_session(&old_key)).unwrap();
-        // when looking up a new head
-        let new_key = pr_key(125, "9999999999999999");
-        let loaded = load_pr_session(&new_key).unwrap();
-        // then
-        assert!(loaded.is_none());
+    fn should_save_under_new_layout_for_local() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        let path = save_session(&session).unwrap();
+        let display = path.display().to_string();
+        assert!(display.contains("/local/"), "expected /local/ in {display}");
+        assert!(display.ends_with("/worktree.json"));
     }
 
     #[test]
-    fn should_skip_pr_files_when_loading_local_session() {
-        let _guard = with_test_reviews_dir();
-        // given a saved PR session and no local sessions
-        let key = pr_key(125, "abcdef0123456789");
-        let _ = save_session(&pr_session(&key)).unwrap();
-        let repo_path = std::env::temp_dir().join(format!("tuicr-repo-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-        // when asking for a local working-tree session
+    fn should_save_under_new_layout_for_pr() {
+        let _g = with_test_reviews_dir();
+        let key = make_pr_key(125, "abcdef0123456789");
+        let session = make_pr_session(&key);
+        let path = save_session(&session).unwrap();
+        let display = path.display().to_string();
+        assert!(
+            display.contains("/gh/agavra/tuicr/pr/125/"),
+            "expected gh/agavra/tuicr/pr/125 segment in {display}"
+        );
+        assert!(display.ends_with("/abcdef0123456789.json"));
+    }
+
+    #[test]
+    fn should_update_manifest_on_save() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        save_session(&session).unwrap();
+
+        let reviews_dir = get_reviews_dir().unwrap();
+        let manifest = manifest::load_manifest(&reviews_dir).unwrap();
+        let slug = slug_for_session(&session).unwrap();
+        let canonical = fs::canonicalize(&repo).unwrap_or(repo);
+        let entry = manifest
+            .get_local(&slug.to_string(), &canonical)
+            .expect("entry exists");
+        assert!(matches!(entry.kind, ManifestKind::Local));
+        assert_eq!(entry.display.file_count, 1);
+    }
+
+    // ---- Lookup ----
+
+    #[test]
+    fn should_return_none_for_unknown_context() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
         let loaded = load_latest_session_for_context(
-            &repo_path,
+            &repo,
             Some("main"),
             "head",
             SessionDiffSource::WorkingTree,
             None,
         )
         .unwrap();
-        // then PR sessions are not surfaced to the local loader
         assert!(loaded.is_none());
     }
 
     #[test]
-    fn should_keep_pr_sessions_separate_per_pr_number() {
-        let _guard = with_test_reviews_dir();
-        // given two PR sessions for different numbers
-        let key_a = pr_key(125, "abcdef0123456789");
-        let key_b = pr_key(148, "abcdef0123456789");
-        let _ = save_session(&pr_session(&key_a)).unwrap();
-        let _ = save_session(&pr_session(&key_b)).unwrap();
-        // when
-        let loaded_a = load_pr_session(&key_a).unwrap().unwrap();
-        let loaded_b = load_pr_session(&key_b).unwrap().unwrap();
-        // then each load returns its matching PR
-        assert_eq!(loaded_a.1.pr_session_key.as_ref(), Some(&key_a));
-        assert_eq!(loaded_b.1.pr_session_key.as_ref(), Some(&key_b));
-    }
-
-    // ---------- Pristine session key tests ----------
-
-    #[test]
-    fn pristine_key_hash_extracts_trailing_segment() {
-        assert_eq!(pristine_key_hash("pristine:abc1234:9f0a"), Some("9f0a"));
-        assert_eq!(pristine_key_hash("pristine:none:0000"), Some("0000"));
-        assert_eq!(pristine_key_hash("worktree:abc1234"), None);
-        assert_eq!(pristine_key_hash("pristine:no-trailing-hash"), None);
-    }
-
-    #[test]
-    fn pristine_keys_match_when_path_hash_equal_even_if_head_changed() {
-        assert!(pristine_keys_match(
-            "pristine:abc1234:9f0a",
-            "pristine:def5678:9f0a"
-        ));
-        assert!(!pristine_keys_match(
-            "pristine:abc1234:9f0a",
-            "pristine:def5678:beef"
-        ));
-        assert!(!pristine_keys_match(
-            "pristine:abc1234:9f0a",
-            "worktree:abc1234"
-        ));
-    }
-
-    #[test]
-    fn pristine_session_reloads_after_head_advance() {
-        let _guard = with_test_reviews_dir();
-        let repo_path =
-            std::env::temp_dir().join(format!("tuicr-pristine-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session = create_session(
-            repo_path.clone(),
-            "pristine:abc1234:9f0a",
-            None,
-            SessionDiffSource::Pristine,
+    fn should_load_session_by_matching_context() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
             None,
         );
-        let saved_path = save_session(&session).unwrap();
+        save_session(&session).unwrap();
 
-        // HEAD advanced; the new key shares the same path hash suffix.
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            None,
-            "pristine:def5678:9f0a",
-            SessionDiffSource::Pristine,
+        let (_, loaded) = load_latest_session_for_context(
+            &repo,
+            Some("main"),
+            "new-head",
+            SessionDiffSource::WorkingTree,
             None,
         )
-        .unwrap();
-        assert!(
-            loaded.is_some(),
-            "advanced HEAD must still find the session"
-        );
-        assert_eq!(loaded.unwrap().0, saved_path);
+        .unwrap()
+        .expect("session should be found regardless of head_commit on a branched session");
+        assert_eq!(loaded.id, session.id);
     }
 
     #[test]
-    fn pristine_session_does_not_reload_when_path_hash_differs() {
-        let _guard = with_test_reviews_dir();
-        let repo_path =
-            std::env::temp_dir().join(format!("tuicr-pristine-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
-
-        let session = create_session(
-            repo_path.clone(),
-            "pristine:abc1234:aaaa",
-            None,
-            SessionDiffSource::Pristine,
+    fn should_ignore_sessions_with_different_diff_source() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
             None,
         );
         save_session(&session).unwrap();
 
         let loaded = load_latest_session_for_context(
-            &repo_path,
-            None,
-            "pristine:abc1234:bbbb",
-            SessionDiffSource::Pristine,
+            &repo,
+            Some("main"),
+            "head",
+            SessionDiffSource::Staged,
             None,
         )
         .unwrap();
-        assert!(
-            loaded.is_none(),
-            "different path-hash must NOT match a stored pristine session"
-        );
+        assert!(loaded.is_none());
     }
 
     #[test]
-    fn pristine_session_does_not_collide_with_single_file_session() {
-        let _guard = with_test_reviews_dir();
-        let repo_path =
-            std::env::temp_dir().join(format!("tuicr-pristine-{}", uuid::Uuid::new_v4()));
-        fs::create_dir_all(&repo_path).unwrap();
+    fn should_require_commit_range_match() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let range_a = vec!["c1".to_string(), "c0".to_string()];
+        let range_b = vec!["c3".to_string(), "c2".to_string()];
 
-        // Single-file `--file` session at the same root_path uses base_commit "file".
-        let single = create_session(
-            repo_path.clone(),
-            "file",
-            None,
-            SessionDiffSource::WorkingTree,
-            None,
+        let session_a = make_local_session(
+            repo.clone(),
+            "c1",
+            Some("main"),
+            SessionDiffSource::CommitRange,
+            Some(range_a.clone()),
         );
-        save_session(&single).unwrap();
+        save_session(&session_a).unwrap();
 
-        // Pristine session at the same root_path uses base_commit "pristine:...".
-        let pristine = create_session(
-            repo_path.clone(),
-            "pristine:abc1234:9f0a",
-            None,
-            SessionDiffSource::Pristine,
-            None,
+        let session_b = make_local_session(
+            repo.clone(),
+            "c3",
+            Some("main"),
+            SessionDiffSource::CommitRange,
+            Some(range_b.clone()),
         );
-        let pristine_path = save_session(&pristine).unwrap();
+        save_session(&session_b).unwrap();
 
-        let loaded = load_latest_session_for_context(
-            &repo_path,
-            None,
-            "pristine:abc1234:9f0a",
-            SessionDiffSource::Pristine,
-            None,
+        let (_, loaded_a) = load_latest_session_for_context(
+            &repo,
+            Some("main"),
+            "c1",
+            SessionDiffSource::CommitRange,
+            Some(range_a.as_slice()),
         )
         .unwrap()
         .unwrap();
-        assert_eq!(
-            loaded.0, pristine_path,
-            "pristine loader must return the pristine session, not the --file one"
+        assert_eq!(loaded_a.id, session_a.id);
+
+        let (_, loaded_b) = load_latest_session_for_context(
+            &repo,
+            Some("main"),
+            "c3",
+            SessionDiffSource::CommitRange,
+            Some(range_b.as_slice()),
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(loaded_b.id, session_b.id);
+    }
+
+    #[test]
+    fn should_disambiguate_two_checkouts_with_same_repo_name() {
+        let _g = with_test_reviews_dir();
+        let base = std::env::temp_dir().join(format!("tuicr-multi-{}", uuid::Uuid::new_v4()));
+        let repo_a = base.join("a").join("same-repo");
+        let repo_b = base.join("b").join("same-repo");
+        fs::create_dir_all(&repo_a).unwrap();
+        fs::create_dir_all(&repo_b).unwrap();
+
+        let session_a = make_local_session(
+            repo_a.clone(),
+            "head-a",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
         );
-        assert_eq!(loaded.1.diff_source, SessionDiffSource::Pristine);
+        let session_b = make_local_session(
+            repo_b.clone(),
+            "head-b",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        save_session(&session_a).unwrap();
+        save_session(&session_b).unwrap();
+
+        // Same slug for both (no remote, fallback to dir name) but
+        // canonical_repo_path disambiguates.
+        let slug = slug_for_session(&session_a).unwrap();
+        let slug_b = slug_for_session(&session_b).unwrap();
+        assert_eq!(slug.to_string(), slug_b.to_string());
+
+        let (_, loaded_a) = load_latest_session_for_context(
+            &repo_a,
+            Some("main"),
+            "head-a",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap()
+        .expect("repo_a lookup");
+        assert_eq!(loaded_a.id, session_a.id);
+
+        let (_, loaded_b) = load_latest_session_for_context(
+            &repo_b,
+            Some("main"),
+            "head-b",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap()
+        .expect("repo_b lookup");
+        assert_eq!(loaded_b.id, session_b.id);
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    // ---- PR sessions ----
+
+    #[test]
+    fn should_roundtrip_pr_session() {
+        let _g = with_test_reviews_dir();
+        let key = make_pr_key(125, "abcdef0123456789");
+        let session = make_pr_session(&key);
+        let path = save_session(&session).unwrap();
+        let (loaded_path, loaded) = load_pr_session(&key).unwrap().unwrap();
+        assert_eq!(loaded_path, path);
+        assert_eq!(loaded.pr_session_key.as_ref(), Some(&key));
+    }
+
+    #[test]
+    fn should_return_none_when_head_changes_for_pr() {
+        let _g = with_test_reviews_dir();
+        let old_key = make_pr_key(125, "abcdef0123456789");
+        let session = make_pr_session(&old_key);
+        save_session(&session).unwrap();
+
+        let new_key = make_pr_key(125, "9999999999999999");
+        let loaded = load_pr_session(&new_key).unwrap();
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn should_separate_pr_sessions_by_number() {
+        let _g = with_test_reviews_dir();
+        let key_a = make_pr_key(125, "abcdef0123456789");
+        let key_b = make_pr_key(148, "abcdef0123456789");
+        save_session(&make_pr_session(&key_a)).unwrap();
+        save_session(&make_pr_session(&key_b)).unwrap();
+
+        let loaded_a = load_pr_session(&key_a).unwrap().unwrap();
+        let loaded_b = load_pr_session(&key_b).unwrap().unwrap();
+        assert_eq!(loaded_a.1.pr_session_key.as_ref(), Some(&key_a));
+        assert_eq!(loaded_b.1.pr_session_key.as_ref(), Some(&key_b));
+    }
+
+    #[test]
+    fn should_skip_pr_files_in_local_context_lookup() {
+        let _g = with_test_reviews_dir();
+        let key = make_pr_key(125, "abcdef0123456789");
+        save_session(&make_pr_session(&key)).unwrap();
+
+        let repo = make_repo();
+        let loaded = load_latest_session_for_context(
+            &repo,
+            Some("main"),
+            "head",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap();
+        assert!(loaded.is_none());
+    }
+
+    // ---- Branch sanitization in paths ----
+
+    #[test]
+    fn should_sanitize_branch_slashes_in_storage_path() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("feature/login"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        let path = save_session(&session).unwrap();
+        let display = path.display().to_string();
+        assert!(
+            display.contains("/feature-login/"),
+            "branch slash not sanitized in {display}"
+        );
+    }
+
+    // ---- Migration ----
+
+    #[test]
+    fn should_migrate_old_flat_layout_on_first_run() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+
+        // Drop an old-style flat session file into the reviews dir directly.
+        let old_file = reviews_dir.join("old_session.json");
+        fs::write(&old_file, "{\"legacy\":true}").unwrap();
+
+        let session = make_local_session(
+            make_repo(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        save_session(&session).unwrap();
+
+        assert!(
+            !old_file.exists(),
+            "old flat session file should have moved during migration"
+        );
+        let parent = reviews_dir.parent().unwrap();
+        let backup_exists = fs::read_dir(parent)
+            .unwrap()
+            .flatten()
+            .any(|e| e.file_name().to_string_lossy().contains(".v1"));
+        assert!(backup_exists, "expected a .v1 backup dir under {parent:?}");
+    }
+
+    #[test]
+    fn should_not_migrate_when_manifest_already_present() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+        let manifest = Manifest::new();
+        manifest::save_manifest(&reviews_dir, &manifest).unwrap();
+
+        let stray = reviews_dir.join("stray.json");
+        fs::write(&stray, "{}").unwrap();
+
+        let session = make_local_session(
+            make_repo(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        save_session(&session).unwrap();
+        assert!(
+            stray.exists(),
+            "stray .json must survive when manifest exists"
+        );
     }
 }

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -1,19 +1,20 @@
 //! Slug-addressed storage layer for review sessions.
 //!
-//! Layout under `~/.local/share/tuicr/reviews/`:
+//! Layout under the platform data dir's `tuicr/reviews/`:
 //!
 //! ```text
 //! reviews/
-//!   index.json                          # manifest, source of truth for lookups
-//!   local/<fp>/<owner>/<repo>/<ref>/<source>.json
-//!   local/<fp>/<repo>/<ref>/<source>.json        # no-owner fallback
-//!   gh/<owner>/<repo>/pr/<number>/<head_sha>.json
+//!   index.json                # manifest, source of truth for lookups
+//!   sessions/
+//!     <16-hex>.json           # one file per session, deterministic name
 //! ```
 //!
-//! Every save writes a session JSON file and updates the manifest. Every load
-//! is a manifest lookup keyed by the slug derived from the caller's context.
-//! Per-session JSON files are self-describing so the manifest can be rebuilt
-//! by walking the tree if it gets lost or corrupted.
+//! The session filename is a hash of the slug plus the canonical repo path
+//! (for local) or head SHA (for PR), so the same logical session always
+//! lands at the same path without consulting the manifest. The manifest is
+//! the authoritative slug -> file mapping; if it goes missing or corrupts,
+//! the session JSONs are self-describing and the manifest can be rebuilt by
+//! walking `sessions/`.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -23,13 +24,11 @@ use directories::ProjectDirs;
 
 use crate::error::{Result, TuicrError};
 use crate::forge::traits::PrSessionKey;
-use crate::hash::fnv1a_64;
+use crate::hash::Fnv1aHasher;
 use crate::model::ReviewSession;
 use crate::model::review::SessionDiffSource;
-use crate::persistence::manifest::{self, MANIFEST_FILENAME, ManifestKind};
-use crate::slug::{self, LocalSlug, Slug, SlugAnchor, SlugSource};
-
-const FINGERPRINT_HEX_LEN: usize = 8;
+use crate::persistence::manifest::{self, MANIFEST_FILENAME, ManifestKind, SESSIONS_DIRNAME};
+use crate::slug::{self, Slug};
 
 // ---------- Public API ----------
 
@@ -203,36 +202,20 @@ fn get_reviews_dir() -> Result<PathBuf> {
     }
 }
 
-/// On first run under the new layout, move any old flat-layout sessions out
-/// of the reviews dir. The new layout is identified by the presence of the
-/// manifest file. If the reviews dir contains top-level `.json` session files
-/// (old layout), rename it to `<reviews>.v1` and start fresh.
+/// On first run under the flat layout, move any pre-existing reviews dir
+/// aside. The current layout is identified by the presence of the
+/// `sessions/` subdirectory; if it's missing but the reviews dir has any
+/// other contents (an older flat layout's `*.json` files, a previous tree
+/// layout with `local/` and `gh/` subdirs, or a stale manifest), rename the
+/// whole directory to `<reviews>.bak1` and start fresh.
 fn maybe_migrate(reviews_dir: &Path) -> Result<()> {
     if !reviews_dir.exists() {
         return Ok(());
     }
-    if reviews_dir.join(MANIFEST_FILENAME).exists() {
+    if reviews_dir.join(SESSIONS_DIRNAME).exists() {
         return Ok(());
     }
-
-    let mut has_top_level_json = false;
-    for entry in fs::read_dir(reviews_dir)? {
-        let entry = entry?;
-        let ft = entry.file_type()?;
-        if !ft.is_file() {
-            continue;
-        }
-        if entry
-            .file_name()
-            .to_str()
-            .is_some_and(|n| n.ends_with(".json"))
-        {
-            has_top_level_json = true;
-            break;
-        }
-    }
-
-    if !has_top_level_json {
+    if fs::read_dir(reviews_dir)?.next().is_none() {
         return Ok(());
     }
 
@@ -243,11 +226,11 @@ fn maybe_migrate(reviews_dir: &Path) -> Result<()> {
         .file_name()
         .and_then(|n| n.to_str())
         .ok_or_else(|| TuicrError::Io(std::io::Error::other("reviews dir has no name")))?;
-    let mut backup = parent.join(format!("{stem}.v1"));
+    let mut backup = parent.join(format!("{stem}.bak1"));
     let mut suffix = 1u32;
     while backup.exists() {
         suffix += 1;
-        backup = parent.join(format!("{stem}.v{suffix}"));
+        backup = parent.join(format!("{stem}.bak{suffix}"));
     }
 
     fs::rename(reviews_dir, &backup)?;
@@ -259,105 +242,51 @@ fn maybe_migrate(reviews_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Compute the relative path of a session's JSON file under `reviews/`.
+///
+/// Files live in a single flat `sessions/` directory; their name is the FNV-1a
+/// hash of identity-defining inputs, so the same logical session always lands
+/// at the same path and no manifest lookup is needed to construct it:
+///
+/// - **Local**: hash of `slug || canonical_repo_path`. Two checkouts of the
+///   same repo produce distinct hashes because their canonical paths differ.
+/// - **PR**: hash of `slug || head_sha`. A new head produces a new file.
 fn relative_path_for_slug(slug: &Slug, session: &ReviewSession) -> Result<PathBuf> {
+    let mut hasher = Fnv1aHasher::new();
     match slug {
-        Slug::Local(local) => Ok(local_relative_path(local, &session.repo_path)),
+        Slug::Local(_) => {
+            hasher.write(b"local|");
+            hasher.write(slug.to_string().as_bytes());
+            hasher.write(b"|");
+            let canonical =
+                fs::canonicalize(&session.repo_path).unwrap_or_else(|_| session.repo_path.clone());
+            let normalized = canonical.to_string_lossy().to_string();
+            let normalized = if cfg!(windows) {
+                normalized.to_lowercase()
+            } else {
+                normalized
+            };
+            hasher.write(normalized.as_bytes());
+        }
         Slug::Pr(_) => {
             let key = session.pr_session_key.as_ref().ok_or_else(|| {
                 TuicrError::CorruptedSession(
                     "PR slug requires session.pr_session_key to be populated".to_string(),
                 )
             })?;
-            Ok(pr_relative_path(key))
+            hasher.write(b"pr|");
+            hasher.write(slug.to_string().as_bytes());
+            hasher.write(b"|");
+            hasher.write(key.head_sha.as_bytes());
         }
     }
-}
-
-fn local_relative_path(local: &LocalSlug, repo_path: &Path) -> PathBuf {
-    let fp = repo_path_fingerprint(repo_path);
-    let mut path = PathBuf::from("local").join(&fp);
-    if let Some(owner) = &local.owner {
-        path = path.join(sanitize_path_segment(owner));
-    }
-    path = path
-        .join(sanitize_path_segment(&local.repo))
-        .join(sanitize_path_segment(&anchor_segment(&local.anchor)));
-    for segment in source_segments(&local.source) {
-        path = path.join(sanitize_path_segment(&segment));
-    }
-    path.with_extension("json")
-}
-
-fn pr_relative_path(key: &PrSessionKey) -> PathBuf {
-    PathBuf::from("gh")
-        .join(sanitize_path_segment(&key.repository.owner))
-        .join(sanitize_path_segment(&key.repository.name))
-        .join("pr")
-        .join(key.number.to_string())
-        .join(format!("{}.json", sanitize_path_segment(&key.head_sha)))
-}
-
-fn anchor_segment(anchor: &SlugAnchor) -> String {
-    match anchor {
-        SlugAnchor::Branch(name) => name.clone(),
-        SlugAnchor::Anonymous(sha) => format!("~{sha}"),
-    }
-}
-
-fn source_segments(source: &SlugSource) -> Vec<String> {
-    match source {
-        SlugSource::Worktree => vec!["worktree".to_string()],
-        SlugSource::Staged => vec!["staged".to_string()],
-        SlugSource::Unstaged => vec!["unstaged".to_string()],
-        SlugSource::StagedAndUnstaged => vec!["staged-and-unstaged".to_string()],
-        SlugSource::Pristine => vec!["pristine".to_string()],
-        SlugSource::Commits(r) => vec!["commits".to_string(), format!("{}..{}", r.base, r.head)],
-        SlugSource::WorktreeAndCommits(r) => vec![
-            "worktree-and-commits".to_string(),
-            format!("{}..{}", r.base, r.head),
-        ],
-        SlugSource::StagedUnstagedAndCommits(r) => vec![
-            "staged-and-unstaged-and-commits".to_string(),
-            format!("{}..{}", r.base, r.head),
-        ],
-    }
-}
-
-/// Filenames must not contain path separators or otherwise-illegal characters.
-/// Slugs are already constrained but path segments may receive raw input
-/// (e.g., owner names with `.`) — be defensive.
-fn sanitize_path_segment(value: &str) -> String {
-    let mut out = String::with_capacity(value.len());
-    for ch in value.chars() {
-        if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '~' | '+') {
-            out.push(ch);
-        } else {
-            out.push('-');
-        }
-    }
-    if out.is_empty() {
-        "unknown".to_string()
-    } else {
-        out
-    }
-}
-
-fn repo_path_fingerprint(repo_path: &Path) -> String {
-    let canonical = fs::canonicalize(repo_path).unwrap_or_else(|_| repo_path.to_path_buf());
-    let normalized = canonical.to_string_lossy().to_string();
-    let normalized = if cfg!(windows) {
-        normalized.to_lowercase()
-    } else {
-        normalized
-    };
-    let hash = fnv1a_64(normalized.as_bytes());
-    let hex = format!("{hash:016x}");
-    hex[..FINGERPRINT_HEX_LEN].to_string()
+    let hex = format!("{:016x}", hasher.finish());
+    Ok(PathBuf::from(SESSIONS_DIRNAME).join(format!("{hex}.json")))
 }
 
 fn manifest_anchor_for(slug: &Slug) -> String {
     match slug {
-        Slug::Local(local) => anchor_segment(&local.anchor),
+        Slug::Local(local) => local.anchor.to_string(),
         Slug::Pr(pr) => format!("pr/{}", pr.number),
     }
 }
@@ -462,7 +391,7 @@ mod tests {
     }
 
     #[test]
-    fn should_save_under_new_layout_for_local() {
+    fn should_save_under_flat_sessions_dir_for_local() {
         let _g = with_test_reviews_dir();
         let repo = make_repo();
         let session = make_local_session(
@@ -474,22 +403,46 @@ mod tests {
         );
         let path = save_session(&session).unwrap();
         let display = path.display().to_string();
-        assert!(display.contains("/local/"), "expected /local/ in {display}");
-        assert!(display.ends_with("/worktree.json"));
+        assert!(
+            display.contains("/sessions/"),
+            "expected /sessions/ in {display}"
+        );
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.len() == 21 && name.ends_with(".json"),
+            "expected 16-hex-char filename, got {name}"
+        );
     }
 
     #[test]
-    fn should_save_under_new_layout_for_pr() {
+    fn should_save_under_flat_sessions_dir_for_pr() {
         let _g = with_test_reviews_dir();
         let key = make_pr_key(125, "abcdef0123456789");
         let session = make_pr_session(&key);
         let path = save_session(&session).unwrap();
         let display = path.display().to_string();
         assert!(
-            display.contains("/gh/agavra/tuicr/pr/125/"),
-            "expected gh/agavra/tuicr/pr/125 segment in {display}"
+            display.contains("/sessions/"),
+            "expected /sessions/ in {display}"
         );
-        assert!(display.ends_with("/abcdef0123456789.json"));
+        let name = path.file_name().unwrap().to_str().unwrap();
+        assert!(
+            name.len() == 21 && name.ends_with(".json"),
+            "expected 16-hex-char filename, got {name}"
+        );
+    }
+
+    #[test]
+    fn should_produce_distinct_paths_for_different_pr_heads() {
+        let _g = with_test_reviews_dir();
+        let key_a = make_pr_key(125, "abcdef0123456789");
+        let key_b = make_pr_key(125, "9999999999999999");
+        let path_a = save_session(&make_pr_session(&key_a)).unwrap();
+        let path_b = save_session(&make_pr_session(&key_b)).unwrap();
+        assert_ne!(
+            path_a, path_b,
+            "PR sessions with different heads must hash to different files"
+        );
     }
 
     #[test]
@@ -744,10 +697,10 @@ mod tests {
         assert!(loaded.is_none());
     }
 
-    // ---- Branch sanitization in paths ----
+    // ---- Branch sanitization in slug ----
 
     #[test]
-    fn should_sanitize_branch_slashes_in_storage_path() {
+    fn should_sanitize_branch_slashes_in_slug() {
         let _g = with_test_reviews_dir();
         let repo = make_repo();
         let session = make_local_session(
@@ -757,24 +710,29 @@ mod tests {
             SessionDiffSource::WorkingTree,
             None,
         );
-        let path = save_session(&session).unwrap();
-        let display = path.display().to_string();
+        save_session(&session).unwrap();
+
+        let slug = slug_for_session(&session).unwrap();
         assert!(
-            display.contains("/feature-login/"),
-            "branch slash not sanitized in {display}"
+            slug.to_string().contains("@feature-login/worktree"),
+            "branch slash not sanitized in {slug}"
         );
     }
 
     // ---- Migration ----
 
     #[test]
-    fn should_migrate_old_flat_layout_on_first_run() {
+    fn should_migrate_pre_flat_layout_on_first_run() {
         let _g = with_test_reviews_dir();
         let reviews_dir = get_reviews_dir().unwrap();
 
-        // Drop an old-style flat session file into the reviews dir directly.
-        let old_file = reviews_dir.join("old_session.json");
-        fs::write(&old_file, "{\"legacy\":true}").unwrap();
+        // Pre-flat artifact: a top-level *.json from the original flat
+        // layout, or a tree-layout subdir from the intermediate v2 layout.
+        let stray = reviews_dir.join("old_session.json");
+        fs::write(&stray, "{\"legacy\":true}").unwrap();
+        let tree_subdir = reviews_dir.join("local").join("abcd");
+        fs::create_dir_all(&tree_subdir).unwrap();
+        fs::write(tree_subdir.join("foo.json"), "{}").unwrap();
 
         let session = make_local_session(
             make_repo(),
@@ -786,21 +744,24 @@ mod tests {
         save_session(&session).unwrap();
 
         assert!(
-            !old_file.exists(),
-            "old flat session file should have moved during migration"
+            !stray.exists(),
+            "pre-flat artifacts should have moved during migration"
         );
+        assert!(reviews_dir.join(SESSIONS_DIRNAME).exists());
+
         let parent = reviews_dir.parent().unwrap();
         let backup_exists = fs::read_dir(parent)
             .unwrap()
             .flatten()
-            .any(|e| e.file_name().to_string_lossy().contains(".v1"));
-        assert!(backup_exists, "expected a .v1 backup dir under {parent:?}");
+            .any(|e| e.file_name().to_string_lossy().contains(".bak"));
+        assert!(backup_exists, "expected a .bak backup dir under {parent:?}");
     }
 
     #[test]
-    fn should_not_migrate_when_manifest_already_present() {
+    fn should_not_migrate_when_sessions_dir_already_present() {
         let _g = with_test_reviews_dir();
         let reviews_dir = get_reviews_dir().unwrap();
+        fs::create_dir_all(reviews_dir.join(SESSIONS_DIRNAME)).unwrap();
         let manifest = Manifest::new();
         manifest::save_manifest(&reviews_dir, &manifest).unwrap();
 
@@ -817,7 +778,30 @@ mod tests {
         save_session(&session).unwrap();
         assert!(
             stray.exists(),
-            "stray .json must survive when manifest exists"
+            "stray .json must survive when sessions/ already exists"
+        );
+    }
+
+    #[test]
+    fn should_not_migrate_when_reviews_dir_is_empty() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+        // Reviews dir exists but is empty: no migration trigger.
+        maybe_migrate(&reviews_dir).unwrap();
+        assert!(reviews_dir.exists());
+        let stem = reviews_dir
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let parent = reviews_dir.parent().unwrap();
+        let our_backup_exists = fs::read_dir(parent).unwrap().flatten().any(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with(&stem) && name.contains(".bak")
+        });
+        assert!(
+            !our_backup_exists,
+            "should not migrate when reviews dir is empty"
         );
     }
 }

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -1,0 +1,746 @@
+//! Deterministic identifiers for review changesets.
+//!
+//! A `Slug` is the agent-facing identity for a review session. It is intended
+//! to be human-readable and computable from public information about the
+//! repository and the kind of review being performed.
+//!
+//! Grammar:
+//!
+//! - Local: `[<owner>/]<repo>@<anchor>/<source>`
+//! - PR:    `gh:<owner>/<repo>/pr/<number>`
+//!
+//! Where `<anchor>` is either a sanitized branch/bookmark name (no `/`) or
+//! `~<short-sha>` for detached / anonymous heads, and `<source>` is one of the
+//! diff-source variants (`worktree`, `staged`, `unstaged`,
+//! `staged-and-unstaged`, `pristine`, `commits/<base>..<head>`, etc.).
+#![allow(dead_code)]
+
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+use git2::Repository;
+
+use crate::forge::traits::{ForgeKind, PrSessionKey};
+use crate::model::review::SessionDiffSource;
+
+const SHORT_SHA_LEN: usize = 7;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum Slug {
+    Local(LocalSlug),
+    Pr(PrSlug),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LocalSlug {
+    pub owner: Option<String>,
+    pub repo: String,
+    pub anchor: SlugAnchor,
+    pub source: SlugSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PrSlug {
+    pub forge: ForgeKind,
+    pub owner: String,
+    pub repo: String,
+    pub number: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SlugAnchor {
+    /// Named branch/bookmark. Slashes are sanitized to `-` at construction
+    /// time so the anchor segment never contains `/`.
+    Branch(String),
+    /// Detached / anonymous head. Short SHA or change-id prefix without the
+    /// leading `~`.
+    Anonymous(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SlugSource {
+    Worktree,
+    Staged,
+    Unstaged,
+    StagedAndUnstaged,
+    Pristine,
+    Commits(CommitRange),
+    WorktreeAndCommits(CommitRange),
+    StagedUnstagedAndCommits(CommitRange),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CommitRange {
+    pub base: String,
+    pub head: String,
+}
+
+// ----- Display -----
+
+impl fmt::Display for Slug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Slug::Local(s) => s.fmt(f),
+            Slug::Pr(s) => s.fmt(f),
+        }
+    }
+}
+
+impl fmt::Display for LocalSlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(owner) = &self.owner {
+            write!(f, "{}/{}@{}/{}", owner, self.repo, self.anchor, self.source)
+        } else {
+            write!(f, "{}@{}/{}", self.repo, self.anchor, self.source)
+        }
+    }
+}
+
+impl fmt::Display for PrSlug {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kind = match self.forge {
+            ForgeKind::GitHub => "gh",
+        };
+        write!(
+            f,
+            "{}:{}/{}/pr/{}",
+            kind, self.owner, self.repo, self.number
+        )
+    }
+}
+
+impl fmt::Display for SlugAnchor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SlugAnchor::Branch(name) => f.write_str(name),
+            SlugAnchor::Anonymous(sha) => write!(f, "~{sha}"),
+        }
+    }
+}
+
+impl fmt::Display for SlugSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SlugSource::Worktree => f.write_str("worktree"),
+            SlugSource::Staged => f.write_str("staged"),
+            SlugSource::Unstaged => f.write_str("unstaged"),
+            SlugSource::StagedAndUnstaged => f.write_str("staged-and-unstaged"),
+            SlugSource::Pristine => f.write_str("pristine"),
+            SlugSource::Commits(r) => write!(f, "commits/{}..{}", r.base, r.head),
+            SlugSource::WorktreeAndCommits(r) => {
+                write!(f, "worktree-and-commits/{}..{}", r.base, r.head)
+            }
+            SlugSource::StagedUnstagedAndCommits(r) => {
+                write!(f, "staged-and-unstaged-and-commits/{}..{}", r.base, r.head)
+            }
+        }
+    }
+}
+
+// ----- Parsing -----
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum SlugParseError {
+    #[error("empty slug")]
+    Empty,
+    #[error("invalid slug shape: {0}")]
+    InvalidShape(String),
+    #[error("unknown diff source: {0}")]
+    UnknownSource(String),
+    #[error("invalid PR number: {0}")]
+    InvalidPrNumber(String),
+    #[error("unknown forge kind: {0}")]
+    UnknownForge(String),
+    #[error("missing or malformed commit range")]
+    MissingRange,
+}
+
+impl FromStr for Slug {
+    type Err = SlugParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(SlugParseError::Empty);
+        }
+        // A PR slug starts with a forge kind followed by `:`. A local slug
+        // never contains `:` in its leading segment because `[<owner>/]<repo>`
+        // is alphanumeric/dash.
+        if let Some((kind, rest)) = s.split_once(':') {
+            let forge = match kind {
+                "gh" => ForgeKind::GitHub,
+                other => return Err(SlugParseError::UnknownForge(other.to_string())),
+            };
+            return parse_pr(forge, rest).map(Slug::Pr);
+        }
+        parse_local(s).map(Slug::Local)
+    }
+}
+
+fn parse_pr(forge: ForgeKind, rest: &str) -> Result<PrSlug, SlugParseError> {
+    let parts: Vec<&str> = rest.split('/').collect();
+    if parts.len() != 4 || parts[2] != "pr" || parts[0].is_empty() || parts[1].is_empty() {
+        return Err(SlugParseError::InvalidShape(rest.to_string()));
+    }
+    let number: u64 = parts[3]
+        .parse()
+        .map_err(|_| SlugParseError::InvalidPrNumber(parts[3].to_string()))?;
+    Ok(PrSlug {
+        forge,
+        owner: parts[0].to_string(),
+        repo: parts[1].to_string(),
+        number,
+    })
+}
+
+fn parse_local(s: &str) -> Result<LocalSlug, SlugParseError> {
+    let (project, rest) = s
+        .split_once('@')
+        .ok_or_else(|| SlugParseError::InvalidShape(s.to_string()))?;
+
+    let (owner, repo) = if let Some((o, r)) = project.split_once('/') {
+        if r.contains('/') || o.is_empty() || r.is_empty() {
+            return Err(SlugParseError::InvalidShape(s.to_string()));
+        }
+        (Some(o.to_string()), r.to_string())
+    } else if project.is_empty() {
+        return Err(SlugParseError::InvalidShape(s.to_string()));
+    } else {
+        (None, project.to_string())
+    };
+
+    let (anchor_str, source_str) = rest
+        .split_once('/')
+        .ok_or_else(|| SlugParseError::InvalidShape(s.to_string()))?;
+
+    let anchor = if let Some(sha) = anchor_str.strip_prefix('~') {
+        if sha.is_empty() {
+            return Err(SlugParseError::InvalidShape(s.to_string()));
+        }
+        SlugAnchor::Anonymous(sha.to_string())
+    } else {
+        if anchor_str.is_empty() {
+            return Err(SlugParseError::InvalidShape(s.to_string()));
+        }
+        SlugAnchor::Branch(anchor_str.to_string())
+    };
+
+    let source = parse_source(source_str)?;
+
+    Ok(LocalSlug {
+        owner,
+        repo,
+        anchor,
+        source,
+    })
+}
+
+fn parse_source(s: &str) -> Result<SlugSource, SlugParseError> {
+    match s {
+        "worktree" => Ok(SlugSource::Worktree),
+        "staged" => Ok(SlugSource::Staged),
+        "unstaged" => Ok(SlugSource::Unstaged),
+        "staged-and-unstaged" => Ok(SlugSource::StagedAndUnstaged),
+        "pristine" => Ok(SlugSource::Pristine),
+        _ => {
+            if let Some(range) = s.strip_prefix("commits/") {
+                Ok(SlugSource::Commits(parse_range(range)?))
+            } else if let Some(range) = s.strip_prefix("worktree-and-commits/") {
+                Ok(SlugSource::WorktreeAndCommits(parse_range(range)?))
+            } else if let Some(range) = s.strip_prefix("staged-and-unstaged-and-commits/") {
+                Ok(SlugSource::StagedUnstagedAndCommits(parse_range(range)?))
+            } else {
+                Err(SlugParseError::UnknownSource(s.to_string()))
+            }
+        }
+    }
+}
+
+fn parse_range(s: &str) -> Result<CommitRange, SlugParseError> {
+    let (base, head) = s.split_once("..").ok_or(SlugParseError::MissingRange)?;
+    if base.is_empty() || head.is_empty() {
+        return Err(SlugParseError::MissingRange);
+    }
+    Ok(CommitRange {
+        base: base.to_string(),
+        head: head.to_string(),
+    })
+}
+
+// ----- Helpers -----
+
+/// Sanitize a branch/bookmark name for use as a slug anchor segment. Replaces
+/// `/` with `-`. Lossy: `feature/login` and `feature-login` collapse to the
+/// same anchor; in practice collisions are rare.
+pub fn sanitize_ref(name: &str) -> String {
+    name.replace('/', "-")
+}
+
+/// Take the first `SHORT_SHA_LEN` chars of a SHA. Shorter inputs pass through.
+pub fn short_sha(sha: &str) -> String {
+    sha.chars().take(SHORT_SHA_LEN).collect()
+}
+
+// ----- Derivation from a PR session key -----
+
+impl From<&PrSessionKey> for Slug {
+    fn from(key: &PrSessionKey) -> Self {
+        Slug::Pr(PrSlug {
+            forge: key.repository.kind,
+            owner: key.repository.owner.clone(),
+            repo: key.repository.name.clone(),
+            number: key.number,
+        })
+    }
+}
+
+// ----- Derivation from local session inputs -----
+
+#[derive(Debug, thiserror::Error)]
+pub enum SlugDeriveError {
+    #[error("cannot determine repo name from path {0}")]
+    NoRepoName(String),
+    #[error("commit range required for diff source {0:?} but missing")]
+    MissingCommitRange(SessionDiffSource),
+    #[error("PullRequest diff source has no local slug")]
+    PullRequestNotLocal,
+}
+
+/// Resolve the `(owner, repo)` pair for a local repo from its remote `origin`
+/// URL. Falls back to the directory name (no owner) when the origin URL is
+/// missing or unparseable.
+pub fn resolve_owner_repo(repo_path: &Path) -> Result<(Option<String>, String), SlugDeriveError> {
+    if let Ok(repo) = Repository::discover(repo_path)
+        && let Some((owner, name)) = origin_owner_repo(&repo)
+    {
+        return Ok((Some(owner), name));
+    }
+    let name = repo_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| SlugDeriveError::NoRepoName(repo_path.display().to_string()))?;
+    Ok((None, name))
+}
+
+fn origin_owner_repo(repo: &Repository) -> Option<(String, String)> {
+    let remote = repo.find_remote("origin").ok()?;
+    let url = remote.url()?;
+    parse_remote_owner_repo(url)
+}
+
+/// Forge-agnostic remote-URL parser. Handles HTTPS, SCP-style SSH
+/// (`git@host:path`), and SSH scheme URLs. Always takes the last two path
+/// segments as `owner/repo` so nested groupings (GitLab subgroups, etc.)
+/// degrade gracefully. Strips a trailing `.git`.
+fn parse_remote_owner_repo(remote_url: &str) -> Option<(String, String)> {
+    let url = remote_url.trim();
+    if let Some(rest) = url.strip_prefix("https://") {
+        parse_path_segments(rest)
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        parse_path_segments(rest)
+    } else if let Some(rest) = url.strip_prefix("ssh://") {
+        parse_path_segments(rest)
+    } else if let Some((_, rest)) = url.split_once('@') {
+        let normalized = rest.replacen(':', "/", 1);
+        parse_path_segments(&normalized)
+    } else {
+        parse_path_segments(url)
+    }
+}
+
+fn parse_path_segments(s: &str) -> Option<(String, String)> {
+    let (_, path) = s.split_once('/')?;
+    let mut segments: Vec<&str> = path
+        .trim_matches('/')
+        .split('/')
+        .filter(|seg| !seg.is_empty())
+        .collect();
+    let repo_seg = segments.pop()?;
+    let owner_seg = segments.pop()?;
+    if owner_seg.is_empty() || repo_seg.is_empty() {
+        return None;
+    }
+    let repo = repo_seg.strip_suffix(".git").unwrap_or(repo_seg);
+    Some((owner_seg.to_string(), repo.to_string()))
+}
+
+/// Build a `LocalSlug` from session inputs. The `owner_repo` pair is taken
+/// pre-resolved (see [`resolve_owner_repo`]) so that the build step itself is
+/// pure and testable without git I/O.
+pub fn build_local_slug(
+    owner_repo: (Option<String>, String),
+    branch_name: Option<&str>,
+    head_commit: &str,
+    diff_source: SessionDiffSource,
+    commit_range: Option<&[String]>,
+) -> Result<LocalSlug, SlugDeriveError> {
+    let (owner, repo) = owner_repo;
+    let anchor = match branch_name {
+        Some(name) => SlugAnchor::Branch(sanitize_ref(name)),
+        None => SlugAnchor::Anonymous(short_sha(head_commit)),
+    };
+    let source = build_source(diff_source, commit_range)?;
+    Ok(LocalSlug {
+        owner,
+        repo,
+        anchor,
+        source,
+    })
+}
+
+fn build_source(
+    diff_source: SessionDiffSource,
+    commit_range: Option<&[String]>,
+) -> Result<SlugSource, SlugDeriveError> {
+    match diff_source {
+        SessionDiffSource::WorkingTree => Ok(SlugSource::Worktree),
+        SessionDiffSource::Staged => Ok(SlugSource::Staged),
+        SessionDiffSource::Unstaged => Ok(SlugSource::Unstaged),
+        SessionDiffSource::StagedAndUnstaged => Ok(SlugSource::StagedAndUnstaged),
+        SessionDiffSource::Pristine => Ok(SlugSource::Pristine),
+        SessionDiffSource::CommitRange => {
+            Ok(SlugSource::Commits(range_from(commit_range, diff_source)?))
+        }
+        SessionDiffSource::WorkingTreeAndCommits => Ok(SlugSource::WorktreeAndCommits(range_from(
+            commit_range,
+            diff_source,
+        )?)),
+        SessionDiffSource::StagedUnstagedAndCommits => Ok(SlugSource::StagedUnstagedAndCommits(
+            range_from(commit_range, diff_source)?,
+        )),
+        SessionDiffSource::PullRequest => Err(SlugDeriveError::PullRequestNotLocal),
+    }
+}
+
+fn range_from(
+    commit_range: Option<&[String]>,
+    diff_source: SessionDiffSource,
+) -> Result<CommitRange, SlugDeriveError> {
+    let range = commit_range.ok_or(SlugDeriveError::MissingCommitRange(diff_source))?;
+    if range.is_empty() {
+        return Err(SlugDeriveError::MissingCommitRange(diff_source));
+    }
+    // `commit_range` is stored newest-first by the App layer.
+    let head = short_sha(&range[0]);
+    let base = short_sha(&range[range.len() - 1]);
+    Ok(CommitRange { base, head })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::traits::ForgeRepository;
+
+    // ---------- Display ----------
+
+    #[test]
+    fn should_render_local_slug_with_owner() {
+        let slug = LocalSlug {
+            owner: Some("agavra".to_string()),
+            repo: "tuicr".to_string(),
+            anchor: SlugAnchor::Branch("main".to_string()),
+            source: SlugSource::Worktree,
+        };
+        assert_eq!(slug.to_string(), "agavra/tuicr@main/worktree");
+    }
+
+    #[test]
+    fn should_render_local_slug_without_owner() {
+        let slug = LocalSlug {
+            owner: None,
+            repo: "tuicr".to_string(),
+            anchor: SlugAnchor::Branch("main".to_string()),
+            source: SlugSource::Worktree,
+        };
+        assert_eq!(slug.to_string(), "tuicr@main/worktree");
+    }
+
+    #[test]
+    fn should_render_anonymous_anchor() {
+        let slug = LocalSlug {
+            owner: Some("agavra".to_string()),
+            repo: "tuicr".to_string(),
+            anchor: SlugAnchor::Anonymous("abc1234".to_string()),
+            source: SlugSource::Worktree,
+        };
+        assert_eq!(slug.to_string(), "agavra/tuicr@~abc1234/worktree");
+    }
+
+    #[test]
+    fn should_render_commits_source() {
+        let slug = LocalSlug {
+            owner: Some("agavra".to_string()),
+            repo: "tuicr".to_string(),
+            anchor: SlugAnchor::Branch("main".to_string()),
+            source: SlugSource::Commits(CommitRange {
+                base: "abc1234".to_string(),
+                head: "def5678".to_string(),
+            }),
+        };
+        assert_eq!(
+            slug.to_string(),
+            "agavra/tuicr@main/commits/abc1234..def5678"
+        );
+    }
+
+    #[test]
+    fn should_render_pr_slug_github() {
+        let slug = PrSlug {
+            forge: ForgeKind::GitHub,
+            owner: "agavra".to_string(),
+            repo: "tuicr".to_string(),
+            number: 125,
+        };
+        assert_eq!(slug.to_string(), "gh:agavra/tuicr/pr/125");
+    }
+
+    // ---------- Round-trip ----------
+
+    fn assert_roundtrip(s: &str) {
+        let parsed: Slug = s.parse().expect(s);
+        assert_eq!(parsed.to_string(), s, "round-trip failed for {s}");
+    }
+
+    #[test]
+    fn should_roundtrip_local_slug_variants() {
+        assert_roundtrip("agavra/tuicr@main/worktree");
+        assert_roundtrip("agavra/tuicr@main/staged");
+        assert_roundtrip("agavra/tuicr@main/unstaged");
+        assert_roundtrip("agavra/tuicr@feature-login/staged-and-unstaged");
+        assert_roundtrip("agavra/tuicr@main/pristine");
+        assert_roundtrip("agavra/tuicr@~abc1234/worktree");
+        assert_roundtrip("agavra/tuicr@main/commits/abc1234..def5678");
+        assert_roundtrip("agavra/tuicr@main/worktree-and-commits/abc1234..def5678");
+        assert_roundtrip("agavra/tuicr@main/staged-and-unstaged-and-commits/abc1234..def5678");
+        assert_roundtrip("tuicr@main/worktree");
+    }
+
+    #[test]
+    fn should_roundtrip_pr_slug() {
+        assert_roundtrip("gh:agavra/tuicr/pr/125");
+        assert_roundtrip("gh:org/svc/pr/9999");
+    }
+
+    // ---------- Parse errors ----------
+
+    #[test]
+    fn should_reject_empty_slug() {
+        assert_eq!("".parse::<Slug>().unwrap_err(), SlugParseError::Empty);
+    }
+
+    #[test]
+    fn should_reject_pr_slug_with_non_numeric_number() {
+        let err = "gh:agavra/tuicr/pr/notanumber".parse::<Slug>().unwrap_err();
+        assert!(matches!(err, SlugParseError::InvalidPrNumber(_)));
+    }
+
+    #[test]
+    fn should_reject_unknown_forge_prefix() {
+        let err = "xy:agavra/tuicr/pr/1".parse::<Slug>().unwrap_err();
+        assert!(matches!(err, SlugParseError::UnknownForge(_)));
+    }
+
+    #[test]
+    fn should_reject_pr_slug_missing_pr_keyword() {
+        assert!("gh:agavra/tuicr/notpr/1".parse::<Slug>().is_err());
+    }
+
+    #[test]
+    fn should_reject_local_slug_without_at_separator() {
+        assert!("agavra/tuicr/worktree".parse::<Slug>().is_err());
+    }
+
+    #[test]
+    fn should_reject_unknown_diff_source() {
+        let err = "agavra/tuicr@main/blarghhh".parse::<Slug>().unwrap_err();
+        assert!(matches!(err, SlugParseError::UnknownSource(_)));
+    }
+
+    #[test]
+    fn should_reject_empty_anchor() {
+        assert!("agavra/tuicr@/worktree".parse::<Slug>().is_err());
+    }
+
+    #[test]
+    fn should_reject_empty_anonymous_anchor() {
+        assert!("agavra/tuicr@~/worktree".parse::<Slug>().is_err());
+    }
+
+    #[test]
+    fn should_reject_commits_source_missing_range() {
+        assert!("agavra/tuicr@main/commits/".parse::<Slug>().is_err());
+        assert!("agavra/tuicr@main/commits/abc1234".parse::<Slug>().is_err());
+        assert!(
+            "agavra/tuicr@main/commits/..abc1234"
+                .parse::<Slug>()
+                .is_err()
+        );
+    }
+
+    // ---------- Sanitization ----------
+
+    #[test]
+    fn should_replace_slashes_in_branch_with_dashes() {
+        assert_eq!(sanitize_ref("feature/login"), "feature-login");
+        assert_eq!(sanitize_ref("dependabot/foo/bar"), "dependabot-foo-bar");
+        assert_eq!(sanitize_ref("main"), "main");
+    }
+
+    #[test]
+    fn should_truncate_to_short_sha_length() {
+        assert_eq!(short_sha("abcdef1234567890"), "abcdef1");
+        assert_eq!(short_sha("abc"), "abc");
+    }
+
+    // ---------- From PrSessionKey ----------
+
+    #[test]
+    fn should_derive_slug_from_pr_session_key() {
+        let key = PrSessionKey::new(
+            ForgeRepository::github("github.com", "agavra", "tuicr"),
+            125,
+            "abcdef0123456789".to_string(),
+        );
+        let slug: Slug = (&key).into();
+        assert_eq!(slug.to_string(), "gh:agavra/tuicr/pr/125");
+    }
+
+    // ---------- Remote URL parser ----------
+
+    #[test]
+    fn should_parse_https_remote_url() {
+        assert_eq!(
+            parse_remote_owner_repo("https://github.com/agavra/tuicr.git"),
+            Some(("agavra".to_string(), "tuicr".to_string()))
+        );
+    }
+
+    #[test]
+    fn should_parse_https_remote_url_without_dot_git_suffix() {
+        assert_eq!(
+            parse_remote_owner_repo("https://github.com/agavra/tuicr"),
+            Some(("agavra".to_string(), "tuicr".to_string()))
+        );
+    }
+
+    #[test]
+    fn should_parse_scp_like_ssh_remote_url() {
+        assert_eq!(
+            parse_remote_owner_repo("git@github.com:agavra/tuicr.git"),
+            Some(("agavra".to_string(), "tuicr".to_string()))
+        );
+    }
+
+    #[test]
+    fn should_parse_ssh_scheme_remote_url() {
+        assert_eq!(
+            parse_remote_owner_repo("ssh://git@github.com/agavra/tuicr.git"),
+            Some(("agavra".to_string(), "tuicr".to_string()))
+        );
+    }
+
+    #[test]
+    fn should_pick_last_two_segments_for_nested_subgroups() {
+        // GitLab subgroups: take last two segments as owner/repo.
+        assert_eq!(
+            parse_remote_owner_repo("git@gitlab.com:org/team/svc.git"),
+            Some(("team".to_string(), "svc".to_string()))
+        );
+    }
+
+    #[test]
+    fn should_return_none_for_unparseable_remote() {
+        assert_eq!(parse_remote_owner_repo("not-a-url"), None);
+        assert_eq!(parse_remote_owner_repo(""), None);
+    }
+
+    // ---------- build_local_slug ----------
+
+    #[test]
+    fn should_build_worktree_slug_from_branch() {
+        let slug = build_local_slug(
+            (Some("agavra".to_string()), "tuicr".to_string()),
+            Some("main"),
+            "abcdef0123",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap();
+        assert_eq!(slug.to_string(), "agavra/tuicr@main/worktree");
+    }
+
+    #[test]
+    fn should_sanitize_branch_at_build_time() {
+        let slug = build_local_slug(
+            (Some("agavra".to_string()), "tuicr".to_string()),
+            Some("feature/login"),
+            "abcdef0123",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap();
+        assert_eq!(slug.to_string(), "agavra/tuicr@feature-login/worktree");
+    }
+
+    #[test]
+    fn should_use_anonymous_anchor_when_branch_is_none() {
+        let slug = build_local_slug(
+            (Some("agavra".to_string()), "tuicr".to_string()),
+            None,
+            "abcdef0123456789",
+            SessionDiffSource::WorkingTree,
+            None,
+        )
+        .unwrap();
+        assert_eq!(slug.to_string(), "agavra/tuicr@~abcdef0/worktree");
+    }
+
+    #[test]
+    fn should_build_commits_slug_from_range() {
+        let range = vec![
+            "def5678aaa".to_string(),
+            "intermediate".to_string(),
+            "abc1234bbb".to_string(),
+        ];
+        let slug = build_local_slug(
+            (Some("agavra".to_string()), "tuicr".to_string()),
+            Some("main"),
+            "def5678",
+            SessionDiffSource::CommitRange,
+            Some(&range),
+        )
+        .unwrap();
+        // commit_range is newest-first: head = first, base = last (short SHAs)
+        assert_eq!(
+            slug.to_string(),
+            "agavra/tuicr@main/commits/abc1234..def5678"
+        );
+    }
+
+    #[test]
+    fn should_reject_build_for_commit_range_without_range() {
+        let err = build_local_slug(
+            (Some("agavra".to_string()), "tuicr".to_string()),
+            Some("main"),
+            "def5678",
+            SessionDiffSource::CommitRange,
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, SlugDeriveError::MissingCommitRange(_)));
+    }
+
+    #[test]
+    fn should_reject_build_for_pull_request_diff_source() {
+        let err = build_local_slug(
+            (Some("agavra".to_string()), "tuicr".to_string()),
+            Some("main"),
+            "def5678",
+            SessionDiffSource::PullRequest,
+            None,
+        )
+        .unwrap_err();
+        assert!(matches!(err, SlugDeriveError::PullRequestNotLocal));
+    }
+}

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -77,6 +77,9 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     if app.is_single_file_view {
         chunks.push("FOCUS".to_string());
     }
+    if let Some(slug) = app.session_slug() {
+        chunks.push(slug);
+    }
     if app.is_pristine_mode {
         // The pristine session key has shape `pristine:<head_or_none>:<hash>`,
         // so the middle segment is the short SHA of the HEAD we're reviewing.


### PR DESCRIPTION
## Summary

Reworks the concept of a "session" in tuicr so coding agents can discover
the session for a given repo/PR without parsing the markdown export. Sessions
are now identified by a deterministic, human-readable **slug**:

- Local: `<owner>/<repo>@<ref>/<source>` (e.g. `agavra/tuicr@main/worktree`)
- PR:    `gh:<owner>/<repo>/pr/<number>` (e.g. `gh:agavra/tuicr/pr/125`)

The slug is computed from public info (git origin URL, branch, diff source),
emitted to stderr at startup as `tuicr-session: <slug>`, shown in the status
bar, and prepended to markdown exports as `## Session: <slug>`. Agents can
either compute the slug themselves or capture it from any of those channels.

## Storage layout

`~/.local/share/tuicr/reviews/` (or `~/Library/Application Support/tuicr/reviews/` on macOS):

```
reviews/
  index.json             # manifest, source of truth for slug -> file lookups
  sessions/
    <16-hex>.json        # one file per session, deterministic name
```

The session filename is `Fnv1aHasher(slug || canonical_repo_path)` for local
sessions and `Fnv1aHasher(slug || head_sha)` for PR sessions. Same logical
session always hashes to the same path; no manifest lookup needed to construct
it. The manifest is authoritative for slug → file routing; if it goes missing
or corrupts, every session JSON is self-describing and `rebuild_from_files`
can reconstruct it by walking the tree.

Multiple checkouts of the same repo (same slug, different canonical paths)
coexist in the manifest as `Vec<ManifestEntry>` per slug; lookups disambiguate
by canonical path.

## Migration

Hard cutover. On first run under the new code, any reviews dir without a
`sessions/` subdir and non-empty contents is moved aside to `<reviews>.bak<n>`.
Catches the pre-rework flat layout and any intermediate layouts.

## Design discussion

Driven by an in-conversation design session covering:

- Changeset vs invocation identity (chose changeset)
- Slug shape (human-readable beat hash and URI)
- Filesystem layout: manifest as source of truth, with file-scan recovery
- Local owner derivation: git remote origin with directory-name fallback
- PR slug: head-less, storage keyed by head SHA (one file per head)
- Branch sanitization: `/` → `-` (lossy, accepted)
- Detached HEAD / anonymous: `@~<short-sha>` anchor
- CLI surface: `tuicr session list/show/path/rm` ([deferred to a follow-up PR](#))
- Hard cutover migration (no support for older layouts)

## Test plan

- [ ] **Migration** — restore old reviews dir, run `tuicr -w`, confirm stderr message and `reviews.bak1/` exists
- [ ] **Slug emission** — verify `tuicr-session: <slug>` on stderr, slug visible in status bar, `## Session: <slug>` in markdown export
- [ ] **Local sessions** — try each diff source (worktree, staged, unstaged, staged+unstaged, commit range, pristine), confirm session reattaches on second run
- [ ] **Branch sanitization** — `git checkout -b feature/foo`, verify slug becomes `…@feature-foo/worktree`
- [ ] **Detached HEAD** — `git checkout <sha>`, verify slug is `…@~<7-char>/worktree`
- [ ] **PR sessions** — `tuicr pr <n>` against a real PR; verify slug + storage; advance head, verify new file appears under `sessions/` and old session no longer surfaces
- [ ] **Multi-checkout disambiguation** — two clones of the same repo, each has its own session
- [ ] **No remote** — fresh `git init` repo; slug has no owner (`<repo>@<branch>/<source>`)
- [ ] **jj / hg backends** — slug uses bookmark / branch correctly
- [ ] **tmux skill** — still works against the existing `--stdout` capture (skill unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)