### PR TITLE
fix: replace deprecated flake output attributes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,8 +13,8 @@
         naersk-lib = pkgs.callPackage naersk { };
       in
       {
-        defaultPackage = naersk-lib.buildPackage ./.;
-        devShell = with pkgs; mkShell {
+        packages.default = naersk-lib.buildPackage ./.;
+        devShells.default = with pkgs; mkShell {
           buildInputs = [ cargo rustc rustfmt rustPackages.clippy jj git ];
           RUST_SRC_PATH = rustPlatform.rustLibSrc;
         };


### PR DESCRIPTION
Replace deprecated `defaultPackage` and `devShell` flake outputs with `packages.<system>.default` and `devShells.<system>.default`.

These were deprecated in Nix 2.7+ and emit warnings in newer versions. See https://nixos.org/manual/nix/stable/release-notes/rl-2.7