### PR TITLE
Attribute comment authorship and surface it in the UI

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -945,6 +945,11 @@ pub struct App {
     /// formatting on submit. Defaults to `ForgeConfig::default()` when the
     /// section is missing.
     pub forge_config: crate::config::ForgeConfig,
+    /// Local viewer identity. Stamped on new comments authored in the TUI,
+    /// and compared against existing comment authors so the comment pane can
+    /// distinguish "your" comments from others. Resolved from the config
+    /// `username` field; defaults to `Comment::DEFAULT_AUTHOR`.
+    pub username: String,
     /// In-flight `:submit*` state. `None` outside the resolver + confirmation
     /// modal flow; preflight populates it.
     pub submit_state: Option<SubmitState>,
@@ -1170,6 +1175,9 @@ pub struct CommentNavigatorItem {
     pub path: Option<String>,
     pub line: Option<u32>,
     pub side: Option<LineSide>,
+    /// Author of the underlying local comment. `None` for remote thread items
+    /// (the renderer styles those by `muted` instead).
+    pub author: Option<String>,
 }
 
 #[derive(Debug)]
@@ -1738,6 +1746,7 @@ impl App {
             forge_review_threads_loading: false,
             pr_threads_rx: None,
             forge_config: crate::config::ForgeConfig::default(),
+            username: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             submit_state: None,
             submit_picker_cursor: 0,
             pr_submit_state: None,
@@ -4854,6 +4863,7 @@ impl App {
                     path: None,
                     line: None,
                     side: None,
+                    author: Some(comment.author.clone()),
                 })
             }
             CommentNavigatorKey::File {
@@ -4873,6 +4883,7 @@ impl App {
                     path: Some(path.display().to_string()),
                     line: None,
                     side: None,
+                    author: Some(comment.author.clone()),
                 })
             }
             CommentNavigatorKey::Line {
@@ -4897,6 +4908,7 @@ impl App {
                     path: Some(path.display().to_string()),
                     line: Some(line),
                     side: Some(side),
+                    author: Some(comment.author.clone()),
                 })
             }
             CommentNavigatorKey::Remote { thread_idx } => {
@@ -4916,6 +4928,7 @@ impl App {
                     path: Some(thread.path.clone()),
                     line: thread.line,
                     side: Some(side),
+                    author: None,
                 })
             }
         }
@@ -6402,6 +6415,7 @@ impl App {
                 target: CommentTarget::Review,
                 content,
                 comment_type: self.comment_type.clone(),
+                author: self.username.clone(),
             };
             message = match add_comment_to_session(&mut self.session, request) {
                 Ok(_) => "Review comment added".to_string(),
@@ -6436,6 +6450,7 @@ impl App {
                 target,
                 content,
                 comment_type: self.comment_type.clone(),
+                author: self.username.clone(),
             };
             message = match add_comment_to_session(&mut self.session, request) {
                 Ok(_) => success_message,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,6 +212,13 @@ pub enum ReviewCommand {
         #[arg(long, value_enum, default_value_t = LineSideArg::New)]
         side: LineSideArg,
 
+        /// Author stamped on the new comment. Pass an explicit value when
+        /// invoking from an agent (e.g. `--username "Claude Opus 4.7"`) so
+        /// human and agent comments are visually distinguished in the TUI.
+        /// Falls back to the config `username` setting, then to `"user"`.
+        #[arg(long, value_name = "NAME")]
+        username: Option<String>,
+
         /// Comment text.
         #[arg(
             value_name = "COMMENT",
@@ -813,6 +820,7 @@ mod tests {
                 line: Some(42),
                 end_line: None,
                 side: LineSideArg::Old,
+                username: None,
                 content: Some("Handle the empty case".to_string()),
             })
         );
@@ -844,6 +852,7 @@ mod tests {
                 line: None,
                 end_line: None,
                 side: LineSideArg::New,
+                username: None,
                 content: None,
             })
         );

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -58,6 +58,10 @@ pub struct AppConfig {
     /// Pristine `--all-files` mode already defaults to true regardless of
     /// this setting. Defaults to false.
     pub single_file_view: Option<bool>,
+    /// Display name stamped on comments authored locally in the TUI, and
+    /// used as the "viewer" identity for per-author coloring in the comment
+    /// pane. Defaults to `"user"` when unset.
+    pub username: Option<String>,
     /// `[forge]` section settings. Always present; `None` means "no override"
     /// and downstream code should treat it as `ForgeConfig::default()`.
     pub forge: Option<ForgeConfig>,
@@ -83,6 +87,7 @@ const KNOWN_KEYS: &[&str] = &[
     "review_watch_interval_ms",
     "no_update_check",
     "single_file_view",
+    "username",
     "forge",
 ];
 
@@ -290,6 +295,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         review_watch_interval_ms: read_usize(table, "review_watch_interval_ms", &mut warnings),
         no_update_check: read_bool(table, "no_update_check", &mut warnings),
         single_file_view: read_bool(table, "single_file_view", &mut warnings),
+        username: read_string(table, "username", &mut warnings),
         forge: table
             .get("forge")
             .and_then(|v| parse_forge(v, &mut warnings)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,14 @@ fn main() -> anyhow::Result<()> {
                 if let Some(leader) = cfg.leader {
                     app.leader_key = leader;
                 }
+                if let Some(username) = cfg
+                    .username
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                {
+                    app.username = username.to_string();
+                }
             }
             app
         }

--- a/src/model/comment.rs
+++ b/src/model/comment.rs
@@ -131,6 +131,15 @@ pub struct LineContext {
     pub content: String,
 }
 
+/// Default author used when a comment is created or deserialized without
+/// an explicit author. Distinguishes human-authored comments from agent /
+/// remote comments which set their own author string.
+pub const DEFAULT_AUTHOR: &str = "user";
+
+fn default_author() -> String {
+    DEFAULT_AUTHOR.to_string()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Comment {
     pub id: String,
@@ -146,6 +155,11 @@ pub struct Comment {
     /// None for file-level comments or single-line comments (backward compatibility)
     #[serde(default)]
     pub line_range: Option<LineRange>,
+    /// Who wrote this comment. Free-form; agents pass `--username "Claude …"`,
+    /// humans default to `"user"`. Old session JSON predates this field and
+    /// rehydrates as `"user"`.
+    #[serde(default = "default_author")]
+    pub author: String,
     /// Where this comment sits in its remote forge lifecycle. Old session
     /// JSON predates this field and rehydrates as `LocalDraft`.
     #[serde(default)]
@@ -170,6 +184,7 @@ impl Comment {
             line_context: None,
             side,
             line_range: None,
+            author: default_author(),
             lifecycle_state: CommentLifecycleState::default(),
             remote_review_id: None,
             remote_comment_id: None,
@@ -191,10 +206,19 @@ impl Comment {
             line_context: None,
             side,
             line_range: Some(line_range),
+            author: default_author(),
             lifecycle_state: CommentLifecycleState::default(),
             remote_review_id: None,
             remote_comment_id: None,
         }
+    }
+
+    /// Builder: set the author and return self. Useful at the boundary where
+    /// we know the username (TUI startup config, CLI `--username` flag) so
+    /// the existing `Comment::new` call sites can stay untouched.
+    pub fn with_author(mut self, author: impl Into<String>) -> Self {
+        self.author = author.into();
+        self
     }
 
     /// True if this comment has been pushed/submitted to the forge and is

--- a/src/review_cli.rs
+++ b/src/review_cli.rs
@@ -7,8 +7,9 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 
 use crate::cli::{LineSideArg, ReviewCommand};
+use crate::config;
 use crate::error::{Result, TuicrError};
-use crate::model::comment::CommentLifecycleState;
+use crate::model::comment::{self, CommentLifecycleState};
 use crate::model::{Comment, CommentType, LineRange, LineSide, ReviewSession};
 use crate::review_store::{
     AddCommentRequest, CommentTarget, ReviewStore, SessionRef, SessionSummary,
@@ -31,6 +32,7 @@ fn run_with_writer(command: ReviewCommand, out: &mut impl Write) -> Result<()> {
             line,
             end_line,
             side,
+            username,
             content,
         } => add_comment(
             &session,
@@ -42,6 +44,7 @@ fn run_with_writer(command: ReviewCommand, out: &mut impl Write) -> Result<()> {
                 line,
                 end_line,
                 side,
+                username,
                 content,
             },
             out,
@@ -69,6 +72,7 @@ struct AddCommentOptions {
     line: Option<u32>,
     end_line: Option<u32>,
     side: LineSideArg,
+    username: Option<String>,
     content: Option<String>,
 }
 
@@ -83,12 +87,14 @@ fn add_comment(
     let request_parts = build_add_request_parts(options)?;
     let target = request_parts.target;
     let comment_type = CommentType::from_id(&request_parts.comment_type);
+    let author = resolve_cli_author(request_parts.username);
     let comment = store.add_comment(
         &session_ref,
         AddCommentRequest {
             target: target.clone(),
             content: request_parts.content,
             comment_type,
+            author,
         },
     )?;
     let output = CommentOutput::from_target(&target, &comment);
@@ -101,6 +107,29 @@ struct AddRequestParts {
     target: CommentTarget,
     comment_type: String,
     content: String,
+    username: Option<String>,
+}
+
+/// Resolve the author for a CLI-authored comment.
+///
+/// Priority: explicit `--username` / JSON `username` ► config `username` ►
+/// `Comment::DEFAULT_AUTHOR`. Trims whitespace so `--username " "` doesn't
+/// produce an awkward all-whitespace badge.
+fn resolve_cli_author(explicit: Option<String>) -> String {
+    if let Some(name) = explicit.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+        return name.to_string();
+    }
+    if let Ok(outcome) = config::load_config()
+        && let Some(name) = outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.username.as_deref())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    {
+        return name.to_string();
+    }
+    comment::DEFAULT_AUTHOR.to_string()
 }
 
 fn build_add_request_parts(options: AddCommentOptions) -> Result<AddRequestParts> {
@@ -110,6 +139,7 @@ fn build_add_request_parts(options: AddCommentOptions) -> Result<AddRequestParts
     let mut line = options.line;
     let mut end_line = options.end_line;
     let mut side = options.side;
+    let mut username = options.username;
     let mut target = None;
 
     if let Some(input) = options.input {
@@ -119,6 +149,9 @@ fn build_add_request_parts(options: AddCommentOptions) -> Result<AddRequestParts
         }
         if payload.content.is_some() {
             content = payload.content;
+        }
+        if payload.username.is_some() {
+            username = payload.username;
         }
         if let Some(payload_target) = payload.target {
             target = Some(payload_target.into_comment_target()?);
@@ -152,6 +185,7 @@ fn build_add_request_parts(options: AddCommentOptions) -> Result<AddRequestParts
         target,
         comment_type,
         content,
+        username,
     })
 }
 
@@ -190,6 +224,8 @@ struct AddCommentPayload {
     end_line: Option<u32>,
     #[serde(default)]
     side: Option<String>,
+    #[serde(default, alias = "author")]
+    username: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -619,6 +655,7 @@ mod tests {
             line: None,
             end_line: None,
             side: LineSideArg::New,
+            username: None,
             content: None,
         })
         .unwrap();
@@ -647,6 +684,7 @@ mod tests {
             line: None,
             end_line: None,
             side: LineSideArg::New,
+            username: None,
             content: None,
         })
         .unwrap();
@@ -691,6 +729,7 @@ mod tests {
                     },
                     content: "check this".to_string(),
                     comment_type: CommentType::Issue,
+                    author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
                 },
             )
             .unwrap();

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -122,6 +122,10 @@ pub struct AddCommentRequest {
     pub target: CommentTarget,
     pub content: String,
     pub comment_type: CommentType,
+    /// Author to stamp on the resulting comment. Caller is responsible for
+    /// picking a sensible default (`Comment::DEFAULT_AUTHOR`) when none is
+    /// supplied.
+    pub author: String,
 }
 
 /// Where a new local draft comment should be attached.
@@ -157,27 +161,30 @@ pub fn add_comment_to_session(
         ));
     }
 
+    let author = request.author;
     let comment = match request.target {
         CommentTarget::Review => {
-            let comment = Comment::new(content, request.comment_type, None);
+            let comment = Comment::new(content, request.comment_type, None).with_author(author);
             session.review_comments.push(comment.clone());
             comment
         }
         CommentTarget::File { path } => {
             let review = file_review_mut(session, &path)?;
-            let comment = Comment::new(content, request.comment_type, None);
+            let comment = Comment::new(content, request.comment_type, None).with_author(author);
             review.add_file_comment(comment.clone());
             comment
         }
         CommentTarget::Line { path, line, side } => {
             let review = file_review_mut(session, &path)?;
-            let comment = Comment::new(content, request.comment_type, Some(side));
+            let comment =
+                Comment::new(content, request.comment_type, Some(side)).with_author(author);
             review.add_line_comment(line, comment.clone());
             comment
         }
         CommentTarget::LineRange { path, range, side } => {
             let review = file_review_mut(session, &path)?;
-            let comment = Comment::new_with_range(content, request.comment_type, Some(side), range);
+            let comment = Comment::new_with_range(content, request.comment_type, Some(side), range)
+                .with_author(author);
             review.add_line_comment(range.end, comment.clone());
             comment
         }
@@ -222,6 +229,7 @@ mod tests {
                 target: CommentTarget::Review,
                 content: "looks good".to_string(),
                 comment_type: CommentType::Praise,
+                author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             },
         )
         .unwrap();
@@ -241,6 +249,7 @@ mod tests {
                 },
                 content: "file note".to_string(),
                 comment_type: CommentType::Note,
+                author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             },
         )
         .unwrap();
@@ -264,6 +273,7 @@ mod tests {
                 },
                 content: "range note".to_string(),
                 comment_type: CommentType::Suggestion,
+                author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             },
         )
         .unwrap();
@@ -284,6 +294,7 @@ mod tests {
                 },
                 content: "note".to_string(),
                 comment_type: CommentType::Note,
+                author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             },
         )
         .unwrap_err();
@@ -328,6 +339,7 @@ mod tests {
                     },
                     content: "line note".to_string(),
                     comment_type: CommentType::Note,
+                    author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
                 },
             )
             .unwrap();

--- a/src/ui/comment_navigator.rs
+++ b/src/ui/comment_navigator.rs
@@ -82,11 +82,20 @@ fn render_comment_row(app: &App, item: &CommentNavigatorItem) -> Line<'static> {
     let dim_style = styles::dim_style(&app.theme);
     let location = comment_location(item);
 
-    Line::from(vec![
-        Span::styled(marker, marker_style),
-        Span::raw(" "),
-        Span::styled(location, dim_style),
-    ])
+    let author_accent = item
+        .author
+        .as_deref()
+        .and_then(|author| styles::author_accent(&app.username, author));
+
+    let mut spans = vec![Span::styled(marker, marker_style), Span::raw(" ")];
+    if let Some(color) = author_accent {
+        spans.push(Span::styled(
+            "● ".to_string(),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ));
+    }
+    spans.push(Span::styled(location, dim_style));
+    Line::from(spans)
 }
 
 fn line_width(line: &Line<'_>) -> usize {

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -310,16 +310,34 @@ pub fn format_remote_thread_lines(
     result
 }
 
-/// Format a comment as multiple lines with a box border (themed version)
+/// Format a comment as multiple lines with a box border (themed version).
+///
+/// `author` advertises the comment's author in the top-row badge and tints
+/// the box border. Callers pass `Some(name)` for non-self comments — the
+/// resulting badge reads `[TYPE @name]`, mirroring the `[github @author]`
+/// format used for remote PR threads. `None` keeps the existing neutral
+/// `[TYPE]` badge and theme border.
 pub fn format_comment_lines(
     theme: &Theme,
     comment_type: CommentTypePresentation,
     content: &str,
     line_range: Option<LineRange>,
     width: usize,
+    author: Option<&str>,
 ) -> Vec<Line<'static>> {
     let type_style = styles::comment_type_style(theme, comment_type.color);
-    let border_style = styles::comment_border_style(theme, comment_type.color);
+    let border_style = match author {
+        Some(name) => Style::default()
+            .fg(styles::author_color_for(name))
+            .add_modifier(ratatui::style::Modifier::BOLD),
+        None => styles::comment_border_style(theme, comment_type.color),
+    };
+
+    let badge_text = match author {
+        Some(name) => format!("[{} @{name}] ", comment_type.label),
+        None => format!("[{}] ", comment_type.label),
+    };
+    let badge_width = badge_text.width();
 
     let line_info = match line_range {
         Some(range) if range.is_single() => format!("L{} ", range.start),
@@ -340,11 +358,12 @@ pub fn format_comment_lines(
     let top_prefix = format!("    {top_corner}── ");
 
     // Top border — fill dynamically so total line = width.
-    // top_prefix = 8, "[LABEL] " = label.len()+3, line_info = variable
-    let top_fill = width.saturating_sub(8 + comment_type.label.len() + 3 + line_info.width());
+    // top_prefix = 8 cols, then the badge (width depends on author), then
+    // optional line_info, then `─` fill out to `width`.
+    let top_fill = width.saturating_sub(8 + badge_width + line_info.width());
     result.push(Line::from(vec![
         Span::styled(top_prefix, border_style),
-        Span::styled(format!("[{}] ", comment_type.label), type_style),
+        Span::styled(badge_text, type_style),
         Span::styled(line_info, styles::dim_style(theme)),
         Span::styled("─".repeat(top_fill), border_style),
     ]));

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -171,6 +171,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 &comment.content,
                 None,
                 ctx.panel_width.saturating_sub(1),
+                (comment.author != app.username).then_some(comment.author.as_str()),
             );
             for mut comment_line in comment_lines {
                 let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
@@ -308,6 +309,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                         &comment.content,
                         None,
                         ctx.panel_width.saturating_sub(1),
+                        (comment.author != app.username).then_some(comment.author.as_str()),
                     );
                     for mut comment_line in comment_lines {
                         let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
@@ -1379,6 +1381,7 @@ fn add_comments_to_line(
                         &comment.content,
                         line_range,
                         ctx.panel_width.saturating_sub(1),
+                        (comment.author != ctx.app.username).then_some(comment.author.as_str()),
                     );
                     let box_top_row = line_idx;
                     for mut comment_line in comment_lines {

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -127,6 +127,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 &comment.content,
                 None,
                 comment_width,
+                (comment.author != app.username).then_some(comment.author.as_str()),
             );
             for mut comment_line in comment_lines {
                 let indicator = cursor_indicator(line_idx, current_line_idx);
@@ -275,6 +276,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         &comment.content,
                         None,
                         comment_width,
+                        (comment.author != app.username).then_some(comment.author.as_str()),
                     );
                     for mut comment_line in comment_lines {
                         let indicator = cursor_indicator(line_idx, current_line_idx);
@@ -624,6 +626,8 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             &comment.content,
                                             line_range,
                                             comment_width,
+                                            (comment.author != app.username)
+                                                .then_some(comment.author.as_str()),
                                         );
                                         let box_top_row = line_idx;
                                         for mut comment_line in comment_lines {
@@ -783,6 +787,8 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                             &comment.content,
                                             line_range,
                                             comment_width,
+                                            (comment.author != app.username)
+                                                .then_some(comment.author.as_str()),
                                         );
                                         let box_top_row = line_idx;
                                         for mut comment_line in comment_lines {

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -113,6 +113,52 @@ pub fn comment_border_style(theme: &Theme, _color: Color) -> Style {
     file_header_style(theme)
 }
 
+/// Fixed palette used to tint comment chrome by author. Excludes red/green so
+/// the colour never collides with diff add/del semantics. Cyan/yellow/magenta/
+/// blue/light-magenta/light-cyan give us six visually distinct slots — enough
+/// for a handful of agents alongside the human reviewer.
+const AUTHOR_PALETTE: &[Color] = &[
+    Color::Cyan,
+    Color::Yellow,
+    Color::Magenta,
+    Color::Blue,
+    Color::LightMagenta,
+    Color::LightCyan,
+];
+
+/// Deterministic palette colour for a given author name. Always returns
+/// a colour; callers gate visibility separately via [`author_accent`].
+/// Hashes via FNV-1a so the mapping is platform-independent and survives
+/// across runs.
+pub fn author_color_for(author: &str) -> Color {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for b in author.as_bytes() {
+        hash ^= *b as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    AUTHOR_PALETTE[(hash as usize) % AUTHOR_PALETTE.len()]
+}
+
+/// `Some(colour)` when `author` differs from the viewer (so the comment
+/// chrome should advertise authorship), `None` when the comment is the
+/// viewer's own.
+pub fn author_accent(viewer: &str, author: &str) -> Option<Color> {
+    if author == viewer {
+        None
+    } else {
+        Some(author_color_for(author))
+    }
+}
+
+/// Border style for a comment box, tinted by author when the comment is not
+/// from the current viewer. Falls back to the neutral header style otherwise.
+pub fn comment_border_style_for_author(theme: &Theme, viewer: &str, author: &str) -> Style {
+    match author_accent(viewer, author) {
+        Some(color) => Style::default().fg(color).add_modifier(Modifier::BOLD),
+        None => file_header_style(theme),
+    }
+}
+
 pub fn visual_selection_style(theme: &Theme) -> Style {
     Style::default().bg(theme.bg_highlight)
 }


### PR DESCRIPTION
## Summary
- Adds an `author` field to local comments (defaults to `"user"`; backward-compatible with existing session JSON).
- Adds `--username <NAME>` to `tuicr review add` (also accepted as `username` in the JSON payload), plus a `username = "..."` config knob that the TUI uses both as the stamp on new comments and as the "viewer" identity for visual distinction.
- In the diff view, non-self comment boxes render with a per-author tinted border and a `[TYPE @author]` badge — mirroring the `[github @author]` style used for remote PR threads. Self comments keep the existing neutral `[TYPE]` style.
- In the comment navigator, non-self entries get a colour-coded `●` chip; the author name is intentionally not shown there to keep rows compact.
- Per-author colour is FNV-1a-hashed onto a 6-slot palette that excludes red/green so it never collides with diff add/del semantics.

## Test plan
- [ ] `cargo test --all-features` (831 passing locally)
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [ ] Open a session in the TUI as `user`; existing comments still render with the neutral border
- [ ] `tuicr review add --session <slug> --username "Claude Opus 4.7" "..."` adds a comment that renders with a tinted border + `[NOTE @Claude Opus 4.7]` badge in the diff view, and a coloured `●` in the navigator
- [ ] Adding a second agent identity (e.g. `--username "GPT-5"`) produces a visibly distinct hash colour
- [ ] Sessions persisted before this change rehydrate with `author: "user"` and keep rendering neutrally

🤖 Generated with [Claude Code](https://claude.com/claude-code)