### PR TITLE
feat(commands): Add command prompt completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `r` | Toggle file reviewed |
 | `y` | Copy review to clipboard |
 | `:submit` | Push review to GitHub |
+| `Tab` in `:` prompt | Complete or cycle commands |
 | `?` | Toggle full help |
 
 Full reference in [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md).

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -92,6 +92,9 @@ Shown below the file tree when local comments or visible remote PR threads exist
 
 ## Commands
 
+In command mode,
+`Tab` and `Shift-Tab` complete or cycle command names.
+
 | Command | Action |
 |---------|--------|
 | `:{N}` | Jump to new-side line N in current file |

--- a/src/app.rs
+++ b/src/app.rs
@@ -464,6 +464,21 @@ pub enum InputMode {
     SubmitActionPicker,
 }
 
+/// CommandCompletionState keeps one Tab-completion run anchored to the text
+/// the user typed before cycling began.
+///
+/// Without this state, repeated Tab presses would re-scan from the currently
+/// displayed candidate and narrow the cycle to a different match set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandCompletionState {
+    /// Prefix used to build `matches`.
+    pub(crate) prefix: String,
+    /// Matching command strings in the order they should cycle.
+    pub(crate) matches: Vec<&'static str>,
+    /// Index of the command currently displayed in the command buffer.
+    pub(crate) selected: usize,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiffSource {
     WorkingTree,
@@ -866,6 +881,7 @@ pub struct App {
     pub diff_state: DiffState,
     pub help_state: HelpState,
     pub command_buffer: String,
+    pub(crate) command_completion: Option<CommandCompletionState>,
     pub search_buffer: String,
     pub last_search_pattern: Option<String>,
     pub comment_buffer: String,
@@ -1726,6 +1742,7 @@ impl App {
             diff_state: DiffState::default(),
             help_state: HelpState::default(),
             command_buffer: String::new(),
+            command_completion: None,
             search_buffer: String::new(),
             last_search_pattern: None,
             comment_buffer: String::new(),
@@ -6264,11 +6281,13 @@ impl App {
     pub fn enter_command_mode(&mut self) {
         self.input_mode = InputMode::Command;
         self.command_buffer.clear();
+        self.command_completion = None;
     }
 
     pub fn exit_command_mode(&mut self) {
         self.input_mode = InputMode::Normal;
         self.command_buffer.clear();
+        self.command_completion = None;
     }
 
     pub fn enter_search_mode(&mut self) {
@@ -10699,6 +10718,98 @@ mod target_selector_tests {
         // then
         assert_eq!(app.target_tab, TargetTab::Local);
         assert_eq!(app.input_mode, InputMode::CommitSelect);
+    }
+
+    #[test]
+    fn should_complete_command_when_only_one_candidate_matches() {
+        // given
+        let mut app = build_app();
+        app.input_mode = InputMode::Command;
+        app.command_buffer = "vers".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::CompleteCommand);
+        // then
+        assert_eq!(app.command_buffer, "version");
+        assert!(app.command_completion.is_none());
+    }
+
+    #[test]
+    fn should_extend_to_common_command_prefix_before_cycling() {
+        // given
+        let mut app = build_app();
+        app.input_mode = InputMode::Command;
+        app.command_buffer = "su".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::CompleteCommand);
+        // then
+        assert_eq!(app.command_buffer, "submit");
+        assert!(app.command_completion.is_none());
+    }
+
+    #[test]
+    fn should_cycle_forward_through_command_matches() {
+        // given
+        let mut app = build_app();
+        app.input_mode = InputMode::Command;
+        app.command_buffer = "submit".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::CompleteCommand);
+        // then
+        assert_eq!(app.command_buffer, "submit comment");
+        assert_eq!(
+            app.command_completion
+                .as_ref()
+                .map(|completion| completion.prefix.as_str()),
+            Some("submit")
+        );
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::CompleteCommand);
+        // then
+        assert_eq!(app.command_buffer, "submit approve");
+    }
+
+    #[test]
+    fn should_cycle_backward_through_command_matches() {
+        // given
+        let mut app = build_app();
+        app.input_mode = InputMode::Command;
+        app.command_buffer = "submit".to_string();
+        // when
+        crate::handler::handle_command_action(
+            &mut app,
+            crate::input::Action::CompleteCommandReverse,
+        );
+        // then
+        assert_eq!(app.command_buffer, "submit draft");
+    }
+
+    #[test]
+    fn should_leave_unknown_command_completion_unchanged() {
+        // given
+        let mut app = build_app();
+        app.input_mode = InputMode::Command;
+        app.command_buffer = "zz".to_string();
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::CompleteCommand);
+        // then
+        assert_eq!(app.command_buffer, "zz");
+        assert!(app.command_completion.is_none());
+    }
+
+    #[test]
+    fn should_clear_command_completion_state_after_manual_edit() {
+        // given
+        let mut app = build_app();
+        app.input_mode = InputMode::Command;
+        app.command_buffer = "set ".to_string();
+        crate::handler::handle_command_action(&mut app, crate::input::Action::CompleteCommand);
+        assert_eq!(app.command_buffer, "set wrap");
+        assert!(app.command_completion.is_some());
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::InsertChar('x'));
+        // then
+        assert_eq!(app.command_buffer, "set wrapx");
+        assert!(app.command_completion.is_none());
     }
 
     // -- async PR open spinner tests -----------------------------------------

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,8 +2,8 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Position;
 
 use crate::app::{
-    self, App, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit, InputMode, TargetTab,
-    VisualSelection,
+    self, App, CommandCompletionState, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit,
+    InputMode, TargetTab, VisualSelection,
 };
 use crate::forge::remote_comments::PrCommentsVisibility;
 use crate::forge::submit::SubmitEvent;
@@ -120,6 +120,12 @@ enum CommandKind {
 enum CommandAfterDispatch {
     ExitCommandMode,
     KeepMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompletionDirection {
+    Forward,
+    Reverse,
 }
 
 pub fn handle_mouse_event(app: &mut App, event: MouseEvent) {
@@ -478,20 +484,32 @@ pub fn handle_help_action(app: &mut App, action: Action) {
 /// Handle actions in Command mode (text input for :commands)
 pub fn handle_command_action(app: &mut App, action: Action) {
     match action {
-        Action::InsertChar(c) => app.command_buffer.push(c),
-        Action::Paste(text) => push_single_line(&mut app.command_buffer, &text),
+        Action::InsertChar(c) => {
+            app.command_completion = None;
+            app.command_buffer.push(c);
+        }
+        Action::Paste(text) => {
+            app.command_completion = None;
+            push_single_line(&mut app.command_buffer, &text);
+        }
         Action::DeleteChar => {
+            app.command_completion = None;
             app.command_buffer.pop();
         }
         Action::DeleteWord => {
+            app.command_completion = None;
             let cursor = app.command_buffer.len();
             delete_word_before(&mut app.command_buffer, cursor);
         }
         Action::ClearLine => {
+            app.command_completion = None;
             app.command_buffer.clear();
         }
+        Action::CompleteCommand => complete_command(app, CompletionDirection::Forward),
+        Action::CompleteCommandReverse => complete_command(app, CompletionDirection::Reverse),
         Action::ExitMode => app.exit_command_mode(),
         Action::SubmitInput => {
+            app.command_completion = None;
             let cmd = app.command_buffer.trim().to_string();
             let after_dispatch = if let Some(spec) = command_spec_for(&cmd) {
                 dispatch_command(app, spec.kind)
@@ -513,6 +531,155 @@ pub fn handle_command_action(app: &mut App, action: Action) {
 
 fn command_spec_for(cmd: &str) -> Option<&'static CommandSpec> {
     COMMAND_SPECS.iter().find(|spec| spec.names.contains(&cmd))
+}
+
+/// CommandCompleter computes command-buffer replacements without mutating App.
+struct CommandCompleter<'a> {
+    /// Registry whose command names are exposed as completion candidates.
+    specs: &'a [CommandSpec],
+}
+
+impl<'a> CommandCompleter<'a> {
+    /// Build a completer over the command registry it should expose.
+    pub fn new(specs: &'a [CommandSpec]) -> Self {
+        Self { specs }
+    }
+
+    /// Return the next command-completion state for the current prompt state.
+    ///
+    /// `buffer` is the command text currently shown to the user. `active` is
+    /// the previous completion cycle, if repeated Tab presses are cycling an
+    /// existing match set. The result describes the next buffer contents and
+    /// active completion cycle without mutating App.
+    pub fn complete(
+        &self,
+        buffer: &str,
+        active: Option<&CommandCompletionState>,
+        direction: CompletionDirection,
+    ) -> CompletionResult {
+        if let Some(result) = self.cycle_existing(buffer, active, direction) {
+            return result;
+        }
+
+        let prefix = buffer.trim_start().to_string();
+        let matches: Vec<&'static str> = self
+            .command_names()
+            .filter(|command| command.starts_with(&prefix))
+            .collect();
+
+        match matches.len() {
+            0 => CompletionResult::NoMatch,
+            1 => CompletionResult::replace(matches[0], None),
+            _ => {
+                let common_prefix = Self::common_prefix(&matches);
+                if common_prefix.len() > prefix.len() {
+                    CompletionResult::replace(common_prefix, None)
+                } else {
+                    self.start_cycle(buffer, prefix, matches, direction)
+                }
+            }
+        }
+    }
+
+    fn command_names(&self) -> impl Iterator<Item = &'static str> + '_ {
+        self.specs
+            .iter()
+            .flat_map(|spec| spec.names.iter().copied())
+    }
+
+    fn cycle_existing(
+        &self,
+        buffer: &str,
+        active: Option<&CommandCompletionState>,
+        direction: CompletionDirection,
+    ) -> Option<CompletionResult> {
+        let completion = active?;
+        let current = completion.matches.get(completion.selected)?;
+        if buffer != *current {
+            return None;
+        }
+
+        let selected = Self::next_index(completion.selected, completion.matches.len(), direction);
+        Some(CompletionResult::replace(
+            completion.matches[selected],
+            Some(CommandCompletionState {
+                prefix: completion.prefix.clone(),
+                matches: completion.matches.clone(),
+                selected,
+            }),
+        ))
+    }
+
+    fn start_cycle(
+        &self,
+        buffer: &str,
+        prefix: String,
+        matches: Vec<&'static str>,
+        direction: CompletionDirection,
+    ) -> CompletionResult {
+        let selected = matches
+            .iter()
+            .position(|command| *command == buffer)
+            .map(|idx| Self::next_index(idx, matches.len(), direction))
+            .unwrap_or_else(|| match direction {
+                CompletionDirection::Forward => 0,
+                CompletionDirection::Reverse => matches.len() - 1,
+            });
+
+        CompletionResult::replace(
+            matches[selected],
+            Some(CommandCompletionState {
+                prefix,
+                matches,
+                selected,
+            }),
+        )
+    }
+
+    fn next_index(selected: usize, match_count: usize, direction: CompletionDirection) -> usize {
+        match direction {
+            CompletionDirection::Forward => (selected + 1) % match_count,
+            CompletionDirection::Reverse => (selected + match_count - 1) % match_count,
+        }
+    }
+
+    fn common_prefix(matches: &[&str]) -> String {
+        let mut prefix = matches
+            .first()
+            .map(|command| (*command).to_string())
+            .unwrap_or_default();
+        for command in &matches[1..] {
+            while !command.starts_with(&prefix) {
+                prefix.pop();
+            }
+        }
+        prefix
+    }
+}
+
+/// CompletionResult tells the handler how to update command-mode state.
+enum CompletionResult {
+    /// Leave the buffer unchanged and surface a no-match message.
+    NoMatch,
+    /// Replace the buffer and optionally keep a cycling state active.
+    Replace {
+        /// New command-buffer contents.
+        buffer: String,
+        /// Completion state used by the next Tab press, if cycling started.
+        completion: Option<CommandCompletionState>,
+    },
+}
+
+impl CompletionResult {
+    fn replace(
+        buffer: impl Into<String>,
+        completion: Option<CommandCompletionState>,
+    ) -> CompletionResult {
+        CompletionResult::Replace {
+            buffer: buffer.into(),
+            completion,
+        }
+    }
 }
 
 fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
@@ -716,6 +883,24 @@ fn set_remote_comments_visibility(app: &mut App, visibility: PrCommentsVisibilit
         app.set_message(format!("Remote comments: {label}"));
     } else {
         app.set_message(format!("Remote comments: already {label}"));
+    }
+}
+
+fn complete_command(app: &mut App, direction: CompletionDirection) {
+    let completer = CommandCompleter::new(COMMAND_SPECS);
+    match completer.complete(
+        &app.command_buffer,
+        app.command_completion.as_ref(),
+        direction,
+    ) {
+        CompletionResult::NoMatch => {
+            app.command_completion = None;
+            app.set_message("No command matches");
+        }
+        CompletionResult::Replace { buffer, completion } => {
+            app.command_buffer = buffer;
+            app.command_completion = completion;
+        }
     }
 }
 

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -66,6 +66,8 @@ pub enum Action {
     DeleteWord,
     ClearLine,
     SubmitInput,
+    CompleteCommand,
+    CompleteCommandReverse,
     TextCursorLeft,
     TextCursorRight,
     TextCursorLineStart,
@@ -219,6 +221,8 @@ fn map_command_mode(key: KeyEvent) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
+        (KeyCode::Tab, KeyModifiers::NONE) => Action::CompleteCommand,
+        (KeyCode::BackTab, _) => Action::CompleteCommandReverse,
         (KeyCode::Backspace, mods) if mods.contains(KeyModifiers::ALT) => Action::DeleteWord,
         (KeyCode::Backspace, KeyModifiers::NONE) => Action::DeleteChar,
         (KeyCode::Char('w'), KeyModifiers::CONTROL) => Action::DeleteWord,
@@ -540,6 +544,18 @@ mod tests {
         assert_eq!(map_comment_mode(alt_backspace), Action::DeleteWord);
         assert_eq!(map_command_mode(alt_backspace), Action::DeleteWord);
         assert_eq!(map_search_mode(alt_backspace), Action::DeleteWord);
+    }
+
+    #[test]
+    fn should_map_tab_to_command_completion_in_command_mode() {
+        let action = map_command_mode(key(KeyCode::Tab));
+        assert_eq!(action, Action::CompleteCommand);
+    }
+
+    #[test]
+    fn should_map_backtab_to_reverse_command_completion_in_command_mode() {
+        let action = map_command_mode(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
+        assert_eq!(action, Action::CompleteCommandReverse);
     }
 
     #[test]

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -43,6 +43,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     status_bar::render_header(frame, app, chunks[0]);
     render_main_content(frame, app, chunks[1]);
     status_bar::render_status_bar(frame, app, chunks[2]);
+    status_bar::render_command_completion_popup(frame, app, chunks[2]);
 
     // Render help popup on top if in help mode
     if app.input_mode == InputMode::Help {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -524,6 +524,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  Tab       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Complete or cycle command names in the : prompt"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  :w        ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -5,12 +5,16 @@ use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph},
 };
 
 use crate::app::{App, DiffSource, InputMode, Message, MessageType};
 use crate::theme::Theme;
+use crate::ui::commit_row::CURSOR_GLYPH;
 use crate::ui::styles;
+
+/// Maximum visible completion candidates in the command prompt popup.
+const COMMAND_COMPLETION_MAX_ROWS: usize = 7;
 
 pub fn build_message_span(message: Option<&Message>, theme: &Theme) -> (Span<'static>, usize) {
     if let Some(msg) = message {
@@ -269,7 +273,9 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 InputMode::Normal => Cow::Borrowed(
                     "   j/k scroll \u{00b7} {/} file \u{00b7} r reviewed \u{00b7} c comment \u{00b7} ? help",
                 ),
-                InputMode::Command => Cow::Borrowed("   \u{21b5} execute \u{00b7} esc cancel"),
+                InputMode::Command => {
+                    Cow::Borrowed("   tab complete \u{00b7} \u{21b5} execute \u{00b7} esc cancel")
+                }
                 InputMode::Search => Cow::Borrowed("   \u{21b5} search \u{00b7} esc cancel"),
                 InputMode::Comment => Cow::Borrowed("   ctrl-s save \u{00b7} esc cancel"),
                 InputMode::Help => Cow::Borrowed("   q/?/esc close"),
@@ -378,6 +384,86 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(status, area);
 }
 
+pub fn render_command_completion_popup(frame: &mut Frame, app: &App, status_area: Rect) {
+    if app.input_mode != InputMode::Command {
+        return;
+    }
+    let Some(completion) = app.command_completion.as_ref() else {
+        return;
+    };
+    if completion.matches.is_empty() || status_area.y < 3 || status_area.width < 4 {
+        return;
+    }
+
+    let available_rows = status_area.y.saturating_sub(2) as usize;
+    let visible_rows = completion
+        .matches
+        .len()
+        .min(COMMAND_COMPLETION_MAX_ROWS)
+        .min(available_rows);
+    if visible_rows == 0 {
+        return;
+    }
+
+    let selected = completion
+        .selected
+        .min(completion.matches.len().saturating_sub(1));
+    let start = completion_window_start(selected, completion.matches.len(), visible_rows);
+    let end = start + visible_rows;
+    let visible_matches = &completion.matches[start..end];
+    let content_width = visible_matches
+        .iter()
+        .map(|command| command.chars().count())
+        .max()
+        .unwrap_or(0)
+        + 2;
+    let popup_width = (content_width as u16 + 2).min(status_area.width);
+    if popup_width == 0 {
+        return;
+    }
+
+    let popup_height = visible_rows as u16 + 2;
+    let popup_area = Rect {
+        x: status_area.x,
+        y: status_area.y.saturating_sub(popup_height),
+        width: popup_width,
+        height: popup_height,
+    };
+
+    let rows: Vec<Line<'_>> = visible_matches
+        .iter()
+        .enumerate()
+        .map(|(offset, command)| {
+            let idx = start + offset;
+            let marker = if idx == selected { CURSOR_GLYPH } else { " " };
+            let style = if idx == selected {
+                styles::selected_style(&app.theme)
+            } else {
+                Style::default().fg(app.theme.fg_secondary)
+            };
+            Line::from(Span::styled(format!("{marker} {command}"), style))
+        })
+        .collect();
+
+    frame.render_widget(Clear, popup_area);
+    frame.render_widget(
+        Paragraph::new(rows)
+            .style(styles::panel_style(&app.theme))
+            .block(Block::default().borders(Borders::ALL)),
+        popup_area,
+    );
+}
+
+fn completion_window_start(selected: usize, match_count: usize, visible_rows: usize) -> usize {
+    if visible_rows >= match_count {
+        return 0;
+    }
+    let half = visible_rows / 2;
+    selected
+        .saturating_sub(half)
+        .min(match_count.saturating_sub(visible_rows))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -405,6 +491,26 @@ mod tests {
         let (span, width) = build_message_span(None, &theme);
         assert_eq!(span.content.as_ref(), "");
         assert_eq!(width, 0);
+    }
+
+    #[test]
+    fn should_center_completion_window_when_possible() {
+        assert_eq!(completion_window_start(5, 12, 7), 2);
+    }
+
+    #[test]
+    fn should_pin_completion_window_to_top_near_start() {
+        assert_eq!(completion_window_start(1, 12, 7), 0);
+    }
+
+    #[test]
+    fn should_pin_completion_window_to_bottom_near_end() {
+        assert_eq!(completion_window_start(10, 12, 7), 5);
+    }
+
+    #[test]
+    fn should_show_all_completion_rows_when_they_fit() {
+        assert_eq!(completion_window_start(3, 5, 7), 0);
     }
 
     #[test]


### PR DESCRIPTION
Command mode now supports Tab completion for fixed `:` commands.
The prompt completes unique matches,
extends shared prefixes,
and cycles through ambiguous matches with forward and reverse Tab.

The completion UI shows nearby matches above the command prompt
with the active candidate highlighted.
The command registry also feeds completion,
so accepted command names and aliases stay aligned with dispatch.

Demo:
<img width="735" height="772" alt="tuicr-completion" src="https://github.com/user-attachments/assets/4c76ae2d-d183-4b0c-89e3-43906040114c" />
