### PR TITLE
feat: (cosmetic) nicer word wrap

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -35,7 +35,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec::new(&["version"], CommandKind::Version),
     CommandSpec::new(&["update"], CommandKind::Update),
     CommandSpec::new(&["set wrap"], CommandKind::SetWrap),
-    CommandSpec::new(&["set wrap!"], CommandKind::ToggleWrap),
+    CommandSpec::new(&["wrap", "set wrap!"], CommandKind::ToggleWrap),
     CommandSpec::new(&["set commits"], CommandKind::SetCommitsVisible(true)),
     CommandSpec::new(&["set nocommits"], CommandKind::SetCommitsVisible(false)),
     CommandSpec::new(&["set commits!"], CommandKind::ToggleCommits),

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::{Block, Borders, Paragraph},
 };
 use unicode_width::UnicodeWidthStr;
 
@@ -1071,10 +1071,25 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
     let scroll_offset = app.diff_state.scroll_offset;
     let wrap = app.diff_state.wrap_lines;
+    let gutter_width = lw + 4;
+    let wrap_effective_width = if wrap {
+        let content_width = (inner.width as usize).saturating_sub(gutter_width);
+        content_width.max(1)
+    } else {
+        inner.width as usize
+    };
+    let wrap_adjusted_widths: Vec<usize> = if wrap {
+        line_widths
+            .iter()
+            .map(|w| w.saturating_sub(gutter_width))
+            .collect()
+    } else {
+        line_widths.clone()
+    };
     app.diff_state.visible_line_count = populate_row_to_annotation(
         &mut app.diff_row_to_annotation,
-        &line_widths,
-        inner.width as usize,
+        &wrap_adjusted_widths,
+        wrap_effective_width,
         inner.height as usize,
         wrap,
         scroll_offset,
@@ -1091,7 +1106,12 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     let scroll_x = app.diff_state.scroll_x;
     let visible_lines_unscrolled_for_bg = visible_lines_unscrolled.clone();
     let visible_lines: Vec<Line> = if app.diff_state.wrap_lines {
-        visible_lines_unscrolled
+        crate::ui::word_wrap::expand_wrapped_lines(
+            visible_lines_unscrolled,
+            gutter_width,
+            inner.width as usize,
+            &app.theme,
+        )
     } else {
         visible_lines_unscrolled
             .into_iter()
@@ -1104,18 +1124,18 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         frame,
         inner,
         &visible_lines_unscrolled_for_bg,
-        &line_widths,
+        &wrap_adjusted_widths,
         app.diff_state.wrap_lines,
-        inner.width as usize,
+        wrap_effective_width,
         |_idx, line| unified_line_bg_style(line, &app.theme),
     );
 
     let overlay_ctx = crate::ui::diff_view::DiffOverlayPaint {
         inner,
         visible_lines_unscrolled: &visible_lines_unscrolled_for_bg,
-        line_widths: &line_widths,
+        line_widths: &wrap_adjusted_widths,
         wrap_lines: app.diff_state.wrap_lines,
-        viewport_width: inner.width as usize,
+        viewport_width: wrap_effective_width,
         scroll_x,
         scroll_offset: app.diff_state.scroll_offset,
         theme: &app.theme,
@@ -1127,11 +1147,9 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     // on the active row.
     crate::ui::diff_view::paint_section_highlight(frame, &overlay_ctx);
 
-    // Keep paragraph bg unset so pre-painted per-row diff backgrounds remain visible.
-    let mut diff = Paragraph::new(visible_lines).style(Style::default().fg(app.theme.fg_primary));
-    if app.diff_state.wrap_lines {
-        diff = diff.wrap(Wrap { trim: false });
-    }
+    // Pre-expanded wrap lines are already sized to the viewport; no Ratatui
+    // Wrap needed. Non-wrap mode passes Lines through as-is.
+    let diff = Paragraph::new(visible_lines).style(Style::default().fg(app.theme.fg_primary));
     frame.render_widget(diff, inner);
 
     // Cursor-line bg has to land after the paragraph: spans on +/- lines carry
@@ -1141,9 +1159,9 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             frame,
             inner,
             &visible_lines_unscrolled_for_bg,
-            &line_widths,
+            &wrap_adjusted_widths,
             app.diff_state.wrap_lines,
-            inner.width as usize,
+            wrap_effective_width,
             |idx, _line| {
                 is_line_highlighted(app, idx).then(|| Style::default().bg(app.theme.cursor_line_bg))
             },
@@ -1177,19 +1195,15 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
             // Calculate visual row by summing wrapped line heights
             let mut visual_row: u16 = 0;
-            let viewport_width = inner.width as usize;
 
-            if app.diff_state.wrap_lines && viewport_width > 0 {
-                // Calculate how many visual rows the lines before cursor take
-                // Note: line_widths is indexed from 0 and corresponds to visible lines
-                // (i.e., line_widths[0] is the first visible line after scroll)
+            if app.diff_state.wrap_lines && wrap_effective_width > 0 {
                 for i in 0..logical_offset {
-                    if i < line_widths.len() {
-                        let width = line_widths[i];
+                    if i < wrap_adjusted_widths.len() {
+                        let width = wrap_adjusted_widths[i];
                         let rows = if width == 0 {
                             1
                         } else {
-                            width.div_ceil(viewport_width)
+                            width.div_ceil(wrap_effective_width)
                         };
                         visual_row += rows as u16;
                     } else {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,5 +13,6 @@ pub mod status_bar;
 pub mod styles;
 pub mod submit_modals;
 pub mod text_utils;
+pub mod word_wrap;
 
 pub use app_layout::render;

--- a/src/ui/word_wrap.rs
+++ b/src/ui/word_wrap.rs
@@ -1,0 +1,163 @@
+use ratatui::text::{Line, Span};
+use unicode_width::UnicodeWidthStr;
+
+use crate::theme::Theme;
+use crate::ui::styles;
+
+pub(super) fn expand_wrapped_lines<'a>(
+    logical_lines: Vec<Line<'a>>,
+    gutter_width: usize,
+    viewport_width: usize,
+    theme: &Theme,
+) -> Vec<Line<'a>> {
+    let content_width = viewport_width.saturating_sub(gutter_width);
+    if content_width == 0 {
+        return logical_lines;
+    }
+
+    let mut expanded = Vec::new();
+
+    for line in logical_lines {
+        let total_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
+        if total_width <= viewport_width {
+            expanded.push(line);
+            continue;
+        }
+
+        let (gutter_spans, content_spans) = split_spans_at_width(&line.spans, gutter_width);
+        let content_text: String = content_spans.iter().map(|s| s.content.as_ref()).collect();
+        let content_text_width = content_text.width();
+
+        if content_text_width <= content_width {
+            expanded.push(line);
+            continue;
+        }
+
+        let mut byte_offset = 0;
+        let mut row_index = 0;
+
+        while byte_offset < content_text.len() {
+            let row_width_limit = content_width;
+            let mut row_end_byte = byte_offset;
+            let mut row_width = 0;
+
+            for character in content_text[byte_offset..].chars() {
+                let character_width =
+                    unicode_width::UnicodeWidthChar::width(character).unwrap_or(0);
+                if row_width + character_width > row_width_limit {
+                    break;
+                }
+                row_width += character_width;
+                row_end_byte += character.len_utf8();
+            }
+
+            if row_end_byte == byte_offset && byte_offset < content_text.len() {
+                let character = content_text[byte_offset..].chars().next().unwrap();
+                row_end_byte += character.len_utf8();
+            }
+
+            let row_spans = slice_spans_by_bytes(&content_spans, byte_offset, row_end_byte);
+
+            let row_line = if row_index == 0 {
+                let mut spans = gutter_spans.clone();
+                spans.extend(row_spans);
+                Line::from(spans)
+            } else {
+                let indicator_span = Span::styled(" ", styles::current_line_indicator_style(theme));
+                let linenum_width = gutter_width.saturating_sub(4);
+                let linenum_span = Span::styled(
+                    format!("{:>w$}↪", "", w = linenum_width),
+                    styles::dim_style(theme),
+                );
+                let prefix_span = gutter_spans
+                    .get(2)
+                    .cloned()
+                    .unwrap_or_else(|| Span::raw("  "));
+                let mut spans = vec![indicator_span, linenum_span, prefix_span];
+                spans.extend(row_spans);
+                Line::from(spans)
+            };
+
+            expanded.push(row_line);
+            byte_offset = row_end_byte;
+            row_index += 1;
+        }
+
+        if row_index == 0 {
+            expanded.push(line);
+        }
+    }
+
+    expanded
+}
+
+fn split_spans_at_width<'a>(
+    spans: &[Span<'a>],
+    split_width: usize,
+) -> (Vec<Span<'a>>, Vec<Span<'a>>) {
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    let mut consumed = 0;
+
+    for span in spans {
+        let span_width = span.content.width();
+        if consumed >= split_width {
+            right.push(span.clone());
+        } else if consumed + span_width <= split_width {
+            left.push(span.clone());
+            consumed += span_width;
+        } else {
+            let chars_needed = split_width - consumed;
+            let mut left_content = String::new();
+            let mut right_content = String::new();
+            let mut char_width = 0;
+            for character in span.content.chars() {
+                let cw = unicode_width::UnicodeWidthChar::width(character).unwrap_or(0);
+                if char_width + cw <= chars_needed {
+                    left_content.push(character);
+                    char_width += cw;
+                } else {
+                    right_content.push(character);
+                }
+            }
+            if !left_content.is_empty() {
+                left.push(Span::styled(left_content, span.style));
+            }
+            if !right_content.is_empty() {
+                right.push(Span::styled(right_content, span.style));
+            }
+            consumed = split_width;
+        }
+    }
+
+    (left, right)
+}
+
+fn slice_spans_by_bytes<'a>(spans: &[Span<'a>], start: usize, end: usize) -> Vec<Span<'a>> {
+    let mut result = Vec::new();
+    let mut position = 0;
+
+    for span in spans {
+        let span_start = position;
+        let span_end = position + span.content.len();
+
+        if span_end <= start || span_start >= end {
+            position = span_end;
+            continue;
+        }
+
+        let slice_start = start.saturating_sub(span_start);
+        let slice_end = (end - span_start).min(span.content.len());
+
+        if slice_start < slice_end && slice_start < span.content.len() {
+            let content = &span.content[slice_start..slice_end];
+            if !content.is_empty() {
+                result.push(Span::styled(content.to_string(), span.style));
+            }
+        }
+
+        position = span_end;
+    }
+
+    result
+}


### PR DESCRIPTION
Wrap mode pre-expands long lines manually instead of delegating to Ratatui's `Wrap`. Continuation rows preserve the gutter structure so line numbers and diff markers stay aligned.

```
  42 ▌ let very_long_variable_name = some_func
   ↪ ▌ tion_call(argument_one, argument_two,
   ↪ ▌ argument_three);
```

- Continuation rows show `↪` in the line-number column and preserve the diff origin marker (`▌`) so add/del coloring stays consistent across wrapped visual rows.
- Overlay painting (cursor highlight, visual selection, diff backgrounds) uses content-adjusted widths (viewport minus gutter) for row prediction, matching the pre-expansion break points exactly.
- `:wrap` toggles wrap on/off (alias for the existing `:set wrap!`).

## Test plan

- [x] `cargo fmt && cargo clippy -- -D warnings` clean
- [x] `cargo test --lib` passes (839 tests)
- [x] Manual: `:wrap` on a file with long lines shows `↪ ▌` on continuation rows, content aligned with original line
- [x] Manual: cursor-line highlight spans all visual rows of a wrapped line
- [x] Manual: visual selection (`V`) highlight tracks the cursor correctly on wrapped lines
- [x] Manual: toggling `:wrap` off restores horizontal scroll mode with no visual artifacts
