### PR TITLE
feat(gitlab): support draft reviews on merge requests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7387,6 +7387,18 @@ impl App {
         self.finish_pr_submit(in_flight, result);
     }
 
+    /// Human-readable name of the forge backing the current PR/MR review.
+    /// Used to keep submit messaging accurate across GitHub and GitLab.
+    pub fn forge_display_name(&self) -> &'static str {
+        match &self.diff_source {
+            DiffSource::PullRequest(pr) => match pr.key.repository.kind {
+                crate::forge::traits::ForgeKind::GitHub => "GitHub",
+                crate::forge::traits::ForgeKind::GitLab => "GitLab",
+            },
+            _ => "forge",
+        }
+    }
+
     /// Apply the create-review result on the main thread. On success: flip
     /// each included `Comment` to `Submitted` (or `PushedDraft` for the
     /// draft event), stamp `remote_review_id`, save the session again, and
@@ -7414,13 +7426,7 @@ impl App {
 
         let inline_count = in_flight.mappable.len();
         let summary_count = in_flight.moved_to_summary_count;
-        let forge_name = match &self.diff_source {
-            DiffSource::PullRequest(pr) => match pr.key.repository.kind {
-                crate::forge::traits::ForgeKind::GitHub => "GitHub",
-                crate::forge::traits::ForgeKind::GitLab => "GitLab",
-            },
-            _ => "forge",
-        };
+        let forge_name = self.forge_display_name();
         let message = match in_flight.event {
             SubmitEvent::Draft => {
                 let pr_url = match &self.diff_source {

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -392,13 +392,16 @@ where
         request: CreateReviewRequest<'_>,
     ) -> Result<GhCreateReviewResponse> {
         match request.event {
-            SubmitEvent::Comment | SubmitEvent::Approve | SubmitEvent::RequestChanges => {}
-            SubmitEvent::Draft => {
-                return Err(TuicrError::UnsupportedOperation(
-                    "GitLab does not support draft reviews".to_string(),
-                ));
-            }
+            SubmitEvent::Comment
+            | SubmitEvent::Approve
+            | SubmitEvent::RequestChanges
+            | SubmitEvent::Draft => {}
         }
+
+        // Draft submissions create GitLab draft notes (the pending-review
+        // primitive) and stop short of publishing, mirroring GitHub's pending
+        // review. The author publishes from the GitLab "Submit review" UI.
+        let is_draft = request.event == SubmitEvent::Draft;
 
         let project = gl_project_path(&pr.repository.owner, &pr.repository.name);
         let start_sha = pr
@@ -411,8 +414,19 @@ where
 
         // Post the overall review body as a general MR note (if non-empty).
         if !request.body.is_empty() {
-            let endpoint = format!("projects/{}/merge_requests/{}/notes", project, pr.number);
-            let body_json = serde_json::to_string(&serde_json::json!({ "body": request.body }))?;
+            let endpoint = if is_draft {
+                format!(
+                    "projects/{}/merge_requests/{}/draft_notes",
+                    project, pr.number
+                )
+            } else {
+                format!("projects/{}/merge_requests/{}/notes", project, pr.number)
+            };
+            let body_json = if is_draft {
+                serde_json::to_string(&serde_json::json!({ "note": request.body }))?
+            } else {
+                serde_json::to_string(&serde_json::json!({ "body": request.body }))?
+            };
             let mut args = vec![
                 "api".to_string(),
                 endpoint,
@@ -479,15 +493,29 @@ where
                     "end": end_endpoint,
                 });
             }
-            let body_json = serde_json::to_string(&serde_json::json!({
-                "body": comment.body,
-                "position": position,
-            }))?;
+            let body_json = if is_draft {
+                serde_json::to_string(&serde_json::json!({
+                    "note": comment.body,
+                    "position": position,
+                }))?
+            } else {
+                serde_json::to_string(&serde_json::json!({
+                    "body": comment.body,
+                    "position": position,
+                }))?
+            };
 
-            let endpoint = format!(
-                "projects/{}/merge_requests/{}/discussions",
-                project, pr.number,
-            );
+            let endpoint = if is_draft {
+                format!(
+                    "projects/{}/merge_requests/{}/draft_notes",
+                    project, pr.number,
+                )
+            } else {
+                format!(
+                    "projects/{}/merge_requests/{}/discussions",
+                    project, pr.number,
+                )
+            };
             let mut args = vec![
                 "api".to_string(),
                 endpoint,
@@ -504,8 +532,13 @@ where
                 let host = &pr.repository.host;
                 let project_encoded =
                     format!("{}/{}", pr.repository.owner, pr.repository.name).replace('/', "%2F");
+                let endpoint_label = if is_draft {
+                    "draft_notes"
+                } else {
+                    "discussions"
+                };
                 let url = format!(
-                    "https://{host}/api/v4/projects/{project_encoded}/merge_requests/{}/discussions",
+                    "https://{host}/api/v4/projects/{project_encoded}/merge_requests/{}/{endpoint_label}",
                     pr.number
                 );
                 glab_debug_log(&format!(
@@ -523,11 +556,17 @@ where
                 glab_debug_log(&format!("[GLAB_DEBUG] glab response: {output}\n"));
             }
 
+            // Discussions return a string `id`; draft_notes return a numeric
+            // one. Capture either so the success message reports a real id.
             if first_discussion_id.is_none()
                 && let Ok(value) = serde_json::from_str::<serde_json::Value>(&output)
-                && let Some(id) = value.get("id").and_then(|v| v.as_str())
+                && let Some(id) = value.get("id").and_then(|v| {
+                    v.as_str()
+                        .map(str::to_string)
+                        .or_else(|| v.as_u64().map(|n| n.to_string()))
+                })
             {
-                first_discussion_id = Some(id.to_string());
+                first_discussion_id = Some(id);
             }
         }
 
@@ -569,6 +608,8 @@ where
 
         let state = if request.event == SubmitEvent::RequestChanges {
             "CHANGES_REQUESTED"
+        } else if is_draft {
+            "PENDING"
         } else {
             "COMMENTED"
         };
@@ -1574,22 +1615,168 @@ mod tests {
     }
 
     #[test]
-    fn should_still_reject_draft_on_gitlab() {
+    fn should_post_draft_notes_for_draft_submission() {
+        // `:submit draft` on GitLab must create draft notes (the pending-review
+        // primitive) for both the body and inline comments, mirroring GitHub's
+        // pending review. No discussion, approve, or GraphQL call should fire.
         let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
         let pr = make_pr_details(repo.clone());
-        let runner = RecordingRunner::new_with_responses(vec![]);
+        let inline = InlineComment {
+            path: "src/lib.rs".into(),
+            line: 15,
+            side: GhSide::Right,
+            counterpart_line: Some(12),
+            start_line: None,
+            start_side: None,
+            old_path: None,
+            body: "inline draft".to_string(),
+            comment_id: "c1".to_string(),
+        };
+        let runner = RecordingRunner::new_with_responses(vec![
+            r#"{"id":10}"#.to_string(),
+            r#"{"id":22}"#.to_string(),
+        ]);
         let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
         let request = CreateReviewRequest {
             event: crate::forge::submit::SubmitEvent::Draft,
             commit_id: "headsha1",
-            body: "",
-            comments: &[],
+            body: "overall draft",
+            comments: &[inline],
         };
-        let err = backend.create_review(&pr, request).unwrap_err();
+        let response = backend.create_review(&pr, request).unwrap();
+        assert_eq!(response.state, "PENDING");
+        // draft_notes return a numeric `id`. The id is captured from the first
+        // inline note (matching the discussion path), so it must be parsed from
+        // the inline response (22), not left at 0.
+        assert_eq!(response.id, 22, "inline draft note id should be reported");
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(calls.len(), 2, "expected one body note and one inline note");
+
+        // Every call must target a draft_notes endpoint; none may publish or
+        // fall back to discussions/approve/graphql.
+        for (args, _) in calls.iter() {
+            let endpoint = &args[1];
+            assert!(
+                endpoint.ends_with("/draft_notes"),
+                "expected draft_notes endpoint, got {endpoint}"
+            );
+            assert!(
+                !endpoint.contains("discussions"),
+                "draft path must not hit discussions"
+            );
+            assert!(
+                !args.iter().any(|a| a.contains("approve") || a == "graphql"),
+                "draft path must not approve or run graphql"
+            );
+        }
+
+        // Body note: { "note": <body> }, no position.
+        let (_, body_stdin) = &calls[0];
+        let body: serde_json::Value = serde_json::from_str(body_stdin.as_ref().unwrap()).unwrap();
+        assert_eq!(body["note"], "overall draft");
         assert!(
-            matches!(err, TuicrError::UnsupportedOperation(_)),
-            "expected UnsupportedOperation for draft, got {err:?}"
+            body.get("body").is_none(),
+            "draft must use `note`, not `body`"
         );
+        assert!(body.get("position").is_none(), "body note has no position");
+
+        // Inline note: `note` + position carrying the expected line numbers.
+        let (_, inline_stdin) = &calls[1];
+        let inline: serde_json::Value =
+            serde_json::from_str(inline_stdin.as_ref().unwrap()).unwrap();
+        assert_eq!(inline["note"], "inline draft");
+        assert!(
+            inline.get("body").is_none(),
+            "inline draft must use `note`, not `body`"
+        );
+        let position = &inline["position"];
+        assert_eq!(position["new_line"], serde_json::Value::Number(15.into()));
+        assert_eq!(position["old_line"], serde_json::Value::Number(12.into()));
+    }
+
+    #[test]
+    fn should_not_publish_draft_notes() {
+        // Draft submissions stop at creating draft notes. Publishing is left to
+        // the GitLab web UI, so no call may touch bulk_publish or /publish.
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let inline = InlineComment {
+            path: "src/lib.rs".into(),
+            line: 15,
+            side: GhSide::Right,
+            counterpart_line: None,
+            start_line: None,
+            start_side: None,
+            old_path: None,
+            body: "inline draft".to_string(),
+            comment_id: "c1".to_string(),
+        };
+        let runner = RecordingRunner::new_with_responses(vec![
+            r#"{"id":1}"#.to_string(),
+            r#"{"id":2}"#.to_string(),
+        ]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+        let request = CreateReviewRequest {
+            event: crate::forge::submit::SubmitEvent::Draft,
+            commit_id: "headsha1",
+            body: "overall draft",
+            comments: &[inline],
+        };
+        backend.create_review(&pr, request).unwrap();
+
+        let calls = backend.runner.calls.borrow();
+        for (args, _) in calls.iter() {
+            assert!(
+                !args
+                    .iter()
+                    .any(|a| a.contains("bulk_publish") || a.contains("/publish")),
+                "draft path must not publish"
+            );
+        }
+    }
+
+    #[test]
+    fn should_post_comment_submission_to_notes_and_discussions() {
+        // Guard against the draft branching regressing the default Comment path:
+        // body goes to `/notes`, inline comments to `/discussions`.
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let inline = InlineComment {
+            path: "src/lib.rs".into(),
+            line: 15,
+            side: GhSide::Right,
+            counterpart_line: None,
+            start_line: None,
+            start_side: None,
+            old_path: None,
+            body: "inline comment".to_string(),
+            comment_id: "c1".to_string(),
+        };
+        let runner = RecordingRunner::new_with_responses(vec![
+            String::new(),
+            r#"{"id":"disc-abc"}"#.to_string(),
+        ]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+        let request = CreateReviewRequest {
+            event: crate::forge::submit::SubmitEvent::Comment,
+            commit_id: "headsha1",
+            body: "overall comment",
+            comments: &[inline],
+        };
+        let response = backend.create_review(&pr, request).unwrap();
+        assert_eq!(response.state, "COMMENTED");
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(calls.len(), 2);
+        assert!(calls[0].0[1].ends_with("/notes"));
+        assert!(calls[1].0[1].ends_with("/discussions"));
+        for (args, _) in calls.iter() {
+            assert!(
+                !args.iter().any(|a| a.contains("draft_notes")),
+                "comment path must not hit draft_notes"
+            );
+        }
     }
 
     #[test]

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -130,9 +130,10 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
 
     frame.render_widget(Clear, area);
 
+    let forge = app.forge_display_name();
     let title = match state.event {
-        SubmitEvent::Draft => " Push pending GitHub review? ".to_string(),
-        _ => " Submit review to GitHub? ".to_string(),
+        SubmitEvent::Draft => format!(" Push pending {forge} review? "),
+        _ => format!(" Submit review to {forge}? "),
     };
 
     let block = Block::default()
@@ -187,7 +188,7 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
             Style::default().fg(theme.pending),
         )));
         lines.push(Line::from(Span::styled(
-            "Some comments may appear outdated on GitHub.",
+            format!("Some comments may appear outdated on {forge}."),
             Style::default().fg(theme.pending),
         )));
     }
@@ -195,11 +196,11 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
     if matches!(state.event, SubmitEvent::Draft) {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
-            "This will create a pending GitHub review.",
+            format!("This will create a pending {forge} review."),
             Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
-            "It will not publish until you finish it in GitHub.",
+            format!("It will not publish until you finish it in {forge}."),
             Style::default().fg(theme.fg_secondary),
         )));
     }
@@ -339,6 +340,10 @@ mod tests {
     }
 
     fn make_pr_app() -> App {
+        make_pr_app_for(ForgeRepository::github("github.com", "agavra", "tuicr"))
+    }
+
+    fn make_pr_app_for(repo: ForgeRepository) -> App {
         let vcs_info = VcsInfo {
             root_path: PathBuf::from("/tmp"),
             head_commit: "abcdef0123".to_string(),
@@ -352,11 +357,7 @@ mod tests {
             SessionDiffSource::PullRequest,
         );
         let pr_source = PullRequestDiffSource {
-            key: PrSessionKey::new(
-                ForgeRepository::github("github.com", "agavra", "tuicr"),
-                125,
-                "abcdef0123".to_string(),
-            ),
+            key: PrSessionKey::new(repo, 125, "abcdef0123".to_string()),
             base_sha: "0000".to_string(),
             title: "test".to_string(),
             url: "https://example".to_string(),
@@ -604,6 +605,28 @@ mod tests {
         assert!(!text.contains("Event: "), "draft body: {text}");
         assert!(text.contains("[y]"));
         assert!(text.contains("push draft"));
+    }
+
+    #[test]
+    fn confirm_uses_gitlab_label_for_gitlab_draft() {
+        let mut app = make_pr_app_for(ForgeRepository::gitlab("gitlab.com", "owner", "repo"));
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Draft,
+            mappable: vec![inline(11)],
+            unmappable: Vec::new(),
+            resolver_choices: Vec::new(),
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
+        });
+        let buffer = draw_confirm(&app);
+        let text = buffer_text(&buffer);
+        assert!(
+            text.contains("Push pending GitLab review?"),
+            "gitlab draft title: {text}"
+        );
+        assert!(text.contains("finish it in GitLab"), "gitlab body: {text}");
+        assert!(!text.contains("GitHub"), "must not mention GitHub: {text}");
     }
 
     #[test]


### PR DESCRIPTION
Adds `:submit draft` for GitLab merge requests. The command creates GitLab draft notes (the pending-review primitive) for the body and each inline comment, then stops. The author finishes the review from the GitLab "Submit review" UI. This mirrors a GitHub pending review: the comments live on the forge as editable drafts until the author publishes them.

The draft path reuses the existing position builder. It swaps two things: the endpoint (`draft_notes` for `notes`/`discussions`) and the JSON field (`note` for `body`). Everything downstream of the backend already handled the draft event generically, so the lifecycle transition to pushed-draft and the success message needed no backend-specific changes.

Follows up on #421, which named this as the next target.

## Notes

- Creating drafts is the whole feature. tuicr does not call `draft_notes/bulk_publish`. Leaving the notes unpublished is what makes this a pending review rather than a normal comment submission.
- Draft notes return a numeric `id`, where discussions return a string one. The response extractor now accepts either, so the success message reports a real id instead of `#0`.
- The submit confirmation dialog and success message are now forge-aware through a small `App::forge_display_name` helper. A GitLab MR previously showed "Push pending GitHub review?"; this path only became reachable for GitLab once drafts worked here.
- Out of scope, for later: publishing drafts from tuicr (`bulk_publish`), auto-adding the user as a reviewer, and clearing request-changes state.

## Testing

New unit tests cover the draft path: body and inline notes posting to `draft_notes` with the `note` field and the expected position, a `PENDING` response state carrying the parsed numeric id, no call touching `bulk_publish` or `/publish`, the default Comment path still hitting `notes`/`discussions`, and the GitLab label in the confirmation dialog.

Verified live against gitlab.com through the TUI, using a throwaway MR ([MR !1](https://gitlab.com/bendrucker1/tuicr-draft-notes-test/-/merge_requests/1)):

- Added a summary comment and an inline comment, then `:submit draft`. The confirmation dialog read "Push pending GitLab review?" and tuicr reported success with the MR URL, flipping both comments to pushed-draft state.
- Confirmed on the API that two draft notes existed (body plus inline at `new_line` 5) and zero notes were published.
- Published the drafts from the API to check the position resolves: the inline note landed on line 5.

Sandbox project (archived): https://gitlab.com/bendrucker1/tuicr-draft-notes-test
