### PR TITLE
Add hunk-level reviewed state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Repository-managed agent integrations:
 
 **ReviewSession** (`src/model/review.rs`):
 - Persisted review state with `files: HashMap<PathBuf, FileReview>`
-- Each `FileReview` has: `reviewed: bool`, `file_comments: Vec<Comment>`, `line_comments: HashMap<u32, Vec<Comment>>`
+- Each `FileReview` has: `reviewed: bool`, `reviewed_hunks: BTreeSet<String>`, `file_comments: Vec<Comment>`, `line_comments: HashMap<u32, Vec<Comment>>`
 
 **ReviewStore** (`src/review_store.rs`):
 - Public library facade for persisted review sessions

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - GitHub-style continuous diff in the terminal. Scroll through every changed file in one stream.
 - PR-style comments at the line, range, file, and review level, with classifications like
   `issue`, `suggestion`, `note`, and `praise`.
+- Review tracking at file or hunk granularity, persisted across sessions.
 - Three export targets: push a real PR review to GitHub, copy structured markdown to your
   clipboard, or pipe to stdout.
 - Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR.
@@ -218,6 +219,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |
 | `r` | Toggle file reviewed |
+| `R` | Toggle hunk reviewed |
 | `y` | Copy review to clipboard |
 | `:edit` | Open focused file in `$EDITOR` |
 | `:submit` | Push review to GitHub |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -62,6 +62,7 @@ Shown below the file tree when local comments or visible remote PR threads exist
 | Key | Action |
 |-----|--------|
 | `r` | Toggle file reviewed |
+| `R` | Toggle hunk reviewed |
 | `c` | Add line comment (or file comment if not on a diff line) |
 | `C` | Add file comment |
 | `<leader>c` | Add review comment |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1736,10 +1736,12 @@ impl App {
         path_filter: Option<&str>,
         repo_url_override: Option<ForgeRepository>,
     ) -> Result<Self> {
-        // Ensure all diff files are registered in the session
-        for file in &diff_files {
-            session.add_file(file.display_path().clone(), file.status, file.content_hash);
-        }
+        // Ensure all diff files are registered in the session. Persisted PR
+        // subsets hydrate through the full PR diff first; keep subset-specific
+        // hunk keys alive until the selected diff is loaded.
+        let preserve_hunks = matches!(diff_source, DiffSource::PullRequest(_))
+            && session.commit_selection_range.is_some();
+        Self::register_diff_files(&mut session, &diff_files, preserve_hunks);
 
         let has_more_commit = commit_list.len() >= VISIBLE_COMMIT_COUNT;
         let visible_commit_count = if commit_list.is_empty() {
@@ -2509,14 +2511,37 @@ impl App {
         // Re-register diff files against the loaded session so any new files
         // in the PR appear with content_hash tracking, and any deleted files
         // simply stop appearing in the file list.
-        for file in &opened.diff_files {
-            let path = file.display_path().clone();
-            persisted.add_file(path, file.status, file.content_hash);
-        }
+        // Strict subset sessions are reloaded through a full PR diff first, so
+        // pruning here would discard hunk keys hidden by the active selector.
+        let preserve_hunks = Self::is_strict_commit_selection(
+            persisted.commit_selection_range,
+            opened.commits.len(),
+        );
+        Self::register_diff_files(&mut persisted, &opened.diff_files, preserve_hunks);
         persisted.pr_session_key = Some(key);
         persisted.diff_source = SessionDiffSource::PullRequest;
         persisted.updated_at = chrono::Utc::now();
         opened.session = persisted;
+    }
+
+    fn is_strict_commit_selection(range: Option<(usize, usize)>, total: usize) -> bool {
+        range.is_some_and(|(start, end)| {
+            total > 0 && start <= end && end < total && (start > 0 || end + 1 < total)
+        })
+    }
+
+    fn register_diff_files(
+        session: &mut ReviewSession,
+        diff_files: &[DiffFile],
+        preserve_hunks: bool,
+    ) {
+        for file in diff_files {
+            if preserve_hunks {
+                session.add_diff_file_preserving_hunks(file);
+            } else {
+                session.add_diff_file(file);
+            }
+        }
     }
 
     /// Direct-entry PR open: `tuicr pr <target>`.
@@ -2723,11 +2748,11 @@ impl App {
             self.review_commits = mapped;
         }
 
-        // Ensure session has all files registered after the swap.
-        for file in &self.diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
-        }
+        // Ensure session has all files registered after the swap. A strict
+        // selector range is a filtered view, not a new review scope.
+        let preserve_hunks =
+            Self::is_strict_commit_selection(self.commit_selection_range, self.pr_commits.len());
+        Self::register_diff_files(&mut self.session, &self.diff_files, preserve_hunks);
 
         self.sort_files_by_directory(true);
         self.expand_all_dirs();
@@ -2927,8 +2952,7 @@ impl App {
         self.diff_files = files;
         self.clear_expanded_gaps();
         for file in &self.diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
+            self.session.add_diff_file(file);
         }
         self.sort_files_by_directory(true);
         self.expand_all_dirs();
@@ -3078,10 +3102,9 @@ impl App {
 
         self.diff_files = files;
         self.clear_expanded_gaps();
-        for file in &self.diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
-        }
+        // Range diffs can hide hunks that are still reviewed in the broader
+        // PR session, so registration must not prune them.
+        Self::register_diff_files(&mut self.session, &self.diff_files, true);
         self.sort_files_by_directory(true);
         self.expand_all_dirs();
         self.rebuild_annotations();
@@ -3215,8 +3238,7 @@ impl App {
             self.diff_files = opened.diff_files;
             self.clear_expanded_gaps();
             for file in &self.diff_files {
-                let path = file.display_path().clone();
-                self.session.add_file(path, file.status, file.content_hash);
+                self.session.add_diff_file(file);
             }
             self.sort_files_by_directory(true);
             self.expand_all_dirs();
@@ -3298,8 +3320,7 @@ impl App {
             self.diff_files = opened.diff_files;
             self.clear_expanded_gaps();
             for file in &self.diff_files {
-                let path = file.display_path().clone();
-                self.session.add_file(path, file.status, file.content_hash);
+                self.session.add_diff_file(file);
             }
             self.sort_files_by_directory(true);
             self.expand_all_dirs();
@@ -3393,11 +3414,7 @@ impl App {
             content_hash,
         };
         self.diff_files.insert(0, commit_msg_file);
-        self.session.add_file(
-            PathBuf::from("Commit Message"),
-            FileStatus::Added,
-            content_hash,
-        );
+        self.session.add_diff_file(&self.diff_files[0]);
     }
 
     fn is_staged_commit(commit: &CommitInfo) -> bool {
@@ -3718,8 +3735,7 @@ impl App {
         self.session =
             Self::load_or_create_session(&self.vcs_info, SessionDiffSource::StagedAndUnstaged);
         for file in &diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
+            self.session.add_diff_file(file);
         }
         self.reset_persisted_session_tracking();
 
@@ -3754,8 +3770,7 @@ impl App {
 
         self.session = Self::load_or_create_session(&self.vcs_info, SessionDiffSource::Staged);
         for file in &diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
+            self.session.add_diff_file(file);
         }
         self.reset_persisted_session_tracking();
 
@@ -3790,8 +3805,7 @@ impl App {
 
         self.session = Self::load_or_create_session(&self.vcs_info, SessionDiffSource::Unstaged);
         for file in &diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
+            self.session.add_diff_file(file);
         }
         self.reset_persisted_session_tracking();
 
@@ -3877,8 +3891,7 @@ impl App {
 
         let mut invalidated = 0;
         for file in &diff_files {
-            let path = file.display_path().clone();
-            if self.session.add_file(path, file.status, file.content_hash) {
+            if self.session.add_diff_file(file) {
                 invalidated += 1;
             }
         }
@@ -4101,6 +4114,95 @@ impl App {
                 self.diff_state.cursor_line = header_line;
                 self.ensure_cursor_visible();
             }
+        }
+    }
+
+    fn hunk_at_cursor(&self) -> Option<(usize, usize)> {
+        match self.line_annotations.get(self.diff_state.cursor_line)? {
+            AnnotatedLine::HunkHeader { file_idx, hunk_idx }
+            | AnnotatedLine::DiffLine {
+                file_idx, hunk_idx, ..
+            }
+            | AnnotatedLine::SideBySideLine {
+                file_idx, hunk_idx, ..
+            } => Some((*file_idx, *hunk_idx)),
+            _ => None,
+        }
+    }
+
+    fn hunk_review_target(&self, file_idx: usize, hunk_idx: usize) -> Option<(PathBuf, String)> {
+        let file = self.diff_files.get(file_idx)?;
+        let key = file.hunk_review_key(hunk_idx)?;
+        Some((file.display_path().clone(), key))
+    }
+
+    fn hunk_header_line(&self, file_idx: usize, hunk_idx: usize) -> Option<usize> {
+        self.line_annotations.iter().position(|line| {
+            matches!(
+                line,
+                AnnotatedLine::HunkHeader {
+                    file_idx: candidate_file_idx,
+                    hunk_idx: candidate_hunk_idx
+                } if *candidate_file_idx == file_idx && *candidate_hunk_idx == hunk_idx
+            )
+        })
+    }
+
+    pub fn is_hunk_reviewed(&self, file_idx: usize, hunk_idx: usize) -> bool {
+        // Skip key computation (which hashes every hunk in the file) when this
+        // file has no reviewed hunks — the common case for users not using `R`.
+        let Some(file) = self.diff_files.get(file_idx) else {
+            return false;
+        };
+        match self.session.files.get(file.display_path()) {
+            Some(review) if !review.reviewed_hunks.is_empty() => {}
+            _ => return false,
+        }
+
+        let Some((path, key)) = self.hunk_review_target(file_idx, hunk_idx) else {
+            return false;
+        };
+        self.session.is_hunk_reviewed(&path, &key)
+    }
+
+    pub fn should_render_gap_before_hunk(&self, file_idx: usize, hunk_idx: usize) -> bool {
+        // Reviewed hunks collapse as a complete review unit: their body and
+        // adjoining hidden-context controls disappear with the header.
+        !self.is_hunk_reviewed(file_idx, hunk_idx)
+            && (hunk_idx == 0 || !self.is_hunk_reviewed(file_idx, hunk_idx - 1))
+    }
+
+    pub fn toggle_hunk_reviewed(&mut self) {
+        let Some((file_idx, hunk_idx)) = self.hunk_at_cursor() else {
+            self.set_warning("Move cursor to a hunk to toggle reviewed");
+            return;
+        };
+
+        let Some((path, key)) = self.hunk_review_target(file_idx, hunk_idx) else {
+            self.set_warning("Move cursor to a hunk to toggle reviewed");
+            return;
+        };
+
+        let Some(review) = self.session.get_file_mut(&path) else {
+            return;
+        };
+
+        let reviewed = review.toggle_hunk_reviewed(key);
+        self.dirty = true;
+        self.rebuild_annotations();
+        self.diff_state.current_file_idx = file_idx;
+        if let Some(tree_idx) = self.file_idx_to_tree_idx(file_idx) {
+            self.file_list_state.select(tree_idx);
+        }
+        if let Some(header_line) = self.hunk_header_line(file_idx, hunk_idx) {
+            self.diff_state.cursor_line = header_line;
+        }
+        self.ensure_cursor_visible();
+
+        if reviewed {
+            self.set_message("Hunk marked reviewed");
+        } else {
+            self.set_message("Hunk marked unreviewed");
         }
     }
 
@@ -5623,10 +5725,12 @@ impl App {
             if file.is_binary || file.hunks.is_empty() {
                 cumulative += 1;
             } else {
-                for hunk in &file.hunks {
+                for (hunk_idx, hunk) in file.hunks.iter().enumerate() {
                     positions.push(cumulative);
                     cumulative += 1;
-                    cumulative += hunk.lines.len();
+                    if !self.is_hunk_reviewed(file_idx, hunk_idx) {
+                        cumulative += hunk.lines.len();
+                    }
                 }
             }
             cumulative += 1; // trailing spacing or "next file" hint
@@ -5800,7 +5904,7 @@ impl App {
 
                 let gap_id = GapId { file_idx, hunk_idx };
 
-                if gap > 0 {
+                if gap > 0 && self.should_render_gap_before_hunk(file_idx, hunk_idx) {
                     let top_len = self.expanded_top.get(&gap_id).map_or(0, |v| v.len());
                     let bot_len = self.expanded_bottom.get(&gap_id).map_or(0, |v| v.len());
                     let remaining = (gap as usize).saturating_sub(top_len + bot_len);
@@ -5810,6 +5914,9 @@ impl App {
 
                 // Hunk header + diff lines
                 content_lines += 1; // Hunk header
+                if self.is_hunk_reviewed(file_idx, hunk_idx) {
+                    continue;
+                }
 
                 // Count diff lines based on view mode
                 match self.diff_view_mode {
@@ -7411,8 +7518,7 @@ impl App {
 
                     // Update session for new files
                     for file in &self.diff_files {
-                        let path = file.display_path().clone();
-                        self.session.add_file(path, file.status, file.content_hash);
+                        self.session.add_diff_file(file);
                     }
 
                     self.sort_files_by_directory(true);
@@ -8369,8 +8475,7 @@ impl App {
 
         // Add files to session
         for file in &diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
+            self.session.add_diff_file(file);
         }
         self.reset_persisted_session_tracking();
 
@@ -8570,8 +8675,7 @@ impl App {
             Self::load_or_create_staged_unstaged_and_commits_session(&self.vcs_info, &selected_ids);
 
         for file in &diff_files {
-            let path = file.display_path().clone();
-            self.session.add_file(path, file.status, file.content_hash);
+            self.session.add_diff_file(file);
         }
         self.reset_persisted_session_tracking();
 
@@ -9043,7 +9147,7 @@ impl App {
 
                     let gap_id = GapId { file_idx, hunk_idx };
 
-                    if gap > 0 {
+                    if gap > 0 && self.should_render_gap_before_hunk(file_idx, hunk_idx) {
                         let top_len = self.expanded_top.get(&gap_id).map_or(0, |v| v.len());
                         let bot_len = self.expanded_bottom.get(&gap_id).map_or(0, |v| v.len());
                         let remaining = (gap as usize).saturating_sub(top_len + bot_len);
@@ -9111,6 +9215,9 @@ impl App {
                     // Hunk header
                     self.line_annotations
                         .push(AnnotatedLine::HunkHeader { file_idx, hunk_idx });
+                    if self.is_hunk_reviewed(file_idx, hunk_idx) {
+                        continue;
+                    }
 
                     // Diff lines - handle differently based on view mode
                     match self.diff_view_mode {
@@ -10442,6 +10549,31 @@ mod target_selector_tests {
         }
     }
 
+    fn two_hunk_patch() -> &'static str {
+        r#"diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-old one
++new one
+@@ -10 +10 @@
+-old two
++new two
+"#
+    }
+
+    fn first_hunk_patch() -> &'static str {
+        r#"diff --git a/src/lib.rs b/src/lib.rs
+index 1111111..2222222 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-old one
++new one
+"#
+    }
+
     #[test]
     fn should_populate_inline_selector_when_pr_has_multiple_commits() {
         // given a PR open path where the forge returns 3 commits
@@ -10555,6 +10687,48 @@ mod target_selector_tests {
         // then — start falls back to the PR's base_sha.
         let expected_base = test_pr_details(42, "base").base_sha;
         assert_eq!(pair, Some((expected_base, "aaa".to_string())));
+    }
+
+    #[test]
+    fn should_preserve_hunk_marks_hidden_by_pr_range_diff() {
+        let mut app = build_app();
+        app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+        app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+        app.pr_tab.start_initial_load();
+        let summary = sample_pr(42, "ranges");
+        app.pr_tab
+            .apply_initial_load(Ok((vec![summary.clone()], false)));
+        let mut backend = FakeForgeBackend::open_pr_details(
+            test_pr_details(42, "ranges"),
+            two_hunk_patch().to_string(),
+        );
+        backend.commits = vec![
+            sample_pr_commit("aaa1111", "first"),
+            sample_pr_commit("bbb2222", "second"),
+        ];
+        app.open_pr_with_backend(&summary, Box::new(backend), None)
+            .unwrap();
+        let path = app.diff_files[0].display_path().clone();
+        let hidden_key = app.diff_files[0].hunk_review_key(1).unwrap();
+        app.session
+            .get_file_mut(&path)
+            .unwrap()
+            .toggle_hunk_reviewed(hidden_key.clone());
+
+        let request = PrRangeReloadRequest {
+            repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
+            pr_number: 42,
+            head_sha: "abcdef0123456789".to_string(),
+            start_sha: "aaa1111".to_string(),
+            end_sha: "bbb2222".to_string(),
+            range: (1, 1),
+            started_at: Instant::now(),
+            anchor: None,
+        };
+        app.finish_pr_range_reload(&request, first_hunk_patch())
+            .unwrap();
+
+        assert!(app.session.is_hunk_reviewed(&path, &hidden_key));
     }
 
     #[test]
@@ -12404,6 +12578,145 @@ mod expand_gap_tests {
             is_commit_message: false,
             content_hash,
         }
+    }
+
+    fn hunk_diff_line(app: &App, file_idx: usize, hunk_idx: usize) -> usize {
+        app.line_annotations
+            .iter()
+            .position(|line| {
+                matches!(
+                    line,
+                    AnnotatedLine::DiffLine {
+                        file_idx: candidate_file_idx,
+                        hunk_idx: candidate_hunk_idx,
+                        ..
+                    } if *candidate_file_idx == file_idx && *candidate_hunk_idx == hunk_idx
+                )
+            })
+            .expect("missing hunk diff annotation")
+    }
+
+    #[test]
+    fn should_toggle_hunk_reviewed_from_header() {
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+        let mut app = build_app_with_files(vec![file], 20);
+        let path = app.diff_files[0].display_path().clone();
+        let key = app.diff_files[0].hunk_review_key(0).unwrap();
+
+        app.diff_state.cursor_line = app.hunk_header_line(0, 0).expect("missing hunk header");
+        app.toggle_hunk_reviewed();
+
+        assert!(app.session.is_hunk_reviewed(&path, &key));
+        assert_eq!(
+            app.message.as_ref().unwrap().content,
+            "Hunk marked reviewed"
+        );
+        assert!(matches!(
+            app.line_annotations[app.diff_state.cursor_line],
+            AnnotatedLine::HunkHeader {
+                file_idx: 0,
+                hunk_idx: 0
+            }
+        ));
+    }
+
+    #[test]
+    fn should_toggle_hunk_reviewed_from_diff_line() {
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+        let mut app = build_app_with_files(vec![file], 20);
+        let path = app.diff_files[0].display_path().clone();
+        let key = app.diff_files[0].hunk_review_key(0).unwrap();
+
+        app.diff_state.cursor_line = hunk_diff_line(&app, 0, 0);
+        app.toggle_hunk_reviewed();
+
+        assert!(app.session.is_hunk_reviewed(&path, &key));
+    }
+
+    #[test]
+    fn should_warn_when_toggling_hunk_outside_hunk() {
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+        let mut app = build_app_with_files(vec![file], 20);
+        let path = app.diff_files[0].display_path().clone();
+        let key = app.diff_files[0].hunk_review_key(0).unwrap();
+
+        app.diff_state.cursor_line = 0;
+        app.toggle_hunk_reviewed();
+
+        assert!(!app.session.is_hunk_reviewed(&path, &key));
+        assert_eq!(
+            app.message.as_ref().unwrap().content,
+            "Move cursor to a hunk to toggle reviewed"
+        );
+        assert_eq!(
+            app.message.as_ref().unwrap().message_type,
+            MessageType::Warning
+        );
+    }
+
+    #[test]
+    fn should_fold_reviewed_hunk_body() {
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3), make_hunk(10, 2)]);
+        let mut app = build_app_with_files(vec![file], 20);
+        let before = app.total_lines();
+
+        app.diff_state.cursor_line = app.hunk_header_line(0, 0).expect("missing hunk header");
+        app.toggle_hunk_reviewed();
+
+        assert_eq!(app.total_lines(), before - 4);
+        assert!(!app.line_annotations.iter().any(|line| {
+            matches!(
+                line,
+                AnnotatedLine::DiffLine {
+                    file_idx: 0,
+                    hunk_idx: 0,
+                    ..
+                }
+            )
+        }));
+        assert!(!app.line_annotations.iter().any(|line| {
+            matches!(
+                line,
+                AnnotatedLine::Expander {
+                    gap_id: GapId {
+                        file_idx: 0,
+                        hunk_idx: 1
+                    },
+                    ..
+                } | AnnotatedLine::HiddenLines {
+                    gap_id: GapId {
+                        file_idx: 0,
+                        hunk_idx: 1
+                    },
+                    ..
+                }
+            )
+        }));
+        assert!(app.line_annotations.iter().any(|line| {
+            matches!(
+                line,
+                AnnotatedLine::DiffLine {
+                    file_idx: 0,
+                    hunk_idx: 1,
+                    ..
+                }
+            )
+        }));
+    }
+
+    #[test]
+    fn should_keep_file_and_hunk_reviewed_state_independent() {
+        let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+        let mut app = build_app_with_files(vec![file], 20);
+        let path = app.diff_files[0].display_path().clone();
+        let key = app.diff_files[0].hunk_review_key(0).unwrap();
+
+        app.diff_state.cursor_line = app.hunk_header_line(0, 0).expect("missing hunk header");
+        app.toggle_hunk_reviewed();
+        app.toggle_reviewed_for_file_idx(0, false);
+
+        assert!(app.session.is_file_reviewed(&path));
+        assert!(app.session.is_hunk_reviewed(&path, &key));
     }
 
     #[test]

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -18,7 +18,7 @@ use crate::error::{Result, TuicrError};
 use crate::forge::traits::{
     ForgeBackend, PrSessionKey, PullRequestCommit, PullRequestDetails, PullRequestTarget,
 };
-use crate::model::{DiffFile, FileStatus, ReviewSession, SessionDiffSource};
+use crate::model::{DiffFile, ReviewSession, SessionDiffSource};
 use crate::syntax::SyntaxHighlighter;
 use crate::tuicrignore;
 use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
@@ -130,9 +130,7 @@ fn build_session(
     );
     session.pr_session_key = Some(key.clone());
     for file in diff_files {
-        let path: PathBuf = file.display_path().clone();
-        let status: FileStatus = file.status;
-        session.add_file(path, status, file.content_hash);
+        session.add_diff_file(file);
     }
     session
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1358,6 +1358,7 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         Action::NextHunk => app.next_hunk(),
         Action::PrevHunk => app.prev_hunk(),
         Action::ToggleReviewed => app.toggle_reviewed(),
+        Action::ToggleHunkReviewed => app.toggle_hunk_reviewed(),
         Action::ToggleFocus => {
             let has_selector = app.has_inline_commit_selector();
             let has_comments = app.has_comment_navigator_items();

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -35,6 +35,7 @@ pub enum Action {
 
     // Review actions
     ToggleReviewed,
+    ToggleHunkReviewed,
     AddLineComment,
     AddFileComment,
     EditComment,
@@ -189,6 +190,7 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
 
         // Review actions
         (KeyCode::Char('r'), KeyModifiers::NONE) => Action::ToggleReviewed,
+        (KeyCode::Char('R'), _) => Action::ToggleHunkReviewed,
         (KeyCode::Char('c'), KeyModifiers::NONE) => Action::AddLineComment,
         (KeyCode::Char('C'), _) => Action::AddFileComment,
         (KeyCode::Char('i'), KeyModifiers::NONE) => Action::EditComment,
@@ -462,6 +464,12 @@ mod tests {
             DEFAULT_LEADER_KEY,
         );
         assert_eq!(action, Action::ScrollViewDown(1));
+    }
+
+    #[test]
+    fn should_map_uppercase_r_to_toggle_hunk_reviewed_in_normal_mode() {
+        let action = map_normal_mode(key_shift('R'), DEFAULT_LEADER_KEY);
+        assert_eq!(action, Action::ToggleHunkReviewed);
     }
 
     #[test]

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -1,6 +1,6 @@
 use ratatui::style::Style;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::hash::Fnv1aHasher;
 use crate::model::comment::LineSide;
@@ -73,20 +73,62 @@ pub struct DiffFile {
     pub content_hash: u64,
 }
 
+impl DiffHunk {
+    fn review_content_hash(&self) -> u64 {
+        let mut hasher = Fnv1aHasher::new();
+        write_hunk_content_hash(&mut hasher, &self.lines);
+        hasher.finish()
+    }
+}
+
 impl DiffFile {
+    /// Stable key for a reviewed hunk.
+    ///
+    /// Unique hunk content ignores hunk header line numbers so unrelated
+    /// edits above a hunk do not clear its reviewed state. Repeated identical
+    /// hunks fall back to a line-aware key because a pure occurrence count can
+    /// move reviewed state onto a different hunk when one duplicate changes.
+    pub fn hunk_review_key(&self, hunk_idx: usize) -> Option<String> {
+        let hash_counts = self.hunk_content_hash_counts();
+        self.hunks
+            .get(hunk_idx)
+            .map(|hunk| self.hunk_review_key_with_counts(hunk, &hash_counts))
+    }
+
+    pub fn hunk_review_keys(&self) -> Vec<String> {
+        let hash_counts = self.hunk_content_hash_counts();
+        self.hunks
+            .iter()
+            .map(|hunk| self.hunk_review_key_with_counts(hunk, &hash_counts))
+            .collect()
+    }
+
+    fn hunk_content_hash_counts(&self) -> HashMap<u64, usize> {
+        let mut hash_counts = HashMap::new();
+        for hunk in &self.hunks {
+            *hash_counts.entry(hunk.review_content_hash()).or_insert(0) += 1;
+        }
+        hash_counts
+    }
+
+    fn hunk_review_key_with_counts(
+        &self,
+        hunk: &DiffHunk,
+        hash_counts: &HashMap<u64, usize>,
+    ) -> String {
+        let hash = hunk.review_content_hash();
+        if hash_counts.get(&hash).copied().unwrap_or_default() > 1 {
+            format_hunk_review_span_key(hunk, hash)
+        } else {
+            format_hunk_review_content_key(hash)
+        }
+    }
+
     /// Computes a hash of the diff content (all hunk line contents) for change detection.
     pub fn compute_content_hash(hunks: &[DiffHunk]) -> u64 {
         let mut hasher = Fnv1aHasher::new();
         for hunk in hunks {
-            for line in &hunk.lines {
-                hasher.write(match line.origin {
-                    LineOrigin::Addition => b"+",
-                    LineOrigin::Deletion => b"-",
-                    LineOrigin::Context => b" ",
-                });
-                hasher.write(line.content.as_bytes());
-                hasher.write(b"\n");
-            }
+            write_hunk_content_hash(&mut hasher, &hunk.lines);
         }
         hasher.finish()
     }
@@ -158,5 +200,28 @@ impl DiffFile {
             }
         }
         (additions, deletions)
+    }
+}
+
+fn format_hunk_review_content_key(hash: u64) -> String {
+    format!("hunk-content-v1:{hash:016x}:0")
+}
+
+fn format_hunk_review_span_key(hunk: &DiffHunk, hash: u64) -> String {
+    format!(
+        "hunk-span-v1:{hash:016x}:{}:{}:{}:{}",
+        hunk.old_start, hunk.old_count, hunk.new_start, hunk.new_count
+    )
+}
+
+fn write_hunk_content_hash(hasher: &mut Fnv1aHasher, lines: &[DiffLine]) {
+    for line in lines {
+        hasher.write(match line.origin {
+            LineOrigin::Addition => b"+",
+            LineOrigin::Deletion => b"-",
+            LineOrigin::Context => b" ",
+        });
+        hasher.write(line.content.as_bytes());
+        hasher.write(b"\n");
     }
 }

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -1,10 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 
 use super::comment::Comment;
-use super::diff_types::FileStatus;
+use super::diff_types::{DiffFile, FileStatus};
 use crate::forge::remote_comments::PrCommentsVisibility;
 use crate::forge::traits::PrSessionKey;
 
@@ -22,6 +22,8 @@ pub struct FileReview {
     pub file_comments: Vec<Comment>,
     pub line_comments: HashMap<u32, Vec<Comment>>,
     #[serde(default)]
+    pub reviewed_hunks: BTreeSet<String>,
+    #[serde(default)]
     pub content_hash: Option<u64>,
 }
 
@@ -33,6 +35,7 @@ impl FileReview {
             status,
             file_comments: Vec::new(),
             line_comments: HashMap::new(),
+            reviewed_hunks: BTreeSet::new(),
             content_hash: Some(content_hash),
         }
     }
@@ -47,6 +50,16 @@ impl FileReview {
 
     pub fn add_line_comment(&mut self, line: u32, comment: Comment) {
         self.line_comments.entry(line).or_default().push(comment);
+    }
+
+    pub fn toggle_hunk_reviewed(&mut self, key: String) -> bool {
+        if self.reviewed_hunks.contains(&key) {
+            self.reviewed_hunks.remove(&key);
+            false
+        } else {
+            self.reviewed_hunks.insert(key);
+            true
+        }
     }
 }
 
@@ -119,7 +132,7 @@ impl ReviewSession {
         let now = Utc::now();
         Self {
             id: uuid::Uuid::new_v4().to_string(),
-            version: "1.2".to_string(),
+            version: "1.3".to_string(),
             repo_path,
             branch_name,
             base_commit,
@@ -157,6 +170,24 @@ impl ReviewSession {
         false
     }
 
+    pub fn add_diff_file(&mut self, file: &DiffFile) -> bool {
+        let path = file.display_path().clone();
+        let invalidated = self.add_file(path.clone(), file.status, file.content_hash);
+        if let Some(review) = self.files.get_mut(&path) {
+            let valid_hunks: BTreeSet<_> = file.hunk_review_keys().into_iter().collect();
+            review
+                .reviewed_hunks
+                .retain(|key| valid_hunks.contains(key));
+        }
+        invalidated
+    }
+
+    /// Register a transient filtered diff without dropping hunk keys that
+    /// belong to the broader persisted review scope.
+    pub fn add_diff_file_preserving_hunks(&mut self, file: &DiffFile) -> bool {
+        self.add_file(file.display_path().clone(), file.status, file.content_hash)
+    }
+
     pub fn get_file_mut(&mut self, path: &PathBuf) -> Option<&mut FileReview> {
         self.files.get_mut(path)
     }
@@ -173,9 +204,12 @@ impl ReviewSession {
             cleared += file.comment_count();
             file.file_comments.clear();
             file.line_comments.clear();
-            if scope == ClearScope::CommentsAndReviewed && file.reviewed {
+            if scope == ClearScope::CommentsAndReviewed {
+                if file.reviewed || !file.reviewed_hunks.is_empty() {
+                    unreviewed += 1;
+                }
                 file.reviewed = false;
-                unreviewed += 1;
+                file.reviewed_hunks.clear();
             }
         }
         (cleared, unreviewed)
@@ -184,12 +218,19 @@ impl ReviewSession {
     pub fn is_file_reviewed(&self, path: &PathBuf) -> bool {
         self.files.get(path).map(|r| r.reviewed).unwrap_or(false)
     }
+
+    pub fn is_hunk_reviewed(&self, path: &PathBuf, key: &str) -> bool {
+        self.files
+            .get(path)
+            .is_some_and(|review| review.reviewed_hunks.contains(key))
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::comment::{Comment, CommentType};
+    use crate::model::{DiffHunk, DiffLine, LineOrigin};
 
     // Arbitrary hash value for tests that don't care about the specific hash.
     const SOME_HASH: u64 = 0xdeadbeef;
@@ -201,6 +242,37 @@ mod tests {
             None,
             SessionDiffSource::WorkingTree,
         )
+    }
+
+    fn test_hunk(new_start: u32, content: &str) -> DiffHunk {
+        DiffHunk {
+            header: format!("@@ -{new_start},1 +{new_start},1 @@"),
+            lines: vec![DiffLine {
+                origin: LineOrigin::Context,
+                content: content.to_string(),
+                old_lineno: Some(new_start),
+                new_lineno: Some(new_start),
+                highlighted_spans: None,
+            }],
+            old_start: new_start,
+            old_count: 1,
+            new_start,
+            new_count: 1,
+        }
+    }
+
+    fn test_diff_file(path: &str, hunks: Vec<DiffHunk>) -> DiffFile {
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from(path)),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
     }
 
     #[test]
@@ -296,6 +368,26 @@ mod tests {
         assert_eq!(cleared, 2);
         assert_eq!(unreviewed, 1);
         assert!(!session.is_file_reviewed(&path));
+    }
+
+    #[test]
+    fn should_clear_hunk_reviewed_status() {
+        let mut session = test_session();
+        let file = test_diff_file("src/main.rs", vec![test_hunk(10, "same")]);
+        let path = file.display_path().clone();
+        let key = file.hunk_review_key(0).unwrap();
+
+        session.add_diff_file(&file);
+        session
+            .get_file_mut(&path)
+            .unwrap()
+            .toggle_hunk_reviewed(key.clone());
+
+        let (cleared, unreviewed) = session.clear_comments(ClearScope::CommentsAndReviewed);
+
+        assert_eq!(cleared, 0);
+        assert_eq!(unreviewed, 1);
+        assert!(!session.is_hunk_reviewed(&path, &key));
     }
 
     #[test]
@@ -482,6 +574,179 @@ mod tests {
     }
 
     #[test]
+    fn should_default_reviewed_hunks_for_legacy_file_review() {
+        let json = r#"{
+            "path": "src/main.rs",
+            "reviewed": false,
+            "status": "modified",
+            "file_comments": [],
+            "line_comments": {},
+            "content_hash": 123
+        }"#;
+
+        let review: FileReview = serde_json::from_str(json).unwrap();
+        assert!(review.reviewed_hunks.is_empty());
+    }
+
+    #[test]
+    fn should_roundtrip_reviewed_hunks() {
+        let mut session = test_session();
+        let file = test_diff_file("src/main.rs", vec![test_hunk(10, "same")]);
+        let path = file.display_path().clone();
+        let key = file.hunk_review_key(0).unwrap();
+
+        session.add_diff_file(&file);
+        session
+            .get_file_mut(&path)
+            .unwrap()
+            .toggle_hunk_reviewed(key.clone());
+
+        let json = serde_json::to_string(&session).unwrap();
+        let loaded: ReviewSession = serde_json::from_str(&json).unwrap();
+        assert!(loaded.is_hunk_reviewed(&path, &key));
+    }
+
+    #[test]
+    fn should_preserve_reviewed_hunk_when_only_line_numbers_shift() {
+        let mut session = test_session();
+        let original = test_diff_file("src/main.rs", vec![test_hunk(10, "same")]);
+        let path = original.display_path().clone();
+        let key = original.hunk_review_key(0).unwrap();
+
+        session.add_diff_file(&original);
+        session
+            .get_file_mut(&path)
+            .unwrap()
+            .toggle_hunk_reviewed(key.clone());
+
+        let shifted = test_diff_file("src/main.rs", vec![test_hunk(30, "same")]);
+        let shifted_key = shifted.hunk_review_key(0).unwrap();
+        session.add_diff_file(&shifted);
+
+        assert_eq!(key, shifted_key);
+        assert!(session.is_hunk_reviewed(&path, &shifted_key));
+    }
+
+    #[test]
+    fn should_use_line_aware_keys_for_repeated_identical_hunks() {
+        let mut session = test_session();
+        let original = test_diff_file(
+            "src/main.rs",
+            vec![test_hunk(10, "same"), test_hunk(20, "same")],
+        );
+        let path = original.display_path().clone();
+        let first_key = original.hunk_review_key(0).unwrap();
+        let second_key = original.hunk_review_key(1).unwrap();
+
+        session.add_diff_file(&original);
+        session
+            .get_file_mut(&path)
+            .unwrap()
+            .toggle_hunk_reviewed(first_key.clone());
+
+        let shifted = test_diff_file(
+            "src/main.rs",
+            vec![test_hunk(30, "same"), test_hunk(40, "same")],
+        );
+        session.add_diff_file(&shifted);
+
+        assert_ne!(first_key, second_key);
+        assert_ne!(first_key, shifted.hunk_review_key(0).unwrap());
+        assert_ne!(second_key, shifted.hunk_review_key(1).unwrap());
+        assert!(!session.is_hunk_reviewed(&path, &first_key));
+        assert!(!session.is_hunk_reviewed(&path, &second_key));
+    }
+
+    #[test]
+    fn should_not_move_reviewed_status_between_identical_hunks() {
+        let mut session = test_session();
+        let original = test_diff_file(
+            "src/main.rs",
+            vec![
+                test_hunk(10, "same"),
+                test_hunk(20, "same"),
+                test_hunk(30, "same"),
+            ],
+        );
+        let path = original.display_path().clone();
+        let first_key = original.hunk_review_key(0).unwrap();
+        let second_key = original.hunk_review_key(1).unwrap();
+        let third_key = original.hunk_review_key(2).unwrap();
+
+        session.add_diff_file(&original);
+        let review = session.get_file_mut(&path).unwrap();
+        review.toggle_hunk_reviewed(first_key.clone());
+        review.toggle_hunk_reviewed(second_key.clone());
+
+        let updated = test_diff_file(
+            "src/main.rs",
+            vec![
+                test_hunk(10, "same"),
+                test_hunk(20, "changed"),
+                test_hunk(30, "same"),
+            ],
+        );
+        let updated_first_key = updated.hunk_review_key(0).unwrap();
+        let updated_third_key = updated.hunk_review_key(2).unwrap();
+        session.add_diff_file(&updated);
+
+        assert_eq!(first_key, updated_first_key);
+        assert_eq!(third_key, updated_third_key);
+        assert!(session.is_hunk_reviewed(&path, &updated_first_key));
+        assert!(!session.is_hunk_reviewed(&path, &updated.hunk_review_key(1).unwrap()));
+        assert!(!session.is_hunk_reviewed(&path, &updated_third_key));
+    }
+
+    #[test]
+    fn should_prune_reviewed_hunks_that_no_longer_exist() {
+        let mut session = test_session();
+        let original = test_diff_file(
+            "src/main.rs",
+            vec![test_hunk(10, "kept"), test_hunk(20, "removed")],
+        );
+        let path = original.display_path().clone();
+        let kept_key = original.hunk_review_key(0).unwrap();
+        let removed_key = original.hunk_review_key(1).unwrap();
+
+        session.add_diff_file(&original);
+        let review = session.get_file_mut(&path).unwrap();
+        review.toggle_hunk_reviewed(kept_key.clone());
+        review.toggle_hunk_reviewed(removed_key.clone());
+
+        let updated = test_diff_file(
+            "src/main.rs",
+            vec![test_hunk(10, "kept"), test_hunk(30, "new")],
+        );
+        session.add_diff_file(&updated);
+
+        assert!(session.is_hunk_reviewed(&path, &kept_key));
+        assert!(!session.is_hunk_reviewed(&path, &removed_key));
+    }
+
+    #[test]
+    fn should_preserve_reviewed_hunks_for_transient_diff_views() {
+        let mut session = test_session();
+        let full = test_diff_file(
+            "src/main.rs",
+            vec![test_hunk(10, "first"), test_hunk(20, "second")],
+        );
+        let path = full.display_path().clone();
+        let first_key = full.hunk_review_key(0).unwrap();
+        let second_key = full.hunk_review_key(1).unwrap();
+
+        session.add_diff_file(&full);
+        let review = session.get_file_mut(&path).unwrap();
+        review.toggle_hunk_reviewed(first_key.clone());
+        review.toggle_hunk_reviewed(second_key.clone());
+
+        let subset = test_diff_file("src/main.rs", vec![test_hunk(10, "first")]);
+        session.add_diff_file_preserving_hunks(&subset);
+
+        assert!(session.is_hunk_reviewed(&path, &first_key));
+        assert!(session.is_hunk_reviewed(&path, &second_key));
+    }
+
+    #[test]
     fn should_reset_reviewed_when_legacy_session_has_no_hash() {
         let mut session = test_session();
         let path = PathBuf::from("legacy.rs");
@@ -495,6 +760,7 @@ mod tests {
                 status: FileStatus::Modified,
                 file_comments: Vec::new(),
                 line_comments: HashMap::new(),
+                reviewed_hunks: BTreeSet::new(),
                 content_hash: None,
             },
         );

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -15,9 +15,9 @@ use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_view::{
     apply_horizontal_scroll, comment_type_presentation, cursor_indicator, cursor_indicator_spaced,
-    diff_stat_title, is_line_highlighted, paint_visual_selection_overlay,
-    populate_row_to_annotation, render_expander_line, render_hidden_lines,
-    scroll_comment_input_into_view,
+    diff_stat_title, hunk_header_text_and_style, is_line_highlighted,
+    paint_visual_selection_overlay, populate_row_to_annotation, render_expander_line,
+    render_hidden_lines, scroll_comment_input_into_view,
 };
 use crate::ui::styles;
 use crate::ui::text_utils::{truncate_or_pad, truncate_or_pad_spans};
@@ -432,7 +432,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
 
                 let gap_id = GapId { file_idx, hunk_idx };
 
-                if gap > 0 {
+                if gap > 0 && app.should_render_gap_before_hunk(file_idx, hunk_idx) {
                     let top_lines = app.expanded_top.get(&gap_id);
                     let bot_lines = app.expanded_bottom.get(&gap_id);
                     let top_len = top_lines.map_or(0, |v| v.len());
@@ -538,15 +538,18 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 }
 
                 // Hunk header
+                let is_hunk_reviewed = app.is_hunk_reviewed(file_idx, hunk_idx);
+                let (hunk_header_text, hunk_header_style) =
+                    hunk_header_text_and_style(&app.theme, hunk, is_hunk_reviewed);
                 let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
                 lines.push(Line::from(vec![
                     Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                    Span::styled(
-                        hunk.header.to_string(),
-                        styles::diff_hunk_header_style(&app.theme),
-                    ),
+                    Span::styled(hunk_header_text, hunk_header_style),
                 ]));
                 line_idx += 1;
+                if is_hunk_reviewed {
+                    continue;
+                }
 
                 // Process diff lines in side-by-side format
                 let (new_line_idx, cursor_info) = render_hunk_lines_side_by_side(

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -16,7 +16,7 @@ use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_view::{
     apply_horizontal_scroll, comment_type_presentation, cursor_indicator, cursor_indicator_spaced,
-    diff_stat_title, is_line_highlighted, paint_unified_diff_rows_with,
+    diff_stat_title, hunk_header_text_and_style, is_line_highlighted, paint_unified_diff_rows_with,
     paint_visual_selection_overlay, populate_row_to_annotation, push_comment_bar,
     render_expander_line, render_hidden_lines, scroll_comment_input_into_view,
     unified_line_bg_style,
@@ -401,7 +401,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
                 let gap_id = GapId { file_idx, hunk_idx };
 
-                if gap > 0 {
+                if gap > 0 && app.should_render_gap_before_hunk(file_idx, hunk_idx) {
                     let top_lines = app.expanded_top.get(&gap_id);
                     let bot_lines = app.expanded_bottom.get(&gap_id);
                     let top_len = top_lines.map_or(0, |v| v.len());
@@ -505,15 +505,18 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 }
 
                 // Hunk header
+                let is_hunk_reviewed = app.is_hunk_reviewed(file_idx, hunk_idx);
+                let (hunk_header_text, hunk_header_style) =
+                    hunk_header_text_and_style(&app.theme, hunk, is_hunk_reviewed);
                 let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
                 lines.push(Line::from(vec![
                     Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                    Span::styled(
-                        hunk.header.to_string(),
-                        styles::diff_hunk_header_style(&app.theme),
-                    ),
+                    Span::styled(hunk_header_text, hunk_header_style),
                 ]));
                 line_idx += 1;
+                if is_hunk_reviewed {
+                    continue;
+                }
 
                 // Diff lines
                 for diff_line in &hunk.lines {

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use crate::app::{
     AnnotatedLine, App, DiffViewMode, ExpandDirection, GAP_EXPAND_BATCH, VisualSelection,
 };
-use crate::model::{Comment, LineSide};
+use crate::model::{Comment, DiffHunk, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_side_by_side::render_side_by_side_diff;
@@ -143,6 +143,21 @@ pub(super) fn cursor_indicator_spaced(line_idx: usize, current_line_idx: usize) 
         "▶ "
     } else {
         "  "
+    }
+}
+
+pub(super) fn hunk_header_text_and_style(
+    theme: &Theme,
+    hunk: &DiffHunk,
+    is_hunk_reviewed: bool,
+) -> (String, Style) {
+    if is_hunk_reviewed {
+        (format!("✓ {}", hunk.header), styles::reviewed_style(theme))
+    } else {
+        (
+            hunk.header.to_string(),
+            styles::diff_hunk_header_style(theme),
+        )
     }
 }
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -366,6 +366,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  R         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Toggle hunk reviewed"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  c         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -271,7 +271,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             match app.input_mode {
                 InputMode::Normal => Cow::Borrowed(
-                    "   j/k scroll \u{00b7} {/} file \u{00b7} r reviewed \u{00b7} c comment \u{00b7} ? help",
+                    "   j/k scroll \u{00b7} {/} file \u{00b7} r file \u{00b7} R hunk \u{00b7} c comment \u{00b7} ? help",
                 ),
                 InputMode::Command => {
                     Cow::Borrowed("   tab complete \u{00b7} \u{21b5} execute \u{00b7} esc cancel")


### PR DESCRIPTION
When reviewing large diffs, marking an entire file as "reviewed" is often too coarse. It is useful to mark only a single "hunk" as reviewed. This PR enables this with the key "R".