### PR TITLE
Attribute commit-message comments to their commit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3397,6 +3397,11 @@ impl App {
     }
 
     /// If we are viewing a single commit, insert a "Commit Message" DiffFile at index 0.
+    ///
+    /// The synthetic path embeds the commit's short id (`Commit Message (<sha>)`)
+    /// so that comments on different commits' messages get distinct session keys
+    /// (the session indexes comments by path) and the exported review records
+    /// which commit each commit-message comment belongs to.
     fn insert_commit_message_if_single(&mut self) {
         self.diff_files.retain(|f| !f.is_commit_message);
 
@@ -3447,7 +3452,10 @@ impl App {
         let content_hash = DiffFile::compute_content_hash(&hunks);
         let commit_msg_file = DiffFile {
             old_path: None,
-            new_path: Some(PathBuf::from("Commit Message")),
+            new_path: Some(PathBuf::from(format!(
+                "Commit Message ({})",
+                commit.short_id
+            ))),
             status: FileStatus::Added,
             hunks,
             is_binary: false,
@@ -5454,7 +5462,7 @@ impl App {
             AnnotatedLine::FileHeader { file_idx } => {
                 let file = self.diff_files.get(*file_idx)?;
                 if file.is_commit_message {
-                    Some("Commit Message".to_string())
+                    Some(file.display_path().display().to_string())
                 } else {
                     Some(format!(
                         "{} [{}]",

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -605,6 +605,57 @@ mod tests {
     }
 
     #[test]
+    fn should_keep_commit_identity_for_commit_message_comments() {
+        // Comments on the messages of different commits must not collapse into
+        // an indistinguishable `Commit Message:N`. The synthetic commit-message
+        // path carries the short id, which keeps each comment attributable to
+        // its commit in the export.
+        let mut session = ReviewSession::new(
+            PathBuf::from("/tmp/test-repo"),
+            "abc1234def".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::CommitRange,
+        );
+        let first = PathBuf::from("Commit Message (ed50028)");
+        let second = PathBuf::from("Commit Message (c17beb2)");
+        session.add_file(first.clone(), FileStatus::Added, 0);
+        session.add_file(second.clone(), FileStatus::Added, 0);
+        if let Some(review) = session.get_file_mut(&first) {
+            review.add_line_comment(
+                1,
+                Comment::new(
+                    "We do not need this commit".to_string(),
+                    CommentType::Note,
+                    Some(LineSide::New),
+                ),
+            );
+        }
+        if let Some(review) = session.get_file_mut(&second) {
+            review.add_line_comment(
+                6,
+                Comment::new(
+                    "This is wrong".to_string(),
+                    CommentType::Note,
+                    Some(LineSide::New),
+                ),
+            );
+        }
+
+        let diff_source =
+            DiffSource::CommitRange(vec!["ed50028".to_string(), "c17beb2".to_string()]);
+        let markdown = generate_markdown(&session, &diff_source, &comment_types(), true, &[], None);
+
+        assert!(
+            markdown.contains("`Commit Message (ed50028):1`"),
+            "expected first commit's message comment to be attributable in:\n{markdown}"
+        );
+        assert!(
+            markdown.contains("`Commit Message (c17beb2):6`"),
+            "expected second commit's message comment to be attributable in:\n{markdown}"
+        );
+    }
+
+    #[test]
     fn should_use_configured_label_and_definition_in_export() {
         let mut session = ReviewSession::new(
             PathBuf::from("/tmp/test-repo"),

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -280,7 +280,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
             let review_mark = if is_reviewed { "✓ " } else { "" };
             let header_text = if file.is_commit_message {
-                format!("═══ {}Commit Message ", review_mark)
+                format!("═══ {}{} ", review_mark, path.display())
             } else {
                 format!("═══ {}{} [{}] ", review_mark, path.display(), status)
             };

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -235,7 +235,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
             let review_mark = if is_reviewed { "✓ " } else { "" };
             let header_text = if file.is_commit_message {
-                format!("═══ {}Commit Message ", review_mark)
+                format!("═══ {}{} ", review_mark, path.display())
             } else if app.is_pristine_mode {
                 // Pristine mode reviews unchanged code; the M/A/D badge would
                 // mislead. Render the header without it.

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -129,7 +129,7 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                     if file.is_commit_message {
                         Line::from(vec![
                             Span::styled(format!("{checkbox} "), checkbox_style),
-                            Span::raw("  Commit Message".to_string()),
+                            Span::raw(format!("  {}", path.display())),
                         ])
                     } else {
                         let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");


### PR DESCRIPTION
## Problem

When reviewing a range of commits one at a time, comments on each commit's message were exported indistinguishably as `Commit Message:N`, so you couldn't tell which commit a given comment applied to. Example export:

```
1. **[NOTE]** `Commit Message:1` - We do not need this commit...
2. **[NOTE]** `Commit Message:6` - This is wrong...
```

Both lines could belong to entirely different commits, but the commit identity was lost.

## Cause

`ReviewSession` indexes comments by path (`files: HashMap<PathBuf, FileReview>`), but the synthetic commit-message `DiffFile` always used the literal path `"Commit Message"`. So message comments across different commits collided into a single key, and the markdown export rendered them all with the same location string.

## Fix

Embed the commit's short id in the synthetic path (`Commit Message (<sha>)`) so each commit's message gets a distinct session key and the exported review records which commit every comment belongs to. The unified/side-by-side diff headers and the file list now surface the same identity instead of the hardcoded `"Commit Message"` label.

Export now reads:

```
1. **[NOTE]** `Commit Message (ed50028):1` - We do not need this commit...
2. **[NOTE]** `Commit Message (560de7d):6` - This is wrong...
```

Note: previously-persisted reviews keep loading/exporting under the bare `"Commit Message"` key; only newly-added comments gain the short id. No migration was attempted.

## Test

Added `should_keep_commit_identity_for_commit_message_comments`, verifying two commit-message comments on different commits export with distinct, attributable locations. Full suite passes (964 tests).