### PR TITLE
feat(cli): add 'mr' as an alias for the 'pr' subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,7 +133,8 @@ struct TuiOptions {
 enum Subcmd {
     /// Open the interactive TUI.
     Tui(TuiCommand),
-    /// Review a GitHub pull request.
+    /// Review a GitHub pull request or GitLab merge request.
+    #[command(visible_alias = "mr")]
     Pr(PrCommand),
     /// Inspect or update persisted review sessions.
     Review {
@@ -155,7 +156,8 @@ struct TuiCommand {
 
 #[derive(Subcommand, Debug, Clone)]
 enum TuiSubcmd {
-    /// Review a GitHub pull request in the TUI.
+    /// Review a GitHub pull request or GitLab merge request in the TUI.
+    #[command(visible_alias = "mr")]
     Pr(PrCommand),
 }
 
@@ -646,6 +648,18 @@ mod tests {
     #[test]
     fn should_parse_pr_target_as_bare_number() {
         let parsed = parse_for_test(&["tuicr", "pr", "125"]).expect("parse should succeed");
+        assert_eq!(parsed.pr_target, Some("125".to_string()));
+    }
+
+    #[test]
+    fn should_parse_mr_alias_like_pr() {
+        let parsed = parse_for_test(&["tuicr", "mr", "125"]).expect("parse should succeed");
+        assert_eq!(parsed.pr_target, Some("125".to_string()));
+    }
+
+    #[test]
+    fn should_parse_tui_mr_alias_like_pr() {
+        let parsed = parse_for_test(&["tuicr", "tui", "mr", "125"]).expect("parse should succeed");
         assert_eq!(parsed.pr_target, Some("125".to_string()));
     }
 


### PR DESCRIPTION
## What

Adds `mr` as a visible alias for the `pr` subcommand, both at the top level (`tuicr mr <target>`) and under `tuicr tui` (`tuicr tui mr <target>`).

## Why

GitLab support landed in e7fbbd8, which means `tuicr pr <target>` already opens GitLab **merge requests** when the repo's remote is a GitLab host (forge is detected from the remote, not the subcommand name). For GitLab users, `pr` is the wrong word. This lets them type the natural `mr` instead.

## How

It's a clap `visible_alias` on the existing `Pr` variant, so `mr` routes through the exact same parsing and dispatch — no duplicated logic. All target forms (bare number, `owner/repo#N`, full URL) behave identically. The alias is purely terminology; it does **not** force a forge — `tuicr mr 125` on a GitHub repo still opens a GitHub PR.

## Tests

Added two parser tests (`should_parse_mr_alias_like_pr`, `should_parse_tui_mr_alias_like_pr`) mirroring the existing `pr` tests. Full cli test suite passes.