### PR TITLE
fix(ui): Preserve wrapped revision headers

### DIFF
--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -1346,6 +1346,7 @@ mod remote_comments_snapshot_tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
     use std::path::{Path, PathBuf};
 
     struct SnapshotVcs {
@@ -1433,6 +1434,21 @@ mod remote_comments_snapshot_tests {
         }
     }
 
+    fn header_only_diff_file_at(path: &str) -> DiffFile {
+        let hunks = Vec::new();
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: Some(PathBuf::from(path)),
+            new_path: Some(PathBuf::from(path)),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
     fn thread(
         id: &str,
         author: &str,
@@ -1503,12 +1519,53 @@ mod remote_comments_snapshot_tests {
         .expect("build app")
     }
 
+    fn make_revision_app(diff_files: Vec<DiffFile>) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp/tuicr"),
+            head_commit: "headsha".to_string(),
+            branch_name: None,
+            vcs_type: VcsType::Git,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            "headsha".to_string(),
+            None,
+            SessionDiffSource::CommitRange,
+        );
+        App::build(
+            Box::new(SnapshotVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            diff_files,
+            session,
+            DiffSource::CommitRange(vec!["HEAD".to_string()]),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+            None,
+        )
+        .expect("build app")
+    }
+
     fn draw(app: &mut App) -> Buffer {
         let backend = TestBackend::new(140, 30);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| render(frame, app))
             .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn draw_unified_diff(app: &mut App) -> Buffer {
+        let backend = TestBackend::new(100, 12);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| super::render_unified_diff(frame, app, Rect::new(0, 0, 100, 12)))
+            .expect("draw unified diff");
         terminal.backend().buffer().clone()
     }
 
@@ -1541,6 +1598,23 @@ mod remote_comments_snapshot_tests {
         assert!(
             body.contains("looks good?"),
             "expected remote comment body in:\n{body}"
+        );
+    }
+
+    // Revision diffs with `wrap = true` render boxed file headers without a
+    // cursor gutter. The right-edge fill overlay must measure that exact row:
+    // treating it like guttered diff content truncated `README.md [M]` to
+    // `README` in `tuicr -r HEAD`.
+    #[test]
+    fn should_render_full_file_header_for_revision_diff() {
+        let mut app = make_revision_app(vec![header_only_diff_file_at("README.md")]);
+        app.diff_state.wrap_lines = true;
+
+        let body = body_text(&draw_unified_diff(&mut app));
+
+        assert!(
+            body.contains("║ README.md [M] "),
+            "expected full README.md file header in:\n{body}"
         );
     }
 

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -14,6 +14,7 @@ use crate::ui::comment_panel;
 use crate::ui::diff_side_by_side::render_side_by_side_diff;
 use crate::ui::diff_unified::render_unified_diff;
 use crate::ui::styles;
+use unicode_width::UnicodeWidthStr;
 
 /// Static header rule used for file/section headers; avoids `"═".repeat(40)` per frame.
 pub(super) const HEADER_RULE: &str = "════════════════════════════════════════";
@@ -839,7 +840,11 @@ pub(super) fn paint_file_header_fill(frame: &mut Frame, ctx: &DiffOverlayPaint) 
                 .or_else(|| line.spans.get(1))
                 .and_then(|s| s.style.fg)
                 .unwrap_or(ctx.theme.fg_primary);
-            let line_width = ctx.line_widths.get(idx).copied().unwrap_or(0);
+            let line_width = line
+                .spans
+                .iter()
+                .map(|span| span.content.width())
+                .sum::<usize>();
             let last_row = rows.saturating_sub(1);
             if visual_row + last_row >= ctx.inner.height as usize {
                 visual_row += rows;


### PR DESCRIPTION
Revision views with `wrap = true` render boxed file headers without a
line-number gutter,
but the right-edge fill overlay reused the gutter-adjusted width cache.
In `tuicr -r HEAD`,
that made the fill start before the visible filename ended.

Bad output:

    ║ README                         ║
    ║ docs/KEYBINDING                ║

Expected output:

    ║ README.md [M]                  ║
    ║ docs/KEYBINDINGS.md [M]        ║

Root cause was that the overlay used the wrapped diff-content width:

    ║ README.md [M]
            ^ fill started here and erased `.md [M]`

Fix:
Measure boxed file-header rows from the text they actually render.
This is a bit less performant than the cached gutter-adjusted widths,
but it only applies to the file-header rows.
Everything else still uses the cached gutter-adjusted widths.