### PR TITLE
feat: tab cycle through comments, comment auto-follow, cursor decoration-skip

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -457,6 +457,34 @@ pub fn find_source_line(
     }
 }
 
+/// True for rendered lines the cursor should never rest on — spacing between
+/// files and file header rows.
+fn is_decoration(annotation: &AnnotatedLine) -> bool {
+    matches!(
+        annotation,
+        AnnotatedLine::Spacing | AnnotatedLine::FileHeader { .. }
+    )
+}
+
+/// Walk `start` forward (capped at `max_line`) to the nearest non-decoration
+/// annotation so scroll and jump motions land on actionable content.
+fn skip_decoration_forward(annotations: &[AnnotatedLine], start: usize, max_line: usize) -> usize {
+    let mut line = start;
+    while line < max_line && annotations.get(line).is_some_and(is_decoration) {
+        line += 1;
+    }
+    line
+}
+
+/// Walk `start` backward to the nearest non-decoration annotation.
+fn skip_decoration_backward(annotations: &[AnnotatedLine], start: usize) -> usize {
+    let mut line = start;
+    while line > 0 && annotations.get(line).is_some_and(is_decoration) {
+        line -= 1;
+    }
+    line
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
     Normal,
@@ -4434,6 +4462,11 @@ impl App {
         let max_line = self.max_cursor_line();
         let max_scroll = self.max_scroll_offset();
         self.diff_state.cursor_line = (self.diff_state.cursor_line + lines).min(max_line);
+        self.diff_state.cursor_line = skip_decoration_forward(
+            &self.line_annotations,
+            self.diff_state.cursor_line,
+            max_line,
+        );
         self.diff_state.scroll_offset = (self.diff_state.scroll_offset + lines).min(max_scroll);
         self.ensure_cursor_visible();
         self.update_current_file_from_cursor();
@@ -4442,6 +4475,8 @@ impl App {
     pub fn scroll_up(&mut self, lines: usize) {
         // For half-page/page scrolling, move both cursor and scroll
         self.diff_state.cursor_line = self.diff_state.cursor_line.saturating_sub(lines);
+        self.diff_state.cursor_line =
+            skip_decoration_backward(&self.line_annotations, self.diff_state.cursor_line);
         self.diff_state.scroll_offset = self.diff_state.scroll_offset.saturating_sub(lines);
         self.ensure_cursor_visible();
         self.update_current_file_from_cursor();
@@ -5640,6 +5675,11 @@ impl App {
             self.up_released_since_arm = false;
             self.diff_state.current_file_idx = idx;
             self.diff_state.cursor_line = self.calculate_file_scroll_offset(idx);
+            self.diff_state.cursor_line = skip_decoration_forward(
+                &self.line_annotations,
+                self.diff_state.cursor_line,
+                self.line_annotations.len().saturating_sub(1),
+            );
             let max_scroll = self.max_scroll_offset();
             self.diff_state.scroll_offset = self.diff_state.cursor_line.min(max_scroll);
 
@@ -12143,6 +12183,66 @@ mod scroll_behavior_tests {
         };
         let margin = state.effective_scroll_margin(0);
         assert_eq!(margin, 0, "margin should be 0 when scroll_offset is 0");
+    }
+}
+
+#[cfg(test)]
+mod decoration_skip_tests {
+    use super::*;
+
+    fn diff_line(file_idx: usize, new_lineno: u32) -> AnnotatedLine {
+        AnnotatedLine::DiffLine {
+            file_idx,
+            hunk_idx: 0,
+            line_idx: 0,
+            old_lineno: None,
+            new_lineno: Some(new_lineno),
+        }
+    }
+
+    /// Two files: header, content, spacing, header, content.
+    fn fixture() -> Vec<AnnotatedLine> {
+        vec![
+            AnnotatedLine::FileHeader { file_idx: 0 }, // 0
+            diff_line(0, 1),                           // 1
+            AnnotatedLine::Spacing,                    // 2
+            AnnotatedLine::FileHeader { file_idx: 1 }, // 3
+            diff_line(1, 1),                           // 4
+        ]
+    }
+
+    #[test]
+    fn forward_skips_spacing_and_header_to_next_content_line() {
+        let annotations = fixture();
+        assert_eq!(skip_decoration_forward(&annotations, 2, 4), 4);
+    }
+
+    #[test]
+    fn forward_keeps_position_on_content_line() {
+        let annotations = fixture();
+        assert_eq!(skip_decoration_forward(&annotations, 1, 4), 1);
+    }
+
+    #[test]
+    fn forward_clamps_at_max_line_even_on_decoration() {
+        let annotations = vec![
+            diff_line(0, 1),                           // 0
+            AnnotatedLine::Spacing,                    // 1
+            AnnotatedLine::FileHeader { file_idx: 1 }, // 2
+        ];
+        assert_eq!(skip_decoration_forward(&annotations, 1, 2), 2);
+    }
+
+    #[test]
+    fn backward_skips_header_and_spacing_to_previous_content_line() {
+        let annotations = fixture();
+        assert_eq!(skip_decoration_backward(&annotations, 3), 1);
+    }
+
+    #[test]
+    fn backward_stops_at_zero_when_top_is_decoration() {
+        let annotations = fixture();
+        assert_eq!(skip_decoration_backward(&annotations, 0), 0);
     }
 }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -33,10 +33,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         CommandKind::Clear(ClearScope::CommentsAndReviewed),
     ),
     CommandSpec::new(&["clearc"], CommandKind::Clear(ClearScope::CommentsOnly)),
+    CommandSpec::new(&["help", "h"], CommandKind::Help),
     CommandSpec::new(&["version"], CommandKind::Version),
     CommandSpec::new(&["update"], CommandKind::Update),
     CommandSpec::new(&["set wrap"], CommandKind::SetWrap),
     CommandSpec::new(&["set wrap!"], CommandKind::ToggleWrap),
+    CommandSpec::new(&["wrap"], CommandKind::ToggleWrap),
     CommandSpec::new(&["set commits"], CommandKind::SetCommitsVisible(true)),
     CommandSpec::new(&["set nocommits"], CommandKind::SetCommitsVisible(false)),
     CommandSpec::new(&["set commits!"], CommandKind::ToggleCommits),
@@ -103,6 +105,7 @@ enum CommandKind {
     Edit,
     Export,
     Clear(ClearScope),
+    Help,
     Version,
     Update,
     SetWrap,
@@ -747,6 +750,13 @@ fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
             app.clear_comments(scope);
             CommandAfterDispatch::ExitCommandMode
         }
+        CommandKind::Help => {
+            // Leave command mode by hand: the dispatch loop's ExitCommandMode
+            // path resets `input_mode` to Normal, which would clobber Help.
+            app.exit_command_mode();
+            app.toggle_help();
+            CommandAfterDispatch::KeepMode
+        }
         CommandKind::Version => {
             app.set_message(format!("tuicr v{}", env!("CARGO_PKG_VERSION")));
             CommandAfterDispatch::ExitCommandMode
@@ -1268,8 +1278,20 @@ pub fn handle_file_list_action(app: &mut App, action: Action) {
 /// Handle actions when the comment navigator panel is focused
 pub fn handle_comment_navigator_action(app: &mut App, action: Action) {
     match action {
-        Action::CursorDown(n) => app.comment_navigator_down(n),
-        Action::CursorUp(n) => app.comment_navigator_up(n),
+        Action::CursorDown(n) => {
+            app.comment_navigator_down(n);
+            // Auto-follow: scroll the diff to the selected comment without
+            // stealing focus from the navigator (Enter still jumps + focuses).
+            let saved_focus = app.focused_panel;
+            app.jump_to_selected_comment();
+            app.focused_panel = saved_focus;
+        }
+        Action::CursorUp(n) => {
+            app.comment_navigator_up(n);
+            let saved_focus = app.focused_panel;
+            app.jump_to_selected_comment();
+            app.focused_panel = saved_focus;
+        }
         Action::ScrollLeft(n) => app.comment_navigator_state.scroll_left(n),
         Action::ScrollRight(n) => app.comment_navigator_state.scroll_right(n),
         Action::MouseScrollDown(n) => app.comment_navigator_viewport_scroll_down(n),
@@ -1373,15 +1395,21 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         Action::ToggleFocus => {
             let has_selector = app.has_inline_commit_selector();
             let has_comments = app.has_comment_navigator_items();
+            // Cycle: FileList -> Diff -> CommitSelector -> Comments -> FileList,
+            // skipping panels that aren't present.
             app.focused_panel = match (app.focused_panel, has_selector, has_comments) {
-                (FocusedPanel::FileList, _, true) => FocusedPanel::Comments,
-                (FocusedPanel::FileList, _, false) => FocusedPanel::Diff,
-                (FocusedPanel::Comments, _, _) => FocusedPanel::Diff,
+                (FocusedPanel::FileList, _, _) => FocusedPanel::Diff,
                 (FocusedPanel::Diff, true, _) => FocusedPanel::CommitSelector,
-                (FocusedPanel::Diff, false, _) => FocusedPanel::FileList,
-                (FocusedPanel::CommitSelector, _, _) => FocusedPanel::FileList,
+                (FocusedPanel::Diff, false, true) => FocusedPanel::Comments,
+                (FocusedPanel::Diff, false, false) => FocusedPanel::FileList,
+                (FocusedPanel::CommitSelector, _, true) => FocusedPanel::Comments,
+                (FocusedPanel::CommitSelector, _, false) => FocusedPanel::FileList,
+                (FocusedPanel::Comments, _, _) => FocusedPanel::FileList,
             };
-            if app.focused_panel == FocusedPanel::FileList {
+            if matches!(
+                app.focused_panel,
+                FocusedPanel::FileList | FocusedPanel::Comments
+            ) {
                 app.show_file_list = true;
             }
         }
@@ -1389,14 +1417,18 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             let has_selector = app.has_inline_commit_selector();
             let has_comments = app.has_comment_navigator_items();
             app.focused_panel = match (app.focused_panel, has_selector, has_comments) {
-                (FocusedPanel::FileList, true, _) => FocusedPanel::CommitSelector,
-                (FocusedPanel::FileList, false, _) => FocusedPanel::Diff,
-                (FocusedPanel::Comments, _, _) => FocusedPanel::FileList,
-                (FocusedPanel::Diff, _, true) => FocusedPanel::Comments,
-                (FocusedPanel::Diff, _, false) => FocusedPanel::FileList,
+                (FocusedPanel::FileList, _, true) => FocusedPanel::Comments,
+                (FocusedPanel::FileList, true, false) => FocusedPanel::CommitSelector,
+                (FocusedPanel::FileList, false, false) => FocusedPanel::Diff,
+                (FocusedPanel::Comments, true, _) => FocusedPanel::CommitSelector,
+                (FocusedPanel::Comments, false, _) => FocusedPanel::Diff,
+                (FocusedPanel::Diff, _, _) => FocusedPanel::FileList,
                 (FocusedPanel::CommitSelector, _, _) => FocusedPanel::Diff,
             };
-            if app.focused_panel == FocusedPanel::FileList {
+            if matches!(
+                app.focused_panel,
+                FocusedPanel::FileList | FocusedPanel::Comments
+            ) {
                 app.show_file_list = true;
             }
         }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -575,17 +575,17 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
-                "  :set wrap ",
-                Style::default().add_modifier(Modifier::BOLD),
-            ),
-            Span::raw("Enable line wrap in diff view"),
-        ]),
-        Line::from(vec![
-            Span::styled(
-                "  :set wrap!",
+                "  :wrap     ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle line wrap in diff view"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :help     ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open this help screen"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
Reworked from scratch on top of current main — the wrap stuff is gone, this no
longer touches diff rendering or line counts.

What's left is the safe half of the original PR:

- Tab cycle goes FileList → Diff → CommitSelector → Comments (reverse mirrors
  it), and tabbing into Comments/FileList unhides the left pane
- j/k in the comment navigator scrolls the diff to the selected comment without
  stealing focus (Enter still jumps + focuses)
- jump_to_file / page scrolls skip spacing + file-header rows so the cursor
  never lands on a non-actionable line — the skip logic is in free functions
  with unit tests
- `:help` / `:h`, and `:wrap` as a short alias for `:set wrap!`

Word-boundary wrap will come back as its own PR, rebuilt against the current
wrap implementation and with rendering tests for the line-count math this time.

Tests: fmt/clippy clean, 972 passing. The 2 failures in `vcs::git::cli::tests`
are pre-existing — they run real `git commit` and inherit the host's
`commit.gpgsign`, so they time out against my YubiKey; same result on a clean
checkout of main.
