### PR TITLE
feat: Open focused file in editor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ src/
 │   └── mod.rs           # User config loading (XDG on Unix, %APPDATA% on Windows)
 ├── app.rs               # Application state (App struct, InputMode, etc.)
 ├── error.rs             # Error types (TuicrError enum)
+├── editor.rs            # External $EDITOR command construction and launch helpers
 ├── review_store.rs      # Library API for session listing/loading and shared comment insertion
 ├── review_cli.rs        # Non-interactive `tuicr review` subcommands over ReviewStore
 ├── tuicrignore.rs       # .tuicrignore loader + diff file filtering (gitignore-style patterns)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,6 +2634,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "shlex",
  "syntect",
  "tempfile",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ base64 = "0.22"
 ignore = "0.4"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
+shlex = "1.3"
 
 # Syntax highlighting
 syntect = "5.2"

--- a/README.md
+++ b/README.md
@@ -214,12 +214,12 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `g` / `G` | Top / bottom |
 | `{` / `}` | Previous / next file |
 | `[` / `]` | Previous / next hunk |
-| `e` | Open focused file in `$EDITOR` |
 | `/` | Search |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |
 | `r` | Toggle file reviewed |
 | `y` | Copy review to clipboard |
+| `:edit` | Open focused file in `$EDITOR` |
 | `:submit` | Push review to GitHub |
 | `Tab` in `:` prompt | Complete or cycle commands |
 | `?` | Toggle full help |

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `g` / `G` | Top / bottom |
 | `{` / `}` | Previous / next file |
 | `[` / `]` | Previous / next hunk |
+| `e` | Open focused file in `$EDITOR` |
 | `/` | Search |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -22,6 +22,7 @@ Full reference. Press `?` inside tuicr for an in-app version of this list.
 | `/` | Search within diff |
 | `n` / `N` | Next / previous search match |
 | `Enter` | Expand or collapse hidden context between hunks |
+| `e` | Open focused file in `$EDITOR` |
 | `zt` | Scroll cursor to top of screen |
 | `zz` | Center cursor on screen |
 | `zb` | Scroll cursor to bottom of screen |
@@ -32,6 +33,7 @@ Full reference. Press `?` inside tuicr for an in-app version of this list.
 |-----|--------|
 | `Space` | Toggle expand directory |
 | `Enter` | Expand directory / jump to file in diff |
+| `e` | Open selected file in `$EDITOR` |
 | `o` | Expand all directories |
 | `O` | Collapse all directories |
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -22,7 +22,6 @@ Full reference. Press `?` inside tuicr for an in-app version of this list.
 | `/` | Search within diff |
 | `n` / `N` | Next / previous search match |
 | `Enter` | Expand or collapse hidden context between hunks |
-| `e` | Open focused file in `$EDITOR` |
 | `zt` | Scroll cursor to top of screen |
 | `zz` | Center cursor on screen |
 | `zb` | Scroll cursor to bottom of screen |
@@ -33,7 +32,6 @@ Full reference. Press `?` inside tuicr for an in-app version of this list.
 |-----|--------|
 | `Space` | Toggle expand directory |
 | `Enter` | Expand directory / jump to file in diff |
-| `e` | Open selected file in `$EDITOR` |
 | `o` | Expand all directories |
 | `O` | Collapse all directories |
 
@@ -103,6 +101,7 @@ In command mode,
 | `:o{N}` | Jump to old-side line N in current file (matches deletions) |
 | `:w` | Save session |
 | `:e` (`:reload`) | Reload diff files |
+| `:edit` | Open focused file in `$EDITOR` |
 | `:clip` (`:export`) | Copy review to clipboard |
 | `:diff` | Toggle diff view (unified / side-by-side) |
 | `:commits` | Select commits to review |

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use chrono::Utc;
 use ratatui::style::Color;
 
 use crate::config::CommentTypeConfig;
+use crate::editor::EditorTarget;
 use crate::error::{Result, TuicrError};
 use crate::forge::context::{ContextProvider, ForgeContextProvider, VcsContextProvider};
 use crate::forge::selector::PullRequestsTab;
@@ -871,6 +872,7 @@ pub struct App {
     pub(crate) ephemeral_session_paths: HashSet<PathBuf>,
     pub diff_files: Vec<DiffFile>,
     pub diff_source: DiffSource,
+    pub pending_editor_target: Option<EditorTarget>,
 
     pub input_mode: InputMode,
     pub focused_panel: FocusedPanel,
@@ -1734,6 +1736,7 @@ impl App {
             ephemeral_session_paths: HashSet::new(),
             diff_files,
             diff_source,
+            pending_editor_target: None,
             input_mode,
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
@@ -3944,6 +3947,93 @@ impl App {
 
     pub fn current_file_path(&self) -> Option<&PathBuf> {
         self.current_file().map(|f| f.display_path())
+    }
+
+    /// Takes the queued editor target after action dispatch.
+    ///
+    /// The main event loop consumes this after leaving raw mode and the
+    /// alternate screen,
+    /// because `App` does not own terminal state.
+    pub fn take_pending_editor_target(&mut self) -> Option<EditorTarget> {
+        self.pending_editor_target.take()
+    }
+
+    /// Resolves the currently focused UI item into an editor target.
+    ///
+    /// The resolved target is queued on `pending_editor_target` so the main
+    /// event loop can perform the terminal handoff.
+    /// Invalid focus states are reported through the status bar instead.
+    pub fn queue_editor_for_focused_item(&mut self) {
+        match self.focused_panel {
+            FocusedPanel::FileList => match self.get_selected_tree_item() {
+                Some(FileTreeItem::File { file_idx, .. }) => {
+                    self.queue_editor_for_file_idx(file_idx, None)
+                }
+                Some(FileTreeItem::Directory { .. }) => {
+                    self.set_warning("Select a file to open in editor");
+                }
+                None => self.set_warning("No file selected"),
+            },
+            FocusedPanel::Diff => {
+                let annotation = self.line_annotations.get(self.diff_state.cursor_line);
+                let file_idx = match annotation {
+                    Some(
+                        AnnotatedLine::Expander { gap_id, .. }
+                        | AnnotatedLine::HiddenLines { gap_id, .. }
+                        | AnnotatedLine::ExpandedContext { gap_id, .. },
+                    ) => gap_id.file_idx,
+                    Some(annotation) => {
+                        annotation_file_idx(annotation).unwrap_or(self.diff_state.current_file_idx)
+                    }
+                    None => self.diff_state.current_file_idx,
+                };
+                let line = match annotation {
+                    Some(AnnotatedLine::ExpandedContext { gap_id, line_idx }) => self
+                        .get_expanded_line(gap_id, *line_idx)
+                        .and_then(|line| line.new_lineno.or(line.old_lineno)),
+                    _ => self.get_line_at_cursor().map(|(line, _side)| line),
+                };
+                self.queue_editor_for_file_idx(file_idx, line);
+            }
+            FocusedPanel::Comments | FocusedPanel::CommitSelector => {
+                self.set_warning("Focus a file or diff line to open in editor");
+            }
+        }
+    }
+
+    fn queue_editor_for_file_idx(&mut self, file_idx: usize, line: Option<u32>) {
+        let Some(file) = self.diff_files.get(file_idx) else {
+            self.set_warning("No file selected");
+            return;
+        };
+        if file.is_commit_message {
+            self.set_warning("Commit message has no local file to open");
+            return;
+        }
+
+        let display_path = file.display_path().clone();
+        // PR mode uses a synthetic forge root when there is no local checkout
+        // to hand to an editor.
+        if !self.vcs_info.root_path.is_absolute() {
+            self.set_warning(format!(
+                "Cannot open {}: no local checkout",
+                display_path.display()
+            ));
+            return;
+        }
+
+        let path = self.vcs_info.root_path.join(&display_path);
+        // Deleted files and remote-only PR files have diff rows,
+        // but no worktree file the external editor can open.
+        if !path.exists() {
+            self.set_warning(format!(
+                "Cannot open {}: file does not exist",
+                path.display()
+            ));
+            return;
+        }
+
+        self.pending_editor_target = Some(EditorTarget { path, line });
     }
 
     pub fn toggle_reviewed(&mut self) {
@@ -14260,6 +14350,7 @@ mod single_file_view_tests {
     use super::*;
     use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
     use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+    use std::fs;
     use std::path::PathBuf;
 
     struct StubVcs(VcsInfo);
@@ -14328,8 +14419,12 @@ mod single_file_view_tests {
     }
 
     fn app_with(files: Vec<DiffFile>) -> App {
+        app_with_root(PathBuf::from("/tmp"), files)
+    }
+
+    fn app_with_root(root_path: PathBuf, files: Vec<DiffFile>) -> App {
         let vcs_info = VcsInfo {
-            root_path: PathBuf::from("/tmp"),
+            root_path,
             head_commit: "head".into(),
             branch_name: Some("main".into()),
             vcs_type: VcsType::Git,
@@ -14355,6 +14450,76 @@ mod single_file_view_tests {
             None,
         )
         .expect("build app")
+    }
+
+    #[test]
+    fn editor_target_uses_selected_file_list_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "fn main() {}\n").expect("write file");
+
+        let mut app = app_with_root(
+            dir.path().to_path_buf(),
+            vec![file("main.rs", vec![hunk(1, 1)])],
+        );
+        app.focused_panel = FocusedPanel::FileList;
+        app.queue_editor_for_focused_item();
+
+        let target = app.take_pending_editor_target().expect("editor target");
+        assert_eq!(target.path, path);
+        assert_eq!(target.line, None);
+    }
+
+    #[test]
+    fn editor_target_uses_diff_cursor_line() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "line 1\nline 2\nline 3\n").expect("write file");
+
+        let mut app = app_with_root(
+            dir.path().to_path_buf(),
+            vec![file("main.rs", vec![hunk(1, 3)])],
+        );
+        app.focused_panel = FocusedPanel::Diff;
+        app.diff_state.cursor_line = app
+            .line_annotations
+            .iter()
+            .position(|annotation| {
+                matches!(
+                    annotation,
+                    AnnotatedLine::DiffLine {
+                        new_lineno: Some(2),
+                        ..
+                    }
+                )
+            })
+            .expect("diff line annotation");
+        app.queue_editor_for_focused_item();
+
+        let target = app.take_pending_editor_target().expect("editor target");
+        assert_eq!(target.path, path);
+        assert_eq!(target.line, Some(2));
+    }
+
+    #[test]
+    fn editor_target_warns_for_missing_local_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut app = app_with_root(
+            dir.path().to_path_buf(),
+            vec![file("missing.rs", vec![hunk(1, 1)])],
+        );
+        app.focused_panel = FocusedPanel::Diff;
+
+        app.queue_editor_for_focused_item();
+
+        assert!(app.take_pending_editor_target().is_none());
+        assert!(
+            app.message
+                .as_ref()
+                .expect("warning")
+                .content
+                .contains("file does not exist")
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -14471,6 +14471,28 @@ mod single_file_view_tests {
     }
 
     #[test]
+    fn edit_command_uses_selected_file_list_row() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("main.rs");
+        fs::write(&path, "fn main() {}\n").expect("write file");
+
+        let mut app = app_with_root(
+            dir.path().to_path_buf(),
+            vec![file("main.rs", vec![hunk(1, 1)])],
+        );
+        app.focused_panel = FocusedPanel::FileList;
+        app.enter_command_mode();
+        app.command_buffer = "edit".to_string();
+
+        crate::handler::handle_command_action(&mut app, crate::input::Action::SubmitInput);
+
+        let target = app.take_pending_editor_target().expect("editor target");
+        assert_eq!(target.path, path);
+        assert_eq!(target.line, None);
+        assert_eq!(app.input_mode, InputMode::Normal);
+    }
+
+    #[test]
     fn editor_target_uses_diff_cursor_line() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("main.rs");

--- a/src/app.rs
+++ b/src/app.rs
@@ -497,6 +497,41 @@ pub enum DiffSource {
     PullRequest(Box<PullRequestDiffSource>),
 }
 
+impl DiffSource {
+    /// Returns true when the active review target includes live worktree changes.
+    ///
+    /// This marks diff sources where reloading after an external editor exits
+    /// can surface newly written worktree edits. Pure staged, commit-range,
+    /// and pull-request reviews intentionally return false because editing the
+    /// local file does not update the selected review target.
+    pub fn includes_worktree_changes(&self) -> bool {
+        matches!(
+            self,
+            Self::WorkingTree
+                | Self::Unstaged
+                | Self::StagedAndUnstaged
+                | Self::StagedUnstagedAndCommits(_)
+        )
+    }
+}
+
+#[cfg(test)]
+mod diff_source_tests {
+    use super::*;
+
+    #[test]
+    fn unstaged_source_includes_worktree_changes() {
+        assert!(DiffSource::Unstaged.includes_worktree_changes());
+    }
+
+    #[test]
+    fn commit_range_source_does_not_include_worktree_changes() {
+        let source = DiffSource::CommitRange(vec!["abc123".to_string()]);
+
+        assert!(!source.includes_worktree_changes());
+    }
+}
+
 /// Runtime PR identity for `DiffSource::PullRequest`.
 ///
 /// The `PrSessionKey` portion is what scopes persistence; the additional

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,0 +1,190 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitStatus};
+
+/// Source location tuicr can hand off to an external editor.
+///
+/// The path is resolved before this reaches the process launcher so terminal
+/// suspend/resume code does not need to know about repository-relative paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorTarget {
+    /// Absolute path to the local worktree file.
+    pub path: PathBuf,
+    /// One-based source line to request from editors that support it.
+    pub line: Option<u32>,
+}
+
+/// Fully expanded editor invocation.
+///
+/// `program` and `args` are kept separate to avoid shelling out after parsing
+/// `$EDITOR`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditorCommand {
+    /// Executable name or path from `$EDITOR`, or the fallback editor.
+    pub program: String,
+    /// Arguments from `$EDITOR` plus the target file and optional line syntax.
+    pub args: Vec<OsString>,
+}
+
+impl EditorCommand {
+    /// Builds an invocation from `$EDITOR`.
+    ///
+    /// An unset, empty, or unparsable value falls back to `vi` so the caller
+    /// always gets a concrete command to run.
+    pub fn from_env(target: &EditorTarget) -> Self {
+        let editor = std::env::var("EDITOR").unwrap_or_default();
+        Self::from_editor(&editor, target)
+    }
+
+    /// Builds an invocation from an editor command string.
+    ///
+    /// The command is split with shell-like quoting rules,
+    /// but it is still executed directly without a shell.
+    /// Known editors receive their line-navigation syntax;
+    /// unknown editors receive only the path.
+    ///
+    /// For example,
+    /// `vim -f` with line 42 becomes `vim -f +42 /repo/src/main.rs`,
+    /// while `code` becomes `code --goto /repo/src/main.rs:42`.
+    pub fn from_editor(editor: &str, target: &EditorTarget) -> Self {
+        let mut parts = shlex::split(editor)
+            .filter(|parts| !parts.is_empty())
+            .unwrap_or_else(|| vec!["vi".to_string()]);
+        let program = parts.remove(0);
+        let mut args: Vec<OsString> = parts.into_iter().map(OsString::from).collect();
+
+        match (editor_family(&program), target.line) {
+            (EditorFamily::PlusLine, Some(line)) => {
+                args.push(OsString::from(format!("+{line}")));
+                args.push(target.path.as_os_str().to_os_string());
+            }
+            (EditorFamily::GotoLine, Some(line)) => {
+                args.push(OsString::from("--goto"));
+                args.push(OsString::from(format!("{}:{line}", target.path.display())));
+            }
+            _ => args.push(target.path.as_os_str().to_os_string()),
+        }
+
+        Self { program, args }
+    }
+
+    /// Runs the prepared editor command and waits for it to exit.
+    ///
+    /// The caller owns terminal suspension and restoration around this process
+    /// boundary.
+    pub fn run(&self) -> std::io::Result<std::process::ExitStatus> {
+        Command::new(&self.program).args(&self.args).status()
+    }
+}
+
+/// Line-navigation syntax family for a recognized editor executable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EditorFamily {
+    /// Opens a source line with `$editor +NN $file`.
+    PlusLine,
+    /// Opens a source line with `$editor --goto $file:NN`.
+    GotoLine,
+    /// Has no known line syntax; opens with `$editor $file`.
+    Plain,
+}
+
+fn editor_family(program: &str) -> EditorFamily {
+    let name = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program);
+    match name {
+        "vi" | "vim" | "nvim" | "nano" => EditorFamily::PlusLine,
+        "code" | "code-insiders" | "codium" | "cursor" => EditorFamily::GotoLine,
+        _ => EditorFamily::Plain,
+    }
+}
+
+/// Error returned when handing control to the external editor fails.
+#[derive(Debug, thiserror::Error)]
+pub enum EditorError {
+    /// The editor process could not be spawned.
+    #[error("Failed to launch editor: {0}")]
+    Launch(#[source] std::io::Error),
+    /// The editor process exited unsuccessfully.
+    #[error("Editor exited with status {}", status_label(.0))]
+    Exit(ExitStatus),
+}
+
+fn status_label(status: &ExitStatus) -> String {
+    status
+        .code()
+        .map(|code| code.to_string())
+        .unwrap_or_else(|| "signal".to_string())
+}
+
+/// Opens `target` in the user's editor.
+///
+/// The caller owns terminal restoration before displaying any returned error.
+pub fn run_editor(target: &EditorTarget) -> Result<(), EditorError> {
+    let command = EditorCommand::from_env(target);
+    match command.run() {
+        Ok(status) if status.success() => Ok(()),
+        Ok(status) => Err(EditorError::Exit(status)),
+        Err(err) => Err(EditorError::Launch(err)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target(line: Option<u32>) -> EditorTarget {
+        EditorTarget {
+            path: PathBuf::from("/repo/src/main.rs"),
+            line,
+        }
+    }
+
+    fn args(command: &EditorCommand) -> Vec<String> {
+        command
+            .args
+            .iter()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn plus_line_editors_receive_line_before_path() {
+        for editor in ["vi", "vim", "nvim", "nano"] {
+            let command = EditorCommand::from_editor(editor, &target(Some(42)));
+            assert_eq!(command.program, editor);
+            assert_eq!(args(&command), vec!["+42", "/repo/src/main.rs"]);
+        }
+    }
+
+    #[test]
+    fn vscode_family_receives_goto_arg() {
+        for editor in ["code", "code-insiders", "codium", "cursor"] {
+            let command = EditorCommand::from_editor(editor, &target(Some(42)));
+            assert_eq!(command.program, editor);
+            assert_eq!(args(&command), vec!["--goto", "/repo/src/main.rs:42"]);
+        }
+    }
+
+    #[test]
+    fn unknown_editor_opens_file_without_line() {
+        let command = EditorCommand::from_editor("zed", &target(Some(42)));
+        assert_eq!(command.program, "zed");
+        assert_eq!(args(&command), vec!["/repo/src/main.rs"]);
+    }
+
+    #[test]
+    fn editor_args_are_preserved() {
+        let command = EditorCommand::from_editor("vim -f", &target(Some(42)));
+        assert_eq!(command.program, "vim");
+        assert_eq!(args(&command), vec!["-f", "+42", "/repo/src/main.rs"]);
+    }
+
+    #[test]
+    fn empty_editor_falls_back_to_vi() {
+        let command = EditorCommand::from_editor("", &target(None));
+        assert_eq!(command.program, "vi");
+        assert_eq!(args(&command), vec!["/repo/src/main.rs"]);
+    }
+}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1248,6 +1248,7 @@ pub fn handle_file_list_action(app: &mut App, action: Action) {
                 app.set_warning("Select a file to toggle reviewed");
             }
         }
+        Action::OpenInEditor => app.queue_editor_for_focused_item(),
         _ => handle_shared_normal_action(app, action),
     }
 }
@@ -1352,6 +1353,7 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         Action::NextHunk => app.next_hunk(),
         Action::PrevHunk => app.prev_hunk(),
         Action::ToggleReviewed => app.toggle_reviewed(),
+        Action::OpenInEditor => app.queue_editor_for_focused_item(),
         Action::ToggleFocus => {
             let has_selector = app.has_inline_commit_selector();
             let has_comments = app.has_comment_navigator_items();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -26,6 +26,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec::new(&["w", "write"], CommandKind::Write),
     CommandSpec::new(&["x", "wq"], CommandKind::WriteQuit),
     CommandSpec::new(&["e", "reload"], CommandKind::Reload),
+    CommandSpec::new(&["edit"], CommandKind::Edit),
     CommandSpec::new(&["clip", "export"], CommandKind::Export),
     CommandSpec::new(
         &["clear"],
@@ -99,6 +100,7 @@ enum CommandKind {
     Write,
     WriteQuit,
     Reload,
+    Edit,
     Export,
     Clear(ClearScope),
     Version,
@@ -729,6 +731,10 @@ fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
             reload_review(app);
             CommandAfterDispatch::ExitCommandMode
         }
+        CommandKind::Edit => {
+            app.queue_editor_for_focused_item();
+            CommandAfterDispatch::ExitCommandMode
+        }
         CommandKind::Export => {
             handle_export(app);
             CommandAfterDispatch::ExitCommandMode
@@ -1248,7 +1254,6 @@ pub fn handle_file_list_action(app: &mut App, action: Action) {
                 app.set_warning("Select a file to toggle reviewed");
             }
         }
-        Action::OpenInEditor => app.queue_editor_for_focused_item(),
         _ => handle_shared_normal_action(app, action),
     }
 }
@@ -1353,7 +1358,6 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         Action::NextHunk => app.next_hunk(),
         Action::PrevHunk => app.prev_hunk(),
         Action::ToggleReviewed => app.toggle_reviewed(),
-        Action::OpenInEditor => app.queue_editor_for_focused_item(),
         Action::ToggleFocus => {
             let has_selector = app.has_inline_commit_selector();
             let has_comments = app.has_comment_navigator_items();

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -35,6 +35,7 @@ pub enum Action {
 
     // Review actions
     ToggleReviewed,
+    OpenInEditor,
     AddLineComment,
     AddFileComment,
     EditComment,
@@ -189,6 +190,7 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
 
         // Review actions
         (KeyCode::Char('r'), KeyModifiers::NONE) => Action::ToggleReviewed,
+        (KeyCode::Char('e'), KeyModifiers::NONE) => Action::OpenInEditor,
         (KeyCode::Char('c'), KeyModifiers::NONE) => Action::AddLineComment,
         (KeyCode::Char('C'), _) => Action::AddFileComment,
         (KeyCode::Char('i'), KeyModifiers::NONE) => Action::EditComment,
@@ -447,6 +449,21 @@ mod tests {
     fn should_map_lowercase_g_to_go_to_top_in_normal_mode() {
         let action = map_normal_mode(key(KeyCode::Char('g')), DEFAULT_LEADER_KEY);
         assert_eq!(action, Action::GoToTop);
+    }
+
+    #[test]
+    fn should_map_lowercase_e_to_open_editor_in_normal_mode() {
+        let action = map_normal_mode(key(KeyCode::Char('e')), DEFAULT_LEADER_KEY);
+        assert_eq!(action, Action::OpenInEditor);
+    }
+
+    #[test]
+    fn should_keep_ctrl_e_as_scroll_down_in_normal_mode() {
+        let action = map_normal_mode(
+            KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL),
+            DEFAULT_LEADER_KEY,
+        );
+        assert_eq!(action, Action::ScrollViewDown(1));
     }
 
     #[test]

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -35,7 +35,6 @@ pub enum Action {
 
     // Review actions
     ToggleReviewed,
-    OpenInEditor,
     AddLineComment,
     AddFileComment,
     EditComment,
@@ -190,7 +189,6 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
 
         // Review actions
         (KeyCode::Char('r'), KeyModifiers::NONE) => Action::ToggleReviewed,
-        (KeyCode::Char('e'), KeyModifiers::NONE) => Action::OpenInEditor,
         (KeyCode::Char('c'), KeyModifiers::NONE) => Action::AddLineComment,
         (KeyCode::Char('C'), _) => Action::AddFileComment,
         (KeyCode::Char('i'), KeyModifiers::NONE) => Action::EditComment,
@@ -452,9 +450,9 @@ mod tests {
     }
 
     #[test]
-    fn should_map_lowercase_e_to_open_editor_in_normal_mode() {
+    fn should_leave_lowercase_e_unbound_in_normal_mode() {
         let action = map_normal_mode(key(KeyCode::Char('e')), DEFAULT_LEADER_KEY);
-        assert_eq!(action, Action::OpenInEditor);
+        assert_eq!(action, Action::None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod cli;
 pub mod config;
+pub mod editor;
 pub mod error;
 pub mod forge;
 pub mod handler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod review_cli;
 pub mod review_store;
 pub mod slug;
 pub mod syntax;
+pub mod terminal_state;
 pub mod text_edit;
 pub mod theme;
 pub mod tuicrignore;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use crossterm::{
 
 use tuicr::app::{self, App, AppStartupOptions, FocusedPanel, InputMode};
 use tuicr::cli::parse_cli_args;
+use tuicr::editor::{EditorError, EditorTarget};
 use tuicr::handler::{
     handle_command_action, handle_comment_action, handle_comment_navigator_action,
     handle_commit_select_action, handle_commit_selector_action, handle_confirm_action,
@@ -19,7 +20,7 @@ use tuicr::handler::{
     handle_submit_resolver_action, handle_visual_action,
 };
 use tuicr::input::{Action, map_key_to_action, map_target_filter_mode};
-use tuicr::terminal_state::TerminalFeatures;
+use tuicr::terminal_state::{TerminalFeatures, TerminalSession};
 use tuicr::theme::resolve_theme_with_config;
 use tuicr::vcs::{DiffWhitespaceMode, GitBackendPreference};
 use tuicr::{config, handler, profile, ui, update};
@@ -599,6 +600,15 @@ fn main() -> anyhow::Result<()> {
                     }
 
                     dispatch_action(&mut app, action);
+                    if let Some(target) = app.take_pending_editor_target() {
+                        match run_editor_from_tui(&mut terminal, &target) {
+                            Ok(Ok(())) => {
+                                app.set_message(format!("Opened {}", target.path.display()));
+                            }
+                            Ok(Err(err)) => app.set_error(err.to_string()),
+                            Err(err) => app.set_error(format!("Failed to restore terminal: {err}")),
+                        }
+                    }
                 }
                 Event::Mouse(mouse_event) => handle_mouse_event(&mut app, mouse_event),
                 Event::Paste(text) => {
@@ -660,4 +670,14 @@ fn dispatch_action(app: &mut App, action: Action) {
             FocusedPanel::CommitSelector => handle_commit_selector_action(app, action),
         },
     }
+}
+
+fn run_editor_from_tui<W: Write>(
+    terminal: &mut TerminalSession<W>,
+    target: &EditorTarget,
+) -> anyhow::Result<Result<(), EditorError>> {
+    let suspension = terminal.suspend()?;
+    let editor_result = tuicr::editor::run_editor(target);
+    suspension.resume()?;
+    Ok(editor_result)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,10 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crossterm::{
-    event::{
-        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-        Event, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
-        PushKeyboardEnhancementFlags,
-    },
+    event::{self, Event, KeyEventKind},
     execute, queue,
-    terminal::{
-        BeginSynchronizedUpdate, EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
-        disable_raw_mode, enable_raw_mode, supports_keyboard_enhancement,
-    },
+    terminal::{BeginSynchronizedUpdate, EndSynchronizedUpdate, supports_keyboard_enhancement},
 };
-use ratatui::{Terminal, backend::CrosstermBackend};
 
 use tuicr::app::{self, App, AppStartupOptions, FocusedPanel, InputMode};
 use tuicr::cli::parse_cli_args;
@@ -27,6 +19,7 @@ use tuicr::handler::{
     handle_submit_resolver_action, handle_visual_action,
 };
 use tuicr::input::{Action, map_key_to_action, map_target_filter_mode};
+use tuicr::terminal_state::TerminalFeatures;
 use tuicr::theme::resolve_theme_with_config;
 use tuicr::vcs::{DiffWhitespaceMode, GitBackendPreference};
 use tuicr::{config, handler, profile, ui, update};
@@ -42,11 +35,7 @@ fn main() -> anyhow::Result<()> {
     // Setup panic hook to restore terminal on panic
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic_info| {
-        let _ = execute!(io::stdout(), PopKeyboardEnhancementFlags);
-        let _ = execute!(io::stdout(), DisableBracketedPaste);
-        let _ = execute!(io::stdout(), DisableMouseCapture);
-        let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        tuicr::terminal_state::restore_stdio_best_effort();
         original_hook(panic_info);
     }));
 
@@ -235,47 +224,21 @@ fn main() -> anyhow::Result<()> {
         eprintln!("tuicr-session: {slug}");
     }
 
-    // Setup terminal
     // When --stdout is used, render TUI to /dev/tty so stdout is free for export output
-    enable_raw_mode()?;
-    let mut tty_output: Box<dyn Write> = if cli_args.output_to_stdout {
+    let tty_output: Box<dyn Write> = if cli_args.output_to_stdout {
         Box::new(File::options().write(true).open("/dev/tty")?)
     } else {
         Box::new(io::stdout())
     };
-    execute!(tty_output, EnterAlternateScreen)?;
     let mouse_enabled = config_outcome
         .config
         .as_ref()
         .and_then(|cfg| cfg.mouse)
         .unwrap_or(true);
-    if mouse_enabled {
-        execute!(tty_output, EnableMouseCapture)?;
-    }
-
-    // Bracketed paste so multi-line / control-char pastes arrive as a single
-    // Event::Paste, instead of each character driving Normal-mode actions
-    // (Enter submitting, ':' opening command mode, etc.) mid-paste.
-    execute!(tty_output, EnableBracketedPaste)?;
-
-    // Enable keyboard enhancement for better modifier key detection (e.g., Alt+Enter)
-    // This is supported by modern terminals like Kitty, iTerm2, WezTerm, etc.
-    if keyboard_enhancement_supported {
-        // REPORT_EVENT_TYPES distinguishes Press from Repeat from Release so
-        // the two-press file walk (j/k at file boundary) can require an
-        // actual key release between the two presses. Without it terminals
-        // emit Press for every auto-repeat tick and held-j would walk past
-        // file boundaries.
-        let _ = execute!(
-            tty_output,
-            PushKeyboardEnhancementFlags(
-                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
-            )
-        );
-    }
-    let backend = CrosstermBackend::new(tty_output);
-    let mut terminal = Terminal::new(backend)?;
+    let mut terminal = TerminalFeatures::new()
+        .mouse_enabled(mouse_enabled)
+        .keyboard_enhancements_supported(keyboard_enhancement_supported)
+        .enter(tty_output)?;
 
     // Apply config-driven defaults
     if let Some(ref cfg) = config_outcome.config {
@@ -661,14 +624,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    // Restore terminal
-    let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
-    let _ = execute!(terminal.backend_mut(), DisableBracketedPaste);
-    if mouse_enabled {
-        let _ = execute!(terminal.backend_mut(), DisableMouseCapture);
-    }
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.restore()?;
 
     if let Err(e) = app.cleanup_empty_ephemeral_sessions() {
         eprintln!("Warning: failed to clean up empty review session: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,7 +603,28 @@ fn main() -> anyhow::Result<()> {
                     if let Some(target) = app.take_pending_editor_target() {
                         match run_editor_from_tui(&mut terminal, &target) {
                             Ok(Ok(())) => {
-                                app.set_message(format!("Opened {}", target.path.display()));
+                                if app.diff_source.includes_worktree_changes() {
+                                    match app.reload_diff_files() {
+                                        Ok((count, invalidated)) => {
+                                            let invalidated_suffix = if invalidated > 0 {
+                                                format!(", {invalidated} changed since last review")
+                                            } else {
+                                                String::new()
+                                            };
+                                            app.set_message(format!(
+                                                "Opened {} and reloaded {count} files{invalidated_suffix}",
+                                                target.path.display()
+                                            ));
+                                        }
+                                        Err(err) => {
+                                            app.set_error(format!(
+                                                "Reload after editor failed: {err}"
+                                            ));
+                                        }
+                                    }
+                                } else {
+                                    app.set_message(format!("Opened {}", target.path.display()));
+                                }
                             }
                             Ok(Err(err)) => app.set_error(err.to_string()),
                             Err(err) => app.set_error(format!("Failed to restore terminal: {err}")),

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -98,6 +98,38 @@ impl<W: Write> TerminalSession<W> {
         if !self.active {
             return Ok(());
         }
+        self.deactivate()?;
+        Ok(())
+    }
+
+    /// Temporarily leaves TUI terminal mode.
+    ///
+    /// The returned guard re-enters TUI mode on `resume()` or,
+    /// as a best-effort fallback,
+    /// when the guard is dropped.
+    pub fn suspend(&mut self) -> anyhow::Result<TerminalSuspension<'_, W>> {
+        self.deactivate()?;
+        Ok(TerminalSuspension {
+            session: Some(self),
+        })
+    }
+
+    fn activate(&mut self) -> anyhow::Result<()> {
+        if self.active {
+            return Ok(());
+        }
+        if let Err(err) = activate_writer(self.terminal.backend_mut(), self.features) {
+            deactivate_writer_best_effort(self.terminal.backend_mut(), self.features.mouse_enabled);
+            return Err(err);
+        }
+        self.active = true;
+        Ok(())
+    }
+
+    fn deactivate(&mut self) -> anyhow::Result<()> {
+        if !self.active {
+            return Ok(());
+        }
         deactivate_writer(self.terminal.backend_mut(), self.features.mouse_enabled)?;
         self.active = false;
         Ok(())
@@ -109,6 +141,41 @@ impl<W: Write> Drop for TerminalSession<W> {
         if self.active {
             deactivate_writer_best_effort(self.terminal.backend_mut(), self.features.mouse_enabled);
             self.active = false;
+        }
+    }
+}
+
+/// Guard for a temporarily suspended TUI terminal session.
+///
+/// Holding this value means tuicr has left raw mode and the alternate screen so
+/// another foreground process can use the terminal.
+/// Dropping the guard re-enters TUI mode on a best-effort basis.
+pub struct TerminalSuspension<'a, W: Write> {
+    session: Option<&'a mut TerminalSession<W>>,
+}
+
+impl<W: Write> TerminalSuspension<'_, W> {
+    /// Re-enters TUI terminal mode and consumes the suspension guard.
+    ///
+    /// Calling this explicit method is preferred on the normal path because it
+    /// reports terminal restoration failures to the caller.
+    pub fn resume(mut self) -> anyhow::Result<()> {
+        let Some(session) = self.session.take() else {
+            return Ok(());
+        };
+        session.activate()?;
+        session.terminal.clear()?;
+        Ok(())
+    }
+}
+
+impl<W: Write> Drop for TerminalSuspension<'_, W> {
+    fn drop(&mut self) {
+        let Some(session) = self.session.take() else {
+            return;
+        };
+        if session.activate().is_ok() {
+            let _ = session.terminal.clear();
         }
     }
 }

--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -1,0 +1,167 @@
+use std::io::{self, Write};
+
+use crossterm::{
+    event::{
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Frame, Terminal, backend::CrosstermBackend};
+
+/// Terminal capabilities enabled for one tuicr TUI session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TerminalFeatures {
+    mouse_enabled: bool,
+    keyboard_enhancements_supported: bool,
+}
+
+impl TerminalFeatures {
+    /// Returns an empty feature set for a terminal session.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Configures whether mouse capture should be active in the TUI.
+    pub fn mouse_enabled(mut self, enabled: bool) -> Self {
+        self.mouse_enabled = enabled;
+        self
+    }
+
+    /// Configures whether keyboard enhancement flags should be pushed.
+    ///
+    /// tuicr only enables these flags after probing support because unsupported
+    /// terminals can echo the probe escape sequences into stdout.
+    pub fn keyboard_enhancements_supported(mut self, supported: bool) -> Self {
+        self.keyboard_enhancements_supported = supported;
+        self
+    }
+
+    /// Enters TUI terminal mode and returns the owning session.
+    pub fn enter<W: Write>(self, writer: W) -> anyhow::Result<TerminalSession<W>> {
+        TerminalSession::enter(writer, self)
+    }
+}
+
+/// Owns terminal mode changes for the active TUI.
+///
+/// `TerminalSession` is the boundary that keeps raw mode,
+/// alternate-screen state,
+/// mouse capture,
+/// bracketed paste,
+/// and keyboard enhancement flags paired with the ratatui terminal.
+/// Dropping the session performs a best-effort restore so early returns do not
+/// leave the user's terminal in TUI mode.
+pub struct TerminalSession<W: Write> {
+    terminal: Terminal<CrosstermBackend<W>>,
+    features: TerminalFeatures,
+    active: bool,
+}
+
+impl<W: Write> TerminalSession<W> {
+    fn enter(writer: W, features: TerminalFeatures) -> anyhow::Result<Self> {
+        let backend = CrosstermBackend::new(writer);
+        let mut terminal = Terminal::new(backend)?;
+        if let Err(err) = activate_writer(terminal.backend_mut(), features) {
+            deactivate_writer_best_effort(terminal.backend_mut(), features.mouse_enabled);
+            return Err(err);
+        }
+        Ok(Self {
+            terminal,
+            features,
+            active: true,
+        })
+    }
+
+    /// Draws one frame while the TUI terminal session is active.
+    pub fn draw<F>(&mut self, render_callback: F) -> std::io::Result<()>
+    where
+        F: FnOnce(&mut Frame),
+    {
+        self.terminal.draw(render_callback).map(|_| ())
+    }
+
+    /// Returns the terminal backend for low-level terminal commands.
+    ///
+    /// This is used for synchronized-update escape sequences that ratatui does
+    /// not manage directly.
+    pub fn backend_mut(&mut self) -> &mut CrosstermBackend<W> {
+        self.terminal.backend_mut()
+    }
+
+    /// Restores the terminal state for the normal exit path.
+    ///
+    /// After this succeeds,
+    /// dropping the session will not attempt a second restore.
+    pub fn restore(&mut self) -> anyhow::Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        deactivate_writer(self.terminal.backend_mut(), self.features.mouse_enabled)?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl<W: Write> Drop for TerminalSession<W> {
+    fn drop(&mut self) {
+        if self.active {
+            deactivate_writer_best_effort(self.terminal.backend_mut(), self.features.mouse_enabled);
+            self.active = false;
+        }
+    }
+}
+
+/// Restores terminal mode on stdout without requiring a live session object.
+///
+/// This is intended for panic hooks,
+/// where ownership may already be unwinding and the session value might not be
+/// reachable.
+pub fn restore_stdio_best_effort() {
+    let mut stdout = io::stdout();
+    deactivate_writer_best_effort(&mut stdout, true);
+}
+
+fn activate_writer<W: Write>(writer: &mut W, features: TerminalFeatures) -> anyhow::Result<()> {
+    enable_raw_mode()?;
+    execute!(writer, EnterAlternateScreen)?;
+    if features.mouse_enabled {
+        execute!(writer, EnableMouseCapture)?;
+    }
+
+    // Bracketed paste makes multi-line and control-character pastes arrive as
+    // one `Event::Paste` instead of letting each character drive normal-mode
+    // actions like Enter submit or command-mode entry.
+    execute!(writer, EnableBracketedPaste)?;
+
+    // REPORT_EVENT_TYPES distinguishes Press from Repeat from Release so the
+    // two-press file walk can require an actual key release between presses.
+    // Without it, terminals emit Press for every auto-repeat tick,
+    // and held j/k could walk past file boundaries.
+    if features.keyboard_enhancements_supported {
+        let _ = execute!(
+            writer,
+            PushKeyboardEnhancementFlags(
+                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES,
+            )
+        );
+    }
+    Ok(())
+}
+
+fn deactivate_writer<W: Write>(writer: &mut W, mouse_enabled: bool) -> anyhow::Result<()> {
+    let _ = execute!(writer, PopKeyboardEnhancementFlags);
+    let _ = execute!(writer, DisableBracketedPaste);
+    if mouse_enabled {
+        let _ = execute!(writer, DisableMouseCapture);
+    }
+    disable_raw_mode()?;
+    execute!(writer, LeaveAlternateScreen)?;
+    Ok(())
+}
+
+fn deactivate_writer_best_effort<W: Write>(writer: &mut W, mouse_enabled: bool) {
+    let _ = deactivate_writer(writer, mouse_enabled);
+}

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -114,13 +114,6 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
-                "  e         ",
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("Open focused file in $EDITOR"),
-        ]),
-        Line::from(vec![
-            Span::styled(
                 "  S-Enter   ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
@@ -551,6 +544,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
             Span::raw(
                 "Reload diff files and comments (in PR mode: refetch PR; may switch session)",
             ),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :edit     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open focused file in $EDITOR"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -114,6 +114,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  e         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open focused file in $EDITOR"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  S-Enter   ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
Reviewers can press `e` in normal mode to open the focused
file in `$EDITOR` without leaving tuicr.

The shortcut resolves file-list selections and diff cursor
locations to local worktree files.
Known editors receive best-effort line navigation,
while unknown editors still open the file path.

This required adding one dependency, shlex,
to parse $EDITOR and determine the editor type.
In the future, a configuration could allow specifying
the editor command with a custom template.

---

This PR contains two commits for review clarity:

- First commit refactors terminal session state management
  into a new `TerminalSession` struct.
  This allows easily (and DRYly) adding support for
  suspending terminal session state to shell out to the editor.
- Second commit implements the editor feature.

---

Demo:

<img width="1047" height="785" alt="tuicr-editor" src="https://github.com/user-attachments/assets/c8f9d4c0-6e0f-4c3b-a4b8-02fcfbd2ab6b" />

