### PR TITLE
feat: Tab unhides the file list, Esc hides it

### DIFF
--- a/docs/decisions/FEAT-0016 File List Visibility.md
+++ b/docs/decisions/FEAT-0016 File List Visibility.md
@@ -1,0 +1,28 @@
+---
+title: File List Visibility
+description: Tab reveals the file list when the focus cycle lands on it, and Esc hides it again
+type: adr
+status: proposed
+created: 2026-05-24
+---
+
+# FEAT-0016 File List Visibility
+
+## Context
+
+The file list can be hidden (`:e` toggle, `--no-file-list`, narrow terminal). Once hidden, two awkward states emerge:
+
+- Tab / Shift+Tab still cycle focus through every panel, including the hidden file list. Focus lands on a panel the user can't see, with no visible cursor and no way to act on it.
+- The diff is the panel a reviewer spends most time in, but there's no fast keystroke to dismiss the file list once it's served its purpose. `:e` works but requires command-mode entry.
+
+## Decision
+
+Tab / Shift+Tab unhide the file list whenever the focus cycle lands on it. The reveal is automatic and unconditional -- a focused-but-hidden panel is invisible state, so the panel surfaces whenever focus enters it.
+
+Esc in any normal-mode panel hides the file list and shifts focus to the diff. This makes Esc the universal "back to the diff, quiet the chrome" keystroke. `:e` and the leader binding (`<leader>e`) still toggle visibility for users who prefer explicit commands.
+
+## Consequences
+
+- [+] Tab can no longer leave focus on an invisible panel.
+- [+] Esc gives reviewers a one-key path back to a clean diff view.
+- [-] Esc in normal mode used to only shift focus to the diff. Hiding the file list is a behavior change for users who hit Esc as a focus-only gesture; mitigated by the focus shift still happening and `:e` / `<leader>e` bringing the file list back.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1013,6 +1013,10 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 app.should_quit = true;
             }
         }
+        Action::ExitMode => {
+            app.show_file_list = false;
+            app.focused_panel = FocusedPanel::Diff;
+        }
         Action::HalfPageDown => app.scroll_down(app.diff_state.viewport_height / 2),
         Action::HalfPageUp => app.scroll_up(app.diff_state.viewport_height / 2),
         Action::PageDown => app.scroll_down(app.diff_state.viewport_height),
@@ -1035,6 +1039,9 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 (FocusedPanel::Diff, false, _) => FocusedPanel::FileList,
                 (FocusedPanel::CommitSelector, _, _) => FocusedPanel::FileList,
             };
+            if app.focused_panel == FocusedPanel::FileList {
+                app.show_file_list = true;
+            }
         }
         Action::ToggleFocusReverse => {
             let has_selector = app.has_inline_commit_selector();
@@ -1047,6 +1054,9 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 (FocusedPanel::Diff, _, false) => FocusedPanel::FileList,
                 (FocusedPanel::CommitSelector, _, _) => FocusedPanel::Diff,
             };
+            if app.focused_panel == FocusedPanel::FileList {
+                app.show_file_list = true;
+            }
         }
         Action::ExpandAll => {
             app.expand_all_dirs();


### PR DESCRIPTION
Split off from the arrow pane navigation PR
- Tab / Shift+Tab unhide the file list when the focus cycle lands on it. A focused-but-hidden panel is invisible state with no way for the user to act on it, so the panel reveals itself whenever focus enters it.
- Esc in any normal-mode panel hides the file list and shifts focus to the diff. `:e` and `<leader>e` still toggle visibility for users who prefer explicit commands.
- ADR: [docs/decisions/FEAT-0016 File List Visibility.md](docs/decisions/FEAT-0016%20File%20List%20Visibility.md)

## Why
- Tab lands focus on the file list when it's hidden, leaving the user on an invisible panel with no cursor; gitui, lazygit, and helix all reveal-on-focus instead of asymmetrically skipping hidden panels.
- Esc already moves focus to the diff in normal mode (not a pure mode-exit), so extending it to also hide the file list adds a one-key dismiss for Tab's reveal without inventing a new keybinding.
- Both behaviors are reversible with `:e` / `<leader>e`, and either can be gated behind a flag if you'd prefer.

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] Manual: hide the file list with `:e`, then Tab from the diff -- file list reveals and takes focus
- [x] Manual: hide the file list, then Shift+Tab from the diff backwards -- file list reveals and takes focus
- [x] Manual: with file list visible and focused, Esc hides it and focus moves to the diff
- [x] Manual: with file list visible and the diff focused, Esc hides the file list (focus stays on the diff)
- [x] Manual: `:e` / `<leader>e` continue to toggle visibility regardless of focus
