### PR TITLE
Preselect commits since last review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ PR review (`tuicr pr <target>` or `tuicr tui pr <target>`) is the only feature i
 - `get_pull_request` — details for a `PullRequestTarget` (resolves to `PullRequestDetails`).
 - `get_pull_request_diff` — the cumulative PR diff as a unified-diff string.
 - `list_pull_request_commits` — commits on the PR for the inline subset selector.
-- `list_pull_request_review_metadata` — best-effort viewer login + review commit OIDs used to preselect commits since the viewer's latest submitted review.
+- `list_pull_request_review_metadata` — best-effort viewer login + review commit OIDs used to preselect commits since the viewer's latest submitted review and mark already-reviewed commits in the inline selector.
   GitHub uses review metadata; GitLab combines `/user`, MR diff versions, approvals, and discussions.
 - `get_pull_request_commit_range_diff` — cumulative diff for a contiguous subrange (`start_sha` is the parent of the first selected commit; `end_sha` is the last).
 - `list_review_threads` — existing GitHub comments + resolved/outdated state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ PR review (`tuicr pr <target>` or `tuicr tui pr <target>`) is the only feature i
 - `get_pull_request_diff` — the cumulative PR diff as a unified-diff string.
 - `list_pull_request_commits` — commits on the PR for the inline subset selector.
 - `list_pull_request_review_metadata` — best-effort viewer login + review commit OIDs used to preselect commits since the viewer's latest submitted review.
+  GitHub uses review metadata; GitLab combines `/user`, MR diff versions, approvals, and discussions.
 - `get_pull_request_commit_range_diff` — cumulative diff for a contiguous subrange (`start_sha` is the parent of the first selected commit; `end_sha` is the last).
 - `list_review_threads` — existing GitHub comments + resolved/outdated state.
 - `fetch_file_lines` — remote context expansion in the diff view.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ src/
 │       ├── gh.rs        # GhCommandRunner: spawn `gh`, parse output, error mapping
 │       ├── models.rs    # JSON parsing for `gh` REST + GraphQL responses
 │       ├── review_threads.rs # GraphQL query for existing review threads
+│       ├── review_metadata.rs # GraphQL review commit metadata for since-last-review scoping
 │       └── submit.rs    # build_review_payload, create_review wiring
 │
 ├── model/
@@ -174,6 +175,7 @@ PR review (`tuicr pr <target>` or `tuicr tui pr <target>`) is the only feature i
 - `get_pull_request` — details for a `PullRequestTarget` (resolves to `PullRequestDetails`).
 - `get_pull_request_diff` — the cumulative PR diff as a unified-diff string.
 - `list_pull_request_commits` — commits on the PR for the inline subset selector.
+- `list_pull_request_review_metadata` — best-effort viewer login + review commit OIDs used to preselect commits since the viewer's latest submitted review.
 - `get_pull_request_commit_range_diff` — cumulative diff for a contiguous subrange (`start_sha` is the parent of the first selected commit; `end_sha` is the last).
 - `list_review_threads` — existing GitHub comments + resolved/outdated state.
 - `fetch_file_lines` — remote context expansion in the diff view.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ tuicr review list           # List saved local review sessions
 
 Inside tuicr, navigate with `j`/`k`, press `c` to comment, then `y` to copy the review or
 `:submit` to push it to GitHub. When opening a GitHub PR or GitLab MR you've reviewed before,
-tuicr preselects commits newer than your latest submitted review when that metadata is available.
+tuicr preselects commits newer than your latest submitted review when that metadata is available;
+commits already covered by that review are marked with `✓` in the inline selector.
 Auto-detects git, jj, or mercurial.
 
 ## How it compares

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ tuicr review list           # List saved local review sessions
 ```
 
 Inside tuicr, navigate with `j`/`k`, press `c` to comment, then `y` to copy the review or
-`:submit` to push it to GitHub. Auto-detects git, jj, or mercurial.
+`:submit` to push it to GitHub. When opening a GitHub PR you've reviewed before, tuicr
+preselects commits newer than your latest submitted review when that metadata is available.
+Auto-detects git, jj, or mercurial.
 
 ## How it compares
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ tuicr review list           # List saved local review sessions
 ```
 
 Inside tuicr, navigate with `j`/`k`, press `c` to comment, then `y` to copy the review or
-`:submit` to push it to GitHub. When opening a GitHub PR you've reviewed before, tuicr
-preselects commits newer than your latest submitted review when that metadata is available.
+`:submit` to push it to GitHub. When opening a GitHub PR or GitLab MR you've reviewed before,
+tuicr preselects commits newer than your latest submitted review when that metadata is available.
 Auto-detects git, jj, or mercurial.
 
 ## How it compares

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -143,8 +143,8 @@ In command mode,
 ## Inline commit selector
 
 Shown at the top of the diff when reviewing multiple commits. Focus it with `<leader>k` or `Tab`.
-When opening a GitHub PR you have reviewed before, tuicr may preselect only commits newer than
-your latest submitted review; use `Space` / `Enter` here to expand or adjust the range.
+When opening a GitHub PR or GitLab MR you have reviewed before, tuicr may preselect only commits
+newer than your latest submitted review; use `Space` / `Enter` here to expand or adjust the range.
 
 | Key | Action |
 |-----|--------|

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -143,6 +143,8 @@ In command mode,
 ## Inline commit selector
 
 Shown at the top of the diff when reviewing multiple commits. Focus it with `<leader>k` or `Tab`.
+When opening a GitHub PR you have reviewed before, tuicr may preselect only commits newer than
+your latest submitted review; use `Space` / `Enter` here to expand or adjust the range.
 
 | Key | Action |
 |-----|--------|

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -144,7 +144,8 @@ In command mode,
 
 Shown at the top of the diff when reviewing multiple commits. Focus it with `<leader>k` or `Tab`.
 When opening a GitHub PR or GitLab MR you have reviewed before, tuicr may preselect only commits
-newer than your latest submitted review; use `Space` / `Enter` here to expand or adjust the range.
+newer than your latest submitted review; commits already covered by that review are marked with
+`✓`. Use `Space` / `Enter` here to expand or adjust the range.
 
 | Key | Action |
 |-----|--------|

--- a/src/app.rs
+++ b/src/app.rs
@@ -382,6 +382,7 @@ pub fn pr_commit_to_commit_info(commit: &crate::forge::traits::PullRequestCommit
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SinceLastReviewSelection {
     range: Option<(usize, usize)>,
+    reviewed_index: usize,
     message: String,
 }
 
@@ -410,6 +411,7 @@ fn commits_since_last_review_selection(
     if reviewed_index == 0 {
         return Some(SinceLastReviewSelection {
             range: None,
+            reviewed_index,
             message: "No commits since your last review".to_string(),
         });
     }
@@ -418,6 +420,7 @@ fn commits_since_last_review_selection(
     let noun = if count == 1 { "commit" } else { "commits" };
     Some(SinceLastReviewSelection {
         range: Some((0, reviewed_index - 1)),
+        reviewed_index,
         message: format!("Showing {count} {noun} since your last review — press Enter to see all"),
     })
 }
@@ -1185,6 +1188,10 @@ pub struct App {
     /// Empty outside PR mode. Used as the source of truth for resolving a
     /// `commit_selection_range` back to (start_sha, end_sha) when toggling.
     pub pr_commits: Vec<crate::forge::traits::PullRequestCommit>,
+    /// Index in `pr_commits`/`review_commits` of the newest commit covered
+    /// by the viewer's latest submitted review. Commits at this index and
+    /// older get a reviewed marker in the inline selector.
+    pub pr_last_reviewed_commit_index: Option<usize>,
     /// In-flight range re-fetch driven by toggling commits in the inline
     /// selector while in PR mode. Drives a spinner in the status bar.
     pub pr_range_reload_state: Option<PrRangeReloadRequest>,
@@ -1927,6 +1934,7 @@ impl App {
             pending_count: None,
             review_commits: Vec::new(),
             pr_commits: Vec::new(),
+            pr_last_reviewed_commit_index: None,
             pr_range_reload_state: None,
             pr_range_reload_rx: None,
             show_commit_selector: false,
@@ -2618,9 +2626,13 @@ impl App {
         commits: Vec<crate::forge::traits::PullRequestCommit>,
         review_metadata: crate::forge::traits::PullRequestReviewMetadata,
     ) -> Option<String> {
+        self.pr_last_reviewed_commit_index = None;
         if commits.len() <= 1 {
             return None;
         }
+
+        let since_last_review = commits_since_last_review_selection(&commits, &review_metadata);
+        self.set_pr_last_reviewed_commit_from_metadata(&commits, &review_metadata);
 
         self.pr_commits = commits.clone();
         let mapped: Vec<CommitInfo> = commits.iter().map(pr_commit_to_commit_info).collect();
@@ -2633,7 +2645,8 @@ impl App {
         self.show_commit_selector = true;
 
         let mut range = (0, mapped.len() - 1);
-        let mut since_last_review = None;
+        let mut auto_scoped_since_last_review = false;
+        let mut since_last_review_message = None;
         // Restore any persisted range scoped to this head SHA. If the
         // restored range exceeds the current commit count (e.g., the PR
         // was rebased), fall back to "all". Only auto-scope to commits
@@ -2643,25 +2656,28 @@ impl App {
             && persisted.0 <= persisted.1
         {
             range = persisted;
-        } else if self.session.commit_selection_range.is_none() {
-            since_last_review = commits_since_last_review_selection(&commits, &review_metadata);
-            if let Some(selection) = since_last_review.as_ref().and_then(|s| s.range) {
-                range = selection;
+        } else if self.session.commit_selection_range.is_none()
+            && let Some(selection) = since_last_review.as_ref()
+        {
+            if let Some(selected_range) = selection.range {
+                range = selected_range;
+                auto_scoped_since_last_review = true;
             }
+            since_last_review_message = Some(selection.message.clone());
         }
 
         self.commit_selection_range = Some(range);
         self.review_commits = mapped;
 
-        if let Some(selection) = since_last_review {
-            if selection.range.is_some()
+        if let Some(message) = since_last_review_message {
+            if auto_scoped_since_last_review
                 && Self::is_strict_commit_selection(Some(range), self.pr_commits.len())
             {
                 self.focused_panel = FocusedPanel::CommitSelector;
                 self.commit_list_cursor = self.pr_commits.len().saturating_sub(1);
                 self.commit_list_scroll_offset = self.commit_list_cursor.saturating_sub(5);
             }
-            return Some(selection.message);
+            return Some(message);
         }
         None
     }
@@ -2879,6 +2895,7 @@ impl App {
         self.commit_selection_range = None;
         self.review_commits.clear();
         self.pr_commits.clear();
+        self.pr_last_reviewed_commit_index = None;
         self.show_commit_selector = false;
         self.range_diff_files = None;
         self.saved_inline_selection = None;
@@ -3379,6 +3396,10 @@ impl App {
                 self.set_message("Reloaded PR at new head — switched to fresh session".to_string());
             }
         } else {
+            self.set_pr_last_reviewed_commit_from_metadata(
+                &opened.commits,
+                &opened.review_metadata,
+            );
             self.diff_files = opened.diff_files;
             self.clear_expanded_gaps();
             for file in &self.diff_files {
@@ -3458,6 +3479,10 @@ impl App {
         } else {
             // Same head: re-parse the diff to pick up any side-channel
             // changes (rare), but keep the session intact.
+            self.set_pr_last_reviewed_commit_from_metadata(
+                &opened.commits,
+                &opened.review_metadata,
+            );
             self.diff_files = opened.diff_files;
             self.clear_expanded_gaps();
             for file in &self.diff_files {
@@ -7503,6 +7528,9 @@ impl App {
                 response.id, inline_count, summary_count,
             ),
         };
+        if in_flight.event != SubmitEvent::Draft {
+            self.mark_pr_commits_reviewed_through(&in_flight.head_sha_snapshot);
+        }
         self.set_message(message);
 
         // Refetch remote threads so the just-submitted comments appear immediately.
@@ -8481,6 +8509,41 @@ impl App {
         }
     }
 
+    fn set_pr_last_reviewed_commit_from_metadata(
+        &mut self,
+        commits: &[crate::forge::traits::PullRequestCommit],
+        review_metadata: &crate::forge::traits::PullRequestReviewMetadata,
+    ) {
+        self.pr_last_reviewed_commit_index = if commits.len() > 1 {
+            commits_since_last_review_selection(commits, review_metadata)
+                .map(|selection| selection.reviewed_index)
+        } else {
+            None
+        };
+    }
+
+    fn mark_pr_commits_reviewed_through(&mut self, commit_id: &str) {
+        if !matches!(&self.diff_source, DiffSource::PullRequest(_)) {
+            return;
+        }
+        if let Some(index) = self
+            .pr_commits
+            .iter()
+            .position(|commit| commit.oid == commit_id)
+        {
+            self.pr_last_reviewed_commit_index = Some(index);
+        }
+    }
+
+    /// Check if a PR commit is covered by the viewer's latest submitted review.
+    pub fn is_commit_reviewed_by_viewer(&self, index: usize) -> bool {
+        matches!(&self.diff_source, DiffSource::PullRequest(_))
+            && index < self.review_commits.len()
+            && self
+                .pr_last_reviewed_commit_index
+                .is_some_and(|reviewed_index| index >= reviewed_index)
+    }
+
     /// Cycle inline commit selector to the next individual commit (`)` key).
     /// all → last, i → i+1, last → all
     pub fn cycle_commit_next(&mut self) {
@@ -8669,6 +8732,8 @@ impl App {
         self.file_list_state = FileListState::default();
 
         // Set up inline commit selector for multi-commit reviews (newest-first display order)
+        self.pr_commits.clear();
+        self.pr_last_reviewed_commit_index = None;
         self.review_commits = selected_commits.iter().rev().cloned().collect();
         self.range_diff_files = Some(self.diff_files.clone());
         self.commit_list = self.review_commits.clone();
@@ -8869,6 +8934,8 @@ impl App {
         self.file_list_state = FileListState::default();
 
         // Set up inline commit selector (newest-first display order)
+        self.pr_commits.clear();
+        self.pr_last_reviewed_commit_index = None;
         self.review_commits = selected_commits.into_iter().rev().collect();
         self.range_diff_files = Some(self.diff_files.clone());
         self.commit_list = self.review_commits.clone();
@@ -10809,6 +10876,7 @@ mod target_selector_tests {
         let selection = commits_since_last_review_selection(&commits, &metadata).unwrap();
 
         assert_eq!(selection.range, Some((0, 0)));
+        assert_eq!(selection.reviewed_index, 1);
         assert_eq!(
             selection.message,
             "Showing 1 commit since your last review — press Enter to see all"
@@ -10830,6 +10898,7 @@ mod target_selector_tests {
         let selection = commits_since_last_review_selection(&commits, &metadata).unwrap();
 
         assert_eq!(selection.range, None);
+        assert_eq!(selection.reviewed_index, 0);
         assert_eq!(selection.message, "No commits since your last review");
     }
 
@@ -10863,8 +10932,33 @@ mod target_selector_tests {
         let message = app.apply_pr_commit_selector(commits, metadata);
 
         assert_eq!(app.commit_selection_range, Some((1, 1)));
+        assert_eq!(app.pr_last_reviewed_commit_index, Some(1));
         assert!(message.is_none());
         assert_eq!(app.focused_panel, FocusedPanel::Diff);
+    }
+
+    #[test]
+    fn should_mark_pr_commits_covered_by_viewers_last_review() {
+        let mut app = build_app();
+        app.diff_source = DiffSource::PullRequest(Box::new(PullRequestDiffSource::from_details(
+            &test_pr_details(42, "reviewed"),
+        )));
+        let commits = vec![
+            sample_pr_commit("c3", "third"),
+            sample_pr_commit("c2", "second"),
+            sample_pr_commit("c1", "first"),
+        ];
+        let metadata = review_metadata(vec![review_record(
+            "ronen-hoffer",
+            "c2",
+            "2026-06-03T10:00:00Z",
+        )]);
+
+        app.apply_pr_commit_selector(commits, metadata);
+
+        assert!(!app.is_commit_reviewed_by_viewer(0));
+        assert!(app.is_commit_reviewed_by_viewer(1));
+        assert!(app.is_commit_reviewed_by_viewer(2));
     }
 
     fn two_hunk_patch() -> &'static str {
@@ -14702,6 +14796,57 @@ mod submit_flow_tests {
             html_url: html_url.to_string(),
             state: state.to_string(),
         }
+    }
+
+    fn pr_commit(oid: &str) -> crate::forge::traits::PullRequestCommit {
+        crate::forge::traits::PullRequestCommit {
+            oid: oid.to_string(),
+            short_oid: oid.chars().take(7).collect(),
+            summary: oid.to_string(),
+            author: "me".to_string(),
+            timestamp: None,
+        }
+    }
+
+    #[test]
+    fn should_mark_reviewed_commits_after_successful_submit() {
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        app.pr_commits = vec![
+            pr_commit("abcdef0123"),
+            pr_commit("deadbeef02"),
+            pr_commit("facecafe01"),
+        ];
+        app.review_commits = app
+            .pr_commits
+            .iter()
+            .map(pr_commit_to_commit_info)
+            .collect();
+        let in_flight = make_in_flight(SubmitEvent::Comment, &[], "deadbeef02", 0);
+        let response = make_response(123, "https://example.com/r", "COMMENTED");
+
+        app.finish_pr_submit(in_flight, Ok(response));
+
+        assert!(!app.is_commit_reviewed_by_viewer(0));
+        assert!(app.is_commit_reviewed_by_viewer(1));
+        assert!(app.is_commit_reviewed_by_viewer(2));
+    }
+
+    #[test]
+    fn should_not_mark_reviewed_commits_after_draft_submit() {
+        let mut app = make_pr_app_with_single_modified_file("src/lib.rs");
+        app.pr_commits = vec![pr_commit("abcdef0123"), pr_commit("deadbeef02")];
+        app.review_commits = app
+            .pr_commits
+            .iter()
+            .map(pr_commit_to_commit_info)
+            .collect();
+        let in_flight = make_in_flight(SubmitEvent::Draft, &[], "abcdef0123", 0);
+        let response = make_response(123, "https://example.com/r", "PENDING");
+
+        app.finish_pr_submit(in_flight, Ok(response));
+
+        assert!(!app.is_commit_reviewed_by_viewer(0));
+        assert!(!app.is_commit_reviewed_by_viewer(1));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -379,6 +379,49 @@ pub fn pr_commit_to_commit_info(commit: &crate::forge::traits::PullRequestCommit
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SinceLastReviewSelection {
+    range: Option<(usize, usize)>,
+    message: String,
+}
+
+fn commits_since_last_review_selection(
+    commits_newest_first: &[crate::forge::traits::PullRequestCommit],
+    review_metadata: &crate::forge::traits::PullRequestReviewMetadata,
+) -> Option<SinceLastReviewSelection> {
+    let viewer = review_metadata.viewer_login.as_deref()?;
+    let last_review = review_metadata
+        .reviews
+        .iter()
+        .filter(|review| {
+            review
+                .author
+                .as_deref()
+                .is_some_and(|author| author.eq_ignore_ascii_case(viewer))
+        })
+        .filter(|review| review.submitted_at.is_some() && review.commit_oid.is_some())
+        .max_by(|a, b| a.submitted_at.cmp(&b.submitted_at))?;
+
+    let reviewed_commit = last_review.commit_oid.as_deref()?;
+    let reviewed_index = commits_newest_first
+        .iter()
+        .position(|commit| commit.oid == reviewed_commit)?;
+
+    if reviewed_index == 0 {
+        return Some(SinceLastReviewSelection {
+            range: None,
+            message: "No commits since your last review".to_string(),
+        });
+    }
+
+    let count = reviewed_index;
+    let noun = if count == 1 { "commit" } else { "commits" };
+    Some(SinceLastReviewSelection {
+        range: Some((0, reviewed_index - 1)),
+        message: format!("Showing {count} {noun} since your last review — press Enter to see all"),
+    })
+}
+
 pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
     match annotation {
         AnnotatedLine::FileHeader { file_idx }
@@ -722,6 +765,7 @@ pub enum PrOpenEvent {
                 crate::forge::traits::PullRequestDetails,
                 String,
                 Vec<crate::forge::traits::PullRequestCommit>,
+                crate::forge::traits::PullRequestReviewMetadata,
             ),
             String,
         >,
@@ -761,6 +805,7 @@ pub enum PrReloadEvent {
                 crate::forge::traits::PullRequestDetails,
                 String,
                 Vec<crate::forge::traits::PullRequestCommit>,
+                crate::forge::traits::PullRequestReviewMetadata,
             ),
             String,
         >,
@@ -2568,6 +2613,59 @@ impl App {
         })
     }
 
+    fn apply_pr_commit_selector(
+        &mut self,
+        commits: Vec<crate::forge::traits::PullRequestCommit>,
+        review_metadata: crate::forge::traits::PullRequestReviewMetadata,
+    ) -> Option<String> {
+        if commits.len() <= 1 {
+            return None;
+        }
+
+        self.pr_commits = commits.clone();
+        let mapped: Vec<CommitInfo> = commits.iter().map(pr_commit_to_commit_info).collect();
+        self.range_diff_files = Some(self.diff_files.clone());
+        self.commit_list = mapped.clone();
+        self.commit_list_cursor = 0;
+        self.commit_list_scroll_offset = 0;
+        self.visible_commit_count = mapped.len();
+        self.has_more_commit = false;
+        self.show_commit_selector = true;
+
+        let mut range = (0, mapped.len() - 1);
+        let mut since_last_review = None;
+        // Restore any persisted range scoped to this head SHA. If the
+        // restored range exceeds the current commit count (e.g., the PR
+        // was rebased), fall back to "all". Only auto-scope to commits
+        // since last review when no explicit per-session range exists.
+        if let Some(persisted) = self.session.commit_selection_range
+            && persisted.1 < mapped.len()
+            && persisted.0 <= persisted.1
+        {
+            range = persisted;
+        } else if self.session.commit_selection_range.is_none() {
+            since_last_review = commits_since_last_review_selection(&commits, &review_metadata);
+            if let Some(selection) = since_last_review.as_ref().and_then(|s| s.range) {
+                range = selection;
+            }
+        }
+
+        self.commit_selection_range = Some(range);
+        self.review_commits = mapped;
+
+        if let Some(selection) = since_last_review {
+            if selection.range.is_some()
+                && Self::is_strict_commit_selection(Some(range), self.pr_commits.len())
+            {
+                self.focused_panel = FocusedPanel::CommitSelector;
+                self.commit_list_cursor = self.pr_commits.len().saturating_sub(1);
+                self.commit_list_scroll_offset = self.commit_list_cursor.saturating_sub(5);
+            }
+            return Some(selection.message);
+        }
+        None
+    }
+
     fn register_diff_files(
         session: &mut ReviewSession,
         diff_files: &[DiffFile],
@@ -2680,6 +2778,8 @@ impl App {
         // Snapshot the PR details before consuming `opened` so we can kick
         // off the remote-thread fetch after `Self::build` returns.
         let details_for_threads = opened.details.clone();
+        let commits_for_selector = opened.commits.clone();
+        let review_metadata = opened.review_metadata.clone();
         let mut app = Self::build(
             vcs,
             vcs_info,
@@ -2703,11 +2803,22 @@ impl App {
         // the user came straight from CLI into PR diff mode).
         app.canonical_resolved = true;
         app.current_pr_head = Some(details_for_threads.head_sha.clone());
+        let since_last_review_message =
+            app.apply_pr_commit_selector(commits_for_selector, review_metadata);
+        if matches!(&app.diff_source, DiffSource::PullRequest(_))
+            && let Some(range) = app.commit_selection_range
+            && !app.pr_commits.is_empty()
+            && (range.0 > 0 || range.1 + 1 < app.pr_commits.len())
+        {
+            app.spawn_pr_range_reload();
+        }
         if let DiffSource::PullRequest(pr) = &app.diff_source.clone()
             && pr.is_read_only()
         {
             let reason = pr.read_only_reason().unwrap_or("read only");
             app.set_warning(format!("This PR is {reason} — review is read-only"));
+        } else if let Some(message) = since_last_review_message {
+            app.set_message(message);
         }
         // Spawn thread-fetch on startup; the main event loop will drain
         // the receiver via `poll_pr_threads_events` once it begins.
@@ -2728,6 +2839,7 @@ impl App {
             session,
             key,
             commits,
+            review_metadata,
         } = opened;
 
         // Save the current session before transitioning so local-mode work
@@ -2777,29 +2889,7 @@ impl App {
         // match the local-mode UX. We mirror `commit_list` and
         // `review_commits` into shared App state so the existing
         // inline_commit_selector renderer Just Works.
-        if commits.len() > 1 {
-            self.pr_commits = commits.clone();
-            let mapped: Vec<CommitInfo> = commits.iter().map(pr_commit_to_commit_info).collect();
-            self.range_diff_files = Some(self.diff_files.clone());
-            self.commit_list = mapped.clone();
-            self.commit_list_cursor = 0;
-            self.commit_list_scroll_offset = 0;
-            self.visible_commit_count = mapped.len();
-            self.has_more_commit = false;
-            self.show_commit_selector = true;
-            let mut range = (0, mapped.len() - 1);
-            // Restore any persisted range scoped to this head SHA. If the
-            // restored range exceeds the current commit count (e.g., the PR
-            // was rebased), fall back to "all".
-            if let Some(persisted) = self.session.commit_selection_range
-                && persisted.1 < mapped.len()
-                && persisted.0 <= persisted.1
-            {
-                range = persisted;
-            }
-            self.commit_selection_range = Some(range);
-            self.review_commits = mapped;
-        }
+        let since_last_review_message = self.apply_pr_commit_selector(commits, review_metadata);
 
         // Ensure session has all files registered after the swap. A strict
         // selector range is a filtered view, not a new review scope.
@@ -2813,6 +2903,8 @@ impl App {
 
         if let Some(reason) = read_only_reason {
             self.set_warning(format!("This PR is {reason} — review is read-only"));
+        } else if let Some(message) = since_last_review_message {
+            self.set_message(message);
         }
 
         // If the restored selection is a strict subset, fire an initial
@@ -3237,8 +3329,10 @@ impl App {
             return;
         }
         match result {
-            Ok((details, patch, commits)) => {
-                if let Err(e) = self.finish_pr_reload(details, patch, commits, &request) {
+            Ok((details, patch, commits, review_metadata)) => {
+                if let Err(e) =
+                    self.finish_pr_reload(details, patch, commits, review_metadata, &request)
+                {
                     self.set_error(format!("Reload failed: {e}"));
                 }
             }
@@ -3253,6 +3347,7 @@ impl App {
         details: crate::forge::traits::PullRequestDetails,
         patch: String,
         commits: Vec<crate::forge::traits::PullRequestCommit>,
+        review_metadata: crate::forge::traits::PullRequestReviewMetadata,
         request: &PrReloadRequest,
     ) -> Result<()> {
         use crate::forge::pr_open::prepare_open_pr;
@@ -3266,6 +3361,7 @@ impl App {
             details,
             &patch,
             commits,
+            review_metadata,
             local_checkout.as_deref(),
             highlighter,
         )?;
@@ -3276,9 +3372,12 @@ impl App {
             let details_for_threads = opened.details.clone();
             Self::load_or_apply_pr_session(&mut opened);
             let backend = create_forge_backend(&request.repository, local_checkout.clone());
+            let previous_message = self.message.clone();
             self.enter_pr_diff_mode(backend, opened)?;
             self.spawn_pr_threads_fetch(&details_for_threads, local_checkout);
-            self.set_message("Reloaded PR at new head — switched to fresh session".to_string());
+            if self.message == previous_message {
+                self.set_message("Reloaded PR at new head — switched to fresh session".to_string());
+            }
         } else {
             self.diff_files = opened.diff_files;
             self.clear_expanded_gaps();
@@ -7834,8 +7933,10 @@ impl App {
                     return;
                 }
                 match result {
-                    Ok((details, patch, commits)) => {
-                        if let Err(e) = self.finish_pr_open(details, patch, commits, &request) {
+                    Ok((details, patch, commits, review_metadata)) => {
+                        if let Err(e) =
+                            self.finish_pr_open(details, patch, commits, review_metadata, &request)
+                        {
                             self.set_error(format!(
                                 "Failed to open PR #{}: {}",
                                 request.pr_number, e
@@ -7859,6 +7960,7 @@ impl App {
         details: crate::forge::traits::PullRequestDetails,
         patch: String,
         commits: Vec<crate::forge::traits::PullRequestCommit>,
+        review_metadata: crate::forge::traits::PullRequestReviewMetadata,
         request: &PrOpenRequest,
     ) -> Result<()> {
         use crate::forge::pr_open::prepare_open_pr;
@@ -7869,20 +7971,24 @@ impl App {
             details.clone(),
             &patch,
             commits,
+            review_metadata,
             local_checkout.as_deref(),
             highlighter,
         )?;
         Self::load_or_apply_pr_session(&mut opened);
         let backend = create_forge_backend(&request.repository, local_checkout.clone());
+        let previous_message = self.message.clone();
         self.enter_pr_diff_mode(backend, opened)?;
         // Kick the remote-thread fetch off on a fresh background thread.
         // The diff view is already up; threads fade in once they land.
         self.spawn_pr_threads_fetch(&details, local_checkout);
-        self.set_message(format!(
-            "Opened PR {}#{}",
-            request.repository.display_name(),
-            request.pr_number,
-        ));
+        if self.message == previous_message {
+            self.set_message(format!(
+                "Opened PR {}#{}",
+                request.repository.display_name(),
+                request.pr_number,
+            ));
+        }
         Ok(())
     }
 
@@ -10281,7 +10387,9 @@ mod commit_selection_tests {
 mod target_selector_tests {
     use super::*;
     use crate::forge::selector::PullRequestsTab;
-    use crate::forge::traits::PullRequestSummary;
+    use crate::forge::traits::{
+        PullRequestReviewMetadata, PullRequestReviewRecord, PullRequestSummary,
+    };
     use crate::model::FileStatus;
     use crate::vcs::traits::{VcsChangeStatus, VcsType};
 
@@ -10432,6 +10540,7 @@ mod target_selector_tests {
         details: crate::forge::traits::PullRequestDetails,
         patch: String,
         commits: Vec<crate::forge::traits::PullRequestCommit>,
+        review_metadata: PullRequestReviewMetadata,
         range_patch: Option<String>,
     }
 
@@ -10444,6 +10553,7 @@ mod target_selector_tests {
                 details,
                 patch,
                 commits: Vec::new(),
+                review_metadata: PullRequestReviewMetadata::default(),
                 range_patch: None,
             }
         }
@@ -10485,6 +10595,12 @@ mod target_selector_tests {
             _pr: &crate::forge::traits::PullRequestDetails,
         ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
             Ok(self.commits.clone())
+        }
+        fn list_pull_request_review_metadata(
+            &self,
+            _pr: &crate::forge::traits::PullRequestDetails,
+        ) -> Result<PullRequestReviewMetadata> {
+            Ok(self.review_metadata.clone())
         }
         fn get_pull_request_commit_range_diff(
             &self,
@@ -10660,6 +10776,95 @@ mod target_selector_tests {
             author: "Alice".to_string(),
             timestamp: None,
         }
+    }
+
+    fn review_record(author: &str, oid: &str, submitted_at: &str) -> PullRequestReviewRecord {
+        PullRequestReviewRecord {
+            author: Some(author.to_string()),
+            submitted_at: Some(submitted_at.parse().unwrap()),
+            commit_oid: Some(oid.to_string()),
+        }
+    }
+
+    fn review_metadata(reviews: Vec<PullRequestReviewRecord>) -> PullRequestReviewMetadata {
+        PullRequestReviewMetadata {
+            viewer_login: Some("ronen-hoffer".to_string()),
+            reviews,
+        }
+    }
+
+    #[test]
+    fn should_select_commits_since_viewers_last_review() {
+        let commits = vec![
+            sample_pr_commit("c3", "third"),
+            sample_pr_commit("c2", "second"),
+            sample_pr_commit("c1", "first"),
+        ];
+        let metadata = review_metadata(vec![
+            review_record("ronen-hoffer", "c1", "2026-06-01T10:00:00Z"),
+            review_record("alice", "c3", "2026-06-02T10:00:00Z"),
+            review_record("ronen-hoffer", "c2", "2026-06-03T10:00:00Z"),
+        ]);
+
+        let selection = commits_since_last_review_selection(&commits, &metadata).unwrap();
+
+        assert_eq!(selection.range, Some((0, 0)));
+        assert_eq!(
+            selection.message,
+            "Showing 1 commit since your last review — press Enter to see all"
+        );
+    }
+
+    #[test]
+    fn should_report_no_new_commits_when_viewers_last_review_is_at_head() {
+        let commits = vec![
+            sample_pr_commit("c3", "third"),
+            sample_pr_commit("c2", "second"),
+        ];
+        let metadata = review_metadata(vec![review_record(
+            "ronen-hoffer",
+            "c3",
+            "2026-06-03T10:00:00Z",
+        )]);
+
+        let selection = commits_since_last_review_selection(&commits, &metadata).unwrap();
+
+        assert_eq!(selection.range, None);
+        assert_eq!(selection.message, "No commits since your last review");
+    }
+
+    #[test]
+    fn should_skip_since_last_review_selection_when_commit_is_missing() {
+        let commits = vec![sample_pr_commit("c3", "third")];
+        let metadata = review_metadata(vec![review_record(
+            "ronen-hoffer",
+            "gone",
+            "2026-06-03T10:00:00Z",
+        )]);
+
+        assert!(commits_since_last_review_selection(&commits, &metadata).is_none());
+    }
+
+    #[test]
+    fn should_preserve_persisted_commit_range_over_since_last_review_default() {
+        let mut app = build_app();
+        app.session.commit_selection_range = Some((1, 1));
+        let commits = vec![
+            sample_pr_commit("c3", "third"),
+            sample_pr_commit("c2", "second"),
+            sample_pr_commit("c1", "first"),
+        ];
+        let metadata = review_metadata(vec![review_record(
+            "ronen-hoffer",
+            "c2",
+            "2026-06-03T10:00:00Z",
+        )]);
+
+        let message = app.apply_pr_commit_selector(commits, metadata);
+
+        assert_eq!(app.commit_selection_range, Some((1, 1)));
+        assert!(message.is_none());
+        assert_eq!(app.focused_panel, FocusedPanel::Diff);
     }
 
     fn two_hunk_patch() -> &'static str {

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -389,6 +389,34 @@ where
         Ok(all)
     }
 
+    fn list_pull_request_review_metadata(
+        &self,
+        pr: &PullRequestDetails,
+    ) -> Result<crate::forge::traits::PullRequestReviewMetadata> {
+        let mut all = crate::forge::traits::PullRequestReviewMetadata::default();
+        let mut cursor: Option<String> = None;
+        for _ in 0..100 {
+            let args = self.build_review_metadata_args(pr, cursor.as_deref());
+            let output = self.run_gh(args, &pr.repository.host)?;
+            let parsed = super::review_metadata::parse_graphql_page(&output)?;
+            if all.viewer_login.is_none() {
+                all.viewer_login = parsed.metadata.viewer_login;
+            }
+            all.reviews.extend(parsed.metadata.reviews);
+            let Some(page_info) = parsed.page_info else {
+                break;
+            };
+            if !page_info.has_next_page {
+                break;
+            }
+            let Some(end_cursor) = page_info.end_cursor else {
+                break;
+            };
+            cursor = Some(end_cursor);
+        }
+        Ok(all)
+    }
+
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
@@ -472,6 +500,14 @@ where
         cursor: Option<&str>,
     ) -> Vec<String> {
         self.build_graphql_args(pr, &build_reviews_query(cursor), cursor)
+    }
+
+    fn build_review_metadata_args(
+        &self,
+        pr: &PullRequestDetails,
+        cursor: Option<&str>,
+    ) -> Vec<String> {
+        self.build_graphql_args(pr, &super::review_metadata::build_query(cursor), cursor)
     }
 
     fn build_graphql_args(
@@ -1021,6 +1057,9 @@ index 1111111..2222222 100644
                         .unwrap_or("");
                     if query.contains("reviewThreads(") {
                         Ok(REVIEW_THREADS_JSON.to_string())
+                    } else if query.contains("viewer { login }") && query.contains("commit { oid }")
+                    {
+                        Ok(REVIEW_METADATA_JSON.to_string())
                     } else if query.contains("reviews(") {
                         Ok(REVIEW_SUMMARIES_JSON.to_string())
                     } else {
@@ -1145,6 +1184,31 @@ index 1111111..2222222 100644
                                 "author": { "login": "alice" },
                                 "submittedAt": "2026-05-12T18:30:00Z",
                                 "url": "https://example.com/r/1"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }"##;
+
+    const REVIEW_METADATA_JSON: &str = r##"{
+        "data": {
+            "viewer": { "login": "ronen-hoffer" },
+            "repository": {
+                "pullRequest": {
+                    "reviews": {
+                        "pageInfo": { "hasNextPage": false, "endCursor": null },
+                        "nodes": [
+                            {
+                                "author": { "login": "alice" },
+                                "submittedAt": "2026-05-12T18:30:00Z",
+                                "commit": { "oid": "aaaaaaa1111111111111111111111111111aaaa" }
+                            },
+                            {
+                                "author": { "login": "ronen-hoffer" },
+                                "submittedAt": "2026-05-13T09:00:00Z",
+                                "commit": { "oid": "bbbbbbb2222222222222222222222222222bbbb" }
                             }
                         ]
                     }
@@ -1652,6 +1716,38 @@ Match host github-work
             .expect("expected a reviews graphql call");
         assert!(summaries_call.iter().any(|a| a == "owner=agavra"));
         assert!(summaries_call.iter().any(|a| a == "number=125"));
+    }
+
+    #[test]
+    fn should_list_pull_request_review_metadata_via_graphql_api_call() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+        // when
+        let metadata = backend.list_pull_request_review_metadata(&details).unwrap();
+        // then
+        assert_eq!(metadata.viewer_login.as_deref(), Some("ronen-hoffer"));
+        assert_eq!(metadata.reviews.len(), 2);
+        assert_eq!(metadata.reviews[1].author.as_deref(), Some("ronen-hoffer"));
+        assert_eq!(
+            metadata.reviews[1].commit_oid.as_deref(),
+            Some("bbbbbbb2222222222222222222222222222bbbb")
+        );
+        // and — the query requests viewer login and review commit oids.
+        let calls = backend.runner.calls.borrow();
+        let metadata_call = calls
+            .iter()
+            .find(|args| {
+                args.first().map(String::as_str) == Some("api")
+                    && args.iter().any(|a| a.contains("viewer { login }"))
+                    && args.iter().any(|a| a.contains("commit { oid }"))
+            })
+            .expect("expected review metadata graphql call");
+        assert!(metadata_call.iter().any(|a| a == "owner=agavra"));
+        assert!(metadata_call.iter().any(|a| a == "number=125"));
     }
 
     #[test]

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -1,5 +1,6 @@
 pub mod gh;
 pub mod models;
+pub mod review_metadata;
 pub mod review_summaries;
 pub mod review_threads;
 pub mod submit;

--- a/src/forge/github/review_metadata.rs
+++ b/src/forge/github/review_metadata.rs
@@ -1,0 +1,221 @@
+//! GraphQL parsing for minimal GitHub pull request review metadata.
+//!
+//! This intentionally differs from `review_summaries`: a bare approval with
+//! an empty body has no summary to render, but it still counts as a submitted
+//! review when deciding whether a PR has commits since the viewer last looked.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::{Result, TuicrError};
+use crate::forge::github::review_threads::GhPageInfo;
+use crate::forge::traits::{PullRequestReviewMetadata, PullRequestReviewRecord};
+
+#[derive(Debug, Deserialize)]
+struct GhViewer {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhAuthor {
+    #[serde(default)]
+    login: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCommit {
+    #[serde(default)]
+    oid: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReview {
+    #[serde(default)]
+    author: Option<GhAuthor>,
+    #[serde(default)]
+    submitted_at: Option<DateTime<Utc>>,
+    #[serde(default)]
+    commit: Option<GhCommit>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhReviewsConn {
+    #[serde(default)]
+    page_info: Option<GhPageInfo>,
+    #[serde(default)]
+    nodes: Vec<GhReview>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPullRequest {
+    #[serde(default)]
+    reviews: Option<GhReviewsConn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRepository {
+    #[serde(default, rename = "pullRequest")]
+    pull_request: Option<GhPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhData {
+    #[serde(default)]
+    viewer: Option<GhViewer>,
+    #[serde(default)]
+    repository: Option<GhRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhResponse {
+    #[serde(default)]
+    data: Option<GhData>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParsedReviewMetadataPage {
+    pub metadata: PullRequestReviewMetadata,
+    pub page_info: Option<GhPageInfo>,
+}
+
+pub(crate) fn parse_graphql_page(json: &str) -> Result<ParsedReviewMetadataPage> {
+    let response: GhResponse = serde_json::from_str(json).map_err(|e| {
+        TuicrError::Forge(format!(
+            "Failed to parse GitHub review metadata response: {e}"
+        ))
+    })?;
+
+    let Some(data) = response.data else {
+        return Ok(ParsedReviewMetadataPage {
+            metadata: PullRequestReviewMetadata::default(),
+            page_info: None,
+        });
+    };
+
+    let viewer_login = data.viewer.and_then(|v| v.login);
+    let conn = data
+        .repository
+        .and_then(|r| r.pull_request)
+        .and_then(|p| p.reviews);
+
+    let Some(conn) = conn else {
+        return Ok(ParsedReviewMetadataPage {
+            metadata: PullRequestReviewMetadata {
+                viewer_login,
+                reviews: Vec::new(),
+            },
+            page_info: None,
+        });
+    };
+
+    let reviews = conn
+        .nodes
+        .into_iter()
+        .map(|raw| PullRequestReviewRecord {
+            author: raw.author.and_then(|a| a.login),
+            submitted_at: raw.submitted_at,
+            commit_oid: raw.commit.and_then(|c| c.oid),
+        })
+        .collect();
+
+    Ok(ParsedReviewMetadataPage {
+        metadata: PullRequestReviewMetadata {
+            viewer_login,
+            reviews,
+        },
+        page_info: conn.page_info,
+    })
+}
+
+pub(crate) fn build_query(after_cursor: Option<&str>) -> String {
+    let cursor_arg = match after_cursor {
+        Some(_) => ", after: $after",
+        None => "",
+    };
+    format!(
+        r#"query($owner: String!, $name: String!, $number: Int!{cursor_param}) {{
+  viewer {{ login }}
+  repository(owner: $owner, name: $name) {{
+    pullRequest(number: $number) {{
+      reviews(first: 100{cursor_arg}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          author {{ login }}
+          submittedAt
+          commit {{ oid }}
+        }}
+      }}
+    }}
+  }}
+}}"#,
+        cursor_param = if after_cursor.is_some() {
+            ", $after: String!"
+        } else {
+            ""
+        },
+        cursor_arg = cursor_arg,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_parse_viewer_and_reviews_with_commit_oids() {
+        let json = r##"{
+            "data": {
+                "viewer": { "login": "ronen-hoffer" },
+                "repository": {
+                    "pullRequest": {
+                        "reviews": {
+                            "pageInfo": { "hasNextPage": false, "endCursor": null },
+                            "nodes": [
+                                {
+                                    "author": { "login": "alice" },
+                                    "submittedAt": "2026-06-01T18:59:23Z",
+                                    "commit": { "oid": "aaa111" }
+                                },
+                                {
+                                    "author": { "login": "ronen-hoffer" },
+                                    "submittedAt": "2026-06-02T06:32:29Z",
+                                    "commit": { "oid": "bbb222" }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }"##;
+
+        let parsed = parse_graphql_page(json).unwrap();
+
+        assert_eq!(
+            parsed.metadata.viewer_login.as_deref(),
+            Some("ronen-hoffer")
+        );
+        assert_eq!(parsed.metadata.reviews.len(), 2);
+        assert_eq!(
+            parsed.metadata.reviews[1].author.as_deref(),
+            Some("ronen-hoffer")
+        );
+        assert_eq!(
+            parsed.metadata.reviews[1].commit_oid.as_deref(),
+            Some("bbb222")
+        );
+    }
+
+    #[test]
+    fn should_build_query_with_cursor_for_subsequent_pages() {
+        let query = build_query(Some("cursor-1"));
+
+        assert!(query.contains("$after: String!"));
+        assert!(query.contains("reviews(first: 100, after: $after)"));
+        assert!(query.contains("viewer { login }"));
+        assert!(query.contains("commit { oid }"));
+    }
+}

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use chrono::{DateTime, Utc};
 use sha1::{Digest, Sha1};
 
 use crate::error::{Result, TuicrError};
@@ -9,14 +10,17 @@ use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestListQuery,
-    PullRequestListScope, PullRequestTarget,
+    PullRequestListScope, PullRequestReviewMetadata, PullRequestReviewRecord, PullRequestTarget,
 };
 use crate::model::{DiffLine, LineOrigin};
 use crate::process::{
     CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
 };
 
-use super::models::{GlabCommit, GlabDiscussion, GlabMrDetails, GlabMrSummary};
+use super::models::{
+    GlabApprovalState, GlabCommit, GlabDiscussion, GlabMrDetails, GlabMrSummary, GlabMrVersion,
+    GlabUser,
+};
 use crate::forge::submit::{GhSide, SubmitEvent};
 use crate::forge::traits::CreateReviewRequest;
 
@@ -132,6 +136,29 @@ fn gl_encode_file_path(path: &str) -> String {
         .replace('?', "%3F")
 }
 
+fn non_empty(value: &str) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.to_string())
+    }
+}
+
+fn version_head_at(versions: &[GlabMrVersion], submitted_at: &DateTime<Utc>) -> Option<String> {
+    versions
+        .iter()
+        .filter_map(|version| {
+            let created_at = version.created_at.as_ref()?;
+            if created_at <= submitted_at && !version.head_commit_sha.is_empty() {
+                Some((created_at, version.head_commit_sha.as_str()))
+            } else {
+                None
+            }
+        })
+        .max_by(|(a, _), (b, _)| a.cmp(b))
+        .map(|(_, sha)| sha.to_string())
+}
+
 #[derive(Debug, Clone)]
 pub struct GitLabGlabBackend<R = SystemGlabRunner> {
     default_repository: Option<ForgeRepository>,
@@ -206,6 +233,112 @@ where
         } else {
             vec![]
         }
+    }
+
+    fn run_api(&self, repo: &ForgeRepository, endpoint: String) -> Result<String> {
+        let mut args = vec!["api".to_string()];
+        args.extend(Self::api_hostname_args(repo));
+        args.push(endpoint);
+        self.run_glab(args, &repo.host)
+    }
+
+    fn current_username(&self, repo: &ForgeRepository) -> Result<Option<String>> {
+        let output = self.run_api(repo, "user".to_string())?;
+        let user: GlabUser = serde_json::from_str(&output)?;
+        Ok(non_empty(&user.username))
+    }
+
+    fn list_mr_versions(&self, pr: &PullRequestDetails) -> Result<Vec<GlabMrVersion>> {
+        let project = gl_project_path(&pr.repository.owner, &pr.repository.name);
+        let mut versions = Vec::new();
+        for page in 1..=100 {
+            let endpoint = format!(
+                "projects/{}/merge_requests/{}/versions?per_page=100&page={}",
+                project, pr.number, page,
+            );
+            let output = self.run_api(&pr.repository, endpoint)?;
+            let rows: Vec<GlabMrVersion> = serde_json::from_str(&output)?;
+            let received = rows.len();
+            versions.extend(rows);
+            if received < 100 {
+                break;
+            }
+        }
+        Ok(versions)
+    }
+
+    fn list_mr_approval_records(
+        &self,
+        pr: &PullRequestDetails,
+        versions: &[GlabMrVersion],
+    ) -> Result<Vec<PullRequestReviewRecord>> {
+        let project = gl_project_path(&pr.repository.owner, &pr.repository.name);
+        let endpoint = format!(
+            "projects/{}/merge_requests/{}/approvals",
+            project, pr.number
+        );
+        let output = self.run_api(&pr.repository, endpoint)?;
+        let approvals: GlabApprovalState = serde_json::from_str(&output)?;
+        Ok(approvals
+            .approved_by
+            .into_iter()
+            .map(|approval| {
+                let commit_oid = approval
+                    .approved_at
+                    .as_ref()
+                    .and_then(|approved_at| version_head_at(versions, approved_at));
+                PullRequestReviewRecord {
+                    author: non_empty(&approval.user.username),
+                    submitted_at: approval.approved_at,
+                    commit_oid,
+                }
+            })
+            .collect())
+    }
+
+    fn list_mr_discussion_review_records(
+        &self,
+        pr: &PullRequestDetails,
+        versions: &[GlabMrVersion],
+    ) -> Result<Vec<PullRequestReviewRecord>> {
+        let project = gl_project_path(&pr.repository.owner, &pr.repository.name);
+        let mut records = Vec::new();
+        for page in 1..=100 {
+            let endpoint = format!(
+                "projects/{}/merge_requests/{}/discussions?per_page=100&page={}",
+                project, pr.number, page,
+            );
+            let output = self.run_api(&pr.repository, endpoint)?;
+            let discussions: Vec<GlabDiscussion> = serde_json::from_str(&output)?;
+            let received = discussions.len();
+            for discussion in discussions {
+                for note in discussion.notes {
+                    if note.system {
+                        continue;
+                    }
+                    let commit_oid = note
+                        .position
+                        .as_ref()
+                        .and_then(|position| position.head_sha.as_deref())
+                        .and_then(non_empty)
+                        .or_else(|| note.commit_id.as_deref().and_then(non_empty))
+                        .or_else(|| {
+                            note.created_at
+                                .as_ref()
+                                .and_then(|created_at| version_head_at(versions, created_at))
+                        });
+                    records.push(PullRequestReviewRecord {
+                        author: non_empty(&note.author.username),
+                        submitted_at: note.created_at,
+                        commit_oid,
+                    });
+                }
+            }
+            if received < 100 {
+                break;
+            }
+        }
+        Ok(records)
     }
 }
 
@@ -299,6 +432,25 @@ where
             }
         }
         Ok(commits)
+    }
+
+    fn list_pull_request_review_metadata(
+        &self,
+        pr: &PullRequestDetails,
+    ) -> Result<PullRequestReviewMetadata> {
+        let viewer_login = self.current_username(&pr.repository).unwrap_or_default();
+        let versions = self.list_mr_versions(pr).unwrap_or_default();
+        let mut reviews = self
+            .list_mr_approval_records(pr, &versions)
+            .unwrap_or_default();
+        reviews.extend(
+            self.list_mr_discussion_review_records(pr, &versions)
+                .unwrap_or_default(),
+        );
+        Ok(PullRequestReviewMetadata {
+            viewer_login,
+            reviews,
+        })
     }
 
     fn get_pull_request_commit_range_diff(
@@ -1071,6 +1223,104 @@ mod tests {
                 "--reviewer=@me",
             ]
         );
+    }
+
+    #[test]
+    fn should_list_pull_request_review_metadata_for_gitlab() {
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let runner = RecordingRunner::new_with_responses(vec![
+            r#"{ "username": "ronen-hoffer", "name": "Ronen" }"#.to_string(),
+            r#"[
+                {
+                    "head_commit_sha": "ccccccc3333333333333333333333333333cccc",
+                    "created_at": "2026-06-03T09:00:00Z"
+                },
+                {
+                    "head_commit_sha": "bbbbbbb2222222222222222222222222222bbbb",
+                    "created_at": "2026-06-02T09:00:00Z"
+                }
+            ]"#
+            .to_string(),
+            r#"{
+                "approved_by": [
+                    {
+                        "user": { "username": "ronen-hoffer", "name": "Ronen" },
+                        "approved_at": "2026-06-02T12:00:00Z"
+                    }
+                ]
+            }"#
+            .to_string(),
+            r#"[
+                {
+                    "id": "disc-1",
+                    "individual_note": false,
+                    "notes": [
+                        {
+                            "id": 100,
+                            "type": "DiffNote",
+                            "body": "left a comment",
+                            "author": { "username": "alice", "name": "Alice" },
+                            "created_at": "2026-06-01T10:00:00Z",
+                            "system": false,
+                            "position": {
+                                "position_type": "text",
+                                "head_sha": "aaaaaaa1111111111111111111111111111aaaa",
+                                "new_path": "src/lib.rs",
+                                "new_line": 12
+                            }
+                        },
+                        {
+                            "id": 101,
+                            "type": "DiffNote",
+                            "body": "my latest comment",
+                            "author": { "username": "ronen-hoffer", "name": "Ronen" },
+                            "created_at": "2026-06-03T10:00:00Z",
+                            "system": false,
+                            "commit_id": "ccccccc3333333333333333333333333333cccc",
+                            "position": {
+                                "position_type": "text",
+                                "head_sha": "ccccccc3333333333333333333333333333cccc",
+                                "new_path": "src/lib.rs",
+                                "new_line": 18
+                            }
+                        }
+                    ]
+                }
+            ]"#
+            .to_string(),
+        ]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        let metadata = backend.list_pull_request_review_metadata(&pr).unwrap();
+
+        assert_eq!(metadata.viewer_login.as_deref(), Some("ronen-hoffer"));
+        assert_eq!(metadata.reviews.len(), 3);
+        assert_eq!(
+            metadata.reviews[0].commit_oid.as_deref(),
+            Some("bbbbbbb2222222222222222222222222222bbbb")
+        );
+        assert_eq!(metadata.reviews[2].author.as_deref(), Some("ronen-hoffer"));
+        assert_eq!(
+            metadata.reviews[2].commit_oid.as_deref(),
+            Some("ccccccc3333333333333333333333333333cccc")
+        );
+
+        let calls = backend.runner.calls.borrow();
+        assert!(calls.iter().any(|(args, _)| args == &["api", "user"]));
+        assert!(calls.iter().any(|(args, _)| {
+            args.iter()
+                .any(|arg| arg.contains("/versions?per_page=100&page=1"))
+        }));
+        assert!(
+            calls
+                .iter()
+                .any(|(args, _)| args.iter().any(|arg| arg.contains("/approvals")))
+        );
+        assert!(calls.iter().any(|(args, _)| {
+            args.iter()
+                .any(|arg| arg.contains("/discussions?per_page=100&page=1"))
+        }));
     }
 
     fn make_pr_details(repo: ForgeRepository) -> PullRequestDetails {

--- a/src/forge/gitlab/models.rs
+++ b/src/forge/gitlab/models.rs
@@ -124,12 +124,34 @@ pub struct GlabDiffRefs {
     pub start_sha: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct GlabUser {
     #[serde(default)]
     pub username: String,
     #[serde(default)]
     pub name: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GlabMrVersion {
+    #[serde(default)]
+    pub head_commit_sha: String,
+    #[serde(default)]
+    pub created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct GlabApprovalState {
+    #[serde(default)]
+    pub approved_by: Vec<GlabApprovedBy>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct GlabApprovedBy {
+    #[serde(default)]
+    pub user: GlabUser,
+    #[serde(default)]
+    pub approved_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -272,6 +294,8 @@ pub struct GlabNote {
     #[serde(default)]
     pub created_at: Option<DateTime<Utc>>,
     #[serde(default)]
+    pub commit_id: Option<String>,
+    #[serde(default)]
     pub position: Option<GlabNotePosition>,
     #[serde(default)]
     pub resolved: bool,
@@ -291,6 +315,8 @@ pub struct GlabNoteAuthor {
 pub struct GlabNotePosition {
     #[serde(default)]
     pub position_type: String,
+    #[serde(default)]
+    pub head_sha: Option<String>,
     pub new_path: Option<String>,
     pub new_line: Option<u32>,
     pub old_path: Option<String>,
@@ -382,8 +408,10 @@ mod tests {
                     name: "Bob".to_string(),
                 },
                 created_at: None,
+                commit_id: None,
                 position: Some(GlabNotePosition {
                     position_type: "text".to_string(),
+                    head_sha: None,
                     new_path: Some("src/lib.rs".to_string()),
                     new_line: Some(42),
                     old_path: None,
@@ -414,6 +442,7 @@ mod tests {
                 body: "general comment".to_string(),
                 author: GlabNoteAuthor::default(),
                 created_at: None,
+                commit_id: None,
                 position: None,
                 resolved: false,
                 system: false,
@@ -435,6 +464,7 @@ mod tests {
                     name: "Alice".to_string(),
                 },
                 created_at: None,
+                commit_id: None,
                 position: None,
                 resolved: false,
                 system: false,
@@ -460,6 +490,7 @@ mod tests {
                 body: "requested review from @bob".to_string(),
                 author: GlabNoteAuthor::default(),
                 created_at: None,
+                commit_id: None,
                 position: None,
                 resolved: false,
                 system: true,

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -16,7 +16,8 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::forge::traits::{
-    ForgeBackend, PrSessionKey, PullRequestCommit, PullRequestDetails, PullRequestTarget,
+    ForgeBackend, PrSessionKey, PullRequestCommit, PullRequestDetails, PullRequestReviewMetadata,
+    PullRequestTarget,
 };
 use crate::model::{DiffFile, ReviewSession, SessionDiffSource};
 use crate::syntax::SyntaxHighlighter;
@@ -34,6 +35,9 @@ pub struct OpenedPullRequest {
     /// returned no commits (or the backend failed and we degraded
     /// gracefully — the cumulative diff stays usable).
     pub commits: Vec<PullRequestCommit>,
+    /// Best-effort metadata for detecting commits since the viewer's last
+    /// submitted review. Empty when unsupported or unavailable.
+    pub review_metadata: PullRequestReviewMetadata,
 }
 
 /// Open a PR target through a forge backend and prepare review state.
@@ -47,8 +51,15 @@ pub fn open_pull_request(
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
-    let (details, patch, commits) = fetch_pr_data(backend, target)?;
-    prepare_open_pr(details, &patch, commits, local_checkout, highlighter)
+    let (details, patch, commits, review_metadata) = fetch_pr_data(backend, target)?;
+    prepare_open_pr(
+        details,
+        &patch,
+        commits,
+        review_metadata,
+        local_checkout,
+        highlighter,
+    )
 }
 
 /// Network-only half of the PR open path: fetch PR metadata, the raw
@@ -61,13 +72,21 @@ pub fn open_pull_request(
 pub fn fetch_pr_data(
     backend: &dyn ForgeBackend,
     target: PullRequestTarget,
-) -> Result<(PullRequestDetails, String, Vec<PullRequestCommit>)> {
+) -> Result<(
+    PullRequestDetails,
+    String,
+    Vec<PullRequestCommit>,
+    PullRequestReviewMetadata,
+)> {
     let details = backend.get_pull_request(target)?;
     let patch = backend.get_pull_request_diff(&details)?;
     let commits = backend
         .list_pull_request_commits(&details)
         .unwrap_or_default();
-    Ok((details, patch, commits))
+    let review_metadata = backend
+        .list_pull_request_review_metadata(&details)
+        .unwrap_or_default();
+    Ok((details, patch, commits, review_metadata))
 }
 
 /// CPU-only half of the PR open path: parse the patch, apply
@@ -77,6 +96,7 @@ pub fn prepare_open_pr(
     details: PullRequestDetails,
     patch: &str,
     commits: Vec<PullRequestCommit>,
+    review_metadata: PullRequestReviewMetadata,
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
@@ -109,6 +129,7 @@ pub fn prepare_open_pr(
         session,
         key,
         commits,
+        review_metadata,
     })
 }
 

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -349,6 +349,22 @@ pub struct PullRequestCommit {
     pub timestamp: Option<DateTime<Utc>>,
 }
 
+/// Minimal review metadata used to infer "commits since my last review".
+/// This is separate from displayed review summaries because empty-body
+/// approvals still count as reviews for scoping purposes.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct PullRequestReviewMetadata {
+    pub viewer_login: Option<String>,
+    pub reviews: Vec<PullRequestReviewRecord>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PullRequestReviewRecord {
+    pub author: Option<String>,
+    pub submitted_at: Option<DateTime<Utc>>,
+    pub commit_oid: Option<String>,
+}
+
 pub trait ForgeBackend {
     fn list_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests>;
     fn get_pull_request(&self, target: PullRequestTarget) -> Result<PullRequestDetails>;
@@ -376,6 +392,14 @@ pub trait ForgeBackend {
     /// list scopes the inline commit selector so users can narrow a PR's
     /// cumulative diff down to a contiguous subrange.
     fn list_pull_request_commits(&self, pr: &PullRequestDetails) -> Result<Vec<PullRequestCommit>>;
+    /// Fetch minimal review metadata for commit-scope inference. Backends
+    /// that cannot expose this cheaply can keep the default empty result.
+    fn list_pull_request_review_metadata(
+        &self,
+        _pr: &PullRequestDetails,
+    ) -> Result<PullRequestReviewMetadata> {
+        Ok(PullRequestReviewMetadata::default())
+    }
     /// Fetch the cumulative diff between two commit SHAs that both belong to
     /// `pr`. `start_sha` is the *parent* of the first commit in the
     /// subrange; `end_sha` is the last commit. Implementations may use a

--- a/src/ui/commit_row.rs
+++ b/src/ui/commit_row.rs
@@ -1,7 +1,7 @@
 //! Shared commit-row rendering used by both the fullscreen review-target
 //! selector and the inline commit selector shown above the diff. Keeps the
-//! row layout (cursor arrow, range bar, checkbox, hash, branch chip, summary,
-//! author/date) consistent across surfaces.
+//! row layout (cursor arrow, range bar, checkbox, reviewed marker, hash,
+//! branch chip, summary, author/date) consistent across surfaces.
 
 use chrono::{DateTime, Utc};
 use ratatui::style::Style;
@@ -17,6 +17,8 @@ pub const CURSOR_GLYPH: &str = "\u{25b8}"; // ▸
 pub const RANGE_BAR_GLYPH: &str = "\u{258c}"; // ▌
 pub const SELECTED_BOX_GLYPH: &str = "\u{25a3}"; // ▣
 pub const UNSELECTED_BOX_GLYPH: &str = "\u{25a2}"; // ▢
+pub const REVIEWED_GLYPH: &str = "\u{2713}"; // ✓
+pub const REVIEWED_LABEL: &str = "✓ ";
 
 // Fixed column widths so author/date land at the same x across every row.
 // Branch column gets `[branch_name]` padded to width including brackets and a
@@ -29,6 +31,7 @@ pub struct CommitRowSpec<'a> {
     pub commit: &'a CommitInfo,
     pub is_cursor: bool,
     pub is_selected: bool,
+    pub is_reviewed: bool,
     pub theme: &'a Theme,
 }
 
@@ -43,7 +46,7 @@ pub fn render_commit_row<'a>(spec: &CommitRowSpec<'a>) -> Line<'a> {
         Style::default().fg(theme.fg_primary)
     };
 
-    let mut spans: Vec<Span<'a>> = Vec::with_capacity(10);
+    let mut spans: Vec<Span<'a>> = Vec::with_capacity(11);
     spans.push(Span::styled(
         if spec.is_cursor {
             format!("{CURSOR_GLYPH} ")
@@ -70,6 +73,18 @@ pub fn render_commit_row<'a>(spec: &CommitRowSpec<'a>) -> Line<'a> {
             styles::reviewed_style(theme)
         } else {
             styles::pending_style(theme)
+        },
+    ));
+    spans.push(Span::styled(
+        if spec.is_reviewed {
+            REVIEWED_LABEL.to_string()
+        } else {
+            " ".repeat(REVIEWED_LABEL.chars().count())
+        },
+        if spec.is_reviewed {
+            styles::reviewed_style(theme)
+        } else {
+            row_text_style
         },
     ));
 
@@ -184,6 +199,7 @@ mod tests {
             commit: &c,
             is_cursor: true,
             is_selected: false,
+            is_reviewed: false,
             theme: &theme,
         });
         // then
@@ -201,6 +217,7 @@ mod tests {
             commit: &c,
             is_cursor: false,
             is_selected: true,
+            is_reviewed: false,
             theme: &theme,
         });
         // then
@@ -219,12 +236,31 @@ mod tests {
             commit: &c,
             is_cursor: false,
             is_selected: false,
+            is_reviewed: false,
             theme: &theme,
         });
         // then
         let text = line_text(&line);
         assert!(!text.contains(RANGE_BAR_GLYPH), "got: {text:?}");
         assert!(text.contains(UNSELECTED_BOX_GLYPH), "got: {text:?}");
+    }
+
+    #[test]
+    fn should_render_reviewed_marker_when_commit_was_already_reviewed() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "Add feature", None);
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            is_cursor: false,
+            is_selected: false,
+            is_reviewed: true,
+            theme: &theme,
+        });
+        // then
+        let text = line_text(&line);
+        assert!(text.contains(REVIEWED_LABEL), "got: {text:?}");
     }
 
     #[test]
@@ -237,6 +273,7 @@ mod tests {
             commit: &c,
             is_cursor: false,
             is_selected: false,
+            is_reviewed: false,
             theme: &theme,
         });
         // then
@@ -256,6 +293,7 @@ mod tests {
             commit: &c,
             is_cursor: false,
             is_selected: false,
+            is_reviewed: false,
             theme: &theme,
         });
         // then

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -1,9 +1,9 @@
 use ratatui::{
+    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
-    Frame,
 };
 
 use crate::app::App;

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
 };
 
 use crate::app::App;
@@ -187,6 +187,9 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
             Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )),
         Line::from(""),
+        Line::from(Span::raw(
+            "  ✓ marks commits covered by your latest submitted review.",
+        )),
         Line::from(vec![
             Span::styled(
                 "  j/k       ",

--- a/src/ui/inline_commit_selector.rs
+++ b/src/ui/inline_commit_selector.rs
@@ -34,6 +34,7 @@ pub(super) fn render_inline_commit_selector(frame: &mut Frame, app: &mut App, ar
                 commit,
                 is_cursor: i == app.commit_list_cursor,
                 is_selected: app.is_commit_selected(i),
+                is_reviewed: app.is_commit_reviewed_by_viewer(i),
                 theme,
             })
         })

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -193,6 +193,7 @@ fn render_local_target_tab(frame: &mut Frame, app: &mut App, area: Rect) {
                 commit,
                 is_cursor: i == app.commit_list_cursor,
                 is_selected: app.is_commit_selected(i),
+                is_reviewed: false,
                 theme: &app.theme,
             })
         })


### PR DESCRIPTION
## Summary
- Fetch viewer review metadata for GitHub PRs and GitLab MRs so multi-commit reviews can default to commits newer than the viewer's latest submitted review.
- Preserve explicit/persisted commit-range selections, and mark commits already covered by the latest review with `✓` in the inline selector.
- Add GitLab metadata support from user, MR versions, approvals, and discussions.

Part of #388.

## How it looks

<img width="188" height="197" alt="image" src="https://github.com/user-attachments/assets/d10fa53d-6d0b-454b-86e3-0ec9d76b815f" />


## Testing
- `cargo fmt --check`
- `cargo check --quiet`
- `cargo clippy --quiet --all-targets -- -D warnings`
- `cargo test --quiet ui::commit_row::tests`
- `cargo test --quiet reviewed_commits_after`
- `cargo test --quiet should_mark_pr_commits_covered_by_viewers_last_review`

Note: full `cargo test --quiet` still hits the existing local Git 2.45 `relativeworktrees` environment failure in unchanged `src/vcs/git/libgit2.rs`.

