### PR TITLE
fix: use macos-15-intel runner for x86_64-apple-darwin builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-15-intel
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc


### PR DESCRIPTION
## Problem

GitHub switched `macos-latest` to Apple Silicon (ARM) runners in late 2024. Since the build step uses `cargo build --release` without a `--target` flag, it compiles for the runner's native architecture. This means both `x86_64-apple-darwin` and `aarch64-apple-darwin` produced `arm64` binaries, making tuicr unusable on Intel Macs. 

## Fix

Use `macos-15-intel` ([GitHub's recommended Intel x86_64 runner](https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/)) for the `x86_64-apple-darwin` build target.

```diff
-   os: macos-latest
+   os: macos-15-intel
```

The `aarch64-apple-darwin` target is unchanged and continues to use `macos-latest` (ARM).

Closes #361