### PR TITLE
feat: default to cursor commit when no range selected

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8507,9 +8507,12 @@ impl App {
     }
 
     fn confirm_commit_selection_inner(&mut self) -> Result<()> {
-        let Some((start, end)) = self.commit_selection_range else {
-            self.set_message("Select at least one commit");
-            return Ok(());
+        let (start, end) = match self.commit_selection_range {
+            Some(range) => range,
+            None => {
+                let cursor = self.commit_list_cursor;
+                (cursor, cursor)
+            }
         };
 
         // Collect selected entries in order from oldest to newest (end..start).


### PR DESCRIPTION
it's extremely frustrating to have to select a commit

if someone presses Enter/Return, I presume there's no possible intent other than choosing the commit already under the cursor in the first place