### PR TITLE
perf(startup): verify change status via cheap path probe

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,8 +21,8 @@ use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
 use crate::vcs::traits::VcsType;
 use crate::vcs::{
-    CommitInfo, FileBackend, GitBackendPreference, PrNoopVcs, VcsBackend, VcsChangeStatus, VcsInfo,
-    detect_vcs,
+    ChangeKind, CommitInfo, FileBackend, GitBackendPreference, PrNoopVcs, VcsBackend,
+    VcsChangeStatus, VcsInfo, detect_vcs,
 };
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
@@ -1298,7 +1298,7 @@ impl App {
                 .rev()
                 .collect();
                 // Prepend staged/unstaged entries only when the backend supports them
-                let (change_status, _) = Self::get_change_status_with_ignore(
+                let change_status = Self::get_change_status_with_ignore(
                     vcs.as_ref(),
                     &vcs_info.root_path,
                     highlighter,
@@ -1427,7 +1427,7 @@ impl App {
 
             Ok(app)
         } else {
-            let (change_status, used_backend_status_probe) = Self::get_change_status_with_ignore(
+            let change_status = Self::get_change_status_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
                 highlighter,
@@ -1436,21 +1436,10 @@ impl App {
             let has_staged_changes = change_status.staged;
             let has_unstaged_changes = change_status.unstaged;
 
-            let working_tree_diff =
-                if (has_staged_changes || has_unstaged_changes) && !used_backend_status_probe {
-                    match Self::get_working_tree_diff_with_ignore(
-                        vcs.as_ref(),
-                        &vcs_info.root_path,
-                        highlighter,
-                        options.path_filter,
-                    ) {
-                        Ok(diff_files) => Some(diff_files),
-                        Err(TuicrError::NoChanges) => None,
-                        Err(e) => return Err(e),
-                    }
-                } else {
-                    None
-                };
+            // No eager working-tree-diff fetch — the selector only needs to
+            // know whether to render the Staged/Unstaged rows. The actual
+            // diff loads when the user picks one (load_staged_selection /
+            // load_unstaged_selection / load_staged_and_unstaged_selection).
 
             let commits = crate::profile::time_with(
                 "startup.recent_commits",
@@ -1497,7 +1486,7 @@ impl App {
                 theme,
                 comment_type_configs,
                 output_to_stdout,
-                working_tree_diff.unwrap_or_default(),
+                Vec::new(),
                 session,
                 diff_source,
                 InputMode::CommitSelect,
@@ -2850,14 +2839,6 @@ impl App {
         Ok(diff_files)
     }
 
-    fn diff_exists(diff_files: Result<Vec<DiffFile>>) -> Result<bool> {
-        match diff_files {
-            Ok(_) => Ok(true),
-            Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => Ok(false),
-            Err(e) => Err(e),
-        }
-    }
-
     fn get_working_tree_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
@@ -2968,55 +2949,146 @@ impl App {
         Self::require_non_empty_diff_files(diff_files)
     }
 
+    /// Resolve the staged/unstaged status the commit selector renders.
+    ///
+    /// When `.gitignore`/`.tuicrignore` rules are present the cheap probe alone
+    /// can't be trusted — a file the probe sees may be ignored. To verify
+    /// without paying the full-diff cost, we ask the backend for just the
+    /// changed paths and filter them through the same ignore rules. Backends
+    /// that don't expose a path probe fall back to parsing the full diff.
     fn get_change_status_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
-    ) -> Result<(VcsChangeStatus, bool)> {
+    ) -> Result<VcsChangeStatus> {
         if path_filter.is_none() {
             match vcs.get_change_status() {
                 Ok(status) => {
                     if !crate::tuicrignore::has_ignore_rules(repo_root) {
-                        return Ok((status, true));
+                        return Ok(status);
                     }
-
-                    let staged = status.staged
-                        && Self::diff_exists(Self::get_staged_diff_with_ignore(
-                            vcs,
-                            repo_root,
-                            highlighter,
-                            path_filter,
-                        ))?;
-                    let unstaged = status.unstaged
-                        && Self::diff_exists(Self::get_unstaged_diff_with_ignore(
-                            vcs,
-                            repo_root,
-                            highlighter,
-                            path_filter,
-                        ))?;
-
-                    return Ok((VcsChangeStatus { staged, unstaged }, true));
+                    return Self::verify_status_against_ignore(
+                        vcs,
+                        repo_root,
+                        highlighter,
+                        path_filter,
+                        status,
+                    );
                 }
                 Err(TuicrError::UnsupportedOperation(_)) => {}
                 Err(e) => return Err(e),
             }
         }
 
-        let staged = Self::diff_exists(Self::get_staged_diff_with_ignore(
+        Self::verify_status_against_ignore(
             vcs,
             repo_root,
             highlighter,
             path_filter,
-        ))?;
-        let unstaged = Self::diff_exists(Self::get_unstaged_diff_with_ignore(
-            vcs,
-            repo_root,
-            highlighter,
-            path_filter,
-        ))?;
+            VcsChangeStatus {
+                staged: true,
+                unstaged: true,
+            },
+        )
+    }
 
-        Ok((VcsChangeStatus { staged, unstaged }, false))
+    /// Refine `assumed_status` by checking each side actually has at least one
+    /// non-ignored, non-filtered path. Tries the cheap path probe first; falls
+    /// back to parsing the full diff for backends that don't implement it.
+    fn verify_status_against_ignore(
+        vcs: &dyn VcsBackend,
+        repo_root: &Path,
+        highlighter: &SyntaxHighlighter,
+        path_filter: Option<&str>,
+        assumed_status: VcsChangeStatus,
+    ) -> Result<VcsChangeStatus> {
+        let staged = if assumed_status.staged {
+            Self::side_has_visible_changes(
+                vcs,
+                repo_root,
+                highlighter,
+                path_filter,
+                ChangeKind::Staged,
+            )?
+        } else {
+            false
+        };
+        let unstaged = if assumed_status.unstaged {
+            Self::side_has_visible_changes(
+                vcs,
+                repo_root,
+                highlighter,
+                path_filter,
+                ChangeKind::Unstaged,
+            )?
+        } else {
+            false
+        };
+        Ok(VcsChangeStatus { staged, unstaged })
+    }
+
+    fn side_has_visible_changes(
+        vcs: &dyn VcsBackend,
+        repo_root: &Path,
+        highlighter: &SyntaxHighlighter,
+        path_filter: Option<&str>,
+        kind: ChangeKind,
+    ) -> Result<bool> {
+        match vcs.list_changed_paths(kind) {
+            Ok(paths) => Ok(Self::any_path_survives_filters(
+                paths,
+                repo_root,
+                path_filter,
+            )),
+            Err(TuicrError::UnsupportedOperation(_)) => {
+                // Backend can't list paths cheaply — parse the diff to see if
+                // anything survives. This still happens for jj/hg today.
+                let diff_result = match kind {
+                    ChangeKind::Staged => {
+                        Self::get_staged_diff_with_ignore(vcs, repo_root, highlighter, path_filter)
+                    }
+                    ChangeKind::Unstaged => Self::get_unstaged_diff_with_ignore(
+                        vcs,
+                        repo_root,
+                        highlighter,
+                        path_filter,
+                    ),
+                };
+                match diff_result {
+                    Ok(_) => Ok(true),
+                    Err(TuicrError::NoChanges) | Err(TuicrError::UnsupportedOperation(_)) => {
+                        Ok(false)
+                    }
+                    Err(e) => Err(e),
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn any_path_survives_filters(
+        paths: Vec<PathBuf>,
+        repo_root: &Path,
+        path_filter: Option<&str>,
+    ) -> bool {
+        let after_ignore = crate::tuicrignore::filter_paths(repo_root, paths);
+        let after_path = match path_filter {
+            Some(p) => Self::filter_paths_by_pathspec(after_ignore, p),
+            None => after_ignore,
+        };
+        !after_path.is_empty()
+    }
+
+    fn filter_paths_by_pathspec(paths: Vec<PathBuf>, pathspec: &str) -> Vec<PathBuf> {
+        let pathspec = pathspec.trim_end_matches('/');
+        paths
+            .into_iter()
+            .filter(|p| {
+                let display = p.to_string_lossy();
+                display == pathspec || display.starts_with(&format!("{pathspec}/"))
+            })
+            .collect()
     }
 
     fn load_staged_and_unstaged_selection(&mut self) -> Result<()> {
@@ -6253,7 +6325,7 @@ impl App {
         }
 
         let highlighter = self.theme.syntax_highlighter();
-        let (change_status, _) = Self::get_change_status_with_ignore(
+        let change_status = Self::get_change_status_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
             highlighter,
@@ -10774,7 +10846,7 @@ mod change_status_tests {
         vcs.staged_files = vec![diff_file("ignored/generated.rs")];
         vcs.unstaged_files = vec![diff_file("src/lib.rs")];
 
-        let (status, used_probe) = App::get_change_status_with_ignore(
+        let status = App::get_change_status_with_ignore(
             &vcs,
             dir.path(),
             &SyntaxHighlighter::default(),
@@ -10782,7 +10854,6 @@ mod change_status_tests {
         )
         .expect("failed to get change status");
 
-        assert!(used_probe);
         assert_eq!(
             status,
             VcsChangeStatus {
@@ -10790,6 +10861,10 @@ mod change_status_tests {
                 unstaged: true,
             }
         );
+        // The mock backend's full-diff path was used (no list_changed_paths
+        // override), so it returned the unstaged file. With a real backend
+        // that implements list_changed_paths the same path-filter logic runs
+        // without ever materializing the diff.
     }
 
     #[test]
@@ -10797,7 +10872,7 @@ mod change_status_tests {
         let dir = tempdir().expect("failed to create temp dir");
         let vcs = mock_vcs(dir.path().to_path_buf());
 
-        let (status, used_probe) = App::get_change_status_with_ignore(
+        let status = App::get_change_status_with_ignore(
             &vcs,
             dir.path(),
             &SyntaxHighlighter::default(),
@@ -10805,7 +10880,6 @@ mod change_status_tests {
         )
         .expect("failed to get change status");
 
-        assert!(used_probe);
         assert_eq!(
             status,
             VcsChangeStatus {
@@ -10813,6 +10887,102 @@ mod change_status_tests {
                 unstaged: true,
             }
         );
+        // No ignore rules → no diffs were loaded by the probe (the mock's
+        // get_X_diff methods would have errored if hit, since staged_files
+        // and unstaged_files are empty).
+    }
+
+    #[test]
+    fn list_changed_paths_used_to_verify_ignore_rules() {
+        use std::cell::Cell;
+
+        struct PathProbeMock {
+            inner: StatusProbeMock,
+            list_calls: Cell<u32>,
+            staged_paths: Vec<PathBuf>,
+            unstaged_paths: Vec<PathBuf>,
+        }
+
+        impl VcsBackend for PathProbeMock {
+            fn info(&self) -> &VcsInfo {
+                self.inner.info()
+            }
+            fn get_working_tree_diff(
+                &self,
+                _highlighter: &SyntaxHighlighter,
+            ) -> Result<Vec<DiffFile>> {
+                Err(TuicrError::UnsupportedOperation(
+                    "should not be called".into(),
+                ))
+            }
+            fn get_staged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+                Err(TuicrError::UnsupportedOperation(
+                    "should not be called".into(),
+                ))
+            }
+            fn get_unstaged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+                Err(TuicrError::UnsupportedOperation(
+                    "should not be called".into(),
+                ))
+            }
+            fn get_change_status(&self) -> Result<VcsChangeStatus> {
+                self.inner.get_change_status()
+            }
+            fn list_changed_paths(&self, kind: ChangeKind) -> Result<Vec<PathBuf>> {
+                self.list_calls.set(self.list_calls.get() + 1);
+                Ok(match kind {
+                    ChangeKind::Staged => self.staged_paths.clone(),
+                    ChangeKind::Unstaged => self.unstaged_paths.clone(),
+                })
+            }
+            fn fetch_context_lines(
+                &self,
+                _file_path: &Path,
+                _file_status: FileStatus,
+                _ref_commit: Option<&str>,
+                _start_line: u32,
+                _end_line: u32,
+            ) -> Result<Vec<DiffLine>> {
+                Ok(Vec::new())
+            }
+            fn file_line_count(
+                &self,
+                _file_path: &Path,
+                _file_status: FileStatus,
+                _ref_commit: Option<&str>,
+            ) -> Result<u32> {
+                Ok(0)
+            }
+        }
+
+        let dir = tempdir().expect("failed to create temp dir");
+        fs::write(dir.path().join(".tuicrignore"), "ignored/\n")
+            .expect("failed to write .tuicrignore");
+
+        let vcs = PathProbeMock {
+            inner: mock_vcs(dir.path().to_path_buf()),
+            list_calls: Cell::new(0),
+            staged_paths: vec![PathBuf::from("ignored/generated.rs")],
+            unstaged_paths: vec![PathBuf::from("src/lib.rs")],
+        };
+
+        let status = App::get_change_status_with_ignore(
+            &vcs,
+            dir.path(),
+            &SyntaxHighlighter::default(),
+            None,
+        )
+        .expect("failed to get change status");
+
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+        // Both sides probed via cheap path listing, not via full diff parsing.
+        assert_eq!(vcs.list_calls.get(), 2);
     }
 }
 

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -20,6 +20,20 @@ pub fn filter_diff_files(repo_root: &Path, diff_files: Vec<DiffFile>) -> Vec<Dif
         .collect()
 }
 
+/// Apply `.tuicrignore` (and `.gitignore`, for `!`-unignore patterns) rules to a
+/// list of paths. Used by the cheap status probe to verify that survives the
+/// ignore filter without paying the full-diff cost.
+pub fn filter_paths(repo_root: &Path, paths: Vec<std::path::PathBuf>) -> Vec<std::path::PathBuf> {
+    let Some(matcher) = load_matcher(repo_root) else {
+        return paths;
+    };
+
+    paths
+        .into_iter()
+        .filter(|p| !matcher.matched_path_or_any_parents(p, false).is_ignore())
+        .collect()
+}
+
 /// Return true when repo-level ignore rules can affect tuicr's diff file list.
 pub fn has_ignore_rules(repo_root: &Path) -> bool {
     repo_root.join(".gitignore").is_file() || repo_root.join(".tuicrignore").is_file()

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -12,7 +12,7 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+use crate::vcs::{ChangeKind, CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
 
 use super::{
@@ -231,6 +231,22 @@ impl VcsBackend for GitCliBackend {
             tracked_unstaged || has_untracked_changes(&self.root_path, &untracked_pathspecs)?;
 
         Ok(VcsChangeStatus { staged, unstaged })
+    }
+
+    fn list_changed_paths(&self, kind: ChangeKind) -> Result<Vec<PathBuf>> {
+        match kind {
+            ChangeKind::Staged => list_diff_paths(
+                &self.root_path,
+                &["diff", "--cached", "--name-only", "-z", "--"],
+            ),
+            ChangeKind::Unstaged => {
+                let mut paths =
+                    list_diff_paths(&self.root_path, &["diff", "--name-only", "-z", "--"])?;
+                let untracked_pathspecs = sparse_checkout_untracked_pathspecs(&self.root_path)?;
+                paths.extend(list_untracked_paths(&self.root_path, &untracked_pathspecs)?);
+                Ok(paths)
+            }
+        }
     }
 
     fn fetch_context_lines(
@@ -467,6 +483,58 @@ fn has_diff_changes(workdir: &Path, args: &[&str]) -> Result<bool> {
             String::from_utf8_lossy(&output.stderr).trim().to_string(),
         )),
     }
+}
+
+/// Parse a `\0`-separated NUL-byte stream of paths (the output of e.g.
+/// `git diff -z --name-only`) into a Vec<PathBuf>. Empty paths skipped.
+fn split_nul_paths(bytes: &[u8]) -> Vec<PathBuf> {
+    bytes
+        .split(|b| *b == 0)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|chunk| PathBuf::from(String::from_utf8_lossy(chunk).into_owned()))
+        .collect()
+}
+
+fn list_diff_paths(workdir: &Path, args: &[&str]) -> Result<Vec<PathBuf>> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(split_nul_paths(&output.stdout))
+}
+
+fn list_untracked_paths(workdir: &Path, pathspecs: &[String]) -> Result<Vec<PathBuf>> {
+    let mut args: Vec<&str> = vec!["ls-files", "--others", "--exclude-standard", "-z"];
+    if !pathspecs.is_empty() {
+        args.push("--");
+        args.extend(pathspecs.iter().map(String::as_str));
+    }
+
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(split_nul_paths(&output.stdout))
 }
 
 fn has_untracked_changes(workdir: &Path, pathspecs: &[String]) -> Result<bool> {

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
+use crate::vcs::traits::ChangeKind;
 use crate::vcs::{enhance_with_full_file_highlight, tabify};
 
 pub fn get_working_tree_diff(
@@ -57,6 +58,44 @@ pub fn get_staged_diff(
 }
 
 /// Get the unstaged diff (working tree vs index)
+/// List the changed paths for either the staged or unstaged diff, without
+/// materializing hunks or running the syntax highlighter. Lets callers verify
+/// `get_change_status` against ignore rules cheaply — full diff parsing only
+/// happens once the user actually selects the staged/unstaged view.
+pub fn list_changed_paths(repo: &Repository, kind: ChangeKind) -> Result<Vec<PathBuf>> {
+    let diff = match kind {
+        ChangeKind::Staged => {
+            let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
+            let index = repo.index()?;
+            repo.diff_tree_to_index(head.as_ref(), Some(&index), None)?
+        }
+        ChangeKind::Unstaged => {
+            let index = repo.index()?;
+            let mut opts = DiffOptions::new();
+            opts.include_untracked(true);
+            // `show_untracked_content(false)` keeps libgit2 from reading each
+            // untracked file's bytes — only the paths are needed here.
+            opts.show_untracked_content(false);
+            opts.recurse_untracked_dirs(true);
+            opts.skip_binary_check(true);
+            repo.diff_index_to_workdir(Some(&index), Some(&mut opts))?
+        }
+    };
+
+    let mut paths: Vec<PathBuf> = Vec::with_capacity(diff.deltas().len());
+    for delta in diff.deltas() {
+        let path = delta
+            .new_file()
+            .path()
+            .or_else(|| delta.old_file().path())
+            .map(PathBuf::from);
+        if let Some(p) = path {
+            paths.push(p);
+        }
+    }
+    Ok(paths)
+}
+
 pub fn get_unstaged_diff(
     repo: &Repository,
     highlighter: &SyntaxHighlighter,

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -1,5 +1,5 @@
 use git2::Repository;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Once;
 
 use crate::error::{Result, TuicrError};
@@ -7,7 +7,7 @@ use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 
 use super::{context, diff, repository, staging};
-use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::traits::{ChangeKind, CommitInfo, VcsBackend, VcsInfo, VcsType};
 
 /// Git backend implementation using the git2/libgit2 library.
 pub struct Libgit2Backend {
@@ -102,6 +102,10 @@ impl VcsBackend for Libgit2Backend {
 
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         diff::get_unstaged_diff(&self.repo, highlighter)
+    }
+
+    fn list_changed_paths(&self, kind: ChangeKind) -> Result<Vec<PathBuf>> {
+        diff::list_changed_paths(&self.repo, kind)
     }
 
     fn fetch_context_lines(

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -6,14 +6,14 @@ pub mod repository;
 pub mod staging;
 
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 use crate::syntax::SyntaxHighlighter;
 
-use super::traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+use super::traits::{ChangeKind, CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 use cli::GitCliBackend;
 pub use libgit2::Libgit2Backend;
 
@@ -196,6 +196,13 @@ impl VcsBackend for GitBackend {
         match self {
             Self::Libgit2(backend) => backend.get_change_status(),
             Self::Cli(backend) => backend.get_change_status(),
+        }
+    }
+
+    fn list_changed_paths(&self, kind: ChangeKind) -> Result<Vec<PathBuf>> {
+        match self {
+            Self::Libgit2(backend) => backend.list_changed_paths(kind),
+            Self::Cli(backend) => backend.list_changed_paths(kind),
         }
     }
 

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -25,7 +25,7 @@ pub use git::{GitBackend, GitBackendPreference};
 pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use pr_noop::PrNoopVcs;
-pub use traits::{CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+pub use traits::{ChangeKind, CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -56,6 +56,16 @@ pub struct VcsChangeStatus {
     pub unstaged: bool,
 }
 
+/// Which side of the working tree to enumerate for the cheap path probes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    /// HEAD vs index — paths that would land in `get_staged_diff`.
+    Staged,
+    /// Index vs workdir, including untracked — paths that would land in
+    /// `get_unstaged_diff`.
+    Unstaged,
+}
+
 /// Trait for VCS backend implementations
 pub trait VcsBackend: Send {
     /// Get repository information
@@ -95,6 +105,15 @@ pub trait VcsBackend: Send {
     fn get_change_status(&self) -> Result<VcsChangeStatus> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Change status not supported for this VCS".into(),
+        ))
+    }
+
+    /// List the paths that would appear in the corresponding diff, without
+    /// parsing hunks or highlighting. Used to verify `get_change_status`
+    /// against `.gitignore`/`.tuicrignore` rules without paying the diff cost.
+    fn list_changed_paths(&self, _kind: ChangeKind) -> Result<Vec<PathBuf>> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "Listing changed paths not supported for this VCS".into(),
         ))
     }
 


### PR DESCRIPTION
## Summary

don't run diff highligihting on worktree unless selected

## Test plan

- [x] `cargo test` — 764 pass (+1 new: `list_changed_paths_used_to_verify_ignore_rules`); existing `change_status_tests` updated to the new `Result<VcsChangeStatus>` signature
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `TUICR_PROFILE=1` on `crate-depot`: confirmed no `diff.load_*` spans during default startup; `tuicr -w` still loads the diff once as expected
- [ ] Manual smoke: pick Staged / Unstaged / Staged+Unstaged from the commit selector and confirm the diff loads (lazy path)
- [ ] Smoke on a jj or hg repo (unchanged code path, but worth confirming the fallback still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)