### PR TITLE
feat(forge): resolve canonical (fork-parent) repo for PR ops

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -602,8 +602,14 @@ pub enum TargetTab {
 /// Background-thread events that the PR tab consumes through `pr_load_rx`.
 #[derive(Debug)]
 pub enum PrLoadEvent {
-    /// Result of the initial PR list fetch.
-    Initial(std::result::Result<(Vec<crate::forge::traits::PullRequestSummary>, bool), String>),
+    /// Result of the initial PR list fetch. `canonical` carries the
+    /// repository the fetch was actually executed against — i.e. the result
+    /// of the canonical (fork-parent) resolver — so the main thread can
+    /// promote `App.forge_repository` to it before applying the rows.
+    Initial {
+        canonical: crate::forge::traits::ForgeRepository,
+        result: std::result::Result<(Vec<crate::forge::traits::PullRequestSummary>, bool), String>,
+    },
     /// Result of a "load more" fetch.
     LoadMore(std::result::Result<(Vec<crate::forge::traits::PullRequestSummary>, bool), String>),
 }
@@ -845,8 +851,16 @@ pub struct App {
     // Review target selector tab state. The selector reuses InputMode::CommitSelect
     // but is conceptually a "target" picker with Local and Pull Requests tabs.
     pub target_tab: TargetTab,
-    /// GitHub forge repository detected from the local `origin` remote, if any.
+    /// GitHub forge repository used for all PR operations. Initially set
+    /// from the local `origin` remote; replaced with the canonical (parent)
+    /// repository on first PR-tab entry, or pre-empted by `--repo-url`.
     pub forge_repository: Option<ForgeRepository>,
+    /// Explicit `--repo-url` override. When `Some`, the canonical resolver
+    /// skips the `gh api` parent lookup and uses this value directly.
+    pub repo_url_override: Option<ForgeRepository>,
+    /// True once the canonical resolver has run for this session — avoids
+    /// repeating the `gh api` parent lookup on every PR-tab visit.
+    pub canonical_resolved: bool,
     /// State machine for the Pull Requests tab.
     pub pr_tab: PullRequestsTab,
     /// Viewport height of the PR list (set during render).
@@ -1139,6 +1153,10 @@ pub struct AppStartupOptions<'a> {
     /// Direct PR target (`tuicr pr <target>`). Mutually exclusive with the
     /// other selectors above; the binary validates that before reaching here.
     pub pr_target: Option<&'a str>,
+    /// `--repo-url` override for PR operations, already parsed into a
+    /// `ForgeRepository`. When `Some`, the canonical resolver short-circuits
+    /// the `gh api` parent lookup and uses this value directly.
+    pub repo_url_override: Option<ForgeRepository>,
 }
 
 impl App {
@@ -1152,7 +1170,13 @@ impl App {
         // selector. Errors here surface before TUI startup like other
         // startup failures.
         if let Some(target) = options.pr_target {
-            return Self::new_from_pr_target(theme, comment_type_configs, output_to_stdout, target);
+            return Self::new_from_pr_target(
+                theme,
+                comment_type_configs,
+                output_to_stdout,
+                target,
+                options.repo_url_override.clone(),
+            );
         }
 
         // --file mode: open a single file for annotation without VCS
@@ -1175,6 +1199,7 @@ impl App {
                 InputMode::Normal,
                 Vec::new(),
                 None, // no path_filter
+                options.repo_url_override.clone(),
             )?;
 
             // Hide the file list only when reviewing a single file; in
@@ -1233,6 +1258,7 @@ impl App {
                 InputMode::Normal,
                 Vec::new(),
                 None, // no path_filter
+                options.repo_url_override.clone(),
             )?;
 
             app.is_pristine_mode = true;
@@ -1325,6 +1351,7 @@ impl App {
                     InputMode::Normal,
                     Vec::new(),
                     options.path_filter,
+                    options.repo_url_override.clone(),
                 )?;
 
                 app.range_diff_files = Some(app.diff_files.clone());
@@ -1379,6 +1406,7 @@ impl App {
                 InputMode::Normal,
                 Vec::new(),
                 options.path_filter,
+                options.repo_url_override.clone(),
             )?;
 
             // Set up inline commit selector for multi-commit reviews
@@ -1423,6 +1451,7 @@ impl App {
                 InputMode::Normal,
                 Vec::new(),
                 options.path_filter,
+                options.repo_url_override.clone(),
             )?;
 
             Ok(app)
@@ -1492,6 +1521,7 @@ impl App {
                 InputMode::CommitSelect,
                 commit_list,
                 options.path_filter,
+                options.repo_url_override.clone(),
             )?;
 
             app.has_more_commit = commits.len() >= VISIBLE_COMMIT_COUNT;
@@ -1518,6 +1548,7 @@ impl App {
         input_mode: InputMode,
         commit_list: Vec<CommitInfo>,
         path_filter: Option<&str>,
+        repo_url_override: Option<ForgeRepository>,
     ) -> Result<Self> {
         // Ensure all diff files are registered in the session
         for file in &diff_files {
@@ -1571,6 +1602,8 @@ impl App {
             has_more_commit,
             target_tab: TargetTab::Local,
             forge_repository: None,
+            repo_url_override,
+            canonical_resolved: false,
             pr_tab: PullRequestsTab::new(None),
             pr_list_viewport_height: 0,
             pr_list_inner_area: None,
@@ -1661,6 +1694,15 @@ impl App {
     /// Lazily called during startup — running this synchronously is fine
     /// because it only reads local config, never the network.
     fn detect_forge_repository(&mut self) {
+        // `--repo-url` short-circuits detection: the user has told us
+        // exactly which repo to target, so skip both the local-remote
+        // probe and the `gh api` parent lookup that runs on PR-tab entry.
+        if let Some(override_repo) = self.repo_url_override.clone() {
+            self.forge_repository = Some(override_repo.clone());
+            self.pr_tab = PullRequestsTab::new(Some(override_repo));
+            self.canonical_resolved = true;
+            return;
+        }
         let repo = crate::forge::detect_github_repository(&self.vcs_info.root_path);
         self.forge_repository = repo.clone();
         self.pr_tab = PullRequestsTab::new(repo);
@@ -1938,22 +1980,36 @@ impl App {
         comment_type_configs: Option<Vec<CommentTypeConfig>>,
         output_to_stdout: bool,
         target: &str,
+        repo_url_override: Option<ForgeRepository>,
     ) -> Result<Self> {
         use crate::forge::github::gh::{GitHubGhBackend, parse_pull_request_target};
         use crate::forge::pr_open::open_pull_request;
 
         let parsed = parse_pull_request_target(target)?;
-        // Detect a default repo when the target is bare (`tuicr pr 125`).
-        // For URL/owner-repo targets, this is just an optional optimization
-        // since `parsed.repository` is already populated.
+        // Resolution order when the target lacks an explicit repo
+        // (`tuicr pr 125`):
+        //   1. `--repo-url` override (explicit user intent; no I/O)
+        //   2. canonical of the local `origin` (gh api parent lookup —
+        //      so `tuicr pr 125` from a fork checkout opens the PR on
+        //      the upstream, matching the PR-tab behavior)
+        //   3. detected local `origin` as the final fallback
+        // URL- and owner-repo-hash targets carry their own repository, which
+        // wins over all of the above since it's PR-specific.
         let local_repo_root = std::env::current_dir().ok();
-        let default_repo = local_repo_root
+        let detected_repo = local_repo_root
             .as_deref()
             .and_then(crate::forge::detect_github_repository);
+        let canonical_repo = detected_repo.as_ref().map(|origin| {
+            use crate::forge::canonical::resolve_canonical_repository;
+            use crate::forge::github::gh::SystemGhRunner;
+            resolve_canonical_repository(origin, repo_url_override.as_ref(), &SystemGhRunner)
+        });
         let target_repo = parsed
             .repository
             .clone()
-            .or_else(|| default_repo.clone())
+            .or_else(|| repo_url_override.clone())
+            .or_else(|| canonical_repo.clone())
+            .or_else(|| detected_repo.clone())
             .ok_or_else(|| {
                 TuicrError::Forge(
                     "tuicr pr <number> requires a local GitHub remote. \
@@ -2013,11 +2069,16 @@ impl App {
             InputMode::Normal,
             Vec::new(),
             None,
+            repo_url_override,
         )?;
 
         // Wire the forge backend so context expansion routes through it.
         app.forge_backend = Some(Box::new(backend));
         app.forge_repository = Some(target_repo);
+        // PR open establishes the target repo directly; no further canonical
+        // resolution needed on PR-tab entry (which won't happen anyway since
+        // the user came straight from CLI into PR diff mode).
+        app.canonical_resolved = true;
         app.current_pr_head = Some(details_for_threads.head_sha.clone());
         if let DiffSource::PullRequest(pr) = &app.diff_source.clone()
             && pr.is_read_only()
@@ -6448,15 +6509,28 @@ impl App {
     /// Triggers the first network call lazily.
     fn on_target_tab_entered(&mut self) {
         if let Some(repo) = self.pr_tab.start_initial_load() {
-            self.spawn_pr_initial_load(repo);
+            let override_repo = self.repo_url_override.clone();
+            let skip_resolution = self.canonical_resolved;
+            self.spawn_pr_initial_load(repo, override_repo, skip_resolution);
         }
     }
 
     /// Spawn a background thread that fetches the initial PR list. The
     /// resulting `PrLoadEvent::Initial` is delivered through `pr_load_rx`
     /// and applied in the main loop via `poll_pr_load_events`.
-    fn spawn_pr_initial_load(&mut self, repository: ForgeRepository) {
-        use crate::forge::github::gh::GitHubGhBackend;
+    ///
+    /// On the first PR-tab visit (`skip_resolution=false`) the thread first
+    /// resolves the detected origin to its canonical (fork-parent) repo via
+    /// `gh api`, then lists PRs against that canonical. Subsequent visits
+    /// reuse the already-resolved repo and skip the resolver.
+    fn spawn_pr_initial_load(
+        &mut self,
+        origin: ForgeRepository,
+        override_repo: Option<ForgeRepository>,
+        skip_resolution: bool,
+    ) {
+        use crate::forge::canonical::resolve_canonical_repository;
+        use crate::forge::github::gh::{GitHubGhBackend, SystemGhRunner};
         use crate::forge::selector::PR_PAGE_SIZE;
         use crate::forge::traits::{ForgeBackend, PullRequestListQuery};
 
@@ -6464,13 +6538,19 @@ impl App {
         self.pr_load_rx = Some(rx);
 
         std::thread::spawn(move || {
-            let backend = GitHubGhBackend::new(Some(repository.clone()));
-            let query = PullRequestListQuery::first_page(repository, PR_PAGE_SIZE);
+            let canonical = if skip_resolution {
+                origin
+            } else {
+                let runner = SystemGhRunner;
+                resolve_canonical_repository(&origin, override_repo.as_ref(), &runner)
+            };
+            let backend = GitHubGhBackend::new(Some(canonical.clone()));
+            let query = PullRequestListQuery::first_page(canonical.clone(), PR_PAGE_SIZE);
             let result = backend
                 .list_pull_requests(query)
                 .map(|page| (page.pull_requests, page.has_more))
                 .map_err(|err| err.to_string());
-            let _ = tx.send(PrLoadEvent::Initial(result));
+            let _ = tx.send(PrLoadEvent::Initial { canonical, result });
         });
     }
 
@@ -6516,7 +6596,16 @@ impl App {
         self.pr_load_rx = None;
         for event in events {
             match event {
-                PrLoadEvent::Initial(result) => self.pr_tab.apply_initial_load(result),
+                PrLoadEvent::Initial { canonical, result } => {
+                    // The background thread may have resolved a fork's origin
+                    // to its upstream parent. Promote App state to the
+                    // resolved repo so every PR-related call (open, threads,
+                    // submit, load-more) targets the canonical from here on.
+                    self.pr_tab.apply_canonical(canonical.clone());
+                    self.forge_repository = Some(canonical);
+                    self.canonical_resolved = true;
+                    self.pr_tab.apply_initial_load(result);
+                }
                 PrLoadEvent::LoadMore(result) => self.pr_tab.apply_load_more(result),
             }
         }
@@ -8833,6 +8922,7 @@ mod commit_selection_tests {
             InputMode::CommitSelect,
             commit_list,
             None,
+            None,
         )
         .expect("failed to build test app")
     }
@@ -8992,6 +9082,7 @@ mod target_selector_tests {
             DiffSource::WorkingTree,
             InputMode::Normal,
             Vec::new(),
+            None,
             None,
         )
         .expect("failed to build test app")
@@ -9587,10 +9678,10 @@ mod target_selector_tests {
         app.pr_tab.start_initial_load();
         let (tx, rx) = std::sync::mpsc::channel();
         app.pr_load_rx = Some(rx);
-        tx.send(PrLoadEvent::Initial(Ok((
-            vec![sample_pr(7, "lucky")],
-            false,
-        ))))
+        tx.send(PrLoadEvent::Initial {
+            canonical: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            result: Ok((vec![sample_pr(7, "lucky")], false)),
+        })
         .unwrap();
         drop(tx);
         // when
@@ -9599,6 +9690,31 @@ mod target_selector_tests {
         assert!(app.pr_load_rx.is_none());
         assert_eq!(app.pr_tab.view().rows.len(), 1);
         assert_eq!(app.pr_tab.view().rows[0].summary.number, 7);
+    }
+
+    #[test]
+    fn should_promote_app_forge_repository_to_canonical_on_initial_load() {
+        // given — origin is a fork; canonical from the background thread is upstream
+        let origin = ForgeRepository::github("github.com", "agavra", "slatedb");
+        let canonical = ForgeRepository::github("github.com", "slatedb", "slatedb");
+        let mut app = build_app();
+        app.forge_repository = Some(origin.clone());
+        app.pr_tab = PullRequestsTab::new(Some(origin));
+        app.pr_tab.start_initial_load();
+        assert!(!app.canonical_resolved);
+        let (tx, rx) = std::sync::mpsc::channel();
+        app.pr_load_rx = Some(rx);
+        tx.send(PrLoadEvent::Initial {
+            canonical: canonical.clone(),
+            result: Ok((Vec::new(), false)),
+        })
+        .unwrap();
+        drop(tx);
+        // when
+        app.poll_pr_load_events();
+        // then
+        assert_eq!(app.forge_repository.as_ref(), Some(&canonical));
+        assert!(app.canonical_resolved);
     }
 
     #[test]
@@ -10209,6 +10325,7 @@ mod scroll_behavior_tests {
             DiffSource::WorkingTree,
             InputMode::Normal,
             Vec::new(),
+            None,
             None,
         )
         .expect("failed to build test app");
@@ -11087,6 +11204,7 @@ mod expand_gap_tests {
             DiffSource::WorkingTree,
             InputMode::Normal,
             Vec::new(),
+            None,
             None,
         )
         .expect("failed to build test app")
@@ -12030,6 +12148,7 @@ mod submit_flow_tests {
             InputMode::Normal,
             Vec::new(),
             None,
+            None,
         )
         .expect("build app");
         app.current_pr_head = Some("abcdef0123".to_string());
@@ -12315,6 +12434,7 @@ mod submit_flow_tests {
             DiffSource::WorkingTree,
             InputMode::Normal,
             Vec::new(),
+            None,
             None,
         )
         .expect("build app");
@@ -13019,6 +13139,7 @@ mod single_file_view_tests {
             DiffSource::WorkingTree,
             InputMode::Normal,
             Vec::new(),
+            None,
             None,
         )
         .expect("build app")

--- a/src/forge/canonical.rs
+++ b/src/forge/canonical.rs
@@ -1,0 +1,205 @@
+//! Resolve a GitHub repository's "canonical" identity — i.e. the upstream
+//! parent of a fork — so PR listings against a local `origin` that points at
+//! a fork (e.g. `agavra/slatedb`) reach the repo where PR activity actually
+//! lives (`slatedb/slatedb`).
+//!
+//! The resolver is intentionally non-fatal: any failure (no `gh` binary,
+//! auth missing, network down, repo private, non-fork response) falls back
+//! to the supplied origin so a tuicr session degrades to the historical
+//! behavior instead of erroring out.
+#![allow(dead_code)]
+
+use serde::Deserialize;
+
+use crate::forge::github::gh::GhCommandRunner;
+use crate::forge::traits::ForgeRepository;
+
+/// Resolve `origin` to its canonical (parent) repository. Order:
+///   1. `override_repo` (from `--repo-url`) wins, no I/O.
+///   2. `gh api repos/<owner>/<repo>` parent lookup.
+///   3. Fall back to `origin` if the lookup fails or the repo is not a fork.
+pub fn resolve_canonical_repository(
+    origin: &ForgeRepository,
+    override_repo: Option<&ForgeRepository>,
+    runner: &dyn GhCommandRunner,
+) -> ForgeRepository {
+    if let Some(repo) = override_repo {
+        return repo.clone();
+    }
+    match fetch_parent(origin, runner) {
+        Some(parent) => parent,
+        None => origin.clone(),
+    }
+}
+
+#[derive(Deserialize)]
+struct RepoView {
+    parent: Option<ParentRepo>,
+}
+
+#[derive(Deserialize)]
+struct ParentRepo {
+    /// `parent.full_name` is `"<owner>/<repo>"`. The host is inherited from
+    /// the origin: GitHub does not let a fork live on a different host than
+    /// its parent, so we don't need to re-parse it from the response.
+    full_name: String,
+}
+
+fn fetch_parent(origin: &ForgeRepository, runner: &dyn GhCommandRunner) -> Option<ForgeRepository> {
+    // `gh api repos/<owner>/<repo>` returns a JSON object with `parent` set
+    // only when the repo is a fork. We ask for just the two fields we need
+    // via `--jq` so the response stays small.
+    let endpoint = format!("repos/{}/{}", origin.owner, origin.name);
+    let mut args = vec![
+        "api".to_string(),
+        endpoint,
+        "--jq".to_string(),
+        "{ parent: (.parent | if . == null then null else { full_name: .full_name } end) }"
+            .to_string(),
+    ];
+    if origin.host != "github.com" {
+        args.push("--hostname".to_string());
+        args.push(origin.host.clone());
+    }
+
+    let output = runner.run(&args).ok()?;
+    let view: RepoView = serde_json::from_str(&output).ok()?;
+    let parent = view.parent?;
+    let (owner, name) = parent.full_name.split_once('/')?;
+    if owner.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(ForgeRepository::github(origin.host.clone(), owner, name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::github::gh::{GhCommandError, GhCommandResult};
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    struct FakeRunner {
+        response: RefCell<Option<GhCommandResult<String>>>,
+        calls: RefCell<Vec<Vec<String>>>,
+    }
+
+    impl FakeRunner {
+        fn with_ok(body: &str) -> Self {
+            let me = Self::default();
+            *me.response.borrow_mut() = Some(Ok(body.to_string()));
+            me
+        }
+
+        fn with_err(err: GhCommandError) -> Self {
+            let me = Self::default();
+            *me.response.borrow_mut() = Some(Err(err));
+            me
+        }
+    }
+
+    impl GhCommandRunner for FakeRunner {
+        fn run(&self, args: &[String]) -> GhCommandResult<String> {
+            self.calls.borrow_mut().push(args.to_vec());
+            self.response
+                .borrow_mut()
+                .take()
+                .unwrap_or(Err(GhCommandError::Failed {
+                    status: Some(1),
+                    stderr: "no response configured".to_string(),
+                }))
+        }
+    }
+
+    fn fork() -> ForgeRepository {
+        ForgeRepository::github("github.com", "agavra", "slatedb")
+    }
+
+    fn upstream() -> ForgeRepository {
+        ForgeRepository::github("github.com", "slatedb", "slatedb")
+    }
+
+    #[test]
+    fn should_return_override_without_calling_gh() {
+        // given
+        let runner = FakeRunner::default();
+        let override_repo = upstream();
+        // when
+        let resolved = resolve_canonical_repository(&fork(), Some(&override_repo), &runner);
+        // then
+        assert_eq!(resolved, upstream());
+        assert!(
+            runner.calls.borrow().is_empty(),
+            "override must short-circuit the gh api call"
+        );
+    }
+
+    #[test]
+    fn should_return_parent_when_gh_reports_fork() {
+        // given
+        let runner = FakeRunner::with_ok(r#"{"parent":{"full_name":"slatedb/slatedb"}}"#);
+        // when
+        let resolved = resolve_canonical_repository(&fork(), None, &runner);
+        // then
+        assert_eq!(resolved, upstream());
+    }
+
+    #[test]
+    fn should_preserve_origin_host_on_enterprise() {
+        // given — fork lives on a GitHub Enterprise host
+        let ghe_fork = ForgeRepository::github("ghe.internal", "agavra", "slatedb");
+        let runner = FakeRunner::with_ok(r#"{"parent":{"full_name":"slatedb/slatedb"}}"#);
+        // when
+        let resolved = resolve_canonical_repository(&ghe_fork, None, &runner);
+        // then — parent inherits the GHE host (GitHub doesn't allow cross-host forks)
+        assert_eq!(
+            resolved,
+            ForgeRepository::github("ghe.internal", "slatedb", "slatedb")
+        );
+        // and — the --hostname flag was passed to gh
+        let calls = runner.calls.borrow();
+        let last = calls.last().expect("expected a gh call");
+        assert!(last.iter().any(|a| a == "--hostname"));
+        assert!(last.iter().any(|a| a == "ghe.internal"));
+    }
+
+    #[test]
+    fn should_fall_back_to_origin_when_repo_is_not_a_fork() {
+        // given — the canonical repo itself; `parent` is null
+        let runner = FakeRunner::with_ok(r#"{"parent":null}"#);
+        // when
+        let resolved = resolve_canonical_repository(&upstream(), None, &runner);
+        // then
+        assert_eq!(resolved, upstream());
+    }
+
+    #[test]
+    fn should_fall_back_to_origin_when_gh_fails() {
+        // given — gh not installed, auth missing, offline, etc.
+        let runner = FakeRunner::with_err(GhCommandError::MissingGh);
+        // when
+        let resolved = resolve_canonical_repository(&fork(), None, &runner);
+        // then — degrade silently to the detected origin
+        assert_eq!(resolved, fork());
+    }
+
+    #[test]
+    fn should_fall_back_to_origin_when_response_is_malformed() {
+        // given
+        let runner = FakeRunner::with_ok("not json");
+        // when
+        let resolved = resolve_canonical_repository(&fork(), None, &runner);
+        // then
+        assert_eq!(resolved, fork());
+    }
+
+    #[test]
+    fn should_fall_back_to_origin_when_parent_full_name_is_malformed() {
+        // given — full_name missing the slash
+        let runner = FakeRunner::with_ok(r#"{"parent":{"full_name":"no-slash"}}"#);
+        // when
+        let resolved = resolve_canonical_repository(&fork(), None, &runner);
+        // then
+        assert_eq!(resolved, fork());
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -5,6 +5,7 @@
 //! instead of shelling out to forge-specific tools directly.
 #![allow(dead_code)]
 
+pub mod canonical;
 pub mod context;
 pub mod github;
 pub mod pr_open;

--- a/src/forge/selector.rs
+++ b/src/forge/selector.rs
@@ -141,6 +141,19 @@ impl PullRequestsTab {
         None
     }
 
+    /// Promote the in-flight `Loading` tab to a (possibly different)
+    /// canonical repository. Called by `poll_pr_load_events` right before
+    /// `apply_initial_load` so the rows land on the correct repo when the
+    /// background thread resolved a fork's parent. No-op when not in
+    /// `Loading` or when the canonical matches the existing repository.
+    pub fn apply_canonical(&mut self, canonical: ForgeRepository) {
+        if let PullRequestsTab::Loading { repository } = self
+            && *repository != canonical
+        {
+            *repository = canonical;
+        }
+    }
+
     /// Apply the result of the initial load.
     pub fn apply_initial_load(&mut self, result: Result<(Vec<PullRequestSummary>, bool), String>) {
         let repository = match self {
@@ -603,6 +616,39 @@ mod tests {
         // then
         assert!(first.is_some());
         assert!(second.is_none());
+    }
+
+    #[test]
+    fn should_promote_loading_repository_via_apply_canonical() {
+        // given — origin is a fork; canonical is the upstream parent
+        let origin = ForgeRepository::github("github.com", "agavra", "slatedb");
+        let canonical = ForgeRepository::github("github.com", "slatedb", "slatedb");
+        let mut tab = PullRequestsTab::new(Some(origin));
+        tab.start_initial_load();
+        // when
+        tab.apply_canonical(canonical.clone());
+        tab.apply_initial_load(Ok((vec![pr(9, "x", "a", "h", "m")], false)));
+        // then — Loaded carries the canonical, not the origin
+        if let PullRequestsTab::Loaded { repository, .. } = &tab {
+            assert_eq!(repository, &canonical);
+        } else {
+            panic!("expected Loaded state");
+        }
+    }
+
+    #[test]
+    fn should_be_noop_when_apply_canonical_called_outside_loading() {
+        // given — tab is still Idle
+        let mut tab = PullRequestsTab::new(Some(repo()));
+        let other = ForgeRepository::github("github.com", "other", "other");
+        // when
+        tab.apply_canonical(other);
+        // then — still Idle on the original repo (no silent promotion)
+        if let PullRequestsTab::Idle { repository } = &tab {
+            assert_eq!(repository, &repo());
+        } else {
+            panic!("expected Idle state");
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,10 @@ fn main() -> anyhow::Result<()> {
                 all_files: cli_args.all_files,
                 git_backend_preference,
                 pr_target: cli_args.pr_target.as_deref(),
+                repo_url_override: cli_args
+                    .repo_url
+                    .as_deref()
+                    .and_then(crate::forge::github::gh::parse_github_remote_url),
             },
         )
     }) {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1595,6 +1595,11 @@ pub struct CliArgs {
     pub all_files: bool,
     /// Direct pull request target from `tuicr pr <target>`.
     pub pr_target: Option<String>,
+    /// Override the GitHub repository used for all PR operations. Useful when
+    /// the local `origin` points at a fork (e.g. `agavra/slatedb`) but PRs
+    /// live on the upstream (`slatedb/slatedb`). Accepts any URL form
+    /// `parse_github_remote_url` understands (HTTPS, SCP-SSH, ssh://).
+    pub repo_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1983,6 +1988,9 @@ Options:
   -A, --all-files        Review every tracked file in the cwd's git repo
   --stdout               Output to stdout instead of clipboard when exporting
   --no-update-check      Skip checking for updates on startup
+  --repo-url <URL>       Override the GitHub repo used for PR operations
+                         (e.g. when origin is a fork and PRs live on upstream).
+                         Accepts HTTPS, SCP-style SSH, or ssh:// URLs.
   -V, --version          Print version
   -h, --help             Print this help message
 
@@ -2002,6 +2010,19 @@ pub fn parse_cli_args() -> CliArgs {
         eprintln!("Error: {err}");
         std::process::exit(2);
     })
+}
+
+/// Reject `--repo-url` values that don't parse as a GitHub remote URL so the
+/// failure is surfaced at startup rather than when the PR tab is opened.
+fn validate_repo_url(value: &str) -> Result<(), String> {
+    if crate::forge::github::gh::parse_github_remote_url(value).is_some() {
+        return Ok(());
+    }
+    Err(format!(
+        "--repo-url value '{value}' is not a recognized GitHub URL. \
+         Expected forms: https://github.com/owner/repo, git@github.com:owner/repo, \
+         or ssh://git@github.com/owner/repo"
+    ))
 }
 
 fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
@@ -2147,6 +2168,26 @@ fn parse_cli_args_from(args: &[String]) -> Result<CliArgs, String> {
         // Handle --all-files / -A
         if args[i] == "--all-files" || args[i] == "-A" {
             cli_args.all_files = true;
+        }
+
+        // Handle --repo-url value
+        if args[i] == "--repo-url" {
+            let value = args
+                .get(i + 1)
+                .ok_or_else(|| "--repo-url requires a value (e.g. https://github.com/owner/repo or git@github.com:owner/repo)".to_string())?;
+            if value.starts_with('-') {
+                return Err("--repo-url requires a value (e.g. https://github.com/owner/repo or git@github.com:owner/repo)".to_string());
+            }
+            validate_repo_url(value)?;
+            cli_args.repo_url = Some(value.clone());
+        }
+        // Handle --repo-url=value
+        if let Some(value) = args[i].strip_prefix("--repo-url=") {
+            if value.is_empty() {
+                return Err("--repo-url requires a value (e.g. https://github.com/owner/repo or git@github.com:owner/repo)".to_string());
+            }
+            validate_repo_url(value)?;
+            cli_args.repo_url = Some(value.to_string());
         }
 
         // Handle -r / --revisions value
@@ -2660,5 +2701,87 @@ mod tests {
         let parsed = parse_for_test(&["tuicr"]).expect("parse should succeed");
         // then
         assert_eq!(parsed.pr_target, None);
+    }
+
+    #[test]
+    fn should_parse_repo_url_https() {
+        // given/when
+        let parsed = parse_for_test(&["tuicr", "--repo-url", "https://github.com/slatedb/slatedb"])
+            .expect("parse should succeed");
+        // then
+        assert_eq!(
+            parsed.repo_url,
+            Some("https://github.com/slatedb/slatedb".to_string())
+        );
+    }
+
+    #[test]
+    fn should_parse_repo_url_equals_form() {
+        // given/when
+        let parsed = parse_for_test(&["tuicr", "--repo-url=git@github.com:slatedb/slatedb.git"])
+            .expect("parse should succeed");
+        // then
+        assert_eq!(
+            parsed.repo_url,
+            Some("git@github.com:slatedb/slatedb.git".to_string())
+        );
+    }
+
+    #[test]
+    fn should_parse_repo_url_ssh_scheme() {
+        // given/when
+        let parsed = parse_for_test(&[
+            "tuicr",
+            "--repo-url",
+            "ssh://git@github.com/slatedb/slatedb.git",
+        ])
+        .expect("parse should succeed");
+        // then
+        assert_eq!(
+            parsed.repo_url,
+            Some("ssh://git@github.com/slatedb/slatedb.git".to_string())
+        );
+    }
+
+    #[test]
+    fn should_error_when_repo_url_value_missing() {
+        // given/when
+        let err = parse_for_test(&["tuicr", "--repo-url"]).expect_err("parse should fail");
+        // then
+        assert!(err.contains("--repo-url requires a value"));
+    }
+
+    #[test]
+    fn should_error_when_repo_url_value_is_flag() {
+        // given/when
+        let err =
+            parse_for_test(&["tuicr", "--repo-url", "--theme"]).expect_err("parse should fail");
+        // then
+        assert!(err.contains("--repo-url requires a value"));
+    }
+
+    #[test]
+    fn should_error_when_repo_url_unparseable() {
+        // given/when
+        let err =
+            parse_for_test(&["tuicr", "--repo-url", "not-a-url"]).expect_err("parse should fail");
+        // then
+        assert!(err.contains("not a recognized GitHub URL"));
+    }
+
+    #[test]
+    fn should_error_when_repo_url_equals_empty() {
+        // given/when
+        let err = parse_for_test(&["tuicr", "--repo-url="]).expect_err("parse should fail");
+        // then
+        assert!(err.contains("--repo-url requires a value"));
+    }
+
+    #[test]
+    fn should_leave_repo_url_none_when_not_provided() {
+        // given/when
+        let parsed = parse_for_test(&["tuicr"]).expect("parse should succeed");
+        // then
+        assert_eq!(parsed.repo_url, None);
     }
 }

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -1612,6 +1612,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             InputMode::Normal,
             Vec::new(),
             None,
+            None,
         )
         .expect("build app");
         app.diff_view_mode = DiffViewMode::SideBySide;

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -1424,6 +1424,7 @@ mod remote_comments_snapshot_tests {
             InputMode::Normal,
             Vec::new(),
             None,
+            None,
         )
         .expect("build app")
     }

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -550,6 +550,7 @@ mod selector_render_snapshot_tests {
             InputMode::CommitSelect,
             commits,
             None,
+            None,
         )
         .expect("build app")
     }

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -522,6 +522,7 @@ mod pr_header_snapshot_tests {
             InputMode::Normal,
             Vec::new(),
             None,
+            None,
         )
         .expect("build pr app")
     }

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -380,6 +380,7 @@ mod tests {
             InputMode::Normal,
             Vec::new(),
             None,
+            None,
         )
         .expect("build app");
         app.current_pr_head = Some("abcdef0123".to_string());


### PR DESCRIPTION
## Summary
- When `origin` points at a fork, tuicr now resolves to the canonical (parent) repo via `gh api repos/<owner>/<repo>` so PR listings and `tuicr pr <num>` reach where the PRs actually live.
- Resolution happens lazily on first PR-tab entry (background thread; same "Loading…" indicator covers it) and synchronously for `tuicr pr <num>`. Result is cached on `App.forge_repository` for the session.
- New `--repo-url <URL>` flag short-circuits the `gh api` call: accepts HTTPS, SCP-style SSH, and `ssh://` URLs; validated at startup via `parse_github_remote_url`. Useful for offline use or pinning when the parent lookup isn't what you want.
- All resolver failures (missing `gh`, auth, network, non-fork, malformed response) silently fall back to the detected origin — no hard errors for what is fundamentally a UX nicety.

## Test plan
- [x] `cargo test` — 782 passed, 0 failed (7 new resolver tests, 8 new CLI parse tests, 2 selector `apply_canonical` tests, 1 end-to-end App test)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt` — applied
- [ ] Manual: run `tuicr` from `agavra/slatedb` checkout, open PR tab → confirm `slatedb/slatedb` PRs appear
- [ ] Manual: `tuicr pr 125` from `agavra/slatedb` checkout → confirm opens against `slatedb/slatedb`
- [ ] Manual: `tuicr --repo-url https://github.com/slatedb/slatedb` → confirm no `gh api` parent call is made

🤖 Generated with [Claude Code](https://claude.com/claude-code)