### PR TITLE
feat: allow :q to quit when only files are marked reviewed

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -120,7 +120,7 @@ In command mode,
 | `:clearc` | Clear comments without clearing reviewed marks |
 | `:version` | Show tuicr version |
 | `:update` | Check for updates |
-| `:q` | Quit (warns if unsaved) |
+| `:q` | Quit (warns on unsaved comments; discards review-only state) |
 | `:q!` | Force quit |
 | `:x` / `:wq` | Save and quit (prompts to copy if comments exist) |
 | `ZZ` | Save and quit |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1988,6 +1988,28 @@ impl App {
         crate::persistence::storage::clear_active_session_for_pid()
     }
 
+    /// Discard this session's persisted state and quit.
+    ///
+    /// Used when the only unsaved change is reviewed-file markers (no
+    /// comments): rather than forcing `:q!`, we drop the persisted session so
+    /// reopening starts clean, then quit. Reviewed markers are persisted
+    /// eagerly, so the on-disk file is removed too.
+    pub fn discard_session_and_quit(&mut self) {
+        let path = self
+            .session_path
+            .clone()
+            .or_else(|| crate::persistence::storage::session_path(&self.session).ok());
+        if let Some(path) = path {
+            let _ = crate::persistence::storage::delete_session(&path);
+            self.ephemeral_session_paths.remove(&path);
+            if self.session_path.as_ref() == Some(&path) {
+                self.session_file_state = None;
+            }
+        }
+        self.dirty = false;
+        self.should_quit = true;
+    }
+
     pub fn save_current_session_merging_external(&mut self) -> Result<PathBuf> {
         let identity = self.session.clone();
         let current = self.session.clone();
@@ -11041,6 +11063,62 @@ index 1111111..2222222 100644
         // then
         assert_eq!(app.forge_repository.as_ref(), Some(&canonical));
         assert!(app.canonical_resolved);
+    }
+
+    #[test]
+    fn should_quit_on_q_when_only_reviewed_files_dirty() {
+        // given: a session dirtied only by a reviewed-file marker (no comments)
+        let mut app = build_app();
+        let path = PathBuf::from("src/main.rs");
+        app.session.add_file(path.clone(), FileStatus::Modified, 0);
+        app.session.get_file_mut(&path).unwrap().reviewed = true;
+        app.dirty = true;
+        assert!(!app.session.has_comments());
+        app.command_buffer = "q".to_string();
+
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::SubmitInput);
+
+        // then: `:q` discards the reviewed-only state and quits, no `:q!` needed
+        assert!(app.should_quit);
+        assert!(!app.dirty);
+        assert!(
+            !matches!(
+                app.message.as_ref().map(|m| &m.message_type),
+                Some(MessageType::Error)
+            ),
+            "should not surface a no-write error"
+        );
+    }
+
+    #[test]
+    fn should_block_q_when_unsaved_comments_exist() {
+        // given: a session with an unsaved comment
+        let mut app = build_app();
+        let path = PathBuf::from("src/main.rs");
+        app.session.add_file(path.clone(), FileStatus::Modified, 0);
+        app.session
+            .get_file_mut(&path)
+            .unwrap()
+            .add_file_comment(crate::model::Comment::new(
+                "needs work".to_string(),
+                crate::model::CommentType::Note,
+                None,
+            ));
+        app.dirty = true;
+        assert!(app.session.has_comments());
+        app.command_buffer = "q".to_string();
+
+        // when
+        crate::handler::handle_command_action(&mut app, crate::input::Action::SubmitInput);
+
+        // then: the guard still requires `:q!`
+        assert!(!app.should_quit);
+        assert!(app.dirty);
+        assert_eq!(
+            app.message.as_ref().map(|m| m.message_type.clone()),
+            Some(MessageType::Error)
+        );
     }
 
     #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -687,8 +687,12 @@ impl CompletionResult {
 fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
     match kind {
         CommandKind::Quit => {
-            if app.dirty {
+            if app.dirty && app.session.has_comments() {
                 app.set_error("No write since last change (add ! to override)");
+            } else if app.dirty {
+                // Dirty from reviewed-file markers only: discard the state and
+                // quit instead of requiring `:q!`.
+                app.discard_session_and_quit();
             } else {
                 app.should_quit = true;
             }
@@ -1336,9 +1340,13 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
 
     match action {
         Action::Quit => {
-            if app.dirty && !app.quit_warned {
+            if app.dirty && app.session.has_comments() && !app.quit_warned {
                 app.set_sticky_warning("Unsaved changes. Press q again to quit.");
                 app.quit_warned = true;
+            } else if app.dirty && !app.session.has_comments() {
+                // Dirty from reviewed-file markers only: discard the state and
+                // quit instead of warning about unsaved changes.
+                app.discard_session_and_quit();
             } else {
                 app.should_quit = true;
             }

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -135,25 +135,55 @@ pub(crate) fn delete_session_if_empty_in_dir(path: &Path, reviews_dir: &Path) ->
             return Ok(false);
         }
 
-        let slug = slug_for_session(&session)?.to_string();
-        let relative = path
-            .strip_prefix(reviews_dir)
-            .map(Path::to_path_buf)
-            .unwrap_or_else(|_| path.to_path_buf());
-
-        let mut manifest = manifest::load_manifest(reviews_dir).unwrap_or_default();
-        if let Some(bucket) = manifest.entries.get_mut(&slug) {
-            bucket.retain(|entry| entry.path != relative);
-            if bucket.is_empty() {
-                manifest.entries.remove(&slug);
-            }
-            manifest::save_manifest(reviews_dir, &manifest)?;
-        }
-
-        fs::remove_file(path)?;
-
+        remove_session_at(path, reviews_dir, &session)?;
         Ok(true)
     })
+}
+
+/// Delete a session file and its manifest entry unconditionally. Returns
+/// `false` when there was no file to remove.
+///
+/// Unlike [`delete_session_if_empty`], this discards a session even when it
+/// has reviewed-file markers. It backs the "discard reviewed-only state on
+/// quit" path, where the session carries no comments worth keeping.
+pub(crate) fn delete_session(path: &Path) -> Result<bool> {
+    let reviews_dir = get_reviews_dir()?;
+    delete_session_in_dir(path, &reviews_dir)
+}
+
+pub(crate) fn delete_session_in_dir(path: &Path, reviews_dir: &Path) -> Result<bool> {
+    maybe_migrate(reviews_dir)?;
+    with_reviews_dir_lock(reviews_dir, || {
+        if !path.exists() {
+            return Ok(false);
+        }
+        let session = load_session(path)?;
+        remove_session_at(path, reviews_dir, &session)?;
+        Ok(true)
+    })
+}
+
+/// Remove `path` and prune its manifest entry. The caller must already hold
+/// the reviews-dir lock and have loaded `session` from `path`.
+fn remove_session_at(path: &Path, reviews_dir: &Path, session: &ReviewSession) -> Result<()> {
+    let slug = slug_for_session(session)?.to_string();
+    let relative = path
+        .strip_prefix(reviews_dir)
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf());
+
+    let mut manifest = manifest::load_manifest(reviews_dir).unwrap_or_default();
+    if let Some(bucket) = manifest.entries.get_mut(&slug) {
+        bucket.retain(|entry| entry.path != relative);
+        if bucket.is_empty() {
+            manifest.entries.remove(&slug);
+        }
+        manifest::save_manifest(reviews_dir, &manifest)?;
+    }
+
+    fs::remove_file(path)?;
+
+    Ok(())
 }
 
 pub(crate) fn mark_session_active(session: &ReviewSession, path: &Path) -> Result<()> {
@@ -809,6 +839,41 @@ mod tests {
         )
         .unwrap();
         assert!(sessions.is_none());
+    }
+
+    #[test]
+    fn should_delete_reviewed_only_session_unconditionally() {
+        let _g = with_test_reviews_dir();
+        let repo = make_repo();
+        let mut session = make_local_session(
+            repo.clone(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        );
+        // Mark the file reviewed: `delete_session_if_empty` would refuse this,
+        // but `delete_session` discards it anyway.
+        session
+            .get_file_mut(&PathBuf::from("src/main.rs"))
+            .unwrap()
+            .reviewed = true;
+        let path = save_session(&session).unwrap();
+        assert!(path.exists());
+
+        assert!(!delete_session_if_empty(&path).unwrap());
+        assert!(path.exists(), "reviewed session must survive empty-delete");
+
+        assert!(delete_session(&path).unwrap());
+        assert!(!path.exists(), "reviewed-only session should be discarded");
+    }
+
+    #[test]
+    fn should_report_false_when_deleting_missing_session() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+        let missing = reviews_dir.join("does-not-exist.json");
+        assert!(!delete_session(&missing).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #233.

When a session has **no comments** but files were collapsed as reviewed with `r`, quitting now just works instead of demanding `:q!`:

- `:q` and the `q` keybinding **discard the persisted state and quit** when the only unsaved change is reviewed-file markers.
- Reviewed-only state can be auto-persisted for PR sessions, so the on-disk session file is deleted too — reopening the PR starts clean.
- Sessions with **unsaved comments** are unchanged: `:q` still errors `No write since last change (add ! to override)` and `q` still warns.

## How it works

The decision keys off `session.has_comments()` rather than the coarse `dirty` flag. The only non-comment action that dirties a session is `toggle_reviewed`, so `dirty && !has_comments()` reliably means "reviewed-markers only":

- `dirty && has_comments()` → keep the `:q!` guard / "press q again" warning.
- `dirty && !has_comments()` → discard persisted state and quit.
- not dirty → quit as before.

New `persistence::delete_session_file` removes the deterministically-named session file (missing file = success); `App::discard_session_and_quit` wires it into both quit paths. `ZQ` (explicit force-quit) is left untouched.

## Tests

- `delete_session_file` removes an existing file and treats a missing one as success.
- `:q` quits cleanly when dirty from reviewed-only markers.
- `:q` still blocks when unsaved comments exist.

All 717 tests pass; `cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo check` are clean.

## Docs

Updated the `:q` row in `docs/KEYBINDINGS.md`.