### PR TITLE
feat: add single-file view with file-walking navigation

### DIFF
--- a/docs/decisions/FEAT-0011 Single-File View.md
+++ b/docs/decisions/FEAT-0011 Single-File View.md
@@ -1,0 +1,60 @@
+---
+title: Single-File View Mode
+description: Add `:focus` toggle that renders the currently selected file alone, with cursor walking across files
+type: adr
+status: proposed
+created: 2026-05-21
+---
+
+# FEAT-0011 Single-File View Mode
+
+## Context and Problem Statement
+
+Whole-repo annotation (`--all-files`, shipped in FEAT-0010) drops the user into a continuous scroll of every tracked file. On a real repo the scroll feels unbounded: the file you want is somewhere down there, the cursor's `current_file_idx` updates as you scroll, and section headers (`═══ filename ═══`) eat horizontal space when long lines need scrolling. The dominant workflow in practice is "focus one file, annotate, move on" -- the continuous view's strength (compare across files at once) is rarely what the user actually does.
+
+This ADR introduces a sticky single-file view: render only the currently focused file in the diff panel, and walk between files by holding `j`/`k`. It does not replace the continuous view; both coexist and the user picks per session. Pane-focus navigation (Left/Right arrow keys, file-list hide/reveal) is a separate concern decided in [FEAT-0012][FEAT-0012].
+
+## Decision Drivers
+
+- Pristine reviews (`--all-files`) need a focus surface; continuous scroll is overwhelming for >100 tracked files.
+- Diff-mode review keeps benefiting from continuous scroll (compare across files), so the new view must be a toggle, not a replacement.
+- Cursor and scroll math must agree with what the renderer produces. The first single-file view PR shipped with four bugs from `total_lines`, `calculate_file_scroll_offset`, `next_hunk`, and `update_current_file_from_cursor` each branching on the mode flag in slightly different ways; the root cause was the lack of a single height helper.
+- Status of which mode is active must be visible at all times (sticky mode without indicator is a classic vi-modal-confusion bug).
+
+## Considered Options
+
+1. **`DiffSource::Pristine` variant carries the focused file set** -- rejected, locks the workflow to pristine mode when commit-range and PR reviews want the same focus surface.
+2. **Filter the rendered line stream at the renderer** -- rejected, cursor math and rendering desynchronize (cursor lands on lines that aren't rendered, `next_hunk` walks past non-rendered hunks).
+3. **Mode flag + render-aware height helper + file-walking cursor** -- chosen.
+
+## Decision Outcome
+
+Chosen: option 3.
+
+The toggle is `:focus` (alias `:f`, leader-prefixed `<leader>f`). `--all-files` defaults to single-file view since whole-repo continuous scroll is the worse default for that surface; every other mode opens in the existing continuous view.
+
+The per-file `═══ filename ═══` separator and the global `═══ Review Comments ═══` banner are dropped in single-file view -- both are redundant with only one file on screen, and both eat horizontal space when long lines force the user to scroll. A `↓ <next-filename>` hint replaces the inter-file blank so the user can see what's on the other side of `j`. Reviewed files render the body under a dimmed `Marked reviewed -- r to re-open` banner instead of collapsing to a header.
+
+Cursor and scroll math route through `effective_file_height(idx, file)`. Multi-file: same as `file_render_height`. Single-file: 0 for non-current files; current file gets body + banner (no header, no reviewed-collapse short-circuit). `total_lines`, `calculate_file_scroll_offset`, `next_hunk`, and `prev_hunk` all consume the helper, so cursor / scroll / hunk-walk semantics agree with what the renderer draws.
+
+`j` past the last line of a file does not immediately walk to the next file -- it arms `primed_walk_next` and parks the cursor on max. The consume gate also requires `down_released_since_arm` (set by a Down/`j` Release event), so held-j auto-repeats fire Press, Repeat, Repeat, ..., Release and never satisfy the gate. A deliberate release + second press walks. The same kitty `REPORT_EVENT_TYPES` enhancement that distinguishes Press from Repeat is pushed at terminal init alongside `DISAMBIGUATE_ESCAPE_CODES`; the event filter widens to accept both kinds so auto-repeat continues to drive cursor movement within a file. On terminals that don't support the enhancement, `supports_keyboard_enhancement` is false and the release gate is bypassed (two press events walk, since Release is never emitted). Symmetric for `k` / Up at the top of a file via `primed_walk_prev` + `up_released_since_arm`. `]` and `[` walk hunks within the current file, and once exhausted cross into the next / previous file's first / last hunk so a single keystream can step the codebase hunk-by-hunk without needing to know file boundaries.
+
+File-list `j`/`k` auto-follows in single-file view: the highlighted file becomes the visible one without pressing Enter. Mouse-wheel on the file list stays as viewport scroll (no auto-follow) because wheel is a "browse" gesture, not a "navigate" gesture.
+
+## Consequences
+
+- [+] Single-file view is a first-class mode that composes with every existing surface: comments, clipboard, persistence, themes, file-tree expansion, search.
+- [+] Holding `j` walks the codebase file-by-file. The previous workaround -- jump-to-file from the file list, repeat -- collapses into a single keystroke.
+- [+] The `effective_file_height` helper gives every geometry-aware code path one place to ask "how tall is this file in the current view?". Adding future modes (e.g. focus on a directory subtree) is a small extension to one helper, not a per-call-site decision.
+- [-] Search and `n`/`N` cursor placement (not touched in this PR) likely have the same cumulative-offset shape as `next_hunk` did and may need the same audit.
+- [-] Sticky mode adds a dimension of "why is `j` behaving differently?" confusion. Mitigated by the `FOCUS` status chip.
+
+Entering Comment mode snaps `diff_state.scroll_x = 0` so the inline input box always lands inside the viewport. Without the snap, opening a comment on a line scrolled past the right edge leaves the input box off-screen and the user types blind until pressing Enter.
+
+## Future Considerations
+
+- Audit search and `n`/`N` cursor placement against `effective_file_height`; today they iterate cumulative offsets the same way `next_hunk` did before this change.
+- Pristine `--all-files` over a very large repo loads every tracked file at startup; the continuous scroll is gone but the initial load isn't paginated. A lazy file-tree load (only build the diff for the visible file plus a small window) would scale further.
+- Consider per-session toggle persistence so a user who toggled `:focus` once does not have to re-toggle every launch.
+
+[FEAT-0012]: FEAT-0012 Arrow-Key Pane Focus.md

--- a/src/app.rs
+++ b/src/app.rs
@@ -921,6 +921,32 @@ pub struct App {
     /// `PRISTINE · N files` chip in the status bar and prevents that chip
     /// from showing in the regular `--file <dir>` directory mode.
     pub is_pristine_mode: bool,
+    /// `true` when single-file view is active. Renders only the currently
+    /// focused file in the diff panel instead of the continuous-scroll
+    /// concatenation. Toggled via `:focus` or `<leader>f`.
+    pub is_single_file_view: bool,
+    /// Set when `j` (or down arrow) tries to overflow past the last line
+    /// of the current file in single-file view. The first overflow press
+    /// arms the flag and parks the cursor on max; a deliberate second
+    /// press then walks to the next file. Reset by any cursor move that
+    /// isn't a continuing overflow attempt.
+    pub primed_walk_next: bool,
+    /// Symmetric inverse of [`primed_walk_next`]: armed by an underflow
+    /// `k` press at the first line of the current file in single-file
+    /// view; consumed by a second underflow press to walk to the
+    /// previous file.
+    pub primed_walk_prev: bool,
+    /// Set when the Down arrow / `j` key is released after
+    /// `primed_walk_next` was armed. The walk consumes only when both
+    /// flags are true so held-key auto-repeat (Press, Repeat, Repeat...)
+    /// never satisfies the gate. Only meaningful on terminals that
+    /// support kitty `REPORT_EVENT_TYPES`; on others Release events are
+    /// never emitted and the gate is bypassed via
+    /// `supports_keyboard_enhancement`.
+    pub down_released_since_arm: bool,
+    /// Symmetric inverse of [`down_released_since_arm`] for the prev-file
+    /// walk gate.
+    pub up_released_since_arm: bool,
     pub cursor_line_highlight: bool,
     pub leader_key: char,
     pub scroll_offset: usize,
@@ -1215,6 +1241,15 @@ impl App {
             // would render two identical panes. The `:diff` command is gated
             // separately so the user cannot toggle back.
             app.diff_view_mode = DiffViewMode::Unified;
+            // Default `--all-files` to single-file view: every tracked file
+            // in one continuous scroll is overwhelming on large repos -- both
+            // visually and at startup, since pristine still loads the whole
+            // tree before render. `:focus` / `<leader>f` toggles back.
+            app.is_single_file_view = true;
+            // Snap the viewport to the first file's start.
+            let start = app.calculate_file_scroll_offset(app.diff_state.current_file_idx);
+            app.diff_state.scroll_offset = start;
+            app.diff_state.cursor_line = start;
 
             return Ok(app);
         }
@@ -1574,6 +1609,11 @@ impl App {
             supports_keyboard_enhancement: false,
             show_file_list: true,
             is_pristine_mode: false,
+            is_single_file_view: false,
+            primed_walk_next: false,
+            primed_walk_prev: false,
+            down_released_since_arm: false,
+            up_released_since_arm: false,
             cursor_line_highlight: true,
             leader_key: crate::config::DEFAULT_LEADER_KEY,
             scroll_offset: 0,
@@ -3268,11 +3308,15 @@ impl App {
         if let Some(review) = self.session.get_file_mut(&path) {
             review.reviewed = !review.reviewed;
             self.dirty = true;
+
+            // Update current_file_idx before rebuilding annotations:
+            // single-file view filters annotations against it.
+            if adjust_cursor {
+                self.diff_state.current_file_idx = file_idx;
+            }
             self.rebuild_annotations();
 
             if adjust_cursor {
-                self.diff_state.current_file_idx = file_idx;
-                // Move cursor to the file header line
                 let header_line = self.calculate_file_scroll_offset(file_idx);
                 self.diff_state.cursor_line = header_line;
                 self.ensure_cursor_visible();
@@ -3351,7 +3395,47 @@ impl App {
         let max_line = self.max_cursor_line();
         let prev_cursor = self.diff_state.cursor_line;
         let prev_scroll = self.diff_state.scroll_offset;
-        self.diff_state.cursor_line = (self.diff_state.cursor_line + lines).min(max_line);
+        let target = self.diff_state.cursor_line + lines;
+        // Single-file view: first overflow press arms `primed_walk_next`
+        // and parks the cursor on max. On kitty terminals the walk
+        // consumes only when the Down key was released between the two
+        // presses (`down_released_since_arm`) -- a held-j sequence emits
+        // Press, Repeat, Repeat, ..., Release and never satisfies the
+        // gate. Non-kitty terminals don't emit Release, so the gate
+        // bypasses on `!supports_keyboard_enhancement` to keep the
+        // two-press walk usable without modern keyboard reporting.
+        self.primed_walk_prev = false;
+        if self.is_single_file_view && target > max_line {
+            let release_gate_ok =
+                !self.supports_keyboard_enhancement || self.down_released_since_arm;
+            if self.primed_walk_next && release_gate_ok {
+                let next_idx = self.diff_state.current_file_idx + 1;
+                if next_idx < self.diff_files.len() {
+                    let overflow = target - max_line;
+                    self.primed_walk_next = false;
+                    self.down_released_since_arm = false;
+                    self.jump_to_file(next_idx);
+                    let new_top = self.diff_state.cursor_line;
+                    let new_max = self.max_cursor_line();
+                    self.diff_state.cursor_line =
+                        (new_top + overflow.saturating_sub(1)).min(new_max);
+                    self.ensure_cursor_visible();
+                    return;
+                }
+                self.primed_walk_next = false;
+                self.down_released_since_arm = false;
+            } else {
+                self.primed_walk_next = true;
+                self.down_released_since_arm = false;
+                self.diff_state.cursor_line = max_line;
+                self.ensure_cursor_visible();
+                return;
+            }
+        } else if target != prev_cursor {
+            self.primed_walk_next = false;
+            self.down_released_since_arm = false;
+        }
+        self.diff_state.cursor_line = target.min(max_line);
         if self.diff_state.cursor_line != prev_cursor {
             self.ensure_cursor_visible();
             // Cap scroll change to cursor movement to prevent multi-line jumps
@@ -3365,6 +3449,38 @@ impl App {
     }
 
     pub fn cursor_up(&mut self, lines: usize) {
+        // Symmetric to cursor_down: first underflow arms `primed_walk_prev`,
+        // second underflow consumes only after a Up/k release event has set
+        // `up_released_since_arm`. See cursor_down for the gate rationale.
+        self.primed_walk_next = false;
+        if self.is_single_file_view {
+            let file_top = self.calculate_file_scroll_offset(self.diff_state.current_file_idx);
+            if self.diff_state.cursor_line < file_top + lines
+                && self.diff_state.current_file_idx > 0
+            {
+                let release_gate_ok =
+                    !self.supports_keyboard_enhancement || self.up_released_since_arm;
+                if self.primed_walk_prev && release_gate_ok {
+                    let underflow = (file_top + lines) - self.diff_state.cursor_line;
+                    let prev_idx = self.diff_state.current_file_idx - 1;
+                    self.primed_walk_prev = false;
+                    self.up_released_since_arm = false;
+                    self.jump_to_file(prev_idx);
+                    let new_max = self.max_cursor_line();
+                    self.diff_state.cursor_line =
+                        new_max.saturating_sub(underflow.saturating_sub(1));
+                    self.ensure_cursor_visible();
+                    return;
+                }
+                self.primed_walk_prev = true;
+                self.up_released_since_arm = false;
+                self.diff_state.cursor_line = file_top;
+                self.ensure_cursor_visible();
+                return;
+            }
+            self.primed_walk_prev = false;
+            self.up_released_since_arm = false;
+        }
         self.diff_state.cursor_line = self.diff_state.cursor_line.saturating_sub(lines);
         let visible_lines = self.diff_state.effective_visible_lines();
         let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
@@ -4002,11 +4118,27 @@ impl App {
         let max_idx = visible_items.len().saturating_sub(1);
         let new_idx = (self.file_list_state.selected() + n).min(max_idx);
         self.file_list_state.select(new_idx);
+        self.follow_file_list_in_single_file_view();
     }
 
     pub fn file_list_up(&mut self, n: usize) {
         let new_idx = self.file_list_state.selected().saturating_sub(n);
         self.file_list_state.select(new_idx);
+        self.follow_file_list_in_single_file_view();
+    }
+
+    /// In single-file view the diff panel always shows one file at a time,
+    /// so navigating the file list with j/k should reveal the highlighted
+    /// file immediately instead of waiting for Enter. Skips directories
+    /// (jumping there has no diff target) and no-ops outside single-file
+    /// view to keep multi-file scrolling exactly as before.
+    fn follow_file_list_in_single_file_view(&mut self) {
+        if !self.is_single_file_view {
+            return;
+        }
+        if let Some(FileTreeItem::File { file_idx, .. }) = self.get_selected_tree_item() {
+            self.jump_to_file(file_idx);
+        }
     }
 
     /// Scroll the file-list viewport down by `lines` without moving the
@@ -4321,6 +4453,11 @@ impl App {
         use std::path::Path;
 
         if idx < self.diff_files.len() {
+            // Deliberate jump cancels any in-flight two-press walk arming.
+            self.primed_walk_next = false;
+            self.primed_walk_prev = false;
+            self.down_released_since_arm = false;
+            self.up_released_since_arm = false;
             self.diff_state.current_file_idx = idx;
             self.diff_state.cursor_line = self.calculate_file_scroll_offset(idx);
             let max_scroll = self.max_scroll_offset();
@@ -4338,6 +4475,13 @@ impl App {
 
             if let Some(tree_idx) = self.file_idx_to_tree_idx(idx) {
                 self.file_list_state.select(tree_idx);
+            }
+
+            // Single-file view filters `line_annotations` by
+            // `current_file_idx`, so a file switch must rebuild them or
+            // click hit-testing would resolve against the previous file.
+            if self.is_single_file_view {
+                self.rebuild_annotations();
             }
         }
     }
@@ -4391,77 +4535,87 @@ impl App {
         None
     }
 
-    pub fn next_hunk(&mut self) {
-        // Find the next hunk header position after current cursor
+    /// Render-line indices of every visible hunk header. Respects
+    /// single-file view (only the current file's hunks) and the
+    /// reviewed-collapse behavior in multi-file view (skipped entirely)
+    /// versus single-file view (body rendered under a banner).
+    fn hunk_positions(&self) -> Vec<usize> {
+        let single = self.is_single_file_view;
+        let current_idx = self.diff_state.current_file_idx;
+        let mut positions = Vec::new();
         let mut cumulative = self.review_comments_render_height();
-        for file in &self.diff_files {
-            let path = file.display_path();
-
-            // File header
-            cumulative += 1;
-
-            // If file is reviewed, skip all content
-            if self.session.is_file_reviewed(path) {
+        for (file_idx, file) in self.diff_files.iter().enumerate() {
+            if single && file_idx != current_idx {
                 continue;
             }
+            let path = file.display_path();
+            let is_reviewed = self.session.is_file_reviewed(path);
 
-            // File comments
+            if !single {
+                cumulative += 1; // File header
+            }
+            if !single && is_reviewed {
+                // multi-file collapsed: no body, no trailing spacing
+                continue;
+            }
+            if single && is_reviewed {
+                cumulative += 1; // banner
+            }
             if let Some(review) = self.session.files.get(path) {
                 cumulative += review.file_comments.len();
             }
-
-            if file.is_binary || file.hunks.is_empty() {
-                cumulative += 1; // "(binary file)" or "(no changes)"
-            } else {
-                for hunk in &file.hunks {
-                    // This is a hunk header position
-                    if cumulative > self.diff_state.cursor_line {
-                        self.diff_state.cursor_line = cumulative;
-                        self.ensure_cursor_visible();
-                        self.update_current_file_from_cursor();
-                        return;
-                    }
-                    cumulative += 1; // hunk header
-                    cumulative += hunk.lines.len(); // diff lines
-                }
-            }
-            cumulative += 1; // spacing
-        }
-    }
-
-    pub fn prev_hunk(&mut self) {
-        // Find the previous hunk header position before current cursor
-        let mut hunk_positions: Vec<usize> = Vec::new();
-        let mut cumulative = self.review_comments_render_height();
-
-        for file in &self.diff_files {
-            let path = file.display_path();
-
-            cumulative += 1; // File header
-
-            // If file is reviewed, skip all content
-            if self.session.is_file_reviewed(path) {
-                continue;
-            }
-
-            if let Some(review) = self.session.files.get(path) {
-                cumulative += review.file_comments.len();
-            }
-
             if file.is_binary || file.hunks.is_empty() {
                 cumulative += 1;
             } else {
                 for hunk in &file.hunks {
-                    hunk_positions.push(cumulative);
+                    positions.push(cumulative);
                     cumulative += 1;
                     cumulative += hunk.lines.len();
                 }
             }
-            cumulative += 1;
+            cumulative += 1; // trailing spacing or "next file" hint
         }
+        positions
+    }
 
-        // Find the last hunk position before current cursor
-        for &pos in hunk_positions.iter().rev() {
+    pub fn next_hunk(&mut self) {
+        // Hunk navigation is a deliberate move, not a continuation of a
+        // boundary walk. Clear any in-flight cursor-walk arming.
+        self.primed_walk_next = false;
+        self.primed_walk_prev = false;
+        self.down_released_since_arm = false;
+        self.up_released_since_arm = false;
+        for pos in self.hunk_positions() {
+            if pos > self.diff_state.cursor_line {
+                self.diff_state.cursor_line = pos;
+                self.ensure_cursor_visible();
+                self.update_current_file_from_cursor();
+                return;
+            }
+        }
+        // No further hunks in the current frame. Single-file view crosses
+        // into the next file's first hunk so `]` can step the codebase
+        // hunk-by-hunk without breaking on file boundaries.
+        if self.is_single_file_view {
+            let next_idx = self.diff_state.current_file_idx + 1;
+            if next_idx < self.diff_files.len() {
+                self.jump_to_file(next_idx);
+                if let Some(&first) = self.hunk_positions().first() {
+                    self.diff_state.cursor_line = first;
+                    self.ensure_cursor_visible();
+                    self.update_current_file_from_cursor();
+                }
+            }
+        }
+    }
+
+    pub fn prev_hunk(&mut self) {
+        self.primed_walk_next = false;
+        self.primed_walk_prev = false;
+        self.down_released_since_arm = false;
+        self.up_released_since_arm = false;
+        let positions = self.hunk_positions();
+        for &pos in positions.iter().rev() {
             if pos < self.diff_state.cursor_line {
                 self.diff_state.cursor_line = pos;
                 self.ensure_cursor_visible();
@@ -4469,8 +4623,19 @@ impl App {
                 return;
             }
         }
-
-        // If no previous hunk, go to start
+        // Symmetric to next_hunk: in single-file view, fall through to the
+        // previous file's last hunk so `[` keeps stepping backward across
+        // files.
+        if self.is_single_file_view && self.diff_state.current_file_idx > 0 {
+            let prev_idx = self.diff_state.current_file_idx - 1;
+            self.jump_to_file(prev_idx);
+            if let Some(&last) = self.hunk_positions().last() {
+                self.diff_state.cursor_line = last;
+                self.ensure_cursor_visible();
+                self.update_current_file_from_cursor();
+                return;
+            }
+        }
         self.diff_state.cursor_line = 0;
         self.ensure_cursor_visible();
         self.update_current_file_from_cursor();
@@ -4482,13 +4647,15 @@ impl App {
             if i == file_idx {
                 break;
             }
-            offset += self.file_render_height(i, file);
+            offset += self.effective_file_height(i, file);
         }
         offset
     }
 
     fn review_comments_render_height(&self) -> usize {
-        let mut height = 1; // Header line
+        // Header line is only rendered in multi-file view. See the guards
+        // in `src/ui/diff_unified.rs` and `src/ui/diff_side_by_side.rs`.
+        let mut height = if self.is_single_file_view { 0 } else { 1 };
         for comment in &self.session.review_comments {
             height += Self::comment_display_lines(comment, self.diff_state.viewport_width);
         }
@@ -4503,15 +4670,21 @@ impl App {
     }
 
     fn file_render_height(&self, file_idx: usize, file: &DiffFile) -> usize {
+        if self.session.is_file_reviewed(file.display_path()) {
+            return 1; // collapsed: header only
+        }
+        1 + self.file_render_body_height(file_idx, file) // header + body
+    }
+
+    /// File body height in lines (comments + content + trailing spacing),
+    /// excluding the file header and ignoring the reviewed-collapse
+    /// short-circuit. Used by `effective_file_height` to size the body of
+    /// the focused file in single-file view, where the header is hidden
+    /// and reviewed files render the body under a banner.
+    fn file_render_body_height(&self, file_idx: usize, file: &DiffFile) -> usize {
         let path = file.display_path();
 
-        // If reviewed, only show header (1 line total)
-        if self.session.is_file_reviewed(path) {
-            return 1;
-        }
-
-        let header_lines = 1; // File header
-        let spacing_lines = 1; // Blank line between files
+        let spacing_lines = 1; // Trailing blank or "next file" hint
         let mut content_lines = 0;
         let mut comment_lines = 0;
 
@@ -4792,10 +4965,37 @@ impl App {
             }
         }
 
-        header_lines + comment_lines + content_lines + spacing_lines
+        comment_lines + content_lines + spacing_lines
+    }
+
+    /// Render-aware file height that knows about `is_single_file_view`.
+    /// Multi-file view: same as `file_render_height`. Single-file view:
+    /// non-current files return 0; the current file returns the body
+    /// (no header) plus a 1-line banner when the file is reviewed.
+    fn effective_file_height(&self, file_idx: usize, file: &DiffFile) -> usize {
+        if !self.is_single_file_view {
+            return self.file_render_height(file_idx, file);
+        }
+        if file_idx != self.diff_state.current_file_idx {
+            return 0;
+        }
+        let banner = if self.session.is_file_reviewed(file.display_path()) {
+            1
+        } else {
+            0
+        };
+        banner + self.file_render_body_height(file_idx, file)
     }
 
     fn update_current_file_from_cursor(&mut self) {
+        // Single-file view renders one file at a time. `cursor_line` is
+        // interpreted relative to that single file's content, so mapping
+        // it back through cumulative-file-heights would wrongly resolve
+        // every position to file 0. The "which file is visible" decision
+        // is owned by `jump_to_file` / toggle / file-list-follow.
+        if self.is_single_file_view {
+            return;
+        }
         let mut cumulative = self.review_comments_render_height();
         if self.diff_state.cursor_line < cumulative {
             if !self.diff_files.is_empty() {
@@ -4825,7 +5025,7 @@ impl App {
                 .diff_files
                 .iter()
                 .enumerate()
-                .map(|(i, f)| self.file_render_height(i, f))
+                .map(|(i, f)| self.effective_file_height(i, f))
                 .sum::<usize>()
     }
 
@@ -5079,6 +5279,7 @@ impl App {
             Some(CommentLocation::Review { index }) => {
                 if let Some(comment) = self.session.review_comments.get(index) {
                     self.input_mode = InputMode::Comment;
+                    self.diff_state.scroll_x = 0;
                     self.comment_buffer = comment.content.clone();
                     self.comment_cursor = self.comment_buffer.len();
                     self.comment_type = comment.comment_type.clone();
@@ -5094,6 +5295,7 @@ impl App {
                     && let Some(comment) = review.file_comments.get(index)
                 {
                     self.input_mode = InputMode::Comment;
+                    self.diff_state.scroll_x = 0;
                     self.comment_buffer = comment.content.clone();
                     self.comment_cursor = self.comment_buffer.len();
                     self.comment_type = comment.comment_type.clone();
@@ -5120,6 +5322,7 @@ impl App {
                         if comment_side == side {
                             if side_idx == index {
                                 self.input_mode = InputMode::Comment;
+                                self.diff_state.scroll_x = 0;
                                 self.comment_buffer = comment.content.clone();
                                 self.comment_cursor = self.comment_buffer.len();
                                 self.comment_type = comment.comment_type.clone();
@@ -5162,6 +5365,9 @@ impl App {
 
     pub fn enter_comment_mode(&mut self, file_level: bool, line: Option<(u32, LineSide)>) {
         self.input_mode = InputMode::Comment;
+        // Snap horizontal scroll back to the left edge so the inline input
+        // box renders inside the viewport on long lines.
+        self.diff_state.scroll_x = 0;
         self.comment_buffer.clear();
         self.comment_cursor = 0;
         self.comment_type = self.default_comment_type();
@@ -5172,6 +5378,7 @@ impl App {
 
     pub fn enter_review_comment_mode(&mut self) {
         self.input_mode = InputMode::Comment;
+        self.diff_state.scroll_x = 0;
         self.comment_buffer.clear();
         self.comment_cursor = 0;
         self.comment_type = self.default_comment_type();
@@ -5292,6 +5499,7 @@ impl App {
             self.comment_line_range = Some((range, side));
             self.comment_line = Some((range.end, side));
             self.input_mode = InputMode::Comment;
+            self.diff_state.scroll_x = 0;
             self.comment_buffer.clear();
             self.comment_cursor = 0;
             self.comment_type = self.default_comment_type();
@@ -6661,6 +6869,27 @@ impl App {
         self.set_message(format!("File list: {status}"));
     }
 
+    /// Toggle single-file view. When on, the diff panel renders only the
+    /// currently focused file instead of the full continuous-scroll
+    /// concatenation. Annotations, navigation, and export work the same
+    /// way on the rendered subset.
+    pub fn toggle_single_file_view(&mut self) {
+        self.is_single_file_view = !self.is_single_file_view;
+        // `calculate_file_scroll_offset` changes meaning across modes
+        // (single-file stops at review-comments header, all-files
+        // accumulates), so re-snap the viewport to the current file.
+        let start = self.calculate_file_scroll_offset(self.diff_state.current_file_idx);
+        self.diff_state.scroll_offset = start;
+        self.diff_state.cursor_line = start;
+        let status = if self.is_single_file_view {
+            "single file"
+        } else {
+            "all files"
+        };
+        self.set_message(format!("View: {status}"));
+        self.rebuild_annotations();
+    }
+
     /// Whether the inline commit selector panel should be displayed.
     pub fn has_inline_commit_selector(&self) -> bool {
         self.show_commit_selector
@@ -7582,8 +7811,13 @@ impl App {
         // are emitted for them.
         let remote_index = self.build_remote_thread_index();
 
-        self.line_annotations
-            .push(AnnotatedLine::ReviewCommentsHeader);
+        // The review-comments header is omitted in single-file view (see
+        // the matching guard in `src/ui/diff_unified.rs`), so the
+        // annotation list mirrors the render.
+        if !self.is_single_file_view {
+            self.line_annotations
+                .push(AnnotatedLine::ReviewCommentsHeader);
+        }
         for (comment_idx, comment) in self.session.review_comments.iter().enumerate() {
             let comment_lines =
                 Self::comment_display_lines(comment, self.diff_state.viewport_width);
@@ -7594,14 +7828,24 @@ impl App {
         }
 
         for (file_idx, file) in self.diff_files.iter().enumerate() {
+            // Single-file view renders only the currently focused file,
+            // so the annotation stream must skip every other file or
+            // click handling lands on lines that aren't visible.
+            if self.is_single_file_view && file_idx != self.diff_state.current_file_idx {
+                continue;
+            }
             let path = file.display_path();
 
-            // File header
-            self.line_annotations
-                .push(AnnotatedLine::FileHeader { file_idx });
+            // File header (only when shown — same gate as the renderer).
+            if !self.is_single_file_view {
+                self.line_annotations
+                    .push(AnnotatedLine::FileHeader { file_idx });
+            }
 
-            // If reviewed, skip all content for this file
-            if self.session.is_file_reviewed(path) {
+            // If reviewed, skip all content for this file. Single-file
+            // view ignores the reviewed-collapse since the user
+            // explicitly focused this file.
+            if self.session.is_file_reviewed(path) && !self.is_single_file_view {
                 continue;
             }
 
@@ -12496,5 +12740,308 @@ mod submit_flow_tests {
             .expect("expected a LineComment annotation");
         app.diff_state.cursor_line = idx;
         assert!(app.cursor_on_locked_comment());
+    }
+}
+
+#[cfg(test)]
+mod single_file_view_tests {
+    use super::*;
+    use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+    use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+    use std::path::PathBuf;
+
+    struct StubVcs(VcsInfo);
+    impl VcsBackend for StubVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.0
+        }
+        fn get_working_tree_diff(
+            &self,
+            _hl: &crate::syntax::SyntaxHighlighter,
+        ) -> crate::error::Result<Vec<DiffFile>> {
+            Ok(Vec::new())
+        }
+        fn fetch_context_lines(
+            &self,
+            _path: &std::path::Path,
+            _status: FileStatus,
+            _ref_commit: Option<&str>,
+            _start: u32,
+            _end: u32,
+        ) -> crate::error::Result<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn file_line_count(
+            &self,
+            _path: &std::path::Path,
+            _status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> crate::error::Result<u32> {
+            Ok(0)
+        }
+    }
+
+    fn hunk(start: u32, count: u32) -> DiffHunk {
+        let lines = (0..count)
+            .map(|i| DiffLine {
+                origin: LineOrigin::Context,
+                content: format!("line {}", start + i),
+                old_lineno: Some(start + i),
+                new_lineno: Some(start + i),
+                highlighted_spans: None,
+            })
+            .collect();
+        DiffHunk {
+            header: format!("@@ -{start},{count} +{start},{count} @@"),
+            lines,
+            old_start: start,
+            old_count: count,
+            new_start: start,
+            new_count: count,
+        }
+    }
+
+    fn file(path: &str, hunks: Vec<DiffHunk>) -> DiffFile {
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from(path)),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    fn app_with(files: Vec<DiffFile>) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp"),
+            head_commit: "head".into(),
+            branch_name: Some("main".into()),
+            vcs_type: VcsType::Git,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::WorkingTree,
+        );
+        App::build(
+            Box::new(StubVcs(vcs_info.clone())),
+            vcs_info,
+            crate::theme::Theme::dark(),
+            None,
+            false,
+            files,
+            session,
+            DiffSource::WorkingTree,
+            InputMode::Normal,
+            Vec::new(),
+            None,
+        )
+        .expect("build app")
+    }
+
+    #[test]
+    fn toggle_preserves_file_position() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3)]),
+            file("b.rs", vec![hunk(1, 3)]),
+            file("c.rs", vec![hunk(1, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.diff_state.current_file_idx = 1;
+        let expected_multi = app.calculate_file_scroll_offset(1);
+        app.diff_state.scroll_offset = expected_multi;
+
+        app.toggle_single_file_view();
+        assert!(app.is_single_file_view);
+        let expected_single = app.calculate_file_scroll_offset(1);
+        assert_eq!(app.diff_state.scroll_offset, expected_single);
+        assert_eq!(app.diff_state.cursor_line, expected_single);
+
+        app.toggle_single_file_view();
+        assert!(!app.is_single_file_view);
+        let expected_back = app.calculate_file_scroll_offset(1);
+        assert_eq!(app.diff_state.scroll_offset, expected_back);
+        assert_eq!(app.diff_state.cursor_line, expected_back);
+    }
+
+    #[test]
+    fn cursor_down_requires_two_presses_to_walk_to_next_file() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3)]),
+            file("b.rs", vec![hunk(1, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 0;
+        app.diff_state.cursor_line = app.max_cursor_line();
+        let max_a = app.max_cursor_line();
+
+        // First press at file end arms primed_walk_next and stays on max.
+        app.cursor_down(1);
+        assert_eq!(app.diff_state.current_file_idx, 0);
+        assert_eq!(app.diff_state.cursor_line, max_a);
+        assert!(app.primed_walk_next);
+
+        // Second press consumes the prime and walks.
+        app.cursor_down(1);
+        assert_eq!(app.diff_state.current_file_idx, 1);
+        assert!(!app.primed_walk_next);
+    }
+
+    #[test]
+    fn cursor_up_requires_two_presses_to_walk_to_prev_file() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3)]),
+            file("b.rs", vec![hunk(1, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 1;
+        let file_top = app.calculate_file_scroll_offset(1);
+        app.diff_state.cursor_line = file_top;
+
+        // First press at file top arms primed_walk_prev and stays.
+        app.cursor_up(1);
+        assert_eq!(app.diff_state.current_file_idx, 1);
+        assert_eq!(app.diff_state.cursor_line, file_top);
+        assert!(app.primed_walk_prev);
+
+        // Second press walks to the previous file.
+        app.cursor_up(1);
+        assert_eq!(app.diff_state.current_file_idx, 0);
+        assert!(!app.primed_walk_prev);
+    }
+
+    #[test]
+    fn primed_walk_clears_on_non_overflow_cursor_move() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 5)]),
+            file("b.rs", vec![hunk(1, 5)]),
+        ];
+        let mut app = app_with(files);
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 0;
+        app.diff_state.cursor_line = app.max_cursor_line();
+        app.cursor_down(1); // arms
+        assert!(app.primed_walk_next);
+
+        // A non-overflow move (cursor up within file) clears the next prime.
+        app.cursor_up(1);
+        assert!(!app.primed_walk_next);
+        assert_eq!(app.diff_state.current_file_idx, 0);
+    }
+
+    #[test]
+    fn next_hunk_crosses_into_next_file_in_single_file_view() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3), hunk(10, 3)]),
+            file("b.rs", vec![hunk(1, 3), hunk(10, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 0;
+        app.rebuild_annotations();
+        let positions = app.hunk_positions();
+        let last_hunk = *positions.last().expect("a.rs has two hunks");
+        app.diff_state.cursor_line = last_hunk;
+
+        // From a.rs's last hunk, `]` should land on b.rs's first hunk.
+        app.next_hunk();
+        assert_eq!(app.diff_state.current_file_idx, 1);
+        let new_first = *app.hunk_positions().first().expect("b.rs has hunks");
+        assert_eq!(app.diff_state.cursor_line, new_first);
+    }
+
+    #[test]
+    fn prev_hunk_crosses_into_prev_file_in_single_file_view() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3), hunk(10, 3)]),
+            file("b.rs", vec![hunk(1, 3), hunk(10, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 1;
+        app.rebuild_annotations();
+        let first_hunk = *app.hunk_positions().first().expect("b.rs has hunks");
+        app.diff_state.cursor_line = first_hunk;
+
+        // From b.rs's first hunk, `[` should land on a.rs's last hunk.
+        app.prev_hunk();
+        assert_eq!(app.diff_state.current_file_idx, 0);
+        let new_last = *app.hunk_positions().last().expect("a.rs has hunks");
+        assert_eq!(app.diff_state.cursor_line, new_last);
+    }
+
+    #[test]
+    fn held_key_does_not_walk_when_keyboard_enhancement_supported() {
+        // Simulates kitty REPORT_EVENT_TYPES: held-j auto-repeats arm the
+        // prime but the release flag never trips, so consecutive
+        // cursor_down calls park on max forever.
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3)]),
+            file("b.rs", vec![hunk(1, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.supports_keyboard_enhancement = true;
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 0;
+        app.diff_state.cursor_line = app.max_cursor_line();
+        let max_a = app.max_cursor_line();
+
+        // 10 consecutive presses (no release) stay parked on max.
+        for _ in 0..10 {
+            app.cursor_down(1);
+        }
+        assert_eq!(app.diff_state.current_file_idx, 0);
+        assert_eq!(app.diff_state.cursor_line, max_a);
+        assert!(app.primed_walk_next);
+        assert!(!app.down_released_since_arm);
+    }
+
+    #[test]
+    fn release_then_press_walks_when_keyboard_enhancement_supported() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3)]),
+            file("b.rs", vec![hunk(1, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.supports_keyboard_enhancement = true;
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 0;
+        app.diff_state.cursor_line = app.max_cursor_line();
+
+        // First press: arm.
+        app.cursor_down(1);
+        assert!(app.primed_walk_next);
+        assert_eq!(app.diff_state.current_file_idx, 0);
+
+        // Simulate a Down-Release event from the main loop.
+        app.down_released_since_arm = true;
+
+        // Second press: walks.
+        app.cursor_down(1);
+        assert_eq!(app.diff_state.current_file_idx, 1);
+        assert!(!app.primed_walk_next);
+        assert!(!app.down_released_since_arm);
+    }
+
+    #[test]
+    fn effective_file_height_is_zero_for_non_current_in_single_file_view() {
+        let files = vec![
+            file("a.rs", vec![hunk(1, 3)]),
+            file("b.rs", vec![hunk(1, 3)]),
+        ];
+        let mut app = app_with(files);
+        app.is_single_file_view = true;
+        app.diff_state.current_file_idx = 0;
+        let other = &app.diff_files[1].clone();
+        assert_eq!(app.effective_file_height(1, other), 0);
+        let current = &app.diff_files[0].clone();
+        assert!(app.effective_file_height(0, current) > 0);
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,6 +53,10 @@ pub struct AppConfig {
     pub transparent_background: Option<bool>,
     pub scroll_offset: Option<usize>,
     pub no_update_check: Option<bool>,
+    /// When true, every session opens in single-file view (`:focus`).
+    /// Pristine `--all-files` mode already defaults to true regardless
+    /// of this setting. Defaults to false.
+    pub single_file_view: Option<bool>,
     /// `[forge]` section settings. Always present; `None` means "no override"
     /// and downstream code should treat it as `ForgeConfig::default()`.
     pub forge: Option<ForgeConfig>,
@@ -76,6 +80,7 @@ const KNOWN_KEYS: &[&str] = &[
     "transparent_background",
     "scroll_offset",
     "no_update_check",
+    "single_file_view",
     "forge",
 ];
 
@@ -262,6 +267,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         transparent_background: read_bool(table, "transparent_background", &mut warnings),
         scroll_offset: read_usize(table, "scroll_offset", &mut warnings),
         no_update_check: read_bool(table, "no_update_check", &mut warnings),
+        single_file_view: read_bool(table, "single_file_view", &mut warnings),
         forge: table
             .get("forge")
             .and_then(|v| parse_forge(v, &mut warnings)),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -450,6 +450,7 @@ pub fn handle_command_action(app: &mut App, action: Action) {
                     app.set_message(format!("Commit selector: {status}"));
                 }
                 "diff" => app.toggle_diff_view_mode(),
+                "focus" | "f" => app.toggle_single_file_view(),
                 "stage" => app.stage_reviewed_files(),
                 "commits" | "targets" => {
                     if let Err(e) = app.enter_target_selector(TargetTab::Local) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,9 +270,17 @@ fn main() -> anyhow::Result<()> {
     // Enable keyboard enhancement for better modifier key detection (e.g., Alt+Enter)
     // This is supported by modern terminals like Kitty, iTerm2, WezTerm, etc.
     if keyboard_enhancement_supported {
+        // REPORT_EVENT_TYPES distinguishes Press from Repeat from Release so
+        // the two-press file walk (j/k at file boundary) can require an
+        // actual key release between the two presses. Without it terminals
+        // emit Press for every auto-repeat tick and held-j would walk past
+        // file boundaries.
         let _ = execute!(
             tty_output,
-            PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+            PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
+            )
         );
     }
     let backend = CrosstermBackend::new(tty_output);
@@ -291,6 +299,12 @@ fn main() -> anyhow::Result<()> {
         }
         if let Some(wrap) = cfg.wrap {
             app.diff_state.wrap_lines = wrap;
+        }
+        // Open in single-file view when the user opts in. Pristine
+        // `--all-files` already turned it on inside `App::new`, so we
+        // only toggle if it's still off.
+        if cfg.single_file_view == Some(true) && !app.is_single_file_view {
+            app.toggle_single_file_view();
         }
         if cfg.export_legend == Some(false) {
             app.export_legend = false;
@@ -368,8 +382,33 @@ fn main() -> anyhow::Result<()> {
         // Handle events
         if event::poll(Duration::from_millis(100))? {
             let event = event::read()?;
+            // Down/Up Release flips the `*_released_since_arm` flag so the
+            // primed two-press file walk in single-file view requires a
+            // deliberate release + press; held-key auto-repeat (Repeat
+            // events) never satisfies the gate. Terminals without kitty
+            // REPORT_EVENT_TYPES support never emit Release, in which case
+            // `supports_keyboard_enhancement` is false and `cursor_down` /
+            // `cursor_up` skip the gate entirely.
+            if let Event::Key(key) = &event
+                && key.kind == KeyEventKind::Release
+            {
+                if matches!(
+                    key.code,
+                    crossterm::event::KeyCode::Down | crossterm::event::KeyCode::Char('j')
+                ) {
+                    app.down_released_since_arm = true;
+                }
+                if matches!(
+                    key.code,
+                    crossterm::event::KeyCode::Up | crossterm::event::KeyCode::Char('k')
+                ) {
+                    app.up_released_since_arm = true;
+                }
+            }
             match event {
-                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                Event::Key(key)
+                    if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                {
                     // Handle Ctrl+C twice to exit (works across all input modes)
                     // In Comment mode, first Ctrl+C also cancels the comment
                     if key.code == crossterm::event::KeyCode::Char('c')
@@ -493,6 +532,10 @@ fn main() -> anyhow::Result<()> {
                             }
                             crossterm::event::KeyCode::Char('c') => {
                                 app.enter_review_comment_mode();
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('f') => {
+                                app.toggle_single_file_view();
                                 continue;
                             }
                             _ => {}

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::Style,
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -115,19 +115,23 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     let is_review_comment_mode =
         app.input_mode == InputMode::Comment && app.comment_is_review_level;
 
-    let general_indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
-    lines.push(Line::from(vec![
-        Span::styled(
-            general_indicator,
-            styles::current_line_indicator_style(&app.theme),
-        ),
-        Span::styled(
-            "═══ Review Comments ",
-            styles::file_header_style(&app.theme),
-        ),
-        Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
-    ]));
-    line_idx += 1;
+    // The `═══ Review Comments ═══` label is redundant in single-file
+    // view -- see the matching guard in `src/ui/diff_unified.rs`.
+    if !app.is_single_file_view {
+        let general_indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
+        lines.push(Line::from(vec![
+            Span::styled(
+                general_indicator,
+                styles::current_line_indicator_style(&app.theme),
+            ),
+            Span::styled(
+                "═══ Review Comments ",
+                styles::file_header_style(&app.theme),
+            ),
+            Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+        ]));
+        line_idx += 1;
+    }
 
     for comment in &app.session.review_comments {
         let is_being_edited =
@@ -208,30 +212,49 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     }
 
     for (file_idx, file) in app.diff_files.iter().enumerate() {
+        // Single-file view: hide everything except the cursor's file. See
+        // src/ui/diff_unified.rs for the matching guard.
+        if app.is_single_file_view && file_idx != app.diff_state.current_file_idx {
+            continue;
+        }
         let path = file.display_path();
         let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);
 
-        // File header
-        let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
+        if !app.is_single_file_view {
+            let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
+            let review_mark = if is_reviewed { "✓ " } else { "" };
+            let header_text = if file.is_commit_message {
+                format!("═══ {}Commit Message ", review_mark)
+            } else {
+                format!("═══ {}{} [{}] ", review_mark, path.display(), status)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled(header_text, styles::file_header_style(&app.theme)),
+                Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+            ]));
+            line_idx += 1;
+        }
 
-        let review_mark = if is_reviewed { "✓ " } else { "" };
-
-        let header_text = if file.is_commit_message {
-            format!("═══ {}Commit Message ", review_mark)
-        } else {
-            format!("═══ {}{} [{}] ", review_mark, path.display(), status)
-        };
-        lines.push(Line::from(vec![
-            Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-            Span::styled(header_text, styles::file_header_style(&app.theme)),
-            Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
-        ]));
-        line_idx += 1;
-
-        // If file is reviewed, skip rendering the body
-        if is_reviewed {
+        // If file is reviewed (and we're in multi-file view), skip the
+        // body. Single-file view keeps the focused file visible under a
+        // dimmed banner.
+        if is_reviewed && !app.is_single_file_view {
             continue;
+        }
+        if is_reviewed && app.is_single_file_view {
+            let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled(
+                    "  Marked reviewed -- r to re-open",
+                    Style::default()
+                        .fg(app.theme.fg_secondary)
+                        .add_modifier(Modifier::DIM),
+                ),
+            ]));
+            line_idx += 1;
         }
 
         // Check if we're editing/adding a file-level comment for this file

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::Style,
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Wrap},
 };
@@ -69,19 +69,24 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     let is_review_comment_mode =
         app.input_mode == InputMode::Comment && app.comment_is_review_level;
 
-    let general_indicator = cursor_indicator_spaced(line_idx, current_line_idx);
-    lines.push(Line::from(vec![
-        Span::styled(
-            general_indicator,
-            styles::current_line_indicator_style(&app.theme),
-        ),
-        Span::styled(
-            "═══ Review Comments ",
-            styles::file_header_style(&app.theme),
-        ),
-        Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
-    ]));
-    line_idx += 1;
+    // The `═══ Review Comments ═══` label is redundant in single-file
+    // view (review-level comments are still rendered below; they just
+    // don't need a banner that confuses horizontal scroll).
+    if !app.is_single_file_view {
+        let general_indicator = cursor_indicator_spaced(line_idx, current_line_idx);
+        lines.push(Line::from(vec![
+            Span::styled(
+                general_indicator,
+                styles::current_line_indicator_style(&app.theme),
+            ),
+            Span::styled(
+                "═══ Review Comments ",
+                styles::file_header_style(&app.theme),
+            ),
+            Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+        ]));
+        line_idx += 1;
+    }
 
     for comment in &app.session.review_comments {
         let is_being_edited =
@@ -163,35 +168,57 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     }
 
     for (file_idx, file) in app.diff_files.iter().enumerate() {
+        // Single-file view hides every file except the one the cursor is
+        // currently on. Navigation (`}`/`{`, file list) flips
+        // `current_file_idx` and the next render shows the new file.
+        if app.is_single_file_view && file_idx != app.diff_state.current_file_idx {
+            continue;
+        }
         let path = file.display_path();
         let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);
 
-        // File header
-        let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
+        // The `═══ filename ═══` separator is redundant in single-file
+        // view: the status bar and file list already name the file, and
+        // the wide bar of `═` characters confuses horizontal scrolling.
+        if !app.is_single_file_view {
+            let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
+            let review_mark = if is_reviewed { "✓ " } else { "" };
+            let header_text = if file.is_commit_message {
+                format!("═══ {}Commit Message ", review_mark)
+            } else if app.is_pristine_mode {
+                // Pristine mode reviews unchanged code; the M/A/D badge would
+                // mislead. Render the header without it.
+                format!("═══ {}{} ", review_mark, path.display())
+            } else {
+                format!("═══ {}{} [{}] ", review_mark, path.display(), status)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled(header_text, styles::file_header_style(&app.theme)),
+                Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+            ]));
+            line_idx += 1;
+        }
 
-        // Add checkmark if reviewed (using same character as file list)
-        let review_mark = if is_reviewed { "✓ " } else { "" };
-
-        let header_text = if file.is_commit_message {
-            format!("═══ {}Commit Message ", review_mark)
-        } else if app.is_pristine_mode {
-            // Pristine mode reviews unchanged code; the M/A/D badge would
-            // mislead. Render the header without it.
-            format!("═══ {}{} ", review_mark, path.display())
-        } else {
-            format!("═══ {}{} [{}] ", review_mark, path.display(), status)
-        };
-        lines.push(Line::from(vec![
-            Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-            Span::styled(header_text, styles::file_header_style(&app.theme)),
-            Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
-        ]));
-        line_idx += 1;
-
-        // If file is reviewed, skip rendering the body (fold it away)
-        if is_reviewed {
+        // If file is reviewed (and we're in multi-file view), skip
+        // rendering the body. In single-file view the user explicitly
+        // focused this file, so show its content under a dimmed banner.
+        if is_reviewed && !app.is_single_file_view {
             continue;
+        }
+        if is_reviewed && app.is_single_file_view {
+            let indicator = cursor_indicator(line_idx, current_line_idx);
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled(
+                    "  Marked reviewed -- r to re-open",
+                    Style::default()
+                        .fg(app.theme.fg_secondary)
+                        .add_modifier(Modifier::DIM),
+                ),
+            ]));
+            line_idx += 1;
         }
 
         // Check if we're editing/adding a file-level comment for this file
@@ -917,12 +944,35 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             }
         }
 
-        // Spacing between files
+        // Inter-file spacing. In single-file view, the row doubles as a
+        // hint pointing at whichever file `j` would walk into next, so
+        // the user always knows what's on the other side of the edge.
+        // Falls back to a plain blank on the last file (or in multi-file
+        // mode) where the indicator is already pulling its weight.
         let indicator = cursor_indicator(line_idx, current_line_idx);
-        lines.push(Line::from(Span::styled(
-            indicator,
-            styles::current_line_indicator_style(&app.theme),
-        )));
+        let next_hint_path = if app.is_single_file_view {
+            app.diff_files
+                .get(app.diff_state.current_file_idx + 1)
+                .map(|f| f.display_path().display().to_string())
+        } else {
+            None
+        };
+        if let Some(next_path) = next_hint_path {
+            lines.push(Line::from(vec![
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+                Span::styled(
+                    format!("  \u{2193}  {next_path}"),
+                    Style::default()
+                        .fg(app.theme.fg_secondary)
+                        .add_modifier(Modifier::DIM),
+                ),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled(
+                indicator,
+                styles::current_line_indicator_style(&app.theme),
+            )));
+        }
         line_idx += 1;
     }
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -147,6 +147,40 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
             ),
             Span::raw("Toggle file list visibility"),
         ]),
+        Line::from(vec![
+            Span::styled(
+                format!("  {}f        ", app.leader_key),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Toggle single-file view (also `:focus` / `:f`)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  h/l       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Scroll diff left/right (or ←/→)"),
+        ]),
+        Line::from(vec![
+            Span::styled("  h/← at 0 ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Reveal + focus file list"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  l/→ in list",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Hide list + focus diff"),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("Single-file view (`:focus`, `:f`, {}f)", app.leader_key),
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        )),
+        Line::from(""),
+        Line::from(Span::raw(
+            "  One file at a time. j/k walks across files, ]/[ walks across hunks. Default in `--all-files`.",
+        )),
         Line::from(""),
         Line::from(Span::styled(
             "Commit Selector (multi-commit reviews)",
@@ -511,6 +545,16 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle unified/side-by-side diff view"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :focus    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(
+                "Toggle single-file view (alias `:f`, {}f)",
+                app.leader_key
+            )),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -74,6 +74,9 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     if let Some(source) = header_source_chunk(app) {
         chunks.push(source);
     }
+    if app.is_single_file_view {
+        chunks.push("FOCUS".to_string());
+    }
     if app.is_pristine_mode {
         // The pristine session key has shape `pristine:<head_or_none>:<hash>`,
         // so the middle segment is the short SHA of the HEAD we're reviewing.


### PR DESCRIPTION
## Summary

- Adds `:focus` (alias `:f`, `<leader>f`) toggle: diff panel renders only the currently selected file instead of a continuous-scroll concatenation of every file.
- `--all-files` opens in single-file view by default; whole-repo continuous scroll is unworkable past ~100 files.
- `j`/`k` walks across files at the boundary: first press parks the cursor on the last (or first) line, a deliberate release + second press walks to the next (or previous) file. Held-key auto-repeat never walks (kitty `REPORT_EVENT_TYPES` distinguishes Press from Repeat from Release).
- `]`/`[` walks across files at hunk boundaries in single-file view.
- New `effective_file_height(idx, file)` helper centralizes view-aware geometry; `total_lines`, `calculate_file_scroll_offset`, `next_hunk`, `prev_hunk`, and the cursor restore in `reload_diff_files` all consume it.
- File-list `j`/`k` auto-follows: the highlighted file becomes the visible one without pressing Enter.
- Reviewed files render the body under a dimmed `Marked reviewed -- r to re-open` banner instead of collapsing to a header.
- Entering Comment mode snaps `diff_state.scroll_x = 0` so the input box stays inside the viewport on long-line files.
- `FOCUS` status chip, help-popup section, `single_file_view` config flag.
- Reasoning in [FEAT-0011 Single-File View](docs/decisions/FEAT-0011%20Single-File%20View.md).

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] 9 unit tests in `single_file_view_tests` pass
- [x] Manual: `tuicr --all-files` opens in single-file view, status bar reads `FOCUS · PRISTINE · <sha> · N files`
- [x] Manual: holding `j` parks at end-of-file; deliberate release + second `j` walks to next file
- [x] Manual: `]` from the last hunk of a file lands on the first hunk of the next file
- [x] Manual: opening a comment on a long-line file shows the input box on screen
- [x] Manual: marking a file reviewed in `:focus` shows the body under the banner