### PR TITLE
feat(vcs): Add whitespace-ignore diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Path: `~/.config/tuicr/config.toml` on Linux/macOS, `%APPDATA%\tuicr\config.toml
 ```toml
 theme = "catppuccin-mocha"
 diff_view = "side-by-side"   # or "unified"
+ignore_whitespace = false    # ignore all whitespace in local VCS diffs
 appearance = "system"        # or "dark" / "light"
 mouse = true
 leader = ";"                  # configurable prefix for leader shortcuts

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -25,6 +25,7 @@ theme_dark = "gruvbox-dark"
 theme_light = "gruvbox-light"
 
 diff_view = "side-by-side"
+ignore_whitespace = false
 show_file_list = true
 mouse = true
 leader = ","
@@ -58,6 +59,7 @@ comment_type_prefix = true
 | `theme_dark` | (none) | Theme name for dark appearance (paired with `theme_light`). |
 | `theme_light` | (none) | Theme name for light appearance (paired with `theme_dark`). |
 | `diff_view` | `unified` | `unified` or `side-by-side`. Toggle in-app with `:diff`. |
+| `ignore_whitespace` | `false` | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged. |
 | `show_file_list` | `true` | Whether the file list panel is visible on startup. Toggle with `<leader>e`. |
 | `mouse` | `true` | Wheel scrolling, clicks, and drag-to-select. |
 | `leader` | `;` | Single-character prefix for panel focus, sidebar toggles, and review-comment shortcuts. Invalid multi-character values are ignored with a startup warning. |

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,8 +22,8 @@ use crate::update::UpdateInfo;
 use crate::vcs::git::calculate_gap;
 use crate::vcs::traits::VcsType;
 use crate::vcs::{
-    ChangeKind, CommitInfo, FileBackend, GitBackendPreference, PrNoopVcs, VcsBackend,
-    VcsChangeStatus, VcsInfo, detect_vcs,
+    ChangeKind, CommitInfo, DiffWhitespaceMode, FileBackend, GitBackendPreference, PrNoopVcs,
+    VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
 };
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
@@ -1279,6 +1279,7 @@ pub struct AppStartupOptions<'a> {
     /// the other selectors; the binary validates that before reaching here.
     pub all_files: bool,
     pub git_backend_preference: GitBackendPreference,
+    pub diff_whitespace_mode: DiffWhitespaceMode,
     /// Direct PR target (`tuicr pr <target>`). Mutually exclusive with the
     /// other selectors above; the binary validates that before reaching here.
     pub pr_target: Option<&'a str>,
@@ -1410,7 +1411,7 @@ impl App {
         }
 
         let vcs = crate::profile::time("startup.detect_vcs", || {
-            detect_vcs(options.git_backend_preference)
+            detect_vcs(options.git_backend_preference, options.diff_whitespace_mode)
         })?;
         let vcs_info = vcs.info().clone();
         let highlighter =

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,6 +45,7 @@ pub struct AppConfig {
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
     pub diff_view: Option<String>,
+    pub ignore_whitespace: Option<bool>,
     pub wrap: Option<bool>,
     pub export_legend: Option<bool>,
     pub cursor_line: Option<bool>,
@@ -77,6 +78,7 @@ const KNOWN_KEYS: &[&str] = &[
     "comment_types",
     "show_file_list",
     "diff_view",
+    "ignore_whitespace",
     "wrap",
     "export_legend",
     "cursor_line",
@@ -285,6 +287,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             &["unified", "side-by-side"],
             &mut warnings,
         ),
+        ignore_whitespace: read_bool(table, "ignore_whitespace", &mut warnings),
         wrap: read_bool(table, "wrap", &mut warnings),
         export_legend: read_bool(table, "export_legend", &mut warnings),
         cursor_line: read_bool(table, "cursor_line", &mut warnings),
@@ -757,6 +760,51 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'diff_view' must be a string; ignoring value"
+        );
+    }
+
+    // ignore_whitespace
+
+    #[test]
+    fn should_parse_ignore_whitespace_true() {
+        let outcome = parse_config("ignore_whitespace = true\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.ignore_whitespace),
+            Some(true)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_ignore_whitespace_false() {
+        let outcome = parse_config("ignore_whitespace = false\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.ignore_whitespace),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_ignore_whitespace_with_invalid_type() {
+        let outcome = parse_config("ignore_whitespace = \"yes\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.ignore_whitespace),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'ignore_whitespace' must be a boolean; ignoring value"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use tuicr::handler::{
 };
 use tuicr::input::{Action, map_key_to_action, map_target_filter_mode};
 use tuicr::theme::resolve_theme_with_config;
-use tuicr::vcs::GitBackendPreference;
+use tuicr::vcs::{DiffWhitespaceMode, GitBackendPreference};
 use tuicr::{config, handler, profile, ui, update};
 
 /// Timeout for the "press Ctrl+C again to exit" feature
@@ -146,6 +146,16 @@ fn main() -> anyhow::Result<()> {
             .as_ref()
             .and_then(|cfg| cfg.backend.as_deref()),
     );
+    let diff_whitespace_mode = if config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.ignore_whitespace)
+        .unwrap_or(false)
+    {
+        DiffWhitespaceMode::IgnoreAll
+    } else {
+        DiffWhitespaceMode::Normal
+    };
 
     let mut app = match profile::time("startup.app_init", || {
         App::new(
@@ -162,6 +172,7 @@ fn main() -> anyhow::Result<()> {
                 file_path: cli_args.file_path.as_deref(),
                 all_files: cli_args.all_files,
                 git_backend_preference,
+                diff_whitespace_mode,
                 pr_target: cli_args.pr_target.as_deref(),
                 repo_url_override: cli_args
                     .repo_url

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -12,7 +12,9 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::{ChangeKind, CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+use crate::vcs::{
+    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsChangeStatus, VcsInfo,
+};
 use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
 
 use super::{
@@ -33,6 +35,7 @@ pub struct GitCliBackend {
     repo_mode: GitRepoMode,
     untracked_cache: bool,
     fsmonitor: bool,
+    whitespace_mode: DiffWhitespaceMode,
 }
 
 #[derive(Clone, Copy)]
@@ -44,7 +47,7 @@ enum GitContentSource<'a> {
 }
 
 impl GitCliBackend {
-    pub(super) fn discover_from(cwd: &Path) -> Result<Self> {
+    pub(super) fn discover_from(cwd: &Path, whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
         let root_path =
             PathBuf::from(run_git_command(cwd, &["rev-parse", "--show-toplevel"])?.trim());
         let repo_mode = GitRepoMode::detect(&root_path)?;
@@ -71,6 +74,7 @@ impl GitCliBackend {
             repo_mode,
             untracked_cache,
             fsmonitor,
+            whitespace_mode,
         })
     }
 
@@ -80,12 +84,15 @@ impl GitCliBackend {
 
     fn get_cli_diff(
         &self,
-        args: Vec<String>,
+        mut args: Vec<String>,
         include_untracked: bool,
         old_source: GitContentSource<'_>,
         new_source: GitContentSource<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
+        if self.whitespace_mode.ignores_all() {
+            args.insert(1, "--ignore-all-space".to_string());
+        }
         let mut files = match run_git_diff_command(&self.root_path, args, highlighter) {
             Ok(files) => files,
             Err(TuicrError::NoChanges) => Vec::new(),
@@ -105,7 +112,6 @@ impl GitCliBackend {
             git_source_content_cache(&self.root_path, old_source, &files, LineSide::Old);
         let new_cache =
             git_source_content_cache(&self.root_path, new_source, &files, LineSide::New);
-
         enhance_with_full_file_highlight(
             &mut files,
             highlighter,
@@ -1167,7 +1173,8 @@ mod tests {
         git(workdir, &["sparse-checkout", "reapply", "--sparse-index"]);
         git(workdir, &["config", "advice.sparseIndexExpanded", "false"]);
 
-        let backend = GitCliBackend::discover_from(workdir).expect("failed to discover backend");
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+            .expect("failed to discover backend");
         (temp_dir, backend, vec![first_id, second_id])
     }
 
@@ -1208,8 +1215,8 @@ mod tests {
         git(workdir, &["add", "staged.txt"]);
         write_file(workdir, "untracked.txt", "untracked\n");
 
-        let cli_backend =
-            GitCliBackend::discover_from(workdir).expect("failed to discover cli backend");
+        let cli_backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+            .expect("failed to discover cli backend");
         let repo = git2::Repository::open(workdir).expect("failed to open git2 repo");
         (temp_dir, cli_backend, repo, vec![first_id, second_id])
     }
@@ -1386,15 +1393,22 @@ mod tests {
 
         assert_eq!(
             summarize_files(cli_backend.get_working_tree_diff(&highlighter).unwrap()),
-            summarize_files(diff::get_working_tree_diff(&repo, &highlighter).unwrap())
+            summarize_files(
+                diff::get_working_tree_diff(&repo, DiffWhitespaceMode::Normal, &highlighter)
+                    .unwrap()
+            )
         );
         assert_eq!(
             summarize_files(cli_backend.get_staged_diff(&highlighter).unwrap()),
-            summarize_files(diff::get_staged_diff(&repo, &highlighter).unwrap())
+            summarize_files(
+                diff::get_staged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter).unwrap()
+            )
         );
         assert_eq!(
             summarize_files(cli_backend.get_unstaged_diff(&highlighter).unwrap()),
-            summarize_files(diff::get_unstaged_diff(&repo, &highlighter).unwrap())
+            summarize_files(
+                diff::get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter).unwrap()
+            )
         );
         assert_eq!(
             summarize_files(
@@ -1403,7 +1417,13 @@ mod tests {
                     .unwrap()
             ),
             summarize_files(
-                diff::get_commit_range_diff(&repo, &[ids[1].clone()], &highlighter).unwrap()
+                diff::get_commit_range_diff(
+                    &repo,
+                    &[ids[1].clone()],
+                    DiffWhitespaceMode::Normal,
+                    &highlighter,
+                )
+                .unwrap()
             )
         );
         assert_eq!(
@@ -1413,8 +1433,13 @@ mod tests {
                     .unwrap()
             ),
             summarize_files(
-                diff::get_working_tree_with_commits_diff(&repo, &[ids[1].clone()], &highlighter)
-                    .unwrap()
+                diff::get_working_tree_with_commits_diff(
+                    &repo,
+                    &[ids[1].clone()],
+                    DiffWhitespaceMode::Normal,
+                    &highlighter,
+                )
+                .unwrap()
             )
         );
 
@@ -1449,5 +1474,34 @@ mod tests {
                 .map(|commit| (&commit.id, &commit.summary, &commit.body))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn cli_diff_ignores_all_whitespace_when_configured() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+
+        git(workdir, &["init"]);
+        git(workdir, &["config", "user.email", "test@example.com"]);
+        git(workdir, &["config", "user.name", "Test User"]);
+        git(workdir, &["config", "commit.gpgsign", "false"]);
+        write_file(workdir, "file.txt", "alpha\nbeta\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "initial"]);
+
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::IgnoreAll)
+            .expect("failed to discover cli backend");
+
+        write_file(workdir, "file.txt", " alpha \n beta\n");
+        assert!(matches!(
+            backend.get_working_tree_diff(&SyntaxHighlighter::default()),
+            Err(TuicrError::NoChanges)
+        ));
+
+        write_file(workdir, "file.txt", " alpha \ngamma\n");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("non-whitespace edit should still produce a diff");
+        assert_eq!(files.len(), 1);
     }
 }

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -4,11 +4,12 @@ use std::path::{Path, PathBuf};
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
-use crate::vcs::traits::ChangeKind;
+use crate::vcs::traits::{ChangeKind, DiffWhitespaceMode};
 use crate::vcs::{enhance_with_full_file_highlight, tabify};
 
 pub fn get_working_tree_diff(
     repo: &Repository,
+    whitespace_mode: DiffWhitespaceMode,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     // Unborn HEAD (fresh `git init` / `git clone` of an empty remote) has no
@@ -16,7 +17,7 @@ pub fn get_working_tree_diff(
     // staged/added files still surface in the working-tree review.
     let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
 
-    let mut opts = DiffOptions::new();
+    let mut opts = diff_options(whitespace_mode);
     opts.include_untracked(true);
     opts.show_untracked_content(true);
     opts.recurse_untracked_dirs(true);
@@ -39,11 +40,14 @@ pub fn get_working_tree_diff(
 /// On repos with no commits (unborn HEAD), diffs against an empty tree.
 pub fn get_staged_diff(
     repo: &Repository,
+    whitespace_mode: DiffWhitespaceMode,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
     let index = repo.index()?;
-    let diff = repo.diff_tree_to_index(head.as_ref(), Some(&index), None)?;
+    let mut opts = diff_options(whitespace_mode);
+
+    let diff = repo.diff_tree_to_index(head.as_ref(), Some(&index), Some(&mut opts))?;
     let mut files = parse_diff(&diff, highlighter)?;
     enhance_with_full_file_highlight(
         &mut files,
@@ -67,11 +71,12 @@ pub fn list_changed_paths(repo: &Repository, kind: ChangeKind) -> Result<Vec<Pat
         ChangeKind::Staged => {
             let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
             let index = repo.index()?;
-            repo.diff_tree_to_index(head.as_ref(), Some(&index), None)?
+            let mut opts = diff_options(DiffWhitespaceMode::Normal);
+            repo.diff_tree_to_index(head.as_ref(), Some(&index), Some(&mut opts))?
         }
         ChangeKind::Unstaged => {
             let index = repo.index()?;
-            let mut opts = DiffOptions::new();
+            let mut opts = diff_options(DiffWhitespaceMode::Normal);
             opts.include_untracked(true);
             // `show_untracked_content(false)` keeps libgit2 from reading each
             // untracked file's bytes — only the paths are needed here.
@@ -98,10 +103,11 @@ pub fn list_changed_paths(repo: &Repository, kind: ChangeKind) -> Result<Vec<Pat
 
 pub fn get_unstaged_diff(
     repo: &Repository,
+    whitespace_mode: DiffWhitespaceMode,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     let index = repo.index()?;
-    let mut opts = DiffOptions::new();
+    let mut opts = diff_options(whitespace_mode);
     opts.include_untracked(true);
     opts.show_untracked_content(true);
     opts.recurse_untracked_dirs(true);
@@ -123,6 +129,7 @@ pub fn get_unstaged_diff(
 pub fn get_commit_range_diff(
     repo: &Repository,
     commit_ids: &[String],
+    whitespace_mode: DiffWhitespaceMode,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     if commit_ids.is_empty() {
@@ -143,7 +150,9 @@ pub fn get_commit_range_diff(
 
     let new_tree = newest_commit.tree()?;
 
-    let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), None)?;
+    let mut opts = diff_options(whitespace_mode);
+
+    let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), Some(&mut opts))?;
     let mut files = parse_diff(&diff, highlighter)?;
     enhance_with_full_file_highlight(
         &mut files,
@@ -163,6 +172,7 @@ pub fn get_commit_range_diff(
 pub fn get_working_tree_with_commits_diff(
     repo: &Repository,
     commit_ids: &[String],
+    whitespace_mode: DiffWhitespaceMode,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     if commit_ids.is_empty() {
@@ -178,7 +188,7 @@ pub fn get_working_tree_with_commits_diff(
         None
     };
 
-    let mut opts = DiffOptions::new();
+    let mut opts = diff_options(whitespace_mode);
     opts.include_untracked(true);
     opts.show_untracked_content(true);
     opts.recurse_untracked_dirs(true);
@@ -196,6 +206,12 @@ pub fn get_working_tree_with_commits_diff(
         |path| read_path_from_workdir(repo, path),
     );
     Ok(files)
+}
+
+fn diff_options(whitespace_mode: DiffWhitespaceMode) -> DiffOptions {
+    let mut opts = DiffOptions::new();
+    opts.ignore_whitespace(whitespace_mode.ignores_all());
+    opts
 }
 
 fn read_path_from_tree(repo: &Repository, tree: &git2::Tree, path: &Path) -> Option<String> {
@@ -410,8 +426,12 @@ mod tests {
         )
         .expect("failed to update file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get diff");
+        let files = get_working_tree_diff(
+            &repo,
+            DiffWhitespaceMode::Normal,
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get diff");
 
         assert_eq!(files.len(), 1);
         let lines = &files[0].hunks[0].lines;
@@ -434,8 +454,12 @@ mod tests {
         let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
         fs::write(temp_dir.path().join("App.vue"), edited).expect("failed to update file");
 
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("failed to get diff");
+        let files = get_working_tree_diff(
+            &repo,
+            DiffWhitespaceMode::Normal,
+            &SyntaxHighlighter::default(),
+        )
+        .expect("failed to get diff");
         assert_eq!(files.len(), 1);
 
         let changed_lines: Vec<_> = files[0].hunks[0]
@@ -470,10 +494,11 @@ mod tests {
 
         let highlighter = SyntaxHighlighter::default();
 
-        let unstaged = get_unstaged_diff(&repo, &highlighter).expect("unstaged diff failed");
+        let unstaged = get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter)
+            .expect("unstaged diff failed");
         assert_eq!(unstaged.len(), 1);
         assert!(matches!(
-            get_staged_diff(&repo, &highlighter),
+            get_staged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter),
             Err(TuicrError::NoChanges)
         ));
 
@@ -483,10 +508,11 @@ mod tests {
             .expect("failed to add file to index");
         index.write().expect("failed to write index");
 
-        let staged = get_staged_diff(&repo, &highlighter).expect("staged diff failed");
+        let staged = get_staged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter)
+            .expect("staged diff failed");
         assert_eq!(staged.len(), 1);
         assert!(matches!(
-            get_unstaged_diff(&repo, &highlighter),
+            get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter),
             Err(TuicrError::NoChanges)
         ));
     }
@@ -503,13 +529,73 @@ mod tests {
         index.write().expect("write index");
 
         // when
-        let files = get_working_tree_diff(&repo, &SyntaxHighlighter::default())
-            .expect("unborn HEAD should produce a diff against an empty tree");
+        let files = get_working_tree_diff(
+            &repo,
+            DiffWhitespaceMode::Normal,
+            &SyntaxHighlighter::default(),
+        )
+        .expect("unborn HEAD should produce a diff against an empty tree");
 
         // then the staged file shows up as an addition rather than crashing
         // with `reference 'refs/heads/main' not found`
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].display_path(), Path::new("file.txt"));
         assert!(matches!(files[0].status, FileStatus::Added));
+    }
+
+    #[test]
+    fn should_surface_noop_file_when_whitespace_only_diff_is_empty() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit(&repo, "file.txt", "alpha\nbeta\n");
+        fs::write(temp_dir.path().join("file.txt"), " alpha \n beta\n")
+            .expect("failed to update file");
+
+        let files = get_working_tree_diff(
+            &repo,
+            DiffWhitespaceMode::IgnoreAll,
+            &SyntaxHighlighter::default(),
+        )
+        .expect("whitespace-only edit may surface as a no-op diff file");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].hunks.is_empty());
+
+        fs::write(temp_dir.path().join("file.txt"), " alpha \ngamma\n")
+            .expect("failed to update file");
+
+        let files = get_working_tree_diff(
+            &repo,
+            DiffWhitespaceMode::IgnoreAll,
+            &SyntaxHighlighter::default(),
+        )
+        .expect("non-whitespace edit should still produce a diff");
+        assert_eq!(files.len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn should_keep_mode_only_changes_when_ignoring_whitespace() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+        create_initial_commit(&repo, "file.txt", "alpha\n");
+
+        let path = temp_dir.path().join("file.txt");
+        let mut permissions = fs::metadata(&path)
+            .expect("failed to stat file")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(path, permissions).expect("failed to update mode");
+
+        let files = get_working_tree_diff(
+            &repo,
+            DiffWhitespaceMode::IgnoreAll,
+            &SyntaxHighlighter::default(),
+        )
+        .expect("mode-only edit should still produce a diff");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].hunks.is_empty());
     }
 }

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -7,12 +7,15 @@ use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 
 use super::{context, diff, repository, staging};
-use crate::vcs::traits::{ChangeKind, CommitInfo, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::traits::{
+    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsInfo, VcsType,
+};
 
 /// Git backend implementation using the git2/libgit2 library.
 pub struct Libgit2Backend {
     repo: Repository,
     info: VcsInfo,
+    whitespace_mode: DiffWhitespaceMode,
 }
 
 /// Declare libgit2 extensions tuicr understands so discovery doesn't refuse
@@ -35,7 +38,7 @@ fn register_supported_extensions() {
 }
 
 impl Libgit2Backend {
-    pub(super) fn discover_from(cwd: &Path) -> Result<Self> {
+    pub(super) fn discover_from(cwd: &Path, whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
         register_supported_extensions();
         let repo = Repository::discover(cwd).map_err(|_| TuicrError::NotARepository)?;
 
@@ -79,7 +82,11 @@ impl Libgit2Backend {
             vcs_type: VcsType::Git,
         };
 
-        Ok(Self { repo, info })
+        Ok(Self {
+            repo,
+            info,
+            whitespace_mode,
+        })
     }
 }
 
@@ -93,15 +100,15 @@ impl VcsBackend for Libgit2Backend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        diff::get_working_tree_diff(&self.repo, highlighter)
+        diff::get_working_tree_diff(&self.repo, self.whitespace_mode, highlighter)
     }
 
     fn get_staged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        diff::get_staged_diff(&self.repo, highlighter)
+        diff::get_staged_diff(&self.repo, self.whitespace_mode, highlighter)
     }
 
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        diff::get_unstaged_diff(&self.repo, highlighter)
+        diff::get_unstaged_diff(&self.repo, self.whitespace_mode, highlighter)
     }
 
     fn list_changed_paths(&self, kind: ChangeKind) -> Result<Vec<PathBuf>> {
@@ -160,7 +167,7 @@ impl VcsBackend for Libgit2Backend {
         commit_ids: &[String],
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        diff::get_commit_range_diff(&self.repo, commit_ids, highlighter)
+        diff::get_commit_range_diff(&self.repo, commit_ids, self.whitespace_mode, highlighter)
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
@@ -184,7 +191,12 @@ impl VcsBackend for Libgit2Backend {
         commit_ids: &[String],
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        diff::get_working_tree_with_commits_diff(&self.repo, commit_ids, highlighter)
+        diff::get_working_tree_with_commits_diff(
+            &self.repo,
+            commit_ids,
+            self.whitespace_mode,
+            highlighter,
+        )
     }
 
     fn stage_file(&self, path: &Path) -> Result<()> {
@@ -255,7 +267,7 @@ mod tests {
         );
 
         // when
-        let backend = Libgit2Backend::discover_from(&worktree)
+        let backend = Libgit2Backend::discover_from(&worktree, DiffWhitespaceMode::Normal)
             .expect("worktree with relativeworktrees extension should open");
 
         // then

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -13,7 +13,9 @@ use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
 use crate::syntax::SyntaxHighlighter;
 
-use super::traits::{ChangeKind, CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+use super::traits::{
+    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsChangeStatus, VcsInfo,
+};
 use cli::GitCliBackend;
 pub use libgit2::Libgit2Backend;
 
@@ -101,24 +103,40 @@ impl GitRepoMode {
 
 impl GitBackend {
     /// Discover a git repository from the current directory.
-    pub fn discover(preference: GitBackendPreference) -> Result<Self> {
+    pub fn discover(
+        preference: GitBackendPreference,
+        whitespace_mode: DiffWhitespaceMode,
+    ) -> Result<Self> {
         let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
-        Self::discover_from(&cwd, preference)
+        Self::discover_from(&cwd, preference, whitespace_mode)
     }
 
-    fn discover_from(cwd: &Path, preference: GitBackendPreference) -> Result<Self> {
+    fn discover_from(
+        cwd: &Path,
+        preference: GitBackendPreference,
+        whitespace_mode: DiffWhitespaceMode,
+    ) -> Result<Self> {
         if preference == GitBackendPreference::Cli {
-            return Ok(Self::Cli(GitCliBackend::discover_from(cwd)?));
+            return Ok(Self::Cli(GitCliBackend::discover_from(
+                cwd,
+                whitespace_mode,
+            )?));
         }
 
         if uses_reftable(cwd) {
-            return Ok(Self::Cli(GitCliBackend::discover_from(cwd)?));
+            return Ok(Self::Cli(GitCliBackend::discover_from(
+                cwd,
+                whitespace_mode,
+            )?));
         }
 
-        let backend = Self::Libgit2(Libgit2Backend::discover_from(cwd)?);
+        let backend = Self::Libgit2(Libgit2Backend::discover_from(cwd, whitespace_mode)?);
         let repo_mode = GitRepoMode::detect(&backend.info().root_path)?;
         if repo_mode.is_sparse_checkout() && !backend.supports_sparse_checkout() {
-            return Ok(Self::Cli(GitCliBackend::discover_from(cwd)?));
+            return Ok(Self::Cli(GitCliBackend::discover_from(
+                cwd,
+                whitespace_mode,
+            )?));
         }
 
         Ok(backend)
@@ -358,8 +376,12 @@ mod tests {
         run_git_command(root, &["sparse-checkout", "set", "src"])
             .expect("failed to set sparse checkout paths");
 
-        let backend = GitBackend::discover_from(root, GitBackendPreference::Libgit2)
-            .expect("failed to discover backend");
+        let backend = GitBackend::discover_from(
+            root,
+            GitBackendPreference::Libgit2,
+            DiffWhitespaceMode::Normal,
+        )
+        .expect("failed to discover backend");
 
         match backend {
             GitBackend::Cli(backend) => {
@@ -379,8 +401,12 @@ mod tests {
         let root = temp_dir.path();
         setup_standard_repo(root);
 
-        let backend = GitBackend::discover_from(root, GitBackendPreference::Libgit2)
-            .expect("failed to discover backend");
+        let backend = GitBackend::discover_from(
+            root,
+            GitBackendPreference::Libgit2,
+            DiffWhitespaceMode::Normal,
+        )
+        .expect("failed to discover backend");
 
         match backend {
             GitBackend::Libgit2(backend) => assert!(!backend.supports_sparse_checkout()),
@@ -398,8 +424,12 @@ mod tests {
         run_git_command(root, &["config", "extensions.refStorage", "reftable"])
             .expect("failed to set reftable extension");
 
-        let backend = GitBackend::discover_from(root, GitBackendPreference::Libgit2)
-            .expect("reftable repo should open via CLI fallback");
+        let backend = GitBackend::discover_from(
+            root,
+            GitBackendPreference::Libgit2,
+            DiffWhitespaceMode::Normal,
+        )
+        .expect("reftable repo should open via CLI fallback");
 
         assert!(
             matches!(backend, GitBackend::Cli(_)),

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -8,7 +9,7 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::traits::{CommitInfo, DiffWhitespaceMode, VcsBackend, VcsInfo, VcsType};
 use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
 
 /// Parse an hg description into (summary, optional body).
@@ -30,11 +31,12 @@ fn parse_hg_description(desc: &str) -> (String, Option<String>) {
 /// Mercurial backend implementation using hg CLI commands
 pub struct HgBackend {
     info: VcsInfo,
+    whitespace_mode: DiffWhitespaceMode,
 }
 
 impl HgBackend {
     /// Discover a Mercurial repository from the current directory
-    pub fn discover() -> Result<Self> {
+    pub fn discover(whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
         // Use `hg root` to find the repository root
         // This handles being called from subdirectories
         let root_output = Command::new("hg")
@@ -48,20 +50,20 @@ impl HgBackend {
 
         let root_path = PathBuf::from(String::from_utf8_lossy(&root_output.stdout).trim());
 
-        Self::from_path(root_path)
+        Self::from_path(root_path, whitespace_mode)
     }
 
     /// Create backend from a known path (used by discover and tests)
-    fn from_path(root_path: PathBuf) -> Result<Self> {
+    fn from_path(root_path: PathBuf, whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
         // Canonicalize to resolve symlinks (e.g., /var -> /private/var on macOS)
         let root_path = root_path.canonicalize().unwrap_or(root_path);
 
         // Get current revision info
-        let head_commit = run_hg_command(&root_path, &["id", "-i"])
+        let head_commit = run_hg_command(&root_path, ["id", "-i"])
             .map(|s| s.trim().trim_end_matches('+').to_string())
             .unwrap_or_else(|_| "unknown".to_string());
 
-        let branch_name = run_hg_command(&root_path, &["branch"])
+        let branch_name = run_hg_command(&root_path, ["branch"])
             .ok()
             .map(|s| s.trim().to_string());
 
@@ -72,7 +74,22 @@ impl HgBackend {
             vcs_type: VcsType::Mercurial,
         };
 
-        Ok(Self { info })
+        Ok(Self {
+            info,
+            whitespace_mode,
+        })
+    }
+
+    fn diff_args<'a>(&self, args: &'a [&'a str]) -> Cow<'a, [&'a str]> {
+        if !self.whitespace_mode.ignores_all() {
+            return Cow::Borrowed(args);
+        }
+
+        let mut args_with_whitespace = Vec::with_capacity(args.len() + 1);
+        args_with_whitespace.push(args[0]);
+        args_with_whitespace.push("--ignore-all-space");
+        args_with_whitespace.extend_from_slice(&args[1..]);
+        Cow::Owned(args_with_whitespace)
     }
 }
 
@@ -82,7 +99,8 @@ impl VcsBackend for HgBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        let diff_output = run_hg_command(&self.info.root_path, &["diff"])?;
+        let args = self.diff_args(&["diff"]);
+        let diff_output = run_hg_command(&self.info.root_path, args.iter().copied())?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -114,9 +132,9 @@ impl VcsBackend for HgBackend {
 
         let path_str = file_path.to_string_lossy();
         let content = if let Some(commit) = ref_commit {
-            run_hg_command(&self.info.root_path, &["cat", "-r", commit, &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", commit, &path_str])?
         } else if file_status == FileStatus::Deleted {
-            run_hg_command(&self.info.root_path, &["cat", "-r", ".", &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", ".", &path_str])?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
@@ -148,9 +166,9 @@ impl VcsBackend for HgBackend {
     ) -> Result<u32> {
         let path_str = file_path.to_string_lossy();
         let content = if let Some(commit) = ref_commit {
-            run_hg_command(&self.info.root_path, &["cat", "-r", commit, &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", commit, &path_str])?
         } else if file_status == FileStatus::Deleted {
-            run_hg_command(&self.info.root_path, &["cat", "-r", ".", &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", ".", &path_str])?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
@@ -162,7 +180,7 @@ impl VcsBackend for HgBackend {
         // hg log outputs newest first; we reverse so oldest is first.
         let output = run_hg_command(
             &self.info.root_path,
-            &["log", "-r", revisions, "--template", "{node}\\n"],
+            ["log", "-r", revisions, "--template", "{node}\\n"],
         )?;
 
         let mut commit_ids: Vec<String> = output
@@ -192,7 +210,7 @@ impl VcsBackend for HgBackend {
             "{node}\\x00{node|short}\\x00{desc}\\x00{author|user}\\x00{date|hgdate}\\x01";
         let output = run_hg_command(
             &self.info.root_path,
-            &[
+            [
                 "log",
                 "-l",
                 &fetch_count.to_string(),
@@ -273,7 +291,7 @@ impl VcsBackend for HgBackend {
         // We use "log -r 'parents({oldest})'" to get the parent hash
         let parent_output = run_hg_command(
             &self.info.root_path,
-            &[
+            [
                 "log",
                 "-r",
                 &format!("parents({})", oldest_short),
@@ -288,10 +306,9 @@ impl VcsBackend for HgBackend {
             _ => "null".to_string(),
         };
 
-        let diff_output = run_hg_command(
-            &self.info.root_path,
-            &["diff", "-r", &from_rev, "-r", newest_short],
-        )?;
+        let diff_args = ["diff", "-r", &from_rev, "-r", newest_short];
+        let args = self.diff_args(&diff_args);
+        let diff_output = run_hg_command(&self.info.root_path, args.iter().copied())?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -329,7 +346,7 @@ impl VcsBackend for HgBackend {
             "{node}\\x00{node|short}\\x00{desc}\\x00{author|user}\\x00{date|hgdate}\\x01";
         let output = run_hg_command(
             &self.info.root_path,
-            &["log", "-r", &revset, "--template", template],
+            ["log", "-r", &revset, "--template", template],
         )?;
 
         let mut by_id: HashMap<String, CommitInfo> = HashMap::new();
@@ -390,7 +407,7 @@ impl VcsBackend for HgBackend {
         // Get the parent of the oldest commit
         let parent_output = run_hg_command(
             &self.info.root_path,
-            &[
+            [
                 "log",
                 "-r",
                 &format!("parents({})", oldest_short),
@@ -404,7 +421,9 @@ impl VcsBackend for HgBackend {
             _ => "null".to_string(),
         };
 
-        let diff_output = run_hg_command(&self.info.root_path, &["diff", "-r", &from_rev])?;
+        let diff_args = ["diff", "-r", &from_rev];
+        let args = self.diff_args(&diff_args);
+        let diff_output = run_hg_command(&self.info.root_path, args.iter().copied())?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -443,20 +462,29 @@ fn hg_cat_batch(root: &Path, rev: &str, paths: &[PathBuf]) -> Result<HashMap<Pat
     Ok(parse_batched_files(&output))
 }
 
-/// Run an hg command and return its stdout
-fn run_hg_command(root: &Path, args: &[&str]) -> Result<String> {
+/// Run an hg command and return its stdout.
+fn run_hg_command<I, S>(root: &Path, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let args: Vec<S> = args.into_iter().collect();
     let output = Command::new("hg")
         .current_dir(root)
-        .args(args)
+        .args(args.iter().map(|arg| arg.as_ref()))
         .output()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run hg: {}", e)))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let rendered_args = args
+            .iter()
+            .map(|arg| arg.as_ref().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
         return Err(TuicrError::VcsCommand(format!(
             "hg {} failed: {}",
-            args.join(" "),
-            stderr
+            rendered_args, stderr
         )));
     }
 
@@ -491,7 +519,7 @@ mod tests {
 
         let root_path = PathBuf::from(String::from_utf8_lossy(&root_output.stdout).trim());
 
-        HgBackend::from_path(root_path)
+        HgBackend::from_path(root_path, DiffWhitespaceMode::Normal)
     }
 
     /// Create a temporary hg repo for testing.
@@ -560,8 +588,8 @@ mod tests {
         };
 
         // Use from_path directly to avoid set_current_dir race conditions
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         // Canonicalize temp path to handle macOS /var -> /private/var symlink
         let expected_path = temp.path().canonicalize().unwrap();
@@ -581,6 +609,82 @@ mod tests {
     }
 
     #[test]
+    fn test_hg_diff_ignores_all_whitespace_when_configured() {
+        let Some(temp) = setup_test_repo() else {
+            eprintln!("Skipping test: hg command not available");
+            return;
+        };
+
+        fs::write(temp.path().join("hello.txt"), " hello world \n")
+            .expect("Failed to write whitespace-only edit");
+        let backend =
+            HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::IgnoreAll)
+                .expect("Failed to create hg backend");
+
+        assert!(matches!(
+            backend.get_working_tree_diff(&SyntaxHighlighter::default()),
+            Err(TuicrError::NoChanges)
+        ));
+
+        fs::write(temp.path().join("hello.txt"), " hello ship \n")
+            .expect("Failed to write non-whitespace edit");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("non-whitespace edit should still produce a diff");
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn test_hg_working_tree_with_commits_ignores_all_whitespace_when_configured() {
+        let Some(temp) = setup_test_repo() else {
+            eprintln!("Skipping test: hg command not available");
+            return;
+        };
+
+        fs::write(temp.path().join("hello.txt"), " hello world \n")
+            .expect("Failed to write whitespace-only edit");
+        let output = Command::new("hg")
+            .args(["commit", "-m", "Whitespace commit"])
+            .current_dir(temp.path())
+            .output()
+            .expect("Failed to commit whitespace edit");
+        assert!(
+            output.status.success(),
+            "hg commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let backend =
+            HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::IgnoreAll)
+                .expect("Failed to create hg backend");
+        let commits = backend
+            .get_recent_commits(0, 5)
+            .expect("Failed to get commits");
+        let whitespace_commit = commits
+            .iter()
+            .find(|commit| commit.summary == "Whitespace commit")
+            .expect("Expected whitespace commit");
+
+        assert!(matches!(
+            backend.get_working_tree_with_commits_diff(
+                &[whitespace_commit.id.clone()],
+                &SyntaxHighlighter::default()
+            ),
+            Err(TuicrError::NoChanges)
+        ));
+
+        fs::write(temp.path().join("hello.txt"), " hello ship \n")
+            .expect("Failed to write non-whitespace edit");
+        let files = backend
+            .get_working_tree_with_commits_diff(
+                &[whitespace_commit.id.clone()],
+                &SyntaxHighlighter::default(),
+            )
+            .expect("non-whitespace edit should still produce a diff");
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
     fn test_hg_fetch_context_lines() {
         let Some(temp) = setup_test_repo() else {
             eprintln!("Skipping test: hg command not available");
@@ -588,8 +692,8 @@ mod tests {
         };
 
         // Use from_path directly to avoid set_current_dir race conditions
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         // Canonicalize temp path to handle macOS /var -> /private/var symlink
         let expected_path = temp.path().canonicalize().unwrap();
@@ -666,8 +770,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         let commits = backend
             .get_recent_commits(0, 5)
@@ -694,8 +798,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         let commits = backend
             .get_recent_commits(0, 5)
@@ -785,8 +889,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -858,8 +962,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -918,8 +1022,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -975,8 +1079,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
             .expect("Failed to get diff");
@@ -1026,8 +1130,8 @@ mod tests {
             .output()
             .expect("Failed to remove file");
 
-        let backend =
-            HgBackend::from_path(temp.path().to_path_buf()).expect("Failed to create hg backend");
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -1,5 +1,6 @@
 //! Jujutsu (jj) backend implementation using CLI commands.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -10,7 +11,7 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::traits::{CommitInfo, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::traits::{CommitInfo, DiffWhitespaceMode, VcsBackend, VcsInfo, VcsType};
 use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
 
 /// Parse a jj description into (summary, optional body).
@@ -32,11 +33,12 @@ fn parse_description(desc: &str) -> (String, Option<String>) {
 /// Jujutsu backend implementation using jj CLI commands
 pub struct JjBackend {
     info: VcsInfo,
+    whitespace_mode: DiffWhitespaceMode,
 }
 
 impl JjBackend {
     /// Discover a Jujutsu repository from the current directory
-    pub fn discover() -> Result<Self> {
+    pub fn discover(whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
         // Use `jj root` to find the repository root
         // This handles being called from subdirectories
         let root_output = Command::new("jj")
@@ -50,18 +52,18 @@ impl JjBackend {
 
         let root_path = PathBuf::from(String::from_utf8_lossy(&root_output.stdout).trim());
 
-        Self::from_path(root_path)
+        Self::from_path(root_path, whitespace_mode)
     }
 
     /// Create backend from a known path (used by discover and tests)
-    fn from_path(root_path: PathBuf) -> Result<Self> {
+    fn from_path(root_path: PathBuf, whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
         // Canonicalize to resolve symlinks (e.g., /var -> /private/var on macOS)
         let root_path = root_path.canonicalize().unwrap_or(root_path);
 
         // Get current change id (jj uses change IDs rather than commit hashes)
         let head_commit = run_jj_command(
             &root_path,
-            &["log", "-r", "@", "--no-graph", "-T", "change_id.short()"],
+            ["log", "-r", "@", "--no-graph", "-T", "change_id.short()"],
         )
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
@@ -70,7 +72,7 @@ impl JjBackend {
         // First check if @ has a bookmark directly, otherwise find the closest ancestor bookmark
         let branch_name = run_jj_command(
             &root_path,
-            &["log", "-r", "@", "--no-graph", "-T", "bookmarks"],
+            ["log", "-r", "@", "--no-graph", "-T", "bookmarks"],
         )
         .ok()
         .map(|s| s.trim().to_string())
@@ -79,7 +81,7 @@ impl JjBackend {
             // Find the closest bookmark in ancestors using heads(::@ & bookmarks())
             run_jj_command(
                 &root_path,
-                &[
+                [
                     "log",
                     "-r",
                     "heads(::@ & bookmarks())",
@@ -109,7 +111,22 @@ impl JjBackend {
             vcs_type: VcsType::Jujutsu,
         };
 
-        Ok(Self { info })
+        Ok(Self {
+            info,
+            whitespace_mode,
+        })
+    }
+
+    fn diff_args<'a>(&self, args: &'a [&'a str]) -> Cow<'a, [&'a str]> {
+        if !self.whitespace_mode.ignores_all() {
+            return Cow::Borrowed(args);
+        }
+
+        let mut args_with_whitespace = Vec::with_capacity(args.len() + 1);
+        args_with_whitespace.push(args[0]);
+        args_with_whitespace.push("--ignore-all-space");
+        args_with_whitespace.extend_from_slice(&args[1..]);
+        Cow::Owned(args_with_whitespace)
     }
 }
 
@@ -119,7 +136,8 @@ impl VcsBackend for JjBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        let diff_output = run_jj_command(&self.info.root_path, &["diff", "--git"])?;
+        let args = self.diff_args(&["diff", "--git"]);
+        let diff_output = run_jj_command(&self.info.root_path, args.iter().copied())?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -154,12 +172,12 @@ impl VcsBackend for JjBackend {
         let content = if let Some(commit) = ref_commit {
             run_jj_command(
                 &self.info.root_path,
-                &["file", "show", "-r", commit, &path_str],
+                ["file", "show", "-r", commit, &path_str],
             )?
         } else if file_status == FileStatus::Deleted {
             run_jj_command(
                 &self.info.root_path,
-                &["file", "show", "-r", "@-", &path_str],
+                ["file", "show", "-r", "@-", &path_str],
             )?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
@@ -194,12 +212,12 @@ impl VcsBackend for JjBackend {
         let content = if let Some(commit) = ref_commit {
             run_jj_command(
                 &self.info.root_path,
-                &["file", "show", "-r", commit, &path_str],
+                ["file", "show", "-r", commit, &path_str],
             )?
         } else if file_status == FileStatus::Deleted {
             run_jj_command(
                 &self.info.root_path,
-                &["file", "show", "-r", "@-", &path_str],
+                ["file", "show", "-r", "@-", &path_str],
             )?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
@@ -212,7 +230,7 @@ impl VcsBackend for JjBackend {
         // We reverse the result so the oldest commit is first (matching get_commit_range_diff expectations).
         let output = run_jj_command(
             &self.info.root_path,
-            &[
+            [
                 "log",
                 "-r",
                 revisions,
@@ -249,7 +267,7 @@ impl VcsBackend for JjBackend {
         let template = r#"commit_id ++ "\x00" ++ commit_id.short() ++ "\x00" ++ description ++ "\x00" ++ author.email() ++ "\x00" ++ committer.timestamp() ++ "\x01""#;
         let output = run_jj_command(
             &self.info.root_path,
-            &[
+            [
                 "log",
                 "-r",
                 "::@",
@@ -313,10 +331,9 @@ impl VcsBackend for JjBackend {
         // Get the parent of the oldest commit to include its changes
         // In jj, we use {commit}- to get the parent(s)
         let from_rev = format!("{}-", oldest);
-        let diff_output = run_jj_command(
-            &self.info.root_path,
-            &["diff", "--from", &from_rev, "--to", newest, "--git"],
-        )?;
+        let diff_args = ["diff", "--from", &from_rev, "--to", newest, "--git"];
+        let args = self.diff_args(&diff_args);
+        let diff_output = run_jj_command(&self.info.root_path, args.iter().copied())?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -348,7 +365,7 @@ impl VcsBackend for JjBackend {
         let template = r#"commit_id ++ "\x00" ++ commit_id.short() ++ "\x00" ++ description ++ "\x00" ++ author.email() ++ "\x00" ++ committer.timestamp() ++ "\x01""#;
         let output = run_jj_command(
             &self.info.root_path,
-            &["log", "-r", &revset, "--no-graph", "-T", template],
+            ["log", "-r", &revset, "--no-graph", "-T", template],
         )?;
 
         let mut by_id: HashMap<String, CommitInfo> = HashMap::new();
@@ -400,10 +417,9 @@ impl VcsBackend for JjBackend {
 
         // Diff from the parent of the oldest commit to the working copy (@)
         let from_rev = format!("{}-", oldest);
-        let diff_output = run_jj_command(
-            &self.info.root_path,
-            &["diff", "--from", &from_rev, "--to", "@", "--git"],
-        )?;
+        let diff_args = ["diff", "--from", &from_rev, "--to", "@", "--git"];
+        let args = self.diff_args(&diff_args);
+        let diff_output = run_jj_command(&self.info.root_path, args.iter().copied())?;
 
         if diff_output.trim().is_empty() {
             return Err(TuicrError::NoChanges);
@@ -441,20 +457,29 @@ fn jj_show_batch(root: &Path, rev: &str, paths: &[PathBuf]) -> Result<HashMap<Pa
     Ok(parse_batched_files(&output))
 }
 
-/// Run a jj command and return its stdout
-fn run_jj_command(root: &Path, args: &[&str]) -> Result<String> {
+/// Run a jj command and return its stdout.
+fn run_jj_command<I, S>(root: &Path, args: I) -> Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let args: Vec<S> = args.into_iter().collect();
     let output = Command::new("jj")
         .current_dir(root)
-        .args(args)
+        .args(args.iter().map(|arg| arg.as_ref()))
         .output()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run jj: {}", e)))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        let rendered_args = args
+            .iter()
+            .map(|arg| arg.as_ref().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
         return Err(TuicrError::VcsCommand(format!(
             "jj {} failed: {}",
-            args.join(" "),
-            stderr
+            rendered_args, stderr
         )));
     }
 
@@ -489,7 +514,7 @@ mod tests {
 
         let root_path = PathBuf::from(String::from_utf8_lossy(&root_output.stdout).trim());
 
-        JjBackend::from_path(root_path)
+        JjBackend::from_path(root_path, DiffWhitespaceMode::Normal)
     }
 
     /// Create a temporary jj repo for testing.
@@ -560,8 +585,8 @@ mod tests {
         };
 
         // Use from_path directly to avoid set_current_dir race conditions
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         // Canonicalize temp path to handle macOS /var -> /private/var symlink
         let expected_path = temp.path().canonicalize().unwrap();
@@ -581,6 +606,84 @@ mod tests {
     }
 
     #[test]
+    fn test_jj_diff_surfaces_noop_file_when_whitespace_only_diff_is_empty() {
+        let Some(temp) = setup_test_repo() else {
+            eprintln!("Skipping test: jj command not available");
+            return;
+        };
+
+        fs::write(temp.path().join("hello.txt"), " hello world \n")
+            .expect("Failed to write whitespace-only edit");
+        let backend =
+            JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::IgnoreAll)
+                .expect("Failed to create jj backend");
+
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("whitespace-only edit may surface as a no-op diff file");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].hunks.is_empty());
+
+        fs::write(temp.path().join("hello.txt"), " hello ship \n")
+            .expect("Failed to write non-whitespace edit");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("non-whitespace edit should still produce a diff");
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn test_jj_working_tree_with_commits_surfaces_noop_file_for_whitespace_only_diff() {
+        let Some(temp) = setup_test_repo() else {
+            eprintln!("Skipping test: jj command not available");
+            return;
+        };
+
+        fs::write(temp.path().join("hello.txt"), " hello world \n")
+            .expect("Failed to write whitespace-only edit");
+        let output = Command::new("jj")
+            .args(["commit", "-m", "Whitespace commit"])
+            .current_dir(temp.path())
+            .output()
+            .expect("Failed to commit whitespace edit");
+        assert!(
+            output.status.success(),
+            "jj commit failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let backend =
+            JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::IgnoreAll)
+                .expect("Failed to create jj backend");
+        let commits = backend
+            .get_recent_commits(0, 10)
+            .expect("Failed to get commits");
+        let whitespace_commit = commits
+            .iter()
+            .find(|commit| commit.summary == "Whitespace commit")
+            .expect("Expected whitespace commit");
+
+        let files = backend
+            .get_working_tree_with_commits_diff(
+                &[whitespace_commit.id.clone()],
+                &SyntaxHighlighter::default(),
+            )
+            .expect("whitespace-only edit may surface as a no-op diff file");
+        assert_eq!(files.len(), 1);
+        assert!(files[0].hunks.is_empty());
+
+        fs::write(temp.path().join("hello.txt"), " hello ship \n")
+            .expect("Failed to write non-whitespace edit");
+        let files = backend
+            .get_working_tree_with_commits_diff(
+                &[whitespace_commit.id.clone()],
+                &SyntaxHighlighter::default(),
+            )
+            .expect("non-whitespace edit should still produce a diff");
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
     fn test_jj_fetch_context_lines() {
         let Some(temp) = setup_test_repo() else {
             eprintln!("Skipping test: jj command not available");
@@ -588,8 +691,8 @@ mod tests {
         };
 
         // Use from_path directly to avoid set_current_dir race conditions
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         // Canonicalize temp path to handle macOS /var -> /private/var symlink
         let expected_path = temp.path().canonicalize().unwrap();
@@ -664,8 +767,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         let commits = backend
             .get_recent_commits(0, 5)
@@ -706,8 +809,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         let commits = backend
             .get_recent_commits(0, 10)
@@ -781,8 +884,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -832,8 +935,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -867,8 +970,8 @@ mod tests {
         // Delete the binary file
         fs::remove_file(root.join("image.png")).expect("Failed to delete file");
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
 
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -961,8 +1064,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
             .expect("Failed to get diff");
@@ -996,8 +1099,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
         let info = backend.info();
 
         assert_eq!(
@@ -1060,8 +1163,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
         let info = backend.info();
 
         assert_eq!(
@@ -1109,8 +1212,8 @@ mod tests {
             return;
         };
 
-        let backend =
-            JjBackend::from_path(temp.path().to_path_buf()).expect("Failed to create jj backend");
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
         let info = backend.info();
 
         assert!(

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -25,7 +25,9 @@ pub use git::{GitBackend, GitBackendPreference};
 pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use pr_noop::PrNoopVcs;
-pub use traits::{ChangeKind, CommitInfo, VcsBackend, VcsChangeStatus, VcsInfo};
+pub use traits::{
+    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsChangeStatus, VcsInfo,
+};
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -298,19 +300,22 @@ fn apply_full_file_spans(
 ///
 /// Detection order: Jujutsu → Git → Mercurial.
 /// Jujutsu is tried first because jj repos are Git-backed.
-pub fn detect_vcs(git_backend_preference: GitBackendPreference) -> Result<Box<dyn VcsBackend>> {
+pub fn detect_vcs(
+    git_backend_preference: GitBackendPreference,
+    whitespace_mode: DiffWhitespaceMode,
+) -> Result<Box<dyn VcsBackend>> {
     // Try jj first since jj repos are Git-backed
-    if let Ok(backend) = JjBackend::discover() {
+    if let Ok(backend) = JjBackend::discover(whitespace_mode) {
         return Ok(Box::new(backend));
     }
 
     // Try git
-    if let Ok(backend) = GitBackend::discover(git_backend_preference) {
+    if let Ok(backend) = GitBackend::discover(git_backend_preference, whitespace_mode) {
         return Ok(Box::new(backend));
     }
 
     // Try hg
-    if let Ok(backend) = HgBackend::discover() {
+    if let Ok(backend) = HgBackend::discover(whitespace_mode) {
         return Ok(Box::new(backend));
     }
 
@@ -326,7 +331,8 @@ mod tests {
     #[test]
     fn exports_are_accessible() {
         // Verify that public types are properly exported
-        let _: fn(GitBackendPreference) -> Result<Box<dyn VcsBackend>> = detect_vcs;
+        let _: fn(GitBackendPreference, DiffWhitespaceMode) -> Result<Box<dyn VcsBackend>> =
+            detect_vcs;
 
         // VcsInfo can be constructed
         let info = VcsInfo {
@@ -356,7 +362,7 @@ mod tests {
         // Note: This test may pass or fail depending on where tests are run
         // In CI or outside a repo, it should fail with NotARepository
         // Inside the tuicr repo (which is git), it will succeed
-        let result = detect_vcs(GitBackendPreference::Libgit2);
+        let result = detect_vcs(GitBackendPreference::Libgit2, DiffWhitespaceMode::Normal);
 
         // We just verify the function runs without panic
         // The actual result depends on the environment

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -35,6 +35,27 @@ pub struct VcsInfo {
     pub vcs_type: VcsType,
 }
 
+/// Whitespace comparison policy used when a backend materializes diff hunks.
+///
+/// This is a local-diff setting,
+/// not a review-session identity or forge option.
+/// Cheap change probes intentionally ignore it so selectors can still show
+/// staged/unstaged choices before the full diff is loaded.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DiffWhitespaceMode {
+    /// Compare whitespace normally.
+    #[default]
+    Normal,
+    /// Ignore all whitespace while comparing lines.
+    IgnoreAll,
+}
+
+impl DiffWhitespaceMode {
+    pub fn ignores_all(self) -> bool {
+        matches!(self, Self::IgnoreAll)
+    }
+}
+
 /// Commit information for commit selection UI
 #[derive(Debug, Clone)]
 pub struct CommitInfo {


### PR DESCRIPTION
Let users opt into whitespace-insensitive local reviews from config:

    ignore_whitespace = true

The `ignore_whitespace` config key now selects all-whitespace
comparison for Git, jj, and hg backends without adding a command
override while command dispatch is being refactored.

PR diffs keep their existing behavior because the forge path does not
yet expose a whitespace-ignore patch contract.

No CLI flags or commands added in this version.
