### PR TITLE
fix: clipboard copy silently drops content on Linux

### DIFF
--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -75,6 +75,9 @@ pub fn copy_text_to_clipboard(text: &str) -> Result<bool> {
         copy_osc52(text)?;
         return Ok(true);
     }
+    if try_copy_via_subprocess(text) {
+        return Ok(false);
+    }
     match Clipboard::new().and_then(|mut cb| cb.set_text(text)) {
         Ok(_) => Ok(false),
         Err(_) => {
@@ -82,6 +85,34 @@ pub fn copy_text_to_clipboard(text: &str) -> Result<bool> {
             Ok(true)
         }
     }
+}
+
+/// Try copying via a CLI tool that forks into the background and holds
+/// clipboard ownership beyond tuicr's process lifetime. Returns true on success.
+fn try_copy_via_subprocess(text: &str) -> bool {
+    // Try xclip (X11), then wl-copy (Wayland).
+    for (cmd, args) in [
+        ("xclip", vec!["-selection", "clipboard"]),
+        ("wl-copy", vec![]),
+    ] {
+        use std::process::{Command, Stdio};
+        let Ok(mut child) = Command::new(cmd)
+            .args(&args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        else {
+            continue;
+        };
+        if let Some(mut stdin) = child.stdin.take() {
+            let _ = std::io::Write::write_all(&mut stdin, text.as_bytes());
+        }
+        if matches!(child.wait(), Ok(s) if s.success()) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Returns true if we should prefer OSC 52 over the system clipboard.

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -87,32 +87,29 @@ pub fn copy_text_to_clipboard(text: &str) -> Result<bool> {
     }
 }
 
+/// Try xclip (X11) then wl-copy (Wayland). Returns true if either succeeds.
+fn try_copy_via_subprocess(text: &str) -> bool {
+    try_clipboard_cmd("xclip", &["-selection", "clipboard"], text)
+        || try_clipboard_cmd("wl-copy", &[], text)
+}
+
 /// Try copying via a CLI tool that forks into the background and holds
 /// clipboard ownership beyond tuicr's process lifetime. Returns true on success.
-fn try_copy_via_subprocess(text: &str) -> bool {
-    // Try xclip (X11), then wl-copy (Wayland).
-    for (cmd, args) in [
-        ("xclip", vec!["-selection", "clipboard"]),
-        ("wl-copy", vec![]),
-    ] {
-        use std::process::{Command, Stdio};
-        let Ok(mut child) = Command::new(cmd)
-            .args(&args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-        else {
-            continue;
-        };
-        if let Some(mut stdin) = child.stdin.take() {
-            let _ = std::io::Write::write_all(&mut stdin, text.as_bytes());
-        }
-        if matches!(child.wait(), Ok(s) if s.success()) {
-            return true;
-        }
+fn try_clipboard_cmd(program: &str, args: &[&str], text: &str) -> bool {
+    use std::process::{Command, Stdio};
+    let Ok(mut child) = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return false;
+    };
+    if let Some(mut stdin) = child.stdin.take() {
+        let _ = std::io::Write::write_all(&mut stdin, text.as_bytes());
     }
-    false
+    matches!(child.wait(), Ok(s) if s.success())
 }
 
 /// Returns true if we should prefer OSC 52 over the system clipboard.


### PR DESCRIPTION
 On Linux, the clipboard is process-owned. arboard holds ownership via an internal thread, but drops it as soon as the Clipboard object goes out of scope. Since it is dropped immediately after set_text, the content was gone before the user could paste.

This PR adds a fix to try xclip (X11) and wl-copy (Wayland). Whichever is available forks into the background and holds ownership independently of tuicr's lifetime.