### PR TITLE
Surface PR review bodies + fix navigator author for remote threads

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -235,6 +235,9 @@ pub enum AnnotatedLine {
     ReviewCommentsHeader,
     /// A review-level comment line (part of a multi-line comment box)
     ReviewComment { comment_idx: usize },
+    /// A read-only line of a rendered remote review summary (PR review body).
+    /// Renders at review scope, parallel to `ReviewComment` for local drafts.
+    RemoteReviewSummaryLine { summary_idx: usize },
     /// File header line
     FileHeader { file_idx: usize },
     /// A file-level comment line (part of a multi-line comment box)
@@ -368,6 +371,7 @@ pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
         | AnnotatedLine::BinaryOrEmpty { file_idx } => Some(*file_idx),
         AnnotatedLine::ReviewCommentsHeader
         | AnnotatedLine::ReviewComment { .. }
+        | AnnotatedLine::RemoteReviewSummaryLine { .. }
         | AnnotatedLine::Expander { .. }
         | AnnotatedLine::HiddenLines { .. }
         | AnnotatedLine::ExpandedContext { .. }
@@ -776,7 +780,10 @@ pub enum PrThreadsEvent {
         repository: crate::forge::traits::ForgeRepository,
         pr_number: u64,
         head_sha: String,
-        result: std::result::Result<Vec<crate::forge::remote_comments::RemoteReviewThread>, String>,
+        threads:
+            std::result::Result<Vec<crate::forge::remote_comments::RemoteReviewThread>, String>,
+        summaries:
+            std::result::Result<Vec<crate::forge::remote_comments::RemoteReviewSummary>, String>,
     },
 }
 
@@ -932,6 +939,10 @@ pub struct App {
     /// `poll_pr_threads_events`). Empty in non-PR modes and during the
     /// loading window.
     pub forge_review_threads: Vec<crate::forge::remote_comments::RemoteReviewThread>,
+    /// Review-level summary comments (body text on each `PullRequestReview`).
+    /// Populated alongside `forge_review_threads`. These render at the top
+    /// of the diff, parallel to local `session.review_comments` drafts.
+    pub forge_review_summaries: Vec<crate::forge::remote_comments::RemoteReviewSummary>,
     /// True while a background remote-thread fetch is in flight for the
     /// currently open PR. Drives the footer "Loading remote comments…"
     /// hint and skips re-fetch if `:e` is hit again before the first
@@ -1158,6 +1169,9 @@ pub enum CommentNavigatorKey {
     },
     Remote {
         thread_idx: usize,
+    },
+    RemoteReview {
+        summary_idx: usize,
     },
 }
 
@@ -1744,6 +1758,7 @@ impl App {
             pr_reload_rx: None,
             forge_backend: None,
             forge_review_threads: Vec::new(),
+            forge_review_summaries: Vec::new(),
             forge_review_threads_loading: false,
             pr_threads_rx: None,
             forge_config: crate::config::ForgeConfig::default(),
@@ -2602,6 +2617,7 @@ impl App {
         // Reset remote-comment state on every PR mode entry; the new PR's
         // threads will be fetched separately by spawn_pr_threads_fetch.
         self.forge_review_threads = Vec::new();
+        self.forge_review_summaries = Vec::new();
         self.forge_review_threads_loading = false;
         self.pr_threads_rx = None;
         // Latest known remote head — equal to the session head at open time;
@@ -4314,6 +4330,11 @@ impl App {
                 let comment = self.session.review_comments.get(*comment_idx)?;
                 Some(comment.content.clone())
             }
+            AnnotatedLine::RemoteReviewSummaryLine { summary_idx } => {
+                let summary = self.forge_review_summaries.get(*summary_idx)?;
+                let author = summary.author.as_deref().unwrap_or("unknown");
+                Some(format!("github @{author} {}", summary.body))
+            }
             AnnotatedLine::FileHeader { file_idx } => {
                 let file = self.diff_files.get(*file_idx)?;
                 Some(format!(
@@ -4845,6 +4866,11 @@ impl App {
             AnnotatedLine::RemoteThreadLine { thread_idx } => Some(CommentNavigatorKey::Remote {
                 thread_idx: *thread_idx,
             }),
+            AnnotatedLine::RemoteReviewSummaryLine { summary_idx } => {
+                Some(CommentNavigatorKey::RemoteReview {
+                    summary_idx: *summary_idx,
+                })
+            }
             _ => None,
         }
     }
@@ -4931,6 +4957,18 @@ impl App {
                     line: thread.line,
                     side: Some(side),
                     author,
+                })
+            }
+            CommentNavigatorKey::RemoteReview { summary_idx } => {
+                let summary = self.forge_review_summaries.get(summary_idx)?;
+                Some(CommentNavigatorItem {
+                    key: CommentNavigatorKey::RemoteReview { summary_idx },
+                    kind: CommentNavigatorKind::Remote { muted: false },
+                    target_annotation,
+                    path: None,
+                    line: None,
+                    side: None,
+                    author: summary.author.clone(),
                 })
             }
         }
@@ -5500,6 +5538,9 @@ impl App {
         // Header line is only rendered in multi-file view. See the guards
         // in `src/ui/diff_unified.rs` and `src/ui/diff_side_by_side.rs`.
         let mut height = if self.is_single_file_view { 0 } else { 1 };
+        for summary in &self.forge_review_summaries {
+            height += crate::forge::remote_comments::summary_display_lines(summary);
+        }
         for comment in &self.session.review_comments {
             height += Self::comment_display_lines(comment, self.diff_state.viewport_width);
         }
@@ -7515,14 +7556,18 @@ impl App {
         std::thread::spawn(move || {
             let backend =
                 GitHubGhBackend::new(Some(repository.clone())).with_local_checkout(local_checkout);
-            let result = backend
+            let threads = backend
                 .list_review_threads(&details_clone)
+                .map_err(|e| e.to_string());
+            let summaries = backend
+                .list_review_summaries(&details_clone)
                 .map_err(|e| e.to_string());
             let _ = tx.send(PrThreadsEvent::Done {
                 repository,
                 pr_number,
                 head_sha,
-                result,
+                threads,
+                summaries,
             });
         });
     }
@@ -7546,7 +7591,8 @@ impl App {
                 repository,
                 pr_number,
                 head_sha,
-                result,
+                threads,
+                summaries,
             } => {
                 // Validate against the currently open PR. If the user has
                 // opened a different PR (or left PR mode) while the fetch
@@ -7566,18 +7612,34 @@ impl App {
                 if !still_relevant {
                     return;
                 }
-                match result {
-                    Ok(threads) => {
-                        self.forge_review_threads = threads;
-                        self.prune_locked_comments();
-                        let _ = self.save_current_session_merging_external();
-                        self.rebuild_annotations();
+                let mut had_error = false;
+                match threads {
+                    Ok(t) => {
+                        self.forge_review_threads = t;
                     }
                     Err(e) => {
                         self.forge_review_threads = Vec::new();
                         self.set_warning(format!("Failed to load remote comments: {e}"));
+                        had_error = true;
                     }
                 }
+                match summaries {
+                    Ok(s) => {
+                        self.forge_review_summaries = s;
+                    }
+                    Err(e) => {
+                        self.forge_review_summaries = Vec::new();
+                        // Only surface the summary error if the threads call
+                        // succeeded — otherwise the user already got a
+                        // warning for the broader failure.
+                        if !had_error {
+                            self.set_warning(format!("Failed to load remote reviews: {e}"));
+                        }
+                    }
+                }
+                self.prune_locked_comments();
+                let _ = self.save_current_session_merging_external();
+                self.rebuild_annotations();
             }
         }
     }
@@ -7671,13 +7733,18 @@ impl App {
             highlighter,
         )?;
         Self::load_or_apply_pr_session(&mut opened);
-        // Sync thread fetch — tests assert on `app.forge_review_threads`
-        // immediately after this returns.
+        // Sync thread + summary fetch — tests assert on
+        // `app.forge_review_threads`/`forge_review_summaries` immediately
+        // after this returns.
         let threads = backend
             .list_review_threads(&opened.details)
             .unwrap_or_default();
+        let summaries = backend
+            .list_review_summaries(&opened.details)
+            .unwrap_or_default();
         self.enter_pr_diff_mode(backend, opened)?;
         self.forge_review_threads = threads;
+        self.forge_review_summaries = summaries;
         self.prune_locked_comments();
         self.rebuild_annotations();
         Ok(())
@@ -8713,6 +8780,13 @@ impl App {
         if !self.is_single_file_view {
             self.line_annotations
                 .push(AnnotatedLine::ReviewCommentsHeader);
+        }
+        for (summary_idx, summary) in self.forge_review_summaries.iter().enumerate() {
+            let summary_lines = crate::forge::remote_comments::summary_display_lines(summary);
+            for _ in 0..summary_lines {
+                self.line_annotations
+                    .push(AnnotatedLine::RemoteReviewSummaryLine { summary_idx });
+            }
         }
         for (comment_idx, comment) in self.session.review_comments.iter().enumerate() {
             let comment_lines =
@@ -10988,7 +11062,8 @@ mod target_selector_tests {
             repository: pr_key.repository.clone(),
             pr_number: pr_key.number,
             head_sha: pr_key.head_sha.clone(),
-            result: Ok(vec![sample_thread(2, "delayed", false, false)]),
+            threads: Ok(vec![sample_thread(2, "delayed", false, false)]),
+            summaries: Ok(Vec::new()),
         })
         .unwrap();
         // when
@@ -11018,7 +11093,8 @@ mod target_selector_tests {
             repository: ForgeRepository::github("github.com", "agavra", "tuicr"),
             pr_number: 999,                         // wrong number
             head_sha: "definitely-not-this".into(), // wrong head
-            result: Ok(vec![sample_thread(2, "stale", false, false)]),
+            threads: Ok(vec![sample_thread(2, "stale", false, false)]),
+            summaries: Ok(Vec::new()),
         })
         .unwrap();
         // when
@@ -12832,6 +12908,39 @@ mod expand_gap_tests {
             CommentNavigatorKey::Remote { thread_idx: 0 }
         ));
         assert_eq!(items[3].author.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn comment_navigator_includes_remote_review_summary() {
+        use crate::forge::remote_comments::{RemoteReviewState, RemoteReviewSummary};
+
+        let file = make_file_with_hunks("a.rs", vec![make_hunk(1, 1)]);
+        let mut app = build_app_with_files(vec![file], 10);
+        app.sync_viewport_width(80);
+
+        app.forge_review_summaries = vec![RemoteReviewSummary {
+            id: "PRR_1".into(),
+            author: Some("alice".into()),
+            body: "Overall LGTM".into(),
+            state: RemoteReviewState::Commented,
+            created_at: None,
+            url: "https://example.com/r/1".into(),
+        }];
+        app.rebuild_annotations();
+
+        let items = app.build_comment_navigator_items();
+
+        // Summary appears as the first navigator item — review-scope, before files.
+        assert!(matches!(
+            items[0].key,
+            CommentNavigatorKey::RemoteReview { summary_idx: 0 }
+        ));
+        assert_eq!(items[0].author.as_deref(), Some("alice"));
+        assert!(items[0].path.is_none());
+        assert!(items[0].line.is_none());
+
+        // Scroll math stays consistent: annotation count matches total_lines.
+        assert_eq!(app.total_lines(), app.line_annotations.len());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1175,8 +1175,9 @@ pub struct CommentNavigatorItem {
     pub path: Option<String>,
     pub line: Option<u32>,
     pub side: Option<LineSide>,
-    /// Author of the underlying local comment. `None` for remote thread items
-    /// (the renderer styles those by `muted` instead).
+    /// Author of the underlying comment — the local commenter for local items,
+    /// or the root comment's author for remote threads. `None` only when the
+    /// forge did not attach an author (e.g. deleted user).
     pub author: Option<String>,
 }
 
@@ -4921,6 +4922,7 @@ impl App {
                     crate::forge::remote_comments::RemoteCommentSide::Right => LineSide::New,
                     crate::forge::remote_comments::RemoteCommentSide::Left => LineSide::Old,
                 };
+                let author = thread.root().and_then(|c| c.author.clone());
                 Some(CommentNavigatorItem {
                     key: CommentNavigatorKey::Remote { thread_idx },
                     kind: CommentNavigatorKind::Remote { muted },
@@ -4928,7 +4930,7 @@ impl App {
                     path: Some(thread.path.clone()),
                     line: thread.line,
                     side: Some(side),
-                    author: None,
+                    author,
                 })
             }
         }
@@ -12829,6 +12831,7 @@ mod expand_gap_tests {
             items[3].key,
             CommentNavigatorKey::Remote { thread_idx: 0 }
         ));
+        assert_eq!(items[3].author.as_deref(), Some("alice"));
     }
 
     #[test]

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
-use crate::forge::remote_comments::RemoteReviewThread;
+use crate::forge::remote_comments::{RemoteReviewSummary, RemoteReviewThread};
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestListQuery,
@@ -15,6 +15,9 @@ use crate::process::{
 };
 
 use super::models::{GhPrCommit, GhPullRequestDetails, GhPullRequestSummary};
+use super::review_summaries::{
+    build_query as build_reviews_query, parse_graphql_page as parse_reviews_page,
+};
 use super::review_threads::{build_query, parse_graphql_page};
 use super::submit::build_review_payload;
 use crate::forge::traits::CreateReviewRequest;
@@ -362,6 +365,28 @@ where
         Ok(all)
     }
 
+    fn list_review_summaries(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewSummary>> {
+        let mut all: Vec<RemoteReviewSummary> = Vec::new();
+        let mut cursor: Option<String> = None;
+        for _ in 0..100 {
+            let args = self.build_review_summaries_args(pr, cursor.as_deref());
+            let output = self.run_gh(args, &pr.repository.host)?;
+            let parsed = parse_reviews_page(&output)?;
+            all.extend(parsed.summaries);
+            let Some(page_info) = parsed.page_info else {
+                break;
+            };
+            if !page_info.has_next_page {
+                break;
+            }
+            let Some(end_cursor) = page_info.end_cursor else {
+                break;
+            };
+            cursor = Some(end_cursor);
+        }
+        Ok(all)
+    }
+
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
@@ -436,7 +461,23 @@ where
         pr: &PullRequestDetails,
         cursor: Option<&str>,
     ) -> Vec<String> {
-        let query = build_query(cursor);
+        self.build_graphql_args(pr, &build_query(cursor), cursor)
+    }
+
+    fn build_review_summaries_args(
+        &self,
+        pr: &PullRequestDetails,
+        cursor: Option<&str>,
+    ) -> Vec<String> {
+        self.build_graphql_args(pr, &build_reviews_query(cursor), cursor)
+    }
+
+    fn build_graphql_args(
+        &self,
+        pr: &PullRequestDetails,
+        query: &str,
+        cursor: Option<&str>,
+    ) -> Vec<String> {
         let mut args = vec![
             "api".to_string(),
             "graphql".to_string(),
@@ -924,9 +965,25 @@ index 1111111..2222222 100644
                         stderr: "unexpected pr command".to_string(),
                     }),
                 },
-                // gh api graphql for review threads.
+                // gh api graphql — dispatch by the query body so the
+                // mock returns shape-appropriate fixtures for both the
+                // reviewThreads and reviews queries.
                 Some("api") if args.get(1).map(String::as_str) == Some("graphql") => {
-                    Ok(REVIEW_THREADS_JSON.to_string())
+                    let query = args
+                        .iter()
+                        .find(|a| a.starts_with("query="))
+                        .map(String::as_str)
+                        .unwrap_or("");
+                    if query.contains("reviewThreads(") {
+                        Ok(REVIEW_THREADS_JSON.to_string())
+                    } else if query.contains("reviews(") {
+                        Ok(REVIEW_SUMMARIES_JSON.to_string())
+                    } else {
+                        Err(GhCommandError::Failed {
+                            status: Some(1),
+                            stderr: "unexpected graphql query".to_string(),
+                        })
+                    }
                 }
                 // gh api repos/.../pulls/<n>/commits (commit list).
                 Some("api")
@@ -1021,6 +1078,28 @@ index 1111111..2222222 100644
                                         }
                                     ]
                                 }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const REVIEW_SUMMARIES_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviews": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [
+                            {
+                                "id": "PRR_1",
+                                "state": "COMMENTED",
+                                "body": "Overall LGTM",
+                                "author": { "login": "alice" },
+                                "submittedAt": "2026-05-12T18:30:00Z",
+                                "url": "https://example.com/r/1"
                             }
                         ]
                     }
@@ -1425,6 +1504,34 @@ Match host github-work
         assert!(graphql_call.iter().any(|a| a == "owner=agavra"));
         assert!(graphql_call.iter().any(|a| a == "name=tuicr"));
         assert!(graphql_call.iter().any(|a| a == "number=125"));
+    }
+
+    #[test]
+    fn should_list_review_summaries_via_graphql_api_call() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let summaries = backend.list_review_summaries(&details).unwrap();
+        // then — the COMMENTED review with body is surfaced.
+        assert_eq!(summaries.len(), 1);
+        assert_eq!(summaries[0].id, "PRR_1");
+        assert_eq!(summaries[0].author.as_deref(), Some("alice"));
+        assert_eq!(summaries[0].body, "Overall LGTM");
+        // and — the call routes the `reviews(` query, not `reviewThreads(`.
+        let calls = backend.runner.calls.borrow();
+        let summaries_call = calls
+            .iter()
+            .find(|args| {
+                args.first().map(String::as_str) == Some("api")
+                    && args.iter().any(|a| a.contains("reviews(first:"))
+            })
+            .expect("expected a reviews graphql call");
+        assert!(summaries_call.iter().any(|a| a == "owner=agavra"));
+        assert!(summaries_call.iter().any(|a| a == "number=125"));
     }
 
     #[test]

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -1,4 +1,5 @@
 pub mod gh;
 pub mod models;
+pub mod review_summaries;
 pub mod review_threads;
 pub mod submit;

--- a/src/forge/github/review_summaries.rs
+++ b/src/forge/github/review_summaries.rs
@@ -1,0 +1,303 @@
+//! GraphQL parsing for GitHub review summaries (the body text on a
+//! `PullRequestReview` itself, not on its line-anchored threads).
+//!
+//! Reviews are a separate connection from `reviewThreads`. The summary is
+//! what shows up on the PR overview as "<reviewer> commented / approved /
+//! requested changes" with body markdown. We surface these in the
+//! top-of-diff review area so reviewers' high-level feedback shows up
+//! alongside local review-level drafts.
+//!
+//! Payload shape (only fields we read):
+//!
+//! ```json
+//! {
+//!   "data": {
+//!     "repository": {
+//!       "pullRequest": {
+//!         "reviews": {
+//!           "pageInfo": { "hasNextPage": false, "endCursor": null },
+//!           "nodes": [
+//!             {
+//!               "id": "PRR_kw...",
+//!               "state": "COMMENTED",
+//!               "body": "Overall this looks tight ...",
+//!               "author": { "login": "alice" },
+//!               "submittedAt": "2026-05-12T18:30:00Z",
+//!               "url": "https://github.com/agavra/tuicr/pull/356#pullrequestreview-1"
+//!             }
+//!           ]
+//!         }
+//!       }
+//!     }
+//!   }
+//! }
+//! ```
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::{Result, TuicrError};
+use crate::forge::github::review_threads::GhPageInfo;
+use crate::forge::remote_comments::{RemoteReviewState, RemoteReviewSummary};
+
+#[derive(Debug, Deserialize)]
+struct GhAuthor {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReview {
+    id: String,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    body: String,
+    #[serde(default)]
+    author: Option<GhAuthor>,
+    #[serde(default)]
+    submitted_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReviewsConn {
+    #[serde(default)]
+    page_info: Option<GhPageInfo>,
+    #[serde(default)]
+    nodes: Vec<GhReview>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPullRequest {
+    #[serde(default)]
+    reviews: Option<GhReviewsConn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRepository {
+    #[serde(default, rename = "pullRequest")]
+    pull_request: Option<GhPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhData {
+    #[serde(default)]
+    repository: Option<GhRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhResponse {
+    #[serde(default)]
+    data: Option<GhData>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParsedReviewsPage {
+    pub summaries: Vec<RemoteReviewSummary>,
+    pub page_info: Option<GhPageInfo>,
+}
+
+/// Parse one GraphQL response page into summaries + pagination info.
+/// Reviews with empty bodies (bare approvals, auto-submitted reviews from
+/// API integrations) are dropped — they have nothing to display.
+pub(crate) fn parse_graphql_page(json: &str) -> Result<ParsedReviewsPage> {
+    let response: GhResponse = serde_json::from_str(json).map_err(|e| {
+        TuicrError::Forge(format!(
+            "Failed to parse GitHub review summaries response: {e}"
+        ))
+    })?;
+
+    let conn = response
+        .data
+        .and_then(|d| d.repository)
+        .and_then(|r| r.pull_request)
+        .and_then(|p| p.reviews);
+
+    let Some(conn) = conn else {
+        return Ok(ParsedReviewsPage {
+            summaries: Vec::new(),
+            page_info: None,
+        });
+    };
+
+    let page_info = conn.page_info;
+    let mut summaries = Vec::with_capacity(conn.nodes.len());
+    for raw in conn.nodes {
+        if raw.body.trim().is_empty() {
+            continue;
+        }
+        summaries.push(RemoteReviewSummary {
+            id: raw.id,
+            author: raw.author.and_then(|a| a.login),
+            body: raw.body,
+            state: raw
+                .state
+                .as_deref()
+                .map(RemoteReviewState::parse)
+                .unwrap_or(RemoteReviewState::Commented),
+            created_at: raw.submitted_at,
+            url: raw.url.unwrap_or_default(),
+        });
+    }
+    Ok(ParsedReviewsPage {
+        summaries,
+        page_info,
+    })
+}
+
+/// Build the GraphQL query for fetching reviews on a PR.
+pub(crate) fn build_query(after_cursor: Option<&str>) -> String {
+    let cursor_arg = match after_cursor {
+        Some(_) => ", after: $after",
+        None => "",
+    };
+    format!(
+        r#"query($owner: String!, $name: String!, $number: Int!{cursor_param}) {{
+  repository(owner: $owner, name: $name) {{
+    pullRequest(number: $number) {{
+      reviews(first: 100{cursor_arg}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          id
+          state
+          body
+          author {{ login }}
+          submittedAt
+          url
+        }}
+      }}
+    }}
+  }}
+}}"#,
+        cursor_param = if after_cursor.is_some() {
+            ", $after: String!"
+        } else {
+            ""
+        },
+        cursor_arg = cursor_arg,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TWO_REVIEWS_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviews": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [
+                            {
+                                "id": "PRR_1",
+                                "state": "COMMENTED",
+                                "body": "Overall this looks tight.",
+                                "author": { "login": "alice" },
+                                "submittedAt": "2026-05-12T18:30:00Z",
+                                "url": "https://example.com/r/1"
+                            },
+                            {
+                                "id": "PRR_2",
+                                "state": "APPROVED",
+                                "body": "LGTM",
+                                "author": { "login": "bob" },
+                                "submittedAt": "2026-05-13T09:00:00Z",
+                                "url": "https://example.com/r/2"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const EMPTY_BODY_JSON: &str = r##"{
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviews": {
+                        "nodes": [
+                            {
+                                "id": "PRR_empty",
+                                "state": "APPROVED",
+                                "body": "",
+                                "author": { "login": "ci-bot" },
+                                "url": "https://example.com/r/empty"
+                            },
+                            {
+                                "id": "PRR_whitespace",
+                                "state": "COMMENTED",
+                                "body": "   \n\t",
+                                "author": { "login": "ci-bot" },
+                                "url": "https://example.com/r/ws"
+                            },
+                            {
+                                "id": "PRR_real",
+                                "state": "COMMENTED",
+                                "body": "Real feedback.",
+                                "author": { "login": "alice" },
+                                "url": "https://example.com/r/real"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const NULL_REPO_JSON: &str = r##"{ "data": { "repository": null } }"##;
+
+    #[test]
+    fn should_parse_two_reviews_with_state_and_author() {
+        // given/when
+        let parsed = parse_graphql_page(TWO_REVIEWS_JSON).unwrap();
+        // then
+        assert_eq!(parsed.summaries.len(), 2);
+        assert_eq!(parsed.summaries[0].id, "PRR_1");
+        assert_eq!(parsed.summaries[0].author.as_deref(), Some("alice"));
+        assert_eq!(parsed.summaries[0].state, RemoteReviewState::Commented);
+        assert_eq!(parsed.summaries[1].state, RemoteReviewState::Approved);
+    }
+
+    #[test]
+    fn should_drop_reviews_with_empty_or_whitespace_body() {
+        // given/when
+        let parsed = parse_graphql_page(EMPTY_BODY_JSON).unwrap();
+        // then — only the review with a real body survives
+        assert_eq!(parsed.summaries.len(), 1);
+        assert_eq!(parsed.summaries[0].id, "PRR_real");
+    }
+
+    #[test]
+    fn should_tolerate_missing_repository_object() {
+        // given/when
+        let parsed = parse_graphql_page(NULL_REPO_JSON).unwrap();
+        // then
+        assert!(parsed.summaries.is_empty());
+        assert!(parsed.page_info.is_none());
+    }
+
+    #[test]
+    fn should_build_query_without_cursor_for_first_page() {
+        // given/when
+        let q = build_query(None);
+        // then
+        assert!(q.contains("reviews(first: 100)"));
+        assert!(!q.contains("after: $after"));
+    }
+
+    #[test]
+    fn should_build_query_with_cursor_for_subsequent_pages() {
+        // given/when
+        let q = build_query(Some("CURSOR"));
+        // then
+        assert!(q.contains("$after: String!"));
+        assert!(q.contains("after: $after"));
+    }
+}

--- a/src/forge/remote_comments.rs
+++ b/src/forge/remote_comments.rs
@@ -47,6 +47,62 @@ pub struct RemoteReviewComment {
     pub url: String,
 }
 
+/// State of a remote review at submit time. GitHub exposes one of
+/// `APPROVED`, `CHANGES_REQUESTED`, `COMMENTED`, `DISMISSED`, `PENDING`;
+/// we keep the same set so display chrome can mark approvals vs. blocks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RemoteReviewState {
+    Commented,
+    Approved,
+    ChangesRequested,
+    Dismissed,
+    Pending,
+}
+
+impl RemoteReviewState {
+    pub fn parse(value: &str) -> Self {
+        match value.to_ascii_uppercase().as_str() {
+            "APPROVED" => RemoteReviewState::Approved,
+            "CHANGES_REQUESTED" => RemoteReviewState::ChangesRequested,
+            "DISMISSED" => RemoteReviewState::Dismissed,
+            "PENDING" => RemoteReviewState::Pending,
+            _ => RemoteReviewState::Commented,
+        }
+    }
+
+    /// Short label for badge/header text (e.g. `[github @alice approved]`).
+    pub fn badge_label(&self) -> Option<&'static str> {
+        match self {
+            RemoteReviewState::Commented => None,
+            RemoteReviewState::Approved => Some("approved"),
+            RemoteReviewState::ChangesRequested => Some("changes requested"),
+            RemoteReviewState::Dismissed => Some("dismissed"),
+            RemoteReviewState::Pending => Some("pending"),
+        }
+    }
+}
+
+/// A review-level summary comment, attached directly to a `PullRequestReview`.
+///
+/// Distinct from `RemoteReviewThread`: these have no file/line anchor and
+/// carry the reviewer's summary text alongside the review state (approved /
+/// changes requested / commented). They render in the top-of-diff review
+/// area, parallel to local `session.review_comments`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RemoteReviewSummary {
+    /// Forge-assigned review node ID.
+    pub id: String,
+    /// Login/handle of the reviewer, when available.
+    pub author: Option<String>,
+    /// Markdown body as submitted. Always non-empty by construction —
+    /// fetchers drop reviews with empty bodies (e.g. bare approvals).
+    pub body: String,
+    pub state: RemoteReviewState,
+    pub created_at: Option<DateTime<Utc>>,
+    /// Permalink to the review on the forge.
+    pub url: String,
+}
+
 /// A discussion thread on a forge — one root comment plus zero or more replies.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RemoteReviewThread {
@@ -159,6 +215,16 @@ pub fn thread_display_lines(thread: &RemoteReviewThread) -> usize {
     // single closing rule for the whole thread
     total += 1;
     total
+}
+
+/// Count the number of rendered lines a review summary occupies in the
+/// diff view's review-scope area. Layout must match
+/// `ui::comment_panel::format_remote_review_summary_lines`:
+/// - 1 header line (`├── [github @author commented] ──`)
+/// - 1 body line per `\n`-split line in the summary body
+/// - 1 footer line (`╰────`)
+pub fn summary_display_lines(summary: &RemoteReviewSummary) -> usize {
+    1 + summary.body.split('\n').count() + 1
 }
 
 /// Group threads by file path for export grouping. Preserves the input

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -310,6 +310,16 @@ pub trait ForgeBackend {
     /// and outdated state. Implementations should return all threads in
     /// posted order; filtering by visibility happens in the App.
     fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>>;
+    /// Fetch review-level summary comments — the body text on each
+    /// `PullRequestReview`, distinct from line-anchored threads. Default
+    /// returns an empty list; only forges with review-summary semantics
+    /// (GitHub) need to override.
+    fn list_review_summaries(
+        &self,
+        _pr: &PullRequestDetails,
+    ) -> Result<Vec<crate::forge::remote_comments::RemoteReviewSummary>> {
+        Ok(Vec::new())
+    }
     /// List the commits that make up a pull request, in chronological order
     /// (oldest first; the App reverses to newest-first display order). The
     /// list scopes the inline commit selector so users can narrow a PR's

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -310,6 +310,51 @@ pub fn format_remote_thread_lines(
     result
 }
 
+/// Format a remote review summary (the body of a `PullRequestReview`) as a
+/// box with a `[github @author <state>]` header. Renders at review scope —
+/// no line anchor — so the top corner is `╭`, not the line-anchored `├`.
+pub fn format_remote_review_summary_lines(
+    theme: &Theme,
+    summary: &crate::forge::remote_comments::RemoteReviewSummary,
+) -> Vec<Line<'static>> {
+    let badge_fg = theme.diff_hunk_header;
+    let border_fg = theme.diff_hunk_header;
+    let body_fg = theme.fg_secondary;
+
+    let badge_style = Style::default().fg(badge_fg).add_modifier(Modifier::BOLD);
+    let border_style = Style::default().fg(border_fg);
+    let body_style = Style::default().fg(body_fg);
+
+    let author = summary.author.as_deref().unwrap_or("unknown");
+    let mut badge_text = format!("[github @{author}");
+    if let Some(state_label) = summary.state.badge_label() {
+        badge_text.push(' ');
+        badge_text.push_str(state_label);
+    }
+    badge_text.push_str("] ");
+
+    let mut result = Vec::new();
+    result.push(Line::from(vec![
+        Span::styled("    ╭── ".to_string(), border_style),
+        Span::styled(badge_text, badge_style),
+        Span::styled("─".repeat(28), border_style),
+    ]));
+
+    for line in summary.body.split('\n') {
+        result.push(Line::from(vec![
+            Span::styled("    │  ".to_string(), border_style),
+            Span::styled(line.to_string(), body_style),
+        ]));
+    }
+
+    result.push(Line::from(vec![Span::styled(
+        "    ╰".to_string() + &"─".repeat(39),
+        border_style,
+    )]));
+
+    result
+}
+
 /// Format a comment as multiple lines with a box border (themed version).
 ///
 /// `author` advertises the comment's author in the top-row badge and tints

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -133,6 +133,19 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         line_idx += 1;
     }
 
+    for summary in &app.forge_review_summaries {
+        let summary_lines = comment_panel::format_remote_review_summary_lines(&app.theme, summary);
+        for mut summary_line in summary_lines {
+            let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+            summary_line.spans.insert(
+                0,
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+            );
+            lines.push(summary_line);
+            line_idx += 1;
+        }
+    }
+
     for comment in &app.session.review_comments {
         let is_being_edited =
             app.editing_comment_id.as_ref() == Some(&comment.id) && is_review_comment_mode;

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -88,6 +88,19 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         line_idx += 1;
     }
 
+    for summary in &app.forge_review_summaries {
+        let summary_lines = comment_panel::format_remote_review_summary_lines(&app.theme, summary);
+        for mut summary_line in summary_lines {
+            let indicator = cursor_indicator(line_idx, current_line_idx);
+            summary_line.spans.insert(
+                0,
+                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
+            );
+            lines.push(summary_line);
+            line_idx += 1;
+        }
+    }
+
     for comment in &app.session.review_comments {
         let is_being_edited =
             app.editing_comment_id.as_ref() == Some(&comment.id) && is_review_comment_mode;


### PR DESCRIPTION
## Summary

fixes #359 

- **#359 fix** (commit 1): The comment navigator now shows the per-author coloured `●` dot for remote PR thread rows by lifting the root comment's author into `CommentNavigatorItem.author`. Remote `@agavra` rows share a colour with local `agavra` comments, matching the diff-view `[github @author]` chrome.
- **Top-level review bodies** (commit 2): GitHub PR reviews carry a body field that lives on `PullRequestReview` itself (separate from the line-anchored `reviewThreads`). tuicr never fetched these, so reviewer summary comments silently vanished. Now fetched via a parallel GraphQL query, rendered as a `[github @author <state>]` box in the top-of-diff review area, and surfaced as a review-scope navigator row. Closes the gap I hit on PR #356.

The `ForgeBackend::list_review_summaries` trait method defaults to empty so jj/hg backends are unaffected. Empty-body reviews (bare approvals, automation submissions) are dropped at the parse seam.

## Test plan

- [x] `cargo test` — 838 pass, 0 fail
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt`
- [ ] Manual: open PR #356 with `tuicr pr 356` — confirm the `[PRAISE] Overall this looks tight…` review body renders at the top of the diff and shows up in the navigator
- [ ] Manual: confirm line-anchored remote comments in the navigator now show the author colour dot

🤖 Generated with [Claude Code](https://claude.com/claude-code)