### PR TITLE
fix(clipboard): copy to system clipboard inside tmux on macOS

### DIFF
--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -71,6 +71,13 @@ pub fn export_to_clipboard(
 /// terminal-based fallback (tmux/OSC 52) was used, `Ok(false)` if the
 /// platform clipboard handled it.
 pub fn copy_text_to_clipboard(text: &str) -> Result<bool> {
+    // On macOS, pbcopy writes straight to the system pasteboard and works even
+    // inside tmux/SSH. OSC 52 (preferred below) instead relies on the outer
+    // terminal honoring the escape, which Terminal.app does not, so the copy
+    // would only reach the tmux buffer. Prefer pbcopy unconditionally here.
+    if cfg!(target_os = "macos") && try_clipboard_cmd("pbcopy", &[], text) {
+        return Ok(false);
+    }
     if should_prefer_osc52() {
         copy_osc52(text)?;
         return Ok(true);


### PR DESCRIPTION
## Problem

On macOS, yanking inside tmux does not reach the system clipboard (`Cmd+V` / `pbpaste` returns stale content). The copied text only lands in the tmux paste-buffer.

## Cause

`copy_text_to_clipboard` calls `should_prefer_osc52()` first, which returns `true` whenever `$TMUX` is set, so it short-circuits straight to `tmux load-buffer -w -`. The `-w` flag forwards to the outer terminal via OSC 52, but that only works if the outer terminal honors OSC 52 writes. Terminal.app does not, so the text never reaches the macOS pasteboard. `pbcopy` is never attempted on macOS (the subprocess path only knows `xclip`/`wl-copy`, and it is skipped anyway).

## Fix

Prefer `pbcopy` unconditionally on macOS, before the OSC 52 preference. `pbcopy` writes straight to the system pasteboard and works even inside tmux/SSH, independent of what the outer terminal supports. If `pbcopy` is unavailable, it falls through to the existing OSC 52 / arboard paths, so no behavior changes on other platforms.

## Testing

- Verified `pbcopy` reaches the system clipboard from inside tmux where `tmux load-buffer -w -` does not.
- `cargo build` passes.
- `cargo test --lib output::markdown` — 27 passed.