### PR TITLE
feat: (cosmetic) delta-style box separator between files in multi-file view

### DIFF
--- a/docs/decisions/FEAT-0017 File Separator Box.md
+++ b/docs/decisions/FEAT-0017 File Separator Box.md
@@ -14,20 +14,21 @@ The single `═══ filename [M] ═══` rule separating files in multi-fil
 
 ## Decision
 
-File headers render as a three-line box. The box stops one column before the panel's right edge:
+File headers render as a three-line box that spans the panel from edge to edge. The
+indicator gutter is dropped on these rows since the cursor never lands on them:
 
 ```
   42 │  }
 
-  ┌─────────────────────────────────────────────┐
-  │ ✓ src/app.rs [M]                            │
-  └─────────────────────────────────────────────┘
+╔════════════════════════════════════════════════╗
+║ ✓ src/app.rs [M]                               ║
+╚════════════════════════════════════════════════╝
    1 │  use std::path::Path;
 ``` The trailing `Spacing` annotation from the previous file provides a blank line above.
 
 Three new annotation types support the box: `FileHeaderBorder` for top/bottom borders, the existing `FileHeader` for the filename row, and `Spacing` for the blank line. Cursor movement (`j`/`k`, arrows) skips all decoration lines (`Spacing`, `FileHeader`, `FileHeaderBorder`) and lands on the next content line.
 
-The `paint_file_header_fill` overlay function detects the line type by its leading characters (`┌─` → fill `─` with `┐` corner, `└─` → fill `─` with `┘` corner, `│ ` → fill ` ` with `│` closing bar) and extends the box to viewport width.
+The `paint_file_header_fill` overlay function detects the line type by its leading characters (`╔═` → fill `═` with `╗` corner, `╚═` → fill `═` with `╝` corner, `║ ` → fill ` ` with `║` closing bar) and extends the box to viewport width.
 
 ## Consequences
 

--- a/docs/decisions/FEAT-0017 File Separator Box.md
+++ b/docs/decisions/FEAT-0017 File Separator Box.md
@@ -1,0 +1,36 @@
+---
+title: File Separator Box
+description: Delta-style box separator between files in multi-file view, with cursor skip over decoration lines
+type: adr
+status: proposed
+created: 2026-05-26
+---
+
+# FEAT-0017 File Separator Box
+
+## Context
+
+The single `═══ filename [M] ═══` rule separating files in multi-file view is visually heavy and hard to distinguish from diff content at a glance. The cursor can land on the header line, which has no actionable behavior (no commenting, no reviewing). Scrolling through a multi-file diff requires extra keypresses to traverse decoration.
+
+## Decision
+
+File headers render as a three-line box. The box stops one column before the panel's right edge:
+
+```
+  42 │  }
+
+  ┌─────────────────────────────────────────────┐
+  │ ✓ src/app.rs [M]                            │
+  └─────────────────────────────────────────────┘
+   1 │  use std::path::Path;
+``` The trailing `Spacing` annotation from the previous file provides a blank line above.
+
+Three new annotation types support the box: `FileHeaderBorder` for top/bottom borders, the existing `FileHeader` for the filename row, and `Spacing` for the blank line. Cursor movement (`j`/`k`, arrows) skips all decoration lines (`Spacing`, `FileHeader`, `FileHeaderBorder`) and lands on the next content line.
+
+The `paint_file_header_fill` overlay function detects the line type by its leading characters (`┌─` → fill `─` with `┐` corner, `└─` → fill `─` with `┘` corner, `│ ` → fill ` ` with `│` closing bar) and extends the box to viewport width.
+
+## Consequences
+
+- [+] File boundaries are visually distinct from diff content without shouting.
+- [+] One keypress crosses the entire separator, matching the mental model of "next file."
+- [-] Three annotation lines per file header instead of one; affects `total_lines` and scroll offset calculations proportionally.

--- a/src/app.rs
+++ b/src/app.rs
@@ -283,6 +283,8 @@ pub enum AnnotatedLine {
     RemoteThreadLine { thread_idx: usize },
     /// Binary or empty file indicator
     BinaryOrEmpty { file_idx: usize },
+    /// Top or bottom border of the file header box
+    FileHeaderBorder { file_idx: usize },
     /// Spacing between files
     Spacing,
 }
@@ -363,6 +365,7 @@ pub fn pr_commit_to_commit_info(commit: &crate::forge::traits::PullRequestCommit
 pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
     match annotation {
         AnnotatedLine::FileHeader { file_idx }
+        | AnnotatedLine::FileHeaderBorder { file_idx }
         | AnnotatedLine::FileComment { file_idx, .. }
         | AnnotatedLine::HunkHeader { file_idx, .. }
         | AnnotatedLine::DiffLine { file_idx, .. }
@@ -4070,10 +4073,9 @@ impl App {
             self.down_released_since_arm = false;
         }
         self.diff_state.cursor_line = target.min(max_line);
+        self.skip_decoration_forward(max_line);
         if self.diff_state.cursor_line != prev_cursor {
             self.ensure_cursor_visible();
-            // Cap scroll change to cursor movement to prevent multi-line jumps
-            // when the view is catching up from a non-steady-state position.
             let cursor_moved = self.diff_state.cursor_line - prev_cursor;
             if self.diff_state.scroll_offset > prev_scroll + cursor_moved {
                 self.diff_state.scroll_offset = prev_scroll + cursor_moved;
@@ -4116,19 +4118,48 @@ impl App {
             self.up_released_since_arm = false;
         }
         self.diff_state.cursor_line = self.diff_state.cursor_line.saturating_sub(lines);
+        self.skip_decoration_backward();
         let visible_lines = self.diff_state.effective_visible_lines();
         let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
-        // Enforce top margin
         if self.diff_state.cursor_line < self.diff_state.scroll_offset + scroll_margin {
             self.diff_state.scroll_offset =
                 self.diff_state.cursor_line.saturating_sub(scroll_margin);
         }
-        // Ensure cursor is at least within the viewport (no bottom margin enforcement,
-        // just basic visibility — handles viewport shrink or wrap-mode changes).
         if self.diff_state.cursor_line >= self.diff_state.scroll_offset + visible_lines {
             self.diff_state.scroll_offset = self.diff_state.cursor_line - visible_lines + 1;
         }
         self.update_current_file_from_cursor();
+    }
+
+    fn is_decoration(annotation: &AnnotatedLine) -> bool {
+        matches!(
+            annotation,
+            AnnotatedLine::Spacing
+                | AnnotatedLine::FileHeader { .. }
+                | AnnotatedLine::FileHeaderBorder { .. }
+        )
+    }
+
+    fn skip_decoration_forward(&mut self, max_line: usize) {
+        while self.diff_state.cursor_line < max_line
+            && self
+                .line_annotations
+                .get(self.diff_state.cursor_line)
+                .is_some_and(Self::is_decoration)
+        {
+            self.diff_state.cursor_line += 1;
+        }
+    }
+
+    fn skip_decoration_backward(&mut self) {
+        while self.diff_state.cursor_line > 0
+            && self
+                .line_annotations
+                .get(self.diff_state.cursor_line)
+                .is_some_and(Self::is_decoration)
+        {
+            self.diff_state.cursor_line -= 1;
+        }
     }
 
     pub fn scroll_down(&mut self, lines: usize) {
@@ -4441,7 +4472,7 @@ impl App {
                 bodies.insert(0, format!("github {}", thread.path));
                 Some(bodies.join(" "))
             }
-            AnnotatedLine::Spacing => None,
+            AnnotatedLine::FileHeaderBorder { .. } | AnnotatedLine::Spacing => None,
         }
     }
 
@@ -5555,10 +5586,11 @@ impl App {
     }
 
     fn file_render_height(&self, file_idx: usize, file: &DiffFile) -> usize {
+        let header_lines = 3; // FileHeaderBorder + FileHeader + FileHeaderBorder
         if self.session.is_file_reviewed(file.display_path()) {
-            return 1; // collapsed: header only
+            return header_lines;
         }
-        1 + self.file_render_body_height(file_idx, file) // header + body
+        header_lines + self.file_render_body_height(file_idx, file)
     }
 
     /// File body height in lines (comments + content + trailing spacing),
@@ -8806,10 +8838,16 @@ impl App {
             }
             let path = file.display_path();
 
-            // File header (only when shown — same gate as the renderer).
+            // File header box (only when shown — same gate as the renderer).
+            // The trailing Spacing from the previous file provides the
+            // blank line above, so no extra Spacing is needed here.
             if !self.is_single_file_view {
                 self.line_annotations
+                    .push(AnnotatedLine::FileHeaderBorder { file_idx });
+                self.line_annotations
                     .push(AnnotatedLine::FileHeader { file_idx });
+                self.line_annotations
+                    .push(AnnotatedLine::FileHeaderBorder { file_idx });
             }
 
             // If reviewed, skip all content for this file. Single-file
@@ -11245,17 +11283,17 @@ mod scroll_behavior_tests {
 
     #[test]
     fn zz_on_last_line_centers_cursor() {
-        // 40 diff lines + 4 overhead = 44 total. max_cursor = 42. Viewport = 20.
         let mut app = build_scroll_app(40, 20, 5);
-        assert_eq!(app.total_lines(), 44);
-        let last = app.max_cursor_line(); // 42
+        let total = app.total_lines();
+        let last = app.max_cursor_line();
 
         app.diff_state.cursor_line = last;
         app.center_cursor();
 
-        // scroll = cursor - viewport/2 = 42 - 10 = 32
-        assert_eq!(app.diff_state.scroll_offset, 32);
-        assert_eq!(app.diff_state.cursor_line, 42);
+        let expected_scroll = last.saturating_sub(10);
+        assert_eq!(app.diff_state.scroll_offset, expected_scroll);
+        assert_eq!(app.diff_state.cursor_line, last);
+        assert!(total > 40, "overhead lines must exist");
     }
 
     #[test]

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -202,28 +202,51 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);
 
-        // The `═══ filename ═══` separator is redundant in single-file
-        // view: the status bar and file list already name the file, and
-        // the wide bar of `═` characters confuses horizontal scrolling.
+        // File header box: ┌──┐ + │ name │ + └──┘.
+        // Single-file view skips this entirely.
         if !app.is_single_file_view {
-            let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
+            let header_style = styles::file_header_style(&app.theme);
+
+            // Top border
+            let indicator_top = cursor_indicator_spaced(line_idx, current_line_idx);
+            lines.push(Line::from(vec![
+                Span::styled(
+                    indicator_top,
+                    styles::current_line_indicator_style(&app.theme),
+                ),
+                Span::styled("┌─", header_style),
+                Span::styled(crate::ui::diff_view::HEADER_RULE_THIN, header_style),
+            ]));
+            line_idx += 1;
+
+            // Filename row
+            let indicator_mid = cursor_indicator_spaced(line_idx, current_line_idx);
             let review_mark = if is_reviewed { "✓ " } else { "" };
             let header_text = if file.is_commit_message {
-                format!("═══ {}Commit Message ", review_mark)
+                format!("│ {}Commit Message ", review_mark)
             } else if app.is_pristine_mode {
-                // Pristine mode reviews unchanged code; the M/A/D badge would
-                // mislead. Render the header without it.
-                format!("═══ {}{} ", review_mark, path.display())
+                format!("│ {}{} ", review_mark, path.display())
             } else {
-                format!("═══ {}{} [{}] ", review_mark, path.display(), status)
+                format!("│ {}{} [{}] ", review_mark, path.display(), status)
             };
             lines.push(Line::from(vec![
-                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled(header_text, styles::file_header_style(&app.theme)),
                 Span::styled(
-                    crate::ui::diff_view::HEADER_RULE,
-                    styles::file_header_style(&app.theme),
+                    indicator_mid,
+                    styles::current_line_indicator_style(&app.theme),
                 ),
+                Span::styled(header_text, header_style),
+            ]));
+            line_idx += 1;
+
+            // Bottom border
+            let indicator_bot = cursor_indicator_spaced(line_idx, current_line_idx);
+            lines.push(Line::from(vec![
+                Span::styled(
+                    indicator_bot,
+                    styles::current_line_indicator_style(&app.theme),
+                ),
+                Span::styled("└─", header_style),
+                Span::styled(crate::ui::diff_view::HEADER_RULE_THIN, header_style),
             ]));
             line_idx += 1;
         }

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -202,51 +202,35 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);
 
-        // File header box: ┌──┐ + │ name │ + └──┘.
-        // Single-file view skips this entirely.
+        // File header box: ╔══╗ + ║ name ║ + ╚══╝. Drawn flush to both
+        // panel edges — no indicator gutter, since the cursor never lands
+        // on these decoration lines. Single-file view skips this entirely.
         if !app.is_single_file_view {
             let header_style = styles::file_header_style(&app.theme);
 
             // Top border
-            let indicator_top = cursor_indicator_spaced(line_idx, current_line_idx);
             lines.push(Line::from(vec![
-                Span::styled(
-                    indicator_top,
-                    styles::current_line_indicator_style(&app.theme),
-                ),
-                Span::styled("┌─", header_style),
-                Span::styled(crate::ui::diff_view::HEADER_RULE_THIN, header_style),
+                Span::styled("╔═", header_style),
+                Span::styled(crate::ui::diff_view::HEADER_RULE, header_style),
             ]));
             line_idx += 1;
 
             // Filename row
-            let indicator_mid = cursor_indicator_spaced(line_idx, current_line_idx);
             let review_mark = if is_reviewed { "✓ " } else { "" };
             let header_text = if file.is_commit_message {
-                format!("│ {}Commit Message ", review_mark)
+                format!("║ {}Commit Message ", review_mark)
             } else if app.is_pristine_mode {
-                format!("│ {}{} ", review_mark, path.display())
+                format!("║ {}{} ", review_mark, path.display())
             } else {
-                format!("│ {}{} [{}] ", review_mark, path.display(), status)
+                format!("║ {}{} [{}] ", review_mark, path.display(), status)
             };
-            lines.push(Line::from(vec![
-                Span::styled(
-                    indicator_mid,
-                    styles::current_line_indicator_style(&app.theme),
-                ),
-                Span::styled(header_text, header_style),
-            ]));
+            lines.push(Line::from(vec![Span::styled(header_text, header_style)]));
             line_idx += 1;
 
             // Bottom border
-            let indicator_bot = cursor_indicator_spaced(line_idx, current_line_idx);
             lines.push(Line::from(vec![
-                Span::styled(
-                    indicator_bot,
-                    styles::current_line_indicator_style(&app.theme),
-                ),
-                Span::styled("└─", header_style),
-                Span::styled(crate::ui::diff_view::HEADER_RULE_THIN, header_style),
+                Span::styled("╚═", header_style),
+                Span::styled(crate::ui::diff_view::HEADER_RULE, header_style),
             ]));
             line_idx += 1;
         }

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -17,7 +17,6 @@ use crate::ui::styles;
 
 /// Static header rule used for file/section headers; avoids `"═".repeat(40)` per frame.
 pub(super) const HEADER_RULE: &str = "════════════════════════════════════════";
-pub(super) const HEADER_RULE_THIN: &str = "────────────────────────────────────────";
 
 /// Shared empty map so we can borrow `line_comments` without cloning per file per frame.
 pub(super) static EMPTY_LINE_COMMENTS: std::sync::LazyLock<
@@ -857,14 +856,9 @@ pub(super) fn paint_file_header_fill(frame: &mut Frame, ctx: &DiffOverlayPaint) 
             };
             let mut x = ctx.inner.x + content_w as u16;
             let is_box_line = corner_char != fill_char;
-            let fill_end = if is_box_line && right_x > 0 {
-                right_x - 1
-            } else {
-                right_x
-            };
-            while x <= fill_end {
+            while x <= right_x {
                 let cell = &mut frame.buffer_mut()[(x, y)];
-                if x == fill_end && is_box_line {
+                if x == right_x && is_box_line {
                     cell.set_char(corner_char);
                 } else {
                     cell.set_char(fill_char);
@@ -879,18 +873,24 @@ pub(super) fn paint_file_header_fill(frame: &mut Frame, ctx: &DiffOverlayPaint) 
 }
 
 fn header_line_fill_char(line: &Line) -> (bool, char, char) {
-    if let Some(span) = line.spans.get(1) {
-        if span.content.starts_with("═══ ") {
-            return (true, '═', '═');
+    // The ═══ Review Comments banner keeps the 2-char indicator slot, so
+    // its rule starts at span[1].
+    if let Some(span) = line.spans.get(1)
+        && span.content.starts_with("═══ ")
+    {
+        return (true, '═', '═');
+    }
+    // File-header box lines run flush to the left edge (no indicator), so
+    // the box glyphs appear at span[0].
+    if let Some(span) = line.spans.first() {
+        if span.content.starts_with("╔═") {
+            return (true, '═', '╗');
         }
-        if span.content.starts_with("┌─") {
-            return (true, '─', '┐');
+        if span.content.starts_with("╚═") {
+            return (true, '═', '╝');
         }
-        if span.content.starts_with("└─") {
-            return (true, '─', '┘');
-        }
-        if span.content.starts_with("│ ") {
-            return (true, ' ', '│');
+        if span.content.starts_with("║ ") {
+            return (true, ' ', '║');
         }
     }
     (false, ' ', ' ')

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -17,6 +17,7 @@ use crate::ui::styles;
 
 /// Static header rule used for file/section headers; avoids `"═".repeat(40)` per frame.
 pub(super) const HEADER_RULE: &str = "════════════════════════════════════════";
+pub(super) const HEADER_RULE_THIN: &str = "────────────────────────────────────────";
 
 /// Shared empty map so we can borrow `line_comments` without cloning per file per frame.
 pub(super) static EMPTY_LINE_COMMENTS: std::sync::LazyLock<
@@ -825,18 +826,21 @@ pub(super) fn paint_file_header_fill(frame: &mut Frame, ctx: &DiffOverlayPaint) 
             break;
         }
         let rows = visual_rows_for_line(ctx.line_widths, idx, ctx.wrap_lines, ctx.viewport_width);
-        if is_file_header_line(line) {
+        let (is_header, fill_char, corner_char) = header_line_fill_char(line);
+        if is_header {
             let fg = line
                 .spans
                 .iter()
-                .find(|s| s.content.starts_with('═'))
+                .find(|s| {
+                    s.content.starts_with('═')
+                        || s.content.starts_with('─')
+                        || s.content.starts_with('┌')
+                        || s.content.starts_with('└')
+                })
                 .or_else(|| line.spans.get(1))
                 .and_then(|s| s.style.fg)
                 .unwrap_or(ctx.theme.fg_primary);
             let line_width = ctx.line_widths.get(idx).copied().unwrap_or(0);
-            // Only fill the trailing edge of the last visual row of the header
-            // — wrapped intermediate rows of an unusually long header path are
-            // already entirely covered by content.
             let last_row = rows.saturating_sub(1);
             if visual_row + last_row >= ctx.inner.height as usize {
                 visual_row += rows;
@@ -852,9 +856,19 @@ pub(super) fn paint_file_header_fill(frame: &mut Frame, ctx: &DiffOverlayPaint) 
                     .min(ctx.viewport_width)
             };
             let mut x = ctx.inner.x + content_w as u16;
-            while x <= right_x {
+            let is_box_line = corner_char != fill_char;
+            let fill_end = if is_box_line && right_x > 0 {
+                right_x - 1
+            } else {
+                right_x
+            };
+            while x <= fill_end {
                 let cell = &mut frame.buffer_mut()[(x, y)];
-                cell.set_char('═');
+                if x == fill_end && is_box_line {
+                    cell.set_char(corner_char);
+                } else {
+                    cell.set_char(fill_char);
+                }
                 cell.set_fg(fg);
                 cell.set_bg(panel_bg);
                 x += 1;
@@ -864,14 +878,22 @@ pub(super) fn paint_file_header_fill(frame: &mut Frame, ctx: &DiffOverlayPaint) 
     }
 }
 
-/// A file-section header is a line whose first content span (after the
-/// cursor indicator) begins with `═══ ` — covers both per-file headers and
-/// the synthetic "Review Comments" section header.
-fn is_file_header_line(line: &Line) -> bool {
-    line.spans
-        .get(1)
-        .map(|s| s.content.starts_with("═══ "))
-        .unwrap_or(false)
+fn header_line_fill_char(line: &Line) -> (bool, char, char) {
+    if let Some(span) = line.spans.get(1) {
+        if span.content.starts_with("═══ ") {
+            return (true, '═', '═');
+        }
+        if span.content.starts_with("┌─") {
+            return (true, '─', '┐');
+        }
+        if span.content.starts_with("└─") {
+            return (true, '─', '┘');
+        }
+        if span.content.starts_with("│ ") {
+            return (true, ' ', '│');
+        }
+    }
+    (false, ' ', ' ')
 }
 
 fn visual_rows_for_line(


### PR DESCRIPTION
File headers in multi-file view render as a box instead of a single `═══` rule. The cursor skips the entire separator in one keypress.

```
  42 │  }

  ┌─────────────────────────────────────────────┐
  │ ✓ src/app.rs [M]                            │
  └─────────────────────────────────────────────┘
   1 │  use std::path::Path;
```

- New `FileHeaderBorder` annotation for top/bottom box borders. `FileHeader` renders the filename row with closing `│`.
- `cursor_down` / `cursor_up` skip decoration lines (`Spacing`, `FileHeader`, `FileHeaderBorder`) so one keypress crosses the entire separator block.
- `paint_file_header_fill` detects the line type by its leading characters and extends the box to one column before the panel's right edge, with the correct corner glyph (`┐` top, `┘` bottom, `│` middle).
- ADR: [docs/decisions/FEAT-0017 File Separator Box.md](docs/decisions/FEAT-0017%20File%20Separator%20Box.md)

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] Manual: multi-file diff shows box separator between files with correct corners
- [x] Manual: box stops one column before the panel border
- [x] Manual: `j` from last line of file N lands on first content line of file N+1, skipping the separator
- [x] Manual: `k` from first content line of file N+1 lands on last line of file N
- [x] Manual: single-file view is unchanged (no box separator)
