### PR TITLE
feat(theme): bundle higher-contrast syntax for tokyo-night-day

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -927,8 +927,10 @@ impl Theme {
             syntax_add_bg: Color::Rgb(216, 230, 236), // #d8e6ec
             syntax_del_bg: Color::Rgb(245, 213, 217), // #f5d5d9
 
-            // Light syntect base with muted blue feel, matching the storm sibling's choice of a base16 family
-            syntax_theme: SyntaxThemeSource::Embedded(EmbeddedThemeName::Base16OceanLight),
+            // Bundled tmTheme drawn from the tokyo-night-day palette. The
+            // previous Base16 Ocean Light pick washed out comments, strings,
+            // and method names on the #e1e2e7 background.
+            syntax_theme: SyntaxThemeSource::Custom(Box::new(tokyo_night_day_syntax_theme())),
 
             file_added: green,
             file_modified: yellow,
@@ -1236,6 +1238,12 @@ struct GruvboxFlavor {
 
 fn rgb(r: u8, g: u8, b: u8) -> Color {
     Color::Rgb(r, g, b)
+}
+
+fn tokyo_night_day_syntax_theme() -> syntect::highlighting::Theme {
+    const BYTES: &[u8] = include_bytes!("tokyo-night-day.tmTheme");
+    ThemeSet::load_from_reader(&mut std::io::Cursor::new(BYTES))
+        .expect("bundled tokyo-night-day.tmTheme must parse")
 }
 
 fn blend(base: Color, accent: Color, accent_percent: u8) -> Color {
@@ -2802,5 +2810,11 @@ mode_bg = "#82aaff"
     fn should_return_accent_for_non_rgb_blend_inputs() {
         let accent = Color::Rgb(100, 110, 120);
         assert_eq!(blend(Color::Reset, accent, 50), accent);
+    }
+
+    #[test]
+    fn should_use_bundled_syntax_theme_for_tokyo_night_day() {
+        let theme = Theme::tokyo_night_day();
+        assert!(theme.uses_custom_syntax_theme());
     }
 }

--- a/src/theme/tokyo-night-day.tmTheme
+++ b/src/theme/tokyo-night-day.tmTheme
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Syntax theme for the built-in tokyo-night-day tuicr theme. Colors are drawn
+  from the folke/tokyonight.nvim "day" palette so syntax tokens stay in-family
+  with the chrome. Tokens that would be too washed-out on the #e1e2e7
+  background (comments, strings) snap to the palette's nearest darker member:
+    comment  #848cb5 -> dark5  #68709a
+    string   #587539 (green) -> green1 #387068
+  Functions stay on `blue` #2e7de9 (the palette's function color and its
+  darkest true blue; the only darker blues are the cyan family, which would
+  collide with types = cyan #007197).
+-->
+<plist version="1.0">
+<dict>
+  <key>name</key>
+  <string>Tokyo Night Day</string>
+  <key>settings</key>
+  <array>
+    <dict>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3760bf</string>
+        <key>background</key>
+        <string>#e1e2e7</string>
+        <key>caret</key>
+        <string>#b15c00</string>
+        <key>selection</key>
+        <string>#c4c8da</string>
+        <key>lineHighlight</key>
+        <string>#c4c8da</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Comment</string>
+      <key>scope</key>
+      <string>comment, punctuation.definition.comment, comment.line.documentation, comment.block.documentation</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#68709a</string>
+        <key>fontStyle</key>
+        <string>italic</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Keyword and storage</string>
+      <key>scope</key>
+      <string>keyword, keyword.control, keyword.operator, storage, storage.modifier</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#7847bd</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>String</string>
+      <key>scope</key>
+      <string>string, string.quoted, string.template, constant.character, punctuation.definition.string</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#387068</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Constant and number</string>
+      <key>scope</key>
+      <string>constant, constant.numeric, constant.language, support.constant</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#b15c00</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Function and method names</string>
+      <key>scope</key>
+      <string>entity.name.function, support.function, meta.function-call, variable.function, meta.function.call entity.name.function, entity.name.function.call</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#2e7de9</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Types</string>
+      <key>scope</key>
+      <string>entity.name.type, support.type, storage.type, entity.name.class, support.class</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#007197</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Variables and parameters</string>
+      <key>scope</key>
+      <string>variable, variable.parameter, variable.other, support.variable</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#3760bf</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Tags and entity names</string>
+      <key>scope</key>
+      <string>entity.name.tag, entity.other.attribute-name, meta.tag</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#2e7de9</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Punctuation and operators</string>
+      <key>scope</key>
+      <string>punctuation, meta.brace, keyword.operator.delimiter</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#6172b0</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Invalid</string>
+      <key>scope</key>
+      <string>invalid, invalid.illegal</string>
+      <key>settings</key>
+      <dict>
+        <key>foreground</key>
+        <string>#e1e2e7</string>
+        <key>background</key>
+        <string>#f52a65</string>
+      </dict>
+    </dict>
+  </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- The built-in `tokyo-night-day` theme was using `Base16 Ocean Light` for syntax highlighting, which washed out comments, strings, and method names on the `#e1e2e7` background and made code in diffs hard to read.
- This change bundles a small palette-native `.tmTheme` (`src/theme/tokyo-night-day.tmTheme`, loaded via `include_bytes!`) and switches `Theme::tokyo_night_day()` to use it via the existing `SyntaxThemeSource::Custom` path.
- Syntax tokens now stay in the folke/tokyonight.nvim "day" family; washed-out tokens snap to the nearest darker palette member (comments → dark5 `#68709a`, strings → green1 `#387068`). Functions stay on blue `#2e7de9` to avoid colliding with types on cyan `#007197`.

No UI-chrome colors change — only the syntax-highlighting layer.

<img width="1920" height="1200" alt="Screenshot 2026-05-28 at 10 23 06 AM" src="https://github.com/user-attachments/assets/489be6ff-0f0f-4ad4-902a-07ddc5a25cf9" />


## Test plan

- [x] `cargo fmt`
- [x] `cargo test` (854 passed, 1 ignored)
- [x] New unit test `should_use_bundled_syntax_theme_for_tokyo_night_day` asserts the day theme reports a custom syntax theme
- [x] Dogfooded locally: ran `tuicr --theme tokyo-night-day` against a diff and confirmed comments / strings / function names are legible on the light background

🤖 Generated with [Claude Code](https://claude.com/claude-code)