### PR TITLE
feat: clicking anywhere on a panel sets focus

### DIFF
--- a/docs/decisions/FEAT-0015 Click To Focus.md
+++ b/docs/decisions/FEAT-0015 Click To Focus.md
@@ -1,0 +1,18 @@
+---
+title: Click to Focus
+description: Clicking anywhere on a panel (border or empty space included) sets focus to that panel
+type: adr
+status: proposed
+created: 2026-05-23
+---
+
+# FEAT-0015 Click to Focus
+
+## Decision
+
+Mouse Down on either panel's outer area sets `focused_panel` to that panel. Outer area includes the border and any empty space below the last row, not just the inner content rows. Inner-area clicks still position the cursor or start a visual selection.
+
+## Consequences
+
+- [+] Clicking on a panel's border or empty space no longer feels broken -- focus moves where the user pointed.
+- [+] Inner-area click behavior is unchanged; no regression for cursor positioning or visual selection start.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -47,6 +47,13 @@ pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
         MouseEventKind::Down(MouseButton::Left)
             if matches!(app.input_mode, InputMode::Normal | InputMode::VisualSelect) =>
         {
+            // Set focus based on the outer panel area (includes the
+            // border) so clicks on dead space still move focus.
+            if app.file_list_area.is_some_and(|r| r.contains(pos)) {
+                app.focused_panel = FocusedPanel::FileList;
+            } else if app.diff_area.is_some_and(|r| r.contains(pos)) {
+                app.focused_panel = FocusedPanel::Diff;
+            }
             // Reset back to Normal so an Up without drag falls through to handle_left_click.
             if app.input_mode == InputMode::VisualSelect {
                 app.exit_visual_mode();


### PR DESCRIPTION
Mouse Down on either panel's outer area (border included, plus empty space below the last row) sets `focused_panel` to that panel. Inner-area clicks still position the cursor or start a visual selection -- the change is that previously dead clicks now also move focus.

- ADR: [docs/decisions/FEAT-0015 Click To Focus.md](docs/decisions/FEAT-0015%20Click%20To%20Focus.md)

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] Manual: clicking on either panel's border sets focus
- [x] Manual: clicking on empty space below the last row sets focus
- [x] Manual: clicking on an inner-area row still positions the cursor (no regression)