### PR TITLE
fix(git): Preserve revision diff endpoints

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ use crate::vcs::git::calculate_gap;
 use crate::vcs::traits::VcsType;
 use crate::vcs::{
     ChangeKind, CommitInfo, DiffWhitespaceMode, FileBackend, GitBackendPreference, PrNoopVcs,
-    VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
+    ResolvedRevisionRange, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
 };
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
@@ -1494,14 +1494,15 @@ impl App {
         //   3. -w only: working tree directly (skip commit selector)
         //   4. neither: commit selection UI
         if let Some(revisions) = options.revisions {
-            let commit_ids = crate::profile::time_with(
+            let revision_range = crate::profile::time_with(
                 "startup.resolve_revisions",
-                || vcs.resolve_revisions(revisions),
+                || vcs.resolve_revision_range(revisions),
                 |result| match result {
-                    Ok(ids) => format!("commits={}", ids.len()),
+                    Ok(range) => format!("commits={}", range.commit_ids.len()),
                     Err(e) => format!("error={e}"),
                 },
             )?;
+            let commit_ids = revision_range.commit_ids.to_vec();
 
             if options.working_tree {
                 // Combined: commit range + staged/unstaged changes
@@ -1581,7 +1582,7 @@ impl App {
             let diff_files = Self::get_commit_range_diff_with_ignore(
                 vcs.as_ref(),
                 &vcs_info.root_path,
-                &commit_ids,
+                &revision_range,
                 highlighter,
                 options.path_filter,
             )?;
@@ -3554,13 +3555,13 @@ impl App {
     fn get_commit_range_diff_with_ignore(
         vcs: &dyn VcsBackend,
         repo_root: &Path,
-        commit_ids: &[String],
+        revision_range: &ResolvedRevisionRange<'_>,
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<Vec<DiffFile>> {
         let diff_files = crate::profile::time_with(
             "diff.load_commit_range",
-            || vcs.get_commit_range_diff(commit_ids, highlighter),
+            || vcs.get_commit_range_diff(revision_range.commit_ids.as_ref(), highlighter),
             profile_diff_result,
         )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
@@ -3863,7 +3864,7 @@ impl App {
             DiffSource::CommitRange(commit_ids) => Self::get_commit_range_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                commit_ids,
+                &ResolvedRevisionRange::from_commit_ids(commit_ids),
                 highlighter,
                 self.path_filter.as_deref(),
             )?,
@@ -8457,7 +8458,7 @@ impl App {
         let diff_files = Self::get_commit_range_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            &selected_ids,
+            &ResolvedRevisionRange::from_commit_ids(&selected_ids),
             highlighter,
             self.path_filter.as_deref(),
         )?;
@@ -8646,7 +8647,7 @@ impl App {
             match Self::get_commit_range_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                &selected_ids,
+                &ResolvedRevisionRange::from_commit_ids(&selected_ids),
                 highlighter,
                 self.path_filter.as_deref(),
             ) {

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,7 +24,7 @@ use crate::vcs::git::calculate_gap;
 use crate::vcs::traits::VcsType;
 use crate::vcs::{
     ChangeKind, CommitInfo, DiffWhitespaceMode, FileBackend, GitBackendPreference, PrNoopVcs,
-    ResolvedRevisionRange, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
+    ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsChangeStatus, VcsInfo, detect_vcs,
 };
 
 const VISIBLE_COMMIT_COUNT: usize = 10;
@@ -1495,7 +1495,7 @@ impl App {
         //   4. neither: commit selection UI
         if let Some(revisions) = options.revisions {
             let revision_range = crate::profile::time_with(
-                "startup.resolve_revisions",
+                "startup.resolve_revision_range",
                 || vcs.resolve_revision_range(revisions),
                 |result| match result {
                     Ok(range) => format!("commits={}", range.commit_ids.len()),
@@ -3561,7 +3561,7 @@ impl App {
     ) -> Result<Vec<DiffFile>> {
         let diff_files = crate::profile::time_with(
             "diff.load_commit_range",
-            || vcs.get_commit_range_diff(revision_range.commit_ids.as_ref(), highlighter),
+            || vcs.get_commit_range_diff(revision_range, highlighter),
             profile_diff_result,
         )?;
         let diff_files = Self::filter_ignored_diff_files(repo_root, diff_files);
@@ -3864,7 +3864,7 @@ impl App {
             DiffSource::CommitRange(commit_ids) => Self::get_commit_range_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                &ResolvedRevisionRange::from_commit_ids(commit_ids),
+                &ResolvedRevisionRange::from_commit_ids(commit_ids, RevisionDiffTarget::CommitList),
                 highlighter,
                 self.path_filter.as_deref(),
             )?,
@@ -8458,7 +8458,7 @@ impl App {
         let diff_files = Self::get_commit_range_diff_with_ignore(
             self.vcs.as_ref(),
             &self.vcs_info.root_path,
-            &ResolvedRevisionRange::from_commit_ids(&selected_ids),
+            &ResolvedRevisionRange::from_commit_ids(&selected_ids, RevisionDiffTarget::CommitList),
             highlighter,
             self.path_filter.as_deref(),
         )?;
@@ -8647,7 +8647,10 @@ impl App {
             match Self::get_commit_range_diff_with_ignore(
                 self.vcs.as_ref(),
                 &self.vcs_info.root_path,
-                &ResolvedRevisionRange::from_commit_ids(&selected_ids),
+                &ResolvedRevisionRange::from_commit_ids(
+                    &selected_ids,
+                    RevisionDiffTarget::CommitList,
+                ),
                 highlighter,
                 self.path_filter.as_deref(),
             ) {

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -13,13 +13,14 @@ use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSid
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::{
-    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsChangeStatus, VcsInfo,
+    ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget,
+    VcsBackend, VcsChangeStatus, VcsInfo,
 };
 use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
 
 use super::{
-    GitRepoMode, git_bool_config_enabled, git_command_error, git_fsmonitor_config_enabled,
-    run_git_command,
+    GitRepoMode, RevisionExpression, git_bool_config_enabled, git_command_error,
+    git_fsmonitor_config_enabled, run_git_command,
 };
 
 // Untracked files larger than this are shown in the file list but their
@@ -318,41 +319,29 @@ impl VcsBackend for GitCliBackend {
         Ok(parse_commit_records(&output, &branch_tip_names))
     }
 
-    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
-        let commit_ids = if revisions.contains("..") {
-            let output = run_git_command(
-                &self.root_path,
-                &["rev-list", "--topo-order", "--reverse", revisions],
-            )?;
-            output
-                .lines()
-                .filter(|line| !line.is_empty())
-                .map(str::to_string)
-                .collect()
-        } else {
-            let revision = format!("{revisions}^{{commit}}");
-            let output = run_git_command(&self.root_path, &["rev-parse", "--verify", &revision])?;
-            vec![output.trim().to_string()]
-        };
-
-        if commit_ids.is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        Ok(commit_ids)
+    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
+        resolve_revision_range_cli(&self.root_path, revisions)
     }
 
     fn get_commit_range_diff(
         &self,
-        commit_ids: &[String],
+        revision_range: &ResolvedRevisionRange<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        if commit_ids.is_empty() {
+        if revision_range.commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
 
-        let base_rev = parent_rev_or_empty(&self.root_path, &commit_ids[0]);
-        let newest_rev = commit_ids.last().unwrap();
+        let (base_rev, newest_rev) = match &revision_range.diff_target {
+            RevisionDiffTarget::CommitList => (
+                parent_rev_or_empty(&self.root_path, &revision_range.commit_ids[0]),
+                revision_range.commit_ids.last().unwrap().clone(),
+            ),
+            RevisionDiffTarget::Explicit { base, head } => (
+                base.clone().unwrap_or_else(|| EMPTY_TREE_OID.to_string()),
+                head.clone(),
+            ),
+        };
         self.get_cli_diff(
             vec![
                 "diff".into(),
@@ -364,7 +353,7 @@ impl VcsBackend for GitCliBackend {
             ],
             false,
             GitContentSource::Revision(&base_rev),
-            GitContentSource::Revision(newest_rev),
+            GitContentSource::Revision(&newest_rev),
             highlighter,
         )
     }
@@ -1086,6 +1075,88 @@ fn parent_rev_or_empty(workdir: &Path, commit_id: &str) -> String {
         .unwrap_or_else(|_| EMPTY_TREE_OID.to_string())
 }
 
+fn resolve_revision_range_cli(
+    workdir: &Path,
+    revisions: &str,
+) -> Result<ResolvedRevisionRange<'static>> {
+    match RevisionExpression::parse(revisions)? {
+        RevisionExpression::Single(revision) => {
+            // `HEAD`
+            let head = resolve_commit_id_cli(workdir, revision)?;
+            let base = parent_rev(workdir, &head)?;
+            Ok(ResolvedRevisionRange::from_owned_commit_ids(
+                vec![head.clone()],
+                RevisionDiffTarget::Explicit { base, head },
+            ))
+        }
+        RevisionExpression::Range { base, head } => {
+            // `A..B`, `A..`, or `..B`
+            let base = resolve_commit_id_cli(workdir, base)?;
+            let head = resolve_commit_id_cli(workdir, head)?;
+            let commit_ids = rev_list_range(workdir, &base, &head)?;
+            Ok(ResolvedRevisionRange::from_owned_commit_ids(
+                commit_ids,
+                RevisionDiffTarget::Explicit {
+                    base: Some(base),
+                    head,
+                },
+            ))
+        }
+        RevisionExpression::MergeBaseRange { left, right } => {
+            // `A...B`
+            let left = resolve_commit_id_cli(workdir, left)?;
+            let right = resolve_commit_id_cli(workdir, right)?;
+            let base = run_git_command(workdir, &["merge-base", &left, &right])?
+                .trim()
+                .to_string();
+            let commit_ids = rev_list_range(workdir, &base, &right)?;
+            Ok(ResolvedRevisionRange::from_owned_commit_ids(
+                commit_ids,
+                RevisionDiffTarget::Explicit {
+                    base: Some(base),
+                    head: right,
+                },
+            ))
+        }
+    }
+}
+
+fn resolve_commit_id_cli(workdir: &Path, revision: &str) -> Result<String> {
+    let revision = format!("{revision}^{{commit}}");
+    Ok(
+        run_git_command(workdir, &["rev-parse", "--verify", &revision])?
+            .trim()
+            .to_string(),
+    )
+}
+
+// Single-revision reviews diff the commit against its first parent.
+// Root commits have no parent,
+// so callers represent the old side as the empty tree with None.
+fn parent_rev(workdir: &Path, commit_id: &str) -> Result<Option<String>> {
+    let parent_spec = format!("{commit_id}^");
+    match run_git_command(workdir, &["rev-parse", &parent_spec]) {
+        Ok(rev) => Ok(Some(rev.trim().to_string())),
+        Err(_) => Ok(None),
+    }
+}
+
+fn rev_list_range(workdir: &Path, base: &str, head: &str) -> Result<Vec<String>> {
+    let revset = format!("{base}..{head}");
+    let output = run_git_command(workdir, &["rev-list", "--topo-order", "--reverse", &revset])?;
+    let commit_ids: Vec<String> = output
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect();
+
+    if commit_ids.is_empty() {
+        return Err(TuicrError::NoChanges);
+    }
+
+    Ok(commit_ids)
+}
+
 fn run_git_command_strings(workdir: &Path, args: Vec<String>) -> Result<String> {
     run_git_command_args(workdir, args.iter().map(String::as_str))
 }
@@ -1221,6 +1292,54 @@ mod tests {
         (temp_dir, cli_backend, repo, vec![first_id, second_id])
     }
 
+    fn setup_merge_range_repo() -> (
+        tempfile::TempDir,
+        GitCliBackend,
+        git2::Repository,
+        String,
+        String,
+    ) {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+
+        git(workdir, &["init"]);
+        git(workdir, &["config", "user.email", "test@example.com"]);
+        git(workdir, &["config", "user.name", "Test User"]);
+        git(workdir, &["config", "commit.gpgsign", "false"]);
+        write_file(workdir, "shared.txt", "base\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "base"]);
+        let base_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve base commit")
+            .trim()
+            .to_string();
+
+        git(workdir, &["switch", "-c", "side"]);
+        write_file(workdir, "side.txt", "side\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "side"]);
+
+        git(workdir, &["switch", "-c", "trunk", &base_id]);
+        write_file(workdir, "shared.txt", "base\ntrunk-only\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "trunk only"]);
+        let left_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve left commit")
+            .trim()
+            .to_string();
+
+        git(workdir, &["merge", "--no-ff", "side", "-m", "merge side"]);
+        let right_id = run_git_command(workdir, &["rev-parse", "HEAD"])
+            .expect("failed to resolve right commit")
+            .trim()
+            .to_string();
+
+        let cli_backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+            .expect("failed to discover cli backend");
+        let repo = git2::Repository::open(workdir).expect("failed to open git2 repo");
+        (temp_dir, cli_backend, repo, left_id, right_id)
+    }
+
     #[test]
     fn parses_runtime_flags_from_single_config_read() {
         let output = "core.untrackedcache true\ncore.fsmonitor .git/hooks/fsmonitor-watchman\n";
@@ -1266,10 +1385,10 @@ mod tests {
         let revset = format!("{}..{}", ids[0], ids[1]);
 
         let resolved = backend
-            .resolve_revisions(&revset)
+            .resolve_revision_range(&revset)
             .expect("failed to resolve revisions");
 
-        assert_eq!(resolved, vec![ids[1].clone()]);
+        assert_eq!(resolved.commit_ids.as_ref(), &[ids[1].clone()]);
     }
 
     #[test]
@@ -1277,7 +1396,13 @@ mod tests {
         let (_temp_dir, backend, ids) = setup_sparse_index_repo();
 
         let files = backend
-            .get_commit_range_diff(&[ids[1].clone()], &SyntaxHighlighter::default())
+            .get_commit_range_diff(
+                &ResolvedRevisionRange::from_owned_commit_ids(
+                    vec![ids[1].clone()],
+                    RevisionDiffTarget::CommitList,
+                ),
+                &SyntaxHighlighter::default(),
+            )
             .expect("failed to get sparse commit range diff");
 
         assert_eq!(files.len(), 1);
@@ -1413,13 +1538,22 @@ mod tests {
         assert_eq!(
             summarize_files(
                 cli_backend
-                    .get_commit_range_diff(&[ids[1].clone()], &highlighter)
+                    .get_commit_range_diff(
+                        &ResolvedRevisionRange::from_owned_commit_ids(
+                            vec![ids[1].clone()],
+                            RevisionDiffTarget::CommitList,
+                        ),
+                        &highlighter
+                    )
                     .unwrap()
             ),
             summarize_files(
                 diff::get_commit_range_diff(
                     &repo,
-                    &[ids[1].clone()],
+                    &ResolvedRevisionRange::from_owned_commit_ids(
+                        vec![ids[1].clone()],
+                        RevisionDiffTarget::CommitList,
+                    ),
                     DiffWhitespaceMode::Normal,
                     &highlighter,
                 )
@@ -1458,8 +1592,8 @@ mod tests {
 
         let revset = format!("{}..{}", ids[0], ids[1]);
         assert_eq!(
-            cli_backend.resolve_revisions(&revset).unwrap(),
-            repository::resolve_revisions(&repo, &revset).unwrap()
+            cli_backend.resolve_revision_range(&revset).unwrap(),
+            repository::resolve_revision_range(&repo, &revset).unwrap()
         );
 
         let cli_commit_info = cli_backend.get_commits_info(&ids).unwrap();
@@ -1473,6 +1607,64 @@ mod tests {
                 .iter()
                 .map(|commit| (&commit.id, &commit.summary, &commit.body))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn commit_range_with_merge_excludes_changes_already_in_left_ref() {
+        // A range whose head is a merge commit must diff the requested
+        // endpoints, not the first selected commit's parent.
+        // Otherwise changes already present in the left ref appear in review.
+        let (_temp_dir, cli_backend, repo, left_id, right_id) = setup_merge_range_repo();
+        let highlighter = SyntaxHighlighter::default();
+        let revisions = format!("{left_id}..{right_id}");
+
+        let cli_range = cli_backend
+            .resolve_revision_range(&revisions)
+            .expect("failed to resolve cli revisions");
+        assert_eq!(
+            cli_range.diff_target,
+            RevisionDiffTarget::Explicit {
+                base: Some(left_id.clone()),
+                head: right_id.clone(),
+            }
+        );
+        let cli_files = cli_backend
+            .get_commit_range_diff(&cli_range, &highlighter)
+            .expect("failed to get cli range diff");
+
+        let libgit2_range =
+            repository::resolve_revision_range(&repo, &revisions).expect("failed to resolve range");
+        assert_eq!(
+            libgit2_range.diff_target,
+            RevisionDiffTarget::Explicit {
+                base: Some(left_id),
+                head: right_id,
+            }
+        );
+        let libgit2_files = diff::get_commit_range_diff(
+            &repo,
+            &libgit2_range,
+            DiffWhitespaceMode::Normal,
+            &highlighter,
+        )
+        .expect("failed to get libgit2 range diff");
+
+        assert_eq!(
+            summarize_files(cli_files),
+            vec![(
+                Some(PathBuf::from("side.txt")),
+                Some(PathBuf::from("side.txt")),
+                FileStatus::Added,
+            )]
+        );
+        assert_eq!(
+            summarize_files(libgit2_files),
+            vec![(
+                Some(PathBuf::from("side.txt")),
+                Some(PathBuf::from("side.txt")),
+                FileStatus::Added,
+            )]
         );
     }
 

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
-use crate::vcs::traits::{ChangeKind, DiffWhitespaceMode};
+use crate::vcs::traits::{
+    ChangeKind, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget,
+};
 use crate::vcs::{enhance_with_full_file_highlight, tabify};
 
 pub fn get_working_tree_diff(
@@ -128,10 +130,31 @@ pub fn get_unstaged_diff(
 /// The diff compares the oldest commit's parent to the newest commit.
 pub fn get_commit_range_diff(
     repo: &Repository,
-    commit_ids: &[String],
+    revision_range: &ResolvedRevisionRange<'_>,
     whitespace_mode: DiffWhitespaceMode,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
+    let (old_tree, new_tree) = match &revision_range.diff_target {
+        RevisionDiffTarget::CommitList => {
+            commit_list_range_trees(repo, &revision_range.commit_ids)?
+        }
+        RevisionDiffTarget::Explicit { base, head } => {
+            let old_tree = match base {
+                Some(base) => Some(tree_for_commit(repo, base)?),
+                None => None,
+            };
+            let new_tree = tree_for_commit(repo, head)?;
+            (old_tree, new_tree)
+        }
+    };
+
+    diff_commit_trees(repo, old_tree, new_tree, whitespace_mode, highlighter)
+}
+
+fn commit_list_range_trees<'repo>(
+    repo: &'repo Repository,
+    commit_ids: &[String],
+) -> Result<(Option<git2::Tree<'repo>>, git2::Tree<'repo>)> {
     if commit_ids.is_empty() {
         return Err(TuicrError::NoChanges);
     }
@@ -148,8 +171,23 @@ pub fn get_commit_range_diff(
         None
     };
 
-    let new_tree = newest_commit.tree()?;
+    Ok((old_tree, newest_commit.tree()?))
+}
 
+// Explicit revision ranges carry commit IDs for old/new endpoints,
+// but libgit2 diffs require the endpoint trees.
+fn tree_for_commit<'repo>(repo: &'repo Repository, commit_id: &str) -> Result<git2::Tree<'repo>> {
+    let oid = git2::Oid::from_str(commit_id)?;
+    Ok(repo.find_commit(oid)?.tree()?)
+}
+
+fn diff_commit_trees(
+    repo: &Repository,
+    old_tree: Option<git2::Tree<'_>>,
+    new_tree: git2::Tree<'_>,
+    whitespace_mode: DiffWhitespaceMode,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>> {
     let mut opts = diff_options(whitespace_mode);
 
     let diff = repo.diff_tree_to_tree(old_tree.as_ref(), Some(&new_tree), Some(&mut opts))?;

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -8,7 +8,7 @@ use crate::syntax::SyntaxHighlighter;
 
 use super::{context, diff, repository, staging};
 use crate::vcs::traits::{
-    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsInfo, VcsType,
+    ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, VcsBackend, VcsInfo, VcsType,
 };
 
 /// Git backend implementation using the git2/libgit2 library.
@@ -158,16 +158,21 @@ impl VcsBackend for Libgit2Backend {
             .collect())
     }
 
-    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
-        repository::resolve_revisions(&self.repo, revisions)
+    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
+        repository::resolve_revision_range(&self.repo, revisions)
     }
 
     fn get_commit_range_diff(
         &self,
-        commit_ids: &[String],
+        revision_range: &ResolvedRevisionRange<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        diff::get_commit_range_diff(&self.repo, commit_ids, self.whitespace_mode, highlighter)
+        diff::get_commit_range_diff(
+            &self.repo,
+            revision_range,
+            self.whitespace_mode,
+            highlighter,
+        )
     }
 
     fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -14,13 +14,61 @@ use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_out
 use crate::syntax::SyntaxHighlighter;
 
 use super::traits::{
-    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsChangeStatus, VcsInfo,
+    ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, VcsBackend, VcsChangeStatus,
+    VcsInfo,
 };
 use cli::GitCliBackend;
 pub use libgit2::Libgit2Backend;
 
 // Re-exported for UI/app gap calculations.
 pub use context::calculate_gap;
+
+/// RevisionExpression is Git's parsed view of a user-supplied revision string.
+///
+/// Accepted forms are:
+/// `REV` for a single commit, such as `HEAD`;
+/// `A..B`, `A..`, or `..B` for a two-dot range; and
+/// `A...B` for a merge-base range.
+pub(super) enum RevisionExpression<'a> {
+    /// A single commit expression, for example `HEAD`.
+    Single(&'a str),
+
+    /// A two-dot range.
+    ///
+    /// `A..B` is represented as `base = "A"` and `head = "B"`.
+    /// `A..` is represented as `base = "A"` and `head = "HEAD"`.
+    /// `..B` is represented as `base = "HEAD"` and `head = "B"`.
+    Range { base: &'a str, head: &'a str },
+
+    /// A three-dot range, for example `A...B`.
+    MergeBaseRange { left: &'a str, right: &'a str },
+}
+
+impl<'a> RevisionExpression<'a> {
+    /// Parse Git revision syntax accepted by tuicr's `-r` option.
+    ///
+    /// This accepts `REV`, `A..B`, `A..`, `..B`, and `A...B`.
+    /// Open-ended two-dot ranges are normalized to use `HEAD` for the
+    /// missing endpoint.
+    pub(super) fn parse(revisions: &'a str) -> Result<Self> {
+        if let Some((left, right)) = revisions.split_once("...") {
+            if left.is_empty() || right.is_empty() {
+                return Err(TuicrError::VcsCommand(
+                    "Invalid revision range: missing endpoint".into(),
+                ));
+            }
+            return Ok(Self::MergeBaseRange { left, right });
+        }
+
+        if let Some((base, head)) = revisions.split_once("..") {
+            let base = if base.is_empty() { "HEAD" } else { base };
+            let head = if head.is_empty() { "HEAD" } else { head };
+            return Ok(Self::Range { base, head });
+        }
+
+        Ok(Self::Single(revisions))
+    }
+}
 
 /// Top-level Git backend.
 ///
@@ -280,21 +328,21 @@ impl VcsBackend for GitBackend {
         }
     }
 
-    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
+    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
         match self {
-            Self::Libgit2(backend) => backend.resolve_revisions(revisions),
-            Self::Cli(backend) => backend.resolve_revisions(revisions),
+            Self::Libgit2(backend) => backend.resolve_revision_range(revisions),
+            Self::Cli(backend) => backend.resolve_revision_range(revisions),
         }
     }
 
     fn get_commit_range_diff(
         &self,
-        commit_ids: &[String],
+        revision_range: &ResolvedRevisionRange<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
         match self {
-            Self::Libgit2(backend) => backend.get_commit_range_diff(commit_ids, highlighter),
-            Self::Cli(backend) => backend.get_commit_range_diff(commit_ids, highlighter),
+            Self::Libgit2(backend) => backend.get_commit_range_diff(revision_range, highlighter),
+            Self::Cli(backend) => backend.get_commit_range_diff(revision_range, highlighter),
         }
     }
 

--- a/src/vcs/git/repository.rs
+++ b/src/vcs/git/repository.rs
@@ -3,6 +3,9 @@ use git2::{BranchType, Oid, Repository};
 use std::collections::HashMap;
 
 use crate::error::{Result, TuicrError};
+use crate::vcs::{ResolvedRevisionRange, RevisionDiffTarget};
+
+use super::RevisionExpression;
 
 #[derive(Debug, Clone)]
 pub struct CommitInfo {
@@ -153,50 +156,91 @@ pub fn get_commits_info(repo: &Repository, ids: &[String]) -> Result<Vec<CommitI
     Ok(commits)
 }
 
-/// Resolve a git revision range expression to a list of commit IDs (oldest first).
+/// Resolve a Git revision expression into selected commits and diff endpoints.
 ///
-/// Supports both single revisions ("HEAD~3") and ranges ("main..feature").
-/// For a range A..B, walks from B back to (but not including) A.
-/// For a single revision, returns just that commit.
-pub fn resolve_revisions(repo: &Repository, revisions: &str) -> Result<Vec<String>> {
-    // Try parsing as a range first (e.g., "A..B")
-    let revspec = repo.revparse(revisions)?;
-
-    let mut commit_ids = if revspec.mode().contains(git2::RevparseMode::RANGE) {
-        // Range: walk from `to` back, stopping before `from`
-        let from = revspec.from().ok_or_else(|| {
-            TuicrError::VcsCommand("Invalid revision range: missing 'from'".into())
-        })?;
-        let to = revspec
-            .to()
-            .ok_or_else(|| TuicrError::VcsCommand("Invalid revision range: missing 'to'".into()))?;
-
-        let mut revwalk = repo.revwalk()?;
-        revwalk.push(to.id())?;
-        revwalk.hide(from.id())?;
-        revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
-
-        let mut ids = Vec::new();
-        for oid in revwalk {
-            ids.push(oid?.to_string());
+/// This preserves the distinction between commits selected for review metadata
+/// and the old/new trees that Git would compare for the original expression.
+pub fn resolve_revision_range(
+    repo: &Repository,
+    revisions: &str,
+) -> Result<ResolvedRevisionRange<'static>> {
+    match RevisionExpression::parse(revisions)? {
+        RevisionExpression::Single(revision) => {
+            // `HEAD`
+            let head = resolve_commit_id(repo, revision)?;
+            let base = first_parent_id(repo, &head)?;
+            Ok(ResolvedRevisionRange::from_owned_commit_ids(
+                vec![head.clone()],
+                RevisionDiffTarget::Explicit { base, head },
+            ))
         }
-        ids
-    } else {
-        // Single revision
-        let obj = revspec
-            .from()
-            .ok_or_else(|| TuicrError::VcsCommand("Invalid revision expression".into()))?;
-        let commit = obj
-            .peel_to_commit()
-            .map_err(|e| TuicrError::VcsCommand(format!("Not a commit: {}", e)))?;
-        vec![commit.id().to_string()]
-    };
+        RevisionExpression::Range { base, head } => {
+            // `A..B`, `A..`, or `..B`
+            let base = resolve_commit_id(repo, base)?;
+            let head = resolve_commit_id(repo, head)?;
+            let commit_ids = revwalk_range(repo, &base, &head)?;
+            Ok(ResolvedRevisionRange::from_owned_commit_ids(
+                commit_ids,
+                RevisionDiffTarget::Explicit {
+                    base: Some(base),
+                    head,
+                },
+            ))
+        }
+        RevisionExpression::MergeBaseRange { left, right } => {
+            // `A...B`
+            let left = resolve_commit_id(repo, left)?;
+            let right = resolve_commit_id(repo, right)?;
+            let base = repo
+                .merge_base(Oid::from_str(&left)?, Oid::from_str(&right)?)?
+                .to_string();
+            let commit_ids = revwalk_range(repo, &base, &right)?;
+            Ok(ResolvedRevisionRange::from_owned_commit_ids(
+                commit_ids,
+                RevisionDiffTarget::Explicit {
+                    base: Some(base),
+                    head: right,
+                },
+            ))
+        }
+    }
+}
+
+fn resolve_commit_id(repo: &Repository, revision: &str) -> Result<String> {
+    let revision = format!("{revision}^{{commit}}");
+    let obj = repo.revparse_single(&revision)?;
+    let commit = obj
+        .peel_to_commit()
+        .map_err(|e| TuicrError::VcsCommand(format!("Not a commit: {e}")))?;
+    Ok(commit.id().to_string())
+}
+
+// Single-revision reviews diff the commit against its first parent.
+// Root commits have no parent,
+// so callers represent the old side as the empty tree with None.
+fn first_parent_id(repo: &Repository, commit_id: &str) -> Result<Option<String>> {
+    let commit = repo.find_commit(Oid::from_str(commit_id)?)?;
+    if commit.parent_count() == 0 {
+        return Ok(None);
+    }
+    Ok(Some(commit.parent(0)?.id().to_string()))
+}
+
+fn revwalk_range(repo: &Repository, base: &str, head: &str) -> Result<Vec<String>> {
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push(Oid::from_str(head)?)?;
+    revwalk.hide(Oid::from_str(base)?)?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::TIME)?;
+
+    let mut commit_ids = Vec::new();
+    for oid in revwalk {
+        commit_ids.push(oid?.to_string());
+    }
 
     if commit_ids.is_empty() {
         return Err(TuicrError::NoChanges);
     }
 
-    // revwalk outputs newest first; reverse so oldest is first
     commit_ids.reverse();
     Ok(commit_ids)
 }

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -9,7 +9,10 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::traits::{CommitInfo, DiffWhitespaceMode, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::traits::{
+    CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsInfo,
+    VcsType,
+};
 use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
 
 /// Parse an hg description into (summary, optional body).
@@ -175,7 +178,7 @@ impl VcsBackend for HgBackend {
         Ok(content.lines().count() as u32)
     }
 
-    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
+    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
         // Use hg log to resolve the revset to commit hashes.
         // hg log outputs newest first; we reverse so oldest is first.
         let output = run_hg_command(
@@ -196,7 +199,10 @@ impl VcsBackend for HgBackend {
 
         // hg log outputs newest first; reverse so oldest is first
         commit_ids.reverse();
-        Ok(commit_ids)
+        Ok(ResolvedRevisionRange::from_owned_commit_ids(
+            commit_ids,
+            RevisionDiffTarget::CommitList,
+        ))
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
@@ -260,9 +266,10 @@ impl VcsBackend for HgBackend {
 
     fn get_commit_range_diff(
         &self,
-        commit_ids: &[String],
+        revision_range: &ResolvedRevisionRange<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
+        let commit_ids = &revision_range.commit_ids;
         if commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
@@ -494,6 +501,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::RevisionDiffTarget;
     use std::fs;
 
     /// Check if hg command is available
@@ -808,7 +816,13 @@ mod tests {
 
         // Get diff for the last two commits (Second and Third)
         let commit_ids = vec![commits[1].id.clone(), commits[0].id.clone()];
-        let diff_result = backend.get_commit_range_diff(&commit_ids, &SyntaxHighlighter::default());
+        let diff_result = backend.get_commit_range_diff(
+            &ResolvedRevisionRange::from_owned_commit_ids(
+                commit_ids,
+                RevisionDiffTarget::CommitList,
+            ),
+            &SyntaxHighlighter::default(),
+        );
 
         // Note: Sapling (Meta's hg fork) may fail with "id_dag_snapshot()" error
         // in certain temporary directory configurations. Skip the test in that case.

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -11,7 +11,10 @@ use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
-use crate::vcs::traits::{CommitInfo, DiffWhitespaceMode, VcsBackend, VcsInfo, VcsType};
+use crate::vcs::traits::{
+    CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsInfo,
+    VcsType,
+};
 use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
 
 /// Parse a jj description into (summary, optional body).
@@ -225,7 +228,7 @@ impl VcsBackend for JjBackend {
         Ok(content.lines().count() as u32)
     }
 
-    fn resolve_revisions(&self, revisions: &str) -> Result<Vec<String>> {
+    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
         // Use jj log to resolve the revisions to commit IDs, reverse-chronological by default.
         // We reverse the result so the oldest commit is first (matching get_commit_range_diff expectations).
         let output = run_jj_command(
@@ -253,7 +256,10 @@ impl VcsBackend for JjBackend {
 
         // jj log outputs newest first; reverse so oldest is first
         commit_ids.reverse();
-        Ok(commit_ids)
+        Ok(ResolvedRevisionRange::from_owned_commit_ids(
+            commit_ids,
+            RevisionDiffTarget::CommitList,
+        ))
     }
 
     fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
@@ -317,9 +323,10 @@ impl VcsBackend for JjBackend {
 
     fn get_commit_range_diff(
         &self,
-        commit_ids: &[String],
+        revision_range: &ResolvedRevisionRange<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
+        let commit_ids = &revision_range.commit_ids;
         if commit_ids.is_empty() {
             return Err(TuicrError::NoChanges);
         }
@@ -489,6 +496,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vcs::RevisionDiffTarget;
     use std::fs;
 
     /// Check if jj command is available
@@ -834,7 +842,13 @@ mod tests {
 
             let commit_ids = vec![oldest.id.clone(), newest.id.clone()];
             let diff = backend
-                .get_commit_range_diff(&commit_ids, &SyntaxHighlighter::default())
+                .get_commit_range_diff(
+                    &ResolvedRevisionRange::from_owned_commit_ids(
+                        commit_ids,
+                        RevisionDiffTarget::CommitList,
+                    ),
+                    &SyntaxHighlighter::default(),
+                )
                 .expect("Failed to get commit range diff");
 
             // Should have changes

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -26,8 +26,8 @@ pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use pr_noop::PrNoopVcs;
 pub use traits::{
-    ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, VcsBackend, VcsChangeStatus,
-    VcsInfo,
+    ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget,
+    VcsBackend, VcsChangeStatus, VcsInfo,
 };
 
 use std::collections::HashMap;

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -26,7 +26,8 @@ pub use hg::HgBackend;
 pub use jj::JjBackend;
 pub use pr_noop::PrNoopVcs;
 pub use traits::{
-    ChangeKind, CommitInfo, DiffWhitespaceMode, VcsBackend, VcsChangeStatus, VcsInfo,
+    ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, VcsBackend, VcsChangeStatus,
+    VcsInfo,
 };
 
 use std::collections::HashMap;

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
 use crate::error::Result;
@@ -68,6 +69,39 @@ pub struct CommitInfo {
     pub body: Option<String>,
     pub author: String,
     pub time: DateTime<Utc>,
+}
+
+/// ResolvedRevisionRange is the VCS boundary's parsed form of a user-provided
+/// revision expression.
+///
+/// It preserves the knowledge gained while resolving the expression so callers
+/// do not need to keep passing the raw revision string through lower layers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedRevisionRange<'a> {
+    /// Commit IDs selected by the expression, oldest first.
+    pub commit_ids: Cow<'a, [String]>,
+}
+
+impl<'a> ResolvedRevisionRange<'a> {
+    /// Build a range from commit IDs already owned by the caller.
+    ///
+    /// This is used by selection and reload paths that already store the
+    /// selected commits in application state.
+    pub fn from_commit_ids(commit_ids: &'a [String]) -> Self {
+        Self {
+            commit_ids: Cow::Borrowed(commit_ids),
+        }
+    }
+
+    /// Build a range from commit IDs produced while resolving a revision.
+    ///
+    /// This is used at VCS adapter boundaries,
+    /// where there is no longer-lived caller-owned slice to borrow from.
+    pub fn from_owned_commit_ids(commit_ids: Vec<String>) -> Self {
+        Self {
+            commit_ids: Cow::Owned(commit_ids),
+        }
+    }
 }
 
 /// Cheap repository change summary used by selection UIs before loading full diffs.
@@ -171,6 +205,14 @@ pub trait VcsBackend: Send {
     fn resolve_revisions(&self, _revisions: &str) -> Result<Vec<String>> {
         Err(crate::error::TuicrError::UnsupportedOperation(
             "Revset resolution not supported for this VCS".into(),
+        ))
+    }
+
+    /// Resolve a revisions expression into the VCS boundary's parsed range.
+    /// Returns error if not supported (default).
+    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
+        Ok(ResolvedRevisionRange::from_owned_commit_ids(
+            self.resolve_revisions(revisions)?,
         ))
     }
 

--- a/src/vcs/traits.rs
+++ b/src/vcs/traits.rs
@@ -80,28 +80,63 @@ pub struct CommitInfo {
 pub struct ResolvedRevisionRange<'a> {
     /// Commit IDs selected by the expression, oldest first.
     pub commit_ids: Cow<'a, [String]>,
+
+    /// Boundary to use when materializing the file diff for this range.
+    pub diff_target: RevisionDiffTarget,
 }
 
 impl<'a> ResolvedRevisionRange<'a> {
-    /// Build a range from commit IDs already owned by the caller.
+    /// Build a range from borrowed commit IDs and a diff boundary.
     ///
-    /// This is used by selection and reload paths that already store the
-    /// selected commits in application state.
-    pub fn from_commit_ids(commit_ids: &'a [String]) -> Self {
+    /// Selection and reload paths use this when application state already
+    /// stores the selected commits and no clone is needed.
+    pub fn from_commit_ids(commit_ids: &'a [String], diff_target: RevisionDiffTarget) -> Self {
         Self {
             commit_ids: Cow::Borrowed(commit_ids),
+            diff_target,
         }
     }
 
-    /// Build a range from commit IDs produced while resolving a revision.
+    /// Build a range from owned commit IDs and a diff boundary.
     ///
-    /// This is used at VCS adapter boundaries,
-    /// where there is no longer-lived caller-owned slice to borrow from.
-    pub fn from_owned_commit_ids(commit_ids: Vec<String>) -> Self {
+    /// VCS adapters use this after resolving both the commit list and the
+    /// old/new diff target that should be used to materialize the range.
+    pub fn from_owned_commit_ids(commit_ids: Vec<String>, diff_target: RevisionDiffTarget) -> Self {
         Self {
             commit_ids: Cow::Owned(commit_ids),
+            diff_target,
         }
     }
+}
+
+/// RevisionDiffTarget describes the old and new sides of a revision diff.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RevisionDiffTarget {
+    /// Infer diff endpoints from the selected commit list.
+    ///
+    /// This is used when the user selected commits as commits,
+    /// for example through the inline commit selector,
+    /// reloading an active commit-range session,
+    /// or a backend that only reports a resolved commit list.
+    /// In this mode,
+    /// backends infer the old side from the oldest selected commit.
+    CommitList,
+
+    /// Compare the resolved base revision to the resolved head revision.
+    ///
+    /// This is used when the user supplied a revision expression,
+    /// for example `tuicr -r A..B`,
+    /// `tuicr -r A...B`,
+    /// or `tuicr -r REV`.
+    /// In this mode,
+    /// the parsed expression supplies the diff boundary directly.
+    Explicit {
+        /// Old side of the diff, or None for the empty tree.
+        base: Option<String>,
+
+        /// New side of the diff.
+        head: String,
+    },
 }
 
 /// Cheap repository change summary used by selection UIs before loading full diffs.
@@ -200,19 +235,11 @@ pub trait VcsBackend: Send {
         Ok(Vec::new())
     }
 
-    /// Resolve a revisions expression to a list of commit IDs (oldest first).
-    /// Returns error if not supported (default).
-    fn resolve_revisions(&self, _revisions: &str) -> Result<Vec<String>> {
-        Err(crate::error::TuicrError::UnsupportedOperation(
-            "Revset resolution not supported for this VCS".into(),
-        ))
-    }
-
     /// Resolve a revisions expression into the VCS boundary's parsed range.
     /// Returns error if not supported (default).
-    fn resolve_revision_range(&self, revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
-        Ok(ResolvedRevisionRange::from_owned_commit_ids(
-            self.resolve_revisions(revisions)?,
+    fn resolve_revision_range(&self, _revisions: &str) -> Result<ResolvedRevisionRange<'static>> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "Revision range resolution not supported for this VCS".into(),
         ))
     }
 
@@ -220,7 +247,7 @@ pub trait VcsBackend: Send {
     /// Returns error if not supported (default).
     fn get_commit_range_diff(
         &self,
-        _commit_ids: &[String],
+        _revision_range: &ResolvedRevisionRange<'_>,
         _highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
         Err(crate::error::TuicrError::UnsupportedOperation(


### PR DESCRIPTION
`tuicr -r A..B` used to turn the revision range into a list of commits,
then ask the diff loader to reconstruct the file diff from that list.
For linear history this happened to work:
the oldest selected commit's parent is the same tree as `A`.

Merge commits break that assumption.
If `B` merges a side branch,
the oldest selected commit can come from the side branch.
tuicr then compared `parent(side-branch-commit)..B`,
which pulled in changes that already existed in `A`.
The UI showed those left-ref-only changes as reviewable diff content even
though `git diff A B` would not show them.

The bug was that commit selection metadata and diff endpoints were coupled.
The selected commit list is useful for review state and commit metadata,
but it is not a reliable source of the old side of the file diff.

Git revision resolution now preserves both pieces of information:
the selected commits for review metadata,
and the resolved old/new endpoints for diff loading.
Commit selector ranges keep the legacy commit-list target,
while parsed revision expressions carry the user-provided diff boundary.

Testing:
The regression test builds an `A..B` range where `B` is a merge commit.
It verifies that changes already present in `A` stay out of tuicr's diff.

---

As this required a small refactor,
this change is split into two commits:
refactor and fix.
