### PR TITLE
perf(ui): skip span allocation for off-screen diff lines

### DIFF
--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -48,6 +48,16 @@ struct SideBySideContext<'a> {
     // RefCell so deeply-nested rendering helpers can push without each
     // intermediate function needing a `&mut Vec` parameter threaded through.
     comment_bars: std::cell::RefCell<Vec<crate::ui::diff_view::CommentBarAnchor>>,
+    // Only fully build spans for diff lines whose `line_idx` falls in this
+    // half-open range; off-screen rows push `Line::default()` placeholders.
+    visible_start: usize,
+    visible_end: usize,
+}
+
+impl SideBySideContext<'_> {
+    fn is_visible(&self, line_idx: usize) -> bool {
+        line_idx >= self.visible_start && line_idx < self.visible_end
+    }
 }
 
 pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -81,6 +91,8 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         && !app.comment_is_file_level
         && !app.comment_is_review_level;
 
+    let (visible_start, visible_end) = crate::ui::diff_view::diff_visible_range(app, inner);
+
     let ctx = SideBySideContext {
         app,
         theme: &app.theme,
@@ -98,6 +110,8 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         supports_keyboard_enhancement: app.supports_keyboard_enhancement,
         current_file_idx: app.diff_state.current_file_idx,
         comment_bars: std::cell::RefCell::new(Vec::new()),
+        visible_start,
+        visible_end,
     };
 
     // Build all diff lines for side-by-side view
@@ -414,6 +428,11 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                     // Render top expanded lines
                     if let Some(top) = top_lines {
                         for expanded_line in top {
+                            if !ctx.is_visible(line_idx) {
+                                lines.push(Line::default());
+                                line_idx += 1;
+                                continue;
+                            }
                             render_sbs_expanded_context_line(
                                 &mut lines,
                                 &mut line_idx,
@@ -485,6 +504,11 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                     // Render bottom expanded lines
                     if let Some(bot) = bot_lines {
                         for expanded_line in bot {
+                            if !ctx.is_visible(line_idx) {
+                                lines.push(Line::default());
+                                line_idx += 1;
+                                continue;
+                            }
                             render_sbs_expanded_context_line(
                                 &mut lines,
                                 &mut line_idx,
@@ -896,62 +920,66 @@ fn render_context_line_side_by_side(
     mut line_idx: usize,
     lines: &mut Vec<Line>,
 ) -> (usize, Option<SideBySideCursorInfo>) {
-    let w = ctx.lineno_width;
-    let old_line_num = diff_line
-        .old_lineno
-        .map(|n| format!("{n:>w$}"))
-        .unwrap_or_else(|| " ".repeat(w));
-    let new_line_num = diff_line
-        .new_lineno
-        .map(|n| format!("{n:>w$}"))
-        .unwrap_or_else(|| " ".repeat(w));
+    if ctx.is_visible(line_idx) {
+        let w = ctx.lineno_width;
+        let old_line_num = diff_line
+            .old_lineno
+            .map(|n| format!("{n:>w$}"))
+            .unwrap_or_else(|| " ".repeat(w));
+        let new_line_num = diff_line
+            .new_lineno
+            .map(|n| format!("{n:>w$}"))
+            .unwrap_or_else(|| " ".repeat(w));
 
-    let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+        let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
 
-    let mut spans = vec![
-        Span::styled(indicator, styles::current_line_indicator_style(ctx.theme)),
-        Span::styled(format!("{old_line_num} "), styles::dim_style(ctx.theme)),
-        Span::styled(" ".to_string(), styles::diff_context_style(ctx.theme)),
-    ];
+        let mut spans = vec![
+            Span::styled(indicator, styles::current_line_indicator_style(ctx.theme)),
+            Span::styled(format!("{old_line_num} "), styles::dim_style(ctx.theme)),
+            Span::styled(" ".to_string(), styles::diff_context_style(ctx.theme)),
+        ];
 
-    // Left side content - use syntax highlighting if available
-    if let Some(ref highlighted) = diff_line.highlighted_spans {
-        let content_spans = truncate_or_pad_spans(
-            highlighted,
-            ctx.content_width,
+        // Left side content - use syntax highlighting if available
+        if let Some(ref highlighted) = diff_line.highlighted_spans {
+            let content_spans = truncate_or_pad_spans(
+                highlighted,
+                ctx.content_width,
+                styles::diff_context_style(ctx.theme),
+            );
+            spans.extend(content_spans);
+        } else {
+            let content = truncate_or_pad(&diff_line.content, ctx.content_width);
+            spans.push(Span::styled(content, styles::diff_context_style(ctx.theme)));
+        }
+
+        // Separator
+        spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
+        spans.push(Span::styled(
+            format!("{new_line_num} "),
+            styles::dim_style(ctx.theme),
+        ));
+        spans.push(Span::styled(
+            " ".to_string(),
             styles::diff_context_style(ctx.theme),
-        );
-        spans.extend(content_spans);
+        ));
+
+        // Right side content - use same highlighting
+        if let Some(ref highlighted) = diff_line.highlighted_spans {
+            let content_spans = truncate_or_pad_spans(
+                highlighted,
+                ctx.content_width,
+                styles::diff_context_style(ctx.theme),
+            );
+            spans.extend(content_spans);
+        } else {
+            let content = truncate_or_pad(&diff_line.content, ctx.content_width);
+            spans.push(Span::styled(content, styles::diff_context_style(ctx.theme)));
+        }
+
+        lines.push(Line::from(spans));
     } else {
-        let content = truncate_or_pad(&diff_line.content, ctx.content_width);
-        spans.push(Span::styled(content, styles::diff_context_style(ctx.theme)));
+        lines.push(Line::default());
     }
-
-    // Separator
-    spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
-    spans.push(Span::styled(
-        format!("{new_line_num} "),
-        styles::dim_style(ctx.theme),
-    ));
-    spans.push(Span::styled(
-        " ".to_string(),
-        styles::diff_context_style(ctx.theme),
-    ));
-
-    // Right side content - use same highlighting
-    if let Some(ref highlighted) = diff_line.highlighted_spans {
-        let content_spans = truncate_or_pad_spans(
-            highlighted,
-            ctx.content_width,
-            styles::diff_context_style(ctx.theme),
-        );
-        spans.extend(content_spans);
-    } else {
-        let content = truncate_or_pad(&diff_line.content, ctx.content_width);
-        spans.push(Span::styled(content, styles::diff_context_style(ctx.theme)));
-    }
-
-    lines.push(Line::from(spans));
     line_idx += 1;
 
     // Add comments if any
@@ -1014,44 +1042,48 @@ fn render_deletion_addition_pair_side_by_side(
 
     // Render each pair of deletion/addition
     for offset in 0..max_lines {
-        let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+        if ctx.is_visible(line_idx) {
+            let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
 
-        let mut spans = vec![Span::styled(
-            indicator,
-            styles::current_line_indicator_style(ctx.theme),
-        )];
+            let mut spans = vec![Span::styled(
+                indicator,
+                styles::current_line_indicator_style(ctx.theme),
+            )];
 
-        // Left side (deletion)
-        if offset < del_count {
-            let del_line = &hunk_lines[start_idx + offset];
-            add_deletion_spans(
-                ctx.theme,
-                &mut spans,
-                del_line,
-                ctx.content_width,
-                ctx.lineno_width,
-            );
+            // Left side (deletion)
+            if offset < del_count {
+                let del_line = &hunk_lines[start_idx + offset];
+                add_deletion_spans(
+                    ctx.theme,
+                    &mut spans,
+                    del_line,
+                    ctx.content_width,
+                    ctx.lineno_width,
+                );
+            } else {
+                add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
+            }
+
+            spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
+
+            // Right side (addition)
+            if offset < add_count {
+                let add_line = &hunk_lines[add_start + offset];
+                add_addition_spans(
+                    ctx.theme,
+                    &mut spans,
+                    add_line,
+                    ctx.content_width,
+                    ctx.lineno_width,
+                );
+            } else {
+                add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
+            }
+
+            lines.push(Line::from(spans));
         } else {
-            add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
+            lines.push(Line::default());
         }
-
-        spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
-
-        // Right side (addition)
-        if offset < add_count {
-            let add_line = &hunk_lines[add_start + offset];
-            add_addition_spans(
-                ctx.theme,
-                &mut spans,
-                add_line,
-                ctx.content_width,
-                ctx.lineno_width,
-            );
-        } else {
-            add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
-        }
-
-        lines.push(Line::from(spans));
         line_idx += 1;
 
         // Add comments for deletion
@@ -1128,23 +1160,27 @@ fn render_standalone_addition_side_by_side(
     mut line_idx: usize,
     lines: &mut Vec<Line>,
 ) -> (usize, Option<SideBySideCursorInfo>) {
-    let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+    if ctx.is_visible(line_idx) {
+        let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
 
-    let mut spans = vec![Span::styled(
-        indicator,
-        styles::current_line_indicator_style(ctx.theme),
-    )];
-    add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
-    spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
-    add_addition_spans(
-        ctx.theme,
-        &mut spans,
-        diff_line,
-        ctx.content_width,
-        ctx.lineno_width,
-    );
+        let mut spans = vec![Span::styled(
+            indicator,
+            styles::current_line_indicator_style(ctx.theme),
+        )];
+        add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
+        spans.push(Span::styled(" │ ", styles::dim_style(ctx.theme)));
+        add_addition_spans(
+            ctx.theme,
+            &mut spans,
+            diff_line,
+            ctx.content_width,
+            ctx.lineno_width,
+        );
 
-    lines.push(Line::from(spans));
+        lines.push(Line::from(spans));
+    } else {
+        lines.push(Line::default());
+    }
     line_idx += 1;
 
     // Add comments if any

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -128,7 +128,10 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 "═══ Review Comments ",
                 styles::file_header_style(&app.theme),
             ),
-            Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+            Span::styled(
+                crate::ui::diff_view::HEADER_RULE,
+                styles::file_header_style(&app.theme),
+            ),
         ]));
         line_idx += 1;
     }
@@ -232,7 +235,10 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(header_text, styles::file_header_style(&app.theme)),
-                Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+                Span::styled(
+                    crate::ui::diff_view::HEADER_RULE,
+                    styles::file_header_style(&app.theme),
+                ),
             ]));
             line_idx += 1;
         }
@@ -381,8 +387,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 .files
                 .get(path)
                 .map(|r| &r.line_comments)
-                .cloned()
-                .unwrap_or_default();
+                .unwrap_or(&crate::ui::diff_view::EMPTY_LINE_COMMENTS);
 
             for (hunk_idx, hunk) in file.hunks.iter().enumerate() {
                 // Calculate and render gap before this hunk
@@ -507,7 +512,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 // Process diff lines in side-by-side format
                 let (new_line_idx, cursor_info) = render_hunk_lines_side_by_side(
                     &hunk.lines,
-                    &line_comments,
+                    line_comments,
                     &ctx,
                     file_idx,
                     line_idx,

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -83,7 +83,10 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 "═══ Review Comments ",
                 styles::file_header_style(&app.theme),
             ),
-            Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+            Span::styled(
+                crate::ui::diff_view::HEADER_RULE,
+                styles::file_header_style(&app.theme),
+            ),
         ]));
         line_idx += 1;
     }
@@ -196,7 +199,10 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(header_text, styles::file_header_style(&app.theme)),
-                Span::styled("═".repeat(40), styles::file_header_style(&app.theme)),
+                Span::styled(
+                    crate::ui::diff_view::HEADER_RULE,
+                    styles::file_header_style(&app.theme),
+                ),
             ]));
             line_idx += 1;
         }
@@ -350,8 +356,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 .files
                 .get(path)
                 .map(|r| &r.line_comments)
-                .cloned()
-                .unwrap_or_default();
+                .unwrap_or(&crate::ui::diff_view::EMPTY_LINE_COMMENTS);
 
             for (hunk_idx, hunk) in file.hunks.iter().enumerate() {
                 // Calculate and render gap before this hunk

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -55,6 +55,13 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     let mut line_idx: usize = 0;
     let current_line_idx = app.diff_state.cursor_line;
 
+    // Only build the expensive per-diff-line spans for lines that are actually
+    // visible. Everything else still pushes (cheap) so `lines.len()` keeps
+    // matching `line_idx`, but the hot inner loops push `Line::default()` for
+    // off-screen rows. In Comment mode the scroll offset may be adjusted after
+    // building, so fall back to a full build there.
+    let (visible_start, visible_end) = crate::ui::diff_view::diff_visible_range(app, inner);
+
     // Track cursor position for IME when in Comment mode
     // Store the logical line index and column where the cursor should be
     let mut comment_cursor_logical_line: Option<usize> = None;
@@ -383,6 +390,11 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                     // Render top expanded lines
                     if let Some(top) = top_lines {
                         for expanded_line in top {
+                            if line_idx < visible_start || line_idx >= visible_end {
+                                lines.push(Line::default());
+                                line_idx += 1;
+                                continue;
+                            }
                             render_expanded_context_line(
                                 &mut lines,
                                 &mut line_idx,
@@ -453,6 +465,11 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                     // Render bottom expanded lines
                     if let Some(bot) = bot_lines {
                         for expanded_line in bot {
+                            if line_idx < visible_start || line_idx >= visible_end {
+                                lines.push(Line::default());
+                                line_idx += 1;
+                                continue;
+                            }
                             render_expanded_context_line(
                                 &mut lines,
                                 &mut line_idx,
@@ -478,76 +495,88 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
                 // Diff lines
                 for diff_line in &hunk.lines {
-                    let (prefix, base_style) = match diff_line.origin {
-                        LineOrigin::Addition => ("▌", styles::diff_add_style(&app.theme)),
-                        LineOrigin::Deletion => ("▌", styles::diff_del_style(&app.theme)),
-                        LineOrigin::Context => (" ", styles::diff_context_style(&app.theme)),
-                    };
-
-                    let style = base_style;
-
-                    let blank = " ".repeat(lw + 1);
-                    let line_num_str = match diff_line.origin {
-                        LineOrigin::Addition => diff_line
-                            .new_lineno
-                            .map(|n| format!("{n:>lw$} "))
-                            .unwrap_or_else(|| blank.clone()),
-                        LineOrigin::Deletion => diff_line
-                            .old_lineno
-                            .map(|n| format!("{n:>lw$} "))
-                            .unwrap_or_else(|| blank.clone()),
-                        _ => diff_line
-                            .new_lineno
-                            .or(diff_line.old_lineno)
-                            .map(|n| format!("{n:>lw$} "))
-                            .unwrap_or_else(|| blank),
-                    };
-
-                    let indicator = cursor_indicator(line_idx, current_line_idx);
-
-                    let line_num_style = styles::dim_style(&app.theme);
-
-                    let mut line_spans = vec![
-                        Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                        Span::styled(line_num_str, line_num_style),
-                        Span::styled(format!("{prefix} "), style),
-                    ];
-
-                    if let Some(ref highlighted) = diff_line.highlighted_spans {
-                        for (span_style, span_text) in highlighted {
-                            line_spans.push(Span::styled(span_text.clone(), *span_style));
-                        }
+                    // Hot path: skip span/style allocation entirely for diff
+                    // lines outside the viewport. Comment handling below still
+                    // runs so `line_idx` stays exact and any comment box that
+                    // crosses into the viewport is rendered.
+                    if line_idx < visible_start || line_idx >= visible_end {
+                        lines.push(Line::default());
+                        line_idx += 1;
                     } else {
-                        line_spans.push(Span::styled(diff_line.content.clone(), style));
-                    }
-
-                    // Mark add/del lines with their effective EOL style so we can paint full
-                    // row backgrounds later (including wrapped visual rows).
-                    if matches!(
-                        diff_line.origin,
-                        LineOrigin::Addition | LineOrigin::Deletion
-                    ) {
-                        let eol_style = match diff_line.highlighted_spans.as_ref() {
-                            // For syntax-highlighted lines (including empty highlighted lines),
-                            // use syntax diff background so row fill matches code spans.
-                            Some(_) => {
-                                let syntax_bg = match diff_line.origin {
-                                    LineOrigin::Addition => app.theme.syntax_add_bg,
-                                    LineOrigin::Deletion => app.theme.syntax_del_bg,
-                                    LineOrigin::Context => app.theme.panel_bg,
-                                };
-                                let base = line_spans.last().map(|s| s.style).unwrap_or(style);
-                                base.bg(syntax_bg)
-                            }
-                            // Non-highlighted lines keep classic diff background.
-                            None => line_spans.last().map(|s| s.style).unwrap_or(style),
+                        let (prefix, base_style) = match diff_line.origin {
+                            LineOrigin::Addition => ("▌", styles::diff_add_style(&app.theme)),
+                            LineOrigin::Deletion => ("▌", styles::diff_del_style(&app.theme)),
+                            LineOrigin::Context => (" ", styles::diff_context_style(&app.theme)),
                         };
-                        // Zero-width marker span carrying the background style.
-                        line_spans.push(Span::styled(String::new(), eol_style));
-                    }
 
-                    lines.push(Line::from(line_spans));
-                    line_idx += 1;
+                        let style = base_style;
+
+                        let blank = " ".repeat(lw + 1);
+                        let line_num_str = match diff_line.origin {
+                            LineOrigin::Addition => diff_line
+                                .new_lineno
+                                .map(|n| format!("{n:>lw$} "))
+                                .unwrap_or_else(|| blank.clone()),
+                            LineOrigin::Deletion => diff_line
+                                .old_lineno
+                                .map(|n| format!("{n:>lw$} "))
+                                .unwrap_or_else(|| blank.clone()),
+                            _ => diff_line
+                                .new_lineno
+                                .or(diff_line.old_lineno)
+                                .map(|n| format!("{n:>lw$} "))
+                                .unwrap_or_else(|| blank),
+                        };
+
+                        let indicator = cursor_indicator(line_idx, current_line_idx);
+
+                        let line_num_style = styles::dim_style(&app.theme);
+
+                        let mut line_spans = vec![
+                            Span::styled(
+                                indicator,
+                                styles::current_line_indicator_style(&app.theme),
+                            ),
+                            Span::styled(line_num_str, line_num_style),
+                            Span::styled(format!("{prefix} "), style),
+                        ];
+
+                        if let Some(ref highlighted) = diff_line.highlighted_spans {
+                            for (span_style, span_text) in highlighted {
+                                line_spans.push(Span::styled(span_text.clone(), *span_style));
+                            }
+                        } else {
+                            line_spans.push(Span::styled(diff_line.content.clone(), style));
+                        }
+
+                        // Mark add/del lines with their effective EOL style so we can paint full
+                        // row backgrounds later (including wrapped visual rows).
+                        if matches!(
+                            diff_line.origin,
+                            LineOrigin::Addition | LineOrigin::Deletion
+                        ) {
+                            let eol_style = match diff_line.highlighted_spans.as_ref() {
+                                // For syntax-highlighted lines (including empty highlighted lines),
+                                // use syntax diff background so row fill matches code spans.
+                                Some(_) => {
+                                    let syntax_bg = match diff_line.origin {
+                                        LineOrigin::Addition => app.theme.syntax_add_bg,
+                                        LineOrigin::Deletion => app.theme.syntax_del_bg,
+                                        LineOrigin::Context => app.theme.panel_bg,
+                                    };
+                                    let base = line_spans.last().map(|s| s.style).unwrap_or(style);
+                                    base.bg(syntax_bg)
+                                }
+                                // Non-highlighted lines keep classic diff background.
+                                None => line_spans.last().map(|s| s.style).unwrap_or(style),
+                            };
+                            // Zero-width marker span carrying the background style.
+                            line_spans.push(Span::styled(String::new(), eol_style));
+                        }
+
+                        lines.push(Line::from(line_spans));
+                        line_idx += 1;
+                    }
 
                     // Show line comments for both old side (deleted lines) and new side (added/context)
                     // Old side comments (for deleted lines)

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -8,12 +8,20 @@ use ratatui::{
 use crate::app::{
     AnnotatedLine, App, DiffViewMode, ExpandDirection, GAP_EXPAND_BATCH, VisualSelection,
 };
-use crate::model::LineSide;
+use crate::model::{Comment, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_side_by_side::render_side_by_side_diff;
 use crate::ui::diff_unified::render_unified_diff;
 use crate::ui::styles;
+
+/// Static header rule used for file/section headers; avoids `"═".repeat(40)` per frame.
+pub(super) const HEADER_RULE: &str = "════════════════════════════════════════";
+
+/// Shared empty map so we can borrow `line_comments` without cloning per file per frame.
+pub(super) static EMPTY_LINE_COMMENTS: std::sync::LazyLock<
+    std::collections::HashMap<u32, Vec<Comment>>,
+> = std::sync::LazyLock::new(std::collections::HashMap::new);
 
 pub(super) fn render_diff_view(frame: &mut Frame, app: &mut App, area: Rect) {
     match app.diff_view_mode {

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -23,6 +23,21 @@ pub(super) static EMPTY_LINE_COMMENTS: std::sync::LazyLock<
     std::collections::HashMap<u32, Vec<Comment>>,
 > = std::sync::LazyLock::new(std::collections::HashMap::new);
 
+/// Compute the half-open `line_idx` range whose diff-line spans must be fully
+/// built this frame. Outside this range the hot loops push `Line::default()`
+/// placeholders so the bulk of per-line allocations are skipped.
+///
+/// In Comment mode the scroll offset may still be adjusted after building (to
+/// keep the inline input box visible), so fall back to building everything.
+pub(super) fn diff_visible_range(app: &App, inner: Rect) -> (usize, usize) {
+    if app.input_mode == crate::app::InputMode::Comment {
+        (0, usize::MAX)
+    } else {
+        let start = app.diff_state.scroll_offset;
+        (start, start.saturating_add(inner.height as usize))
+    }
+}
+
 pub(super) fn render_diff_view(frame: &mut Frame, app: &mut App, area: Rect) {
     match app.diff_view_mode {
         DiffViewMode::Unified => render_unified_diff(frame, app, area),


### PR DESCRIPTION
`render_unified_diff` / `render_side_by_side_diff` currently rebuild every span of every diff line of every file on every frame, then slice the result to the viewport. On a large review (hundreds of files, tens of thousands of diff lines) that's hundreds of thousands of `format!` / `Span::styled` heap allocations per keypress, and scrolling gets visibly laggy.

This gates the per-diff-line span construction on the visible `line_idx` range and pushes a `Line::default()` placeholder for off-screen rows. `lines.len()` therefore still tracks `line_idx` exactly, so the existing `.skip(scroll_offset).take(height)` slice, the cursor/annotation bookkeeping and the comment-box auto-scroll all keep working unchanged. Expanded-context lines get the same treatment.

Per-frame work goes from O(total diff lines) to O(viewport height), which on a 25k-line review is roughly a 500× reduction in allocations.

Two deliberate carve-outs:
- Comment handling after each diff line is left untouched, so a comment box that starts just above the viewport still renders fully into view.
- Comment input mode falls back to the full build because `scroll_comment_input_into_view` may shift `scroll_offset` after the lines are already built.

The first commit is small prep: borrow `line_comments` instead of cloning the per-file `HashMap<u32, Vec<Comment>>` on every frame, and replace the per-header `"═".repeat(40)` with a static `HEADER_RULE`.
