### PR TITLE
docs: document GitLab merge request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tuicr
 
-**A code review TUI with vim keybindings. Export to GitHub or clipboard.**
+**A code review TUI with vim keybindings. Export to GitHub, GitLab, or clipboard.**
 
 [![Crates.io](https://img.shields.io/crates/v/tuicr)](https://crates.io/crates/tuicr)
 [![License](https://img.shields.io/crates/l/tuicr)](./LICENSE)
@@ -17,9 +17,10 @@
 - PR-style comments at the line, range, file, and review level, with classifications like
   `issue`, `suggestion`, `note`, and `praise`.
 - Review tracking at file or hunk granularity, persisted across sessions.
-- Three export targets: push a real PR review to GitHub, copy structured markdown to your
+- Three export targets: push a real review to GitHub or GitLab, copy structured markdown to your
   clipboard, or pipe to stdout.
-- Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR.
+- Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR
+  or GitLab MR.
 
 ## Install
 
@@ -63,6 +64,7 @@ tuicr tui                   # Same TUI, explicit subcommand
 tuicr -w                    # Uncommitted changes (skip selector)
 tuicr -r main..HEAD         # Commit range
 tuicr pr 125                # GitHub PR
+tuicr mr 125                # GitLab MR
 tuicr tui pr 125            # GitHub PR via explicit TUI subcommand
 tuicr --stdout              # Pipe the review to stdout
 tuicr review list           # List saved local review sessions
@@ -79,6 +81,7 @@ Inside tuicr, navigate with `j`/`k`, press `c` to comment, then `y` to copy the 
 | Write comments in the TUI | ✅ | ✅ | ✅ | ❌ | ❌ |
 | Vim keybindings | ✅ | ❌ | partial¹ | ❌ | ❌ |
 | Push inline review to GitHub | ✅ | ❌ | ❌ | partial² | ❌ |
+| Push inline review to GitLab | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Agent-ready markdown export | ✅ | via CLI skill | ❌ | ❌ | ❌ |
 | git | ✅ | ✅ | ✅ | ❌ | ✅ |
 | jj | ✅ | ✅ | ✅ | ❌ | ❌ |
@@ -98,8 +101,15 @@ When you're done reviewing, send your comments wherever the work continues.
 ### To GitHub
 
 `:submit` opens a picker for Comment, Approve, Request changes, or Draft. Inline comments land
-on the right lines as a real PR review; review-level comments become the review summary.
+on the right lines as a real PR review. Review-level comments become the review summary.
 Requires `gh` authenticated to the repo.
+
+### To GitLab
+
+`:submit` offers Comment or Approve on a GitLab MR. Inline comments post as discussion notes.
+Review-level comments become the summary. Requires `glab` authenticated to the host. tuicr submits
+only Comment and Approve to GitLab. Request changes and Draft are GitHub-only here. See
+[docs/GITLAB.md](docs/GITLAB.md) for setup, self-hosted instances, and troubleshooting.
 
 ### To your coding agent
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -179,7 +179,7 @@ comment_types = [
 
 ## Forge
 
-Settings under the `[forge]` section control how tuicr submits reviews to GitHub.
+Settings under the `[forge]` section control how tuicr submits reviews to GitHub and GitLab.
 
 ```toml
 [forge]
@@ -206,7 +206,7 @@ Magic number should be a named constant
 This module could use a doc comment
 ```
 
-This applies to inline line comments, file-level comments, and review-level comments pushed via `:submit`.
+This applies to inline line comments, file-level comments, and review-level comments pushed via `:submit`. The prefix works the same way on GitLab MR submissions.
 
 ## .tuicrignore
 

--- a/docs/GITLAB.md
+++ b/docs/GITLAB.md
@@ -1,0 +1,90 @@
+# GitLab
+
+tuicr reviews GitLab merge requests the same way it reviews GitHub pull
+requests, through the `glab` CLI.
+
+## Setup
+
+Install the [GitLab CLI](https://gitlab.com/gitlab-org/cli) and authenticate:
+
+```bash
+glab auth login
+```
+
+tuicr shells out to `glab` for every GitLab operation and stores no tokens of
+its own. tuicr submits as whatever account `glab` is logged into.
+
+## Open a merge request
+
+```bash
+tuicr mr 125
+```
+
+`mr` is an alias for `pr`, so `tuicr mr 125`, `tuicr pr 125`, and `tuicr tui mr 125`
+all open the same review. The target accepts several forms:
+
+| Target | Example |
+|--------|---------|
+| MR IID | `125` |
+| MR URL | `https://gitlab.com/owner/repo/-/merge_requests/125` |
+| `owner/repo#iid` | `mygroup/myrepo#125` |
+| `host/owner/repo#iid` | `git.example.com/mygroup/myrepo#125` |
+
+Nested groups and subgroups work in the `owner/repo` slot, for example
+`mygroup/subgroup/myrepo#125`.
+
+tuicr detects the forge from the repository's remotes. A remote routes to GitLab
+when its host contains `gitlab` or matches a self-hosted host configured in
+`glab`. Everything else falls back to GitHub.
+
+## Submit a review
+
+`:submit` opens a picker. On GitLab it offers two events:
+
+| Event | Result |
+|-------|--------|
+| Comment | Posts your inline and review-level comments without changing approval state. |
+| Approve | Posts your comments and approves the merge request. |
+
+Inline comments land on their lines as merge request discussion notes.
+Review-level comments post as the review summary.
+
+tuicr submits only Comment and Approve to GitLab. `:submit request-changes` and
+`:submit draft` are GitHub-only in tuicr. Run either against a GitLab MR and
+tuicr returns an unsupported-operation error rather than submitting.
+
+## Self-hosted GitLab
+
+Authenticate against your instance once:
+
+```bash
+glab auth login --hostname git.example.com
+```
+
+After that, tuicr recognizes remotes on `git.example.com` as GitLab because the
+host is configured in `glab`. Pass the full URL or a `host/owner/repo#iid`
+target, and tuicr builds the `https://git.example.com/owner/repo` repository
+argument for `glab` on its own.
+
+## SSH over port 443
+
+If your network only allows SSH on port 443, GitLab's `altssh.gitlab.com`
+endpoint works. tuicr maps `altssh.gitlab.com` back to `gitlab.com` when it
+reads your remote, so the MR resolves against the real host. `HostName` aliases
+in `~/.ssh/config` are resolved the same way.
+
+## Limitations and troubleshooting
+
+Reviewing a commit range within an MR requires a local checkout of the branch.
+A remote-only commit-range diff returns a "not yet supported" error.
+
+For verbose tracing of the `glab` calls tuicr makes, set `TUICR_GLAB_DEBUG=1`.
+tuicr appends each interaction to `/tmp/tuicr-glab-debug.log`.
+
+Common errors:
+
+| Message | Fix |
+|---------|-----|
+| `GitLab integration requires glab.` | Install the GitLab CLI, then run `glab auth login`. |
+| `GitLab authentication failed.` | Run `glab auth login` for the host named in the error. |
+| `GitLab token lacks merge request write permission.` | Authenticate with an account or token that has merge request write access. |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -128,6 +128,9 @@ In command mode,
 | `?` | Toggle help |
 | `q` | Quick quit |
 
+`request-changes` and `draft` apply to GitHub only. tuicr submits `comment` and `approve` to
+GitLab MRs.
+
 ## Commit selection / review target selector
 
 | Key | Action |


### PR DESCRIPTION
This PR adds documentation for tuicr's GitLab support. The feature has improved steadily (#364, #412, #416) but had no docs.

I'm planning a handful of feature contributions too, but figured I'd start here. I'm primarily a GitHub user, though I've had jobs using GitLab, so I'm motivated to help work toward parity. I also have a personal account I use for testing automation, so I can help with testing and bug fixing.

## What's here

- New `docs/GITLAB.md`: setup with `glab`, opening an MR, submitting Comment and Approve reviews, self-hosted instances, SSH over port 443, and troubleshooting.
- `README.md`: GitLab is now a first-class forge. That covers the tagline, the "what it does" bullets, the comparison table, a new "To GitLab" export subsection, and a quick-start example.
- `docs/CONFIG.md`: the `[forge]` section now covers GitHub and GitLab.
- `docs/KEYBINDINGS.md`: a note on which submit events apply to which forge.

No code changes. This is documentation only.

## Notes

GitLab does have a request-changes review state, but tuicr doesn't currently submit it (or draft reviews) to a GitLab MR. It returns an "unsupported operation" error instead. I documented the behavior as it stands today rather than change the code here. The current error string is also worded as if GitLab lacks the feature, which isn't accurate. I left both alone on purpose and plan to come back for the real parity work in a follow-up.
