### PR TITLE
fix(forge): show expand row after last hunk in PR review

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9128,6 +9128,7 @@ impl App {
                 | DiffSource::StagedAndUnstaged
                 | DiffSource::StagedUnstagedAndCommits(_)
                 | DiffSource::CommitRange(_)
+                | DiffSource::PullRequest(_)
         )
     }
 
@@ -9137,14 +9138,32 @@ impl App {
             return;
         }
         if let Some(file) = self.diff_files.get(file_idx) {
-            let path = file.display_path().clone();
+            let old_path = file.old_path.clone();
+            let new_path = file.new_path.clone();
             let status = file.status;
-            let ref_commit = self.ref_commit().map(|s| s.to_string());
-            if let Ok(count) = self
-                .vcs
-                .file_line_count(&path, status, ref_commit.as_deref())
+
+            let count = if let (DiffSource::PullRequest(pr), Some(backend)) =
+                (&self.diff_source, self.forge_backend.as_ref())
             {
-                self.file_line_count_cache.insert(file_idx, count);
+                let provider = ForgeContextProvider {
+                    forge: backend.as_ref(),
+                    repository: pr.key.repository.clone(),
+                    base_sha: pr.base_sha.clone(),
+                    head_sha: pr.key.head_sha.clone(),
+                };
+                provider
+                    .file_line_count(old_path.as_ref(), new_path.as_ref(), status)
+                    .ok()
+            } else {
+                let path = new_path.or(old_path).unwrap_or_default();
+                let ref_commit = self.ref_commit().map(|s| s.to_string());
+                self.vcs
+                    .file_line_count(&path, status, ref_commit.as_deref())
+                    .ok()
+            };
+
+            if let Some(c) = count {
+                self.file_line_count_cache.insert(file_idx, c);
             }
         }
     }

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -32,6 +32,15 @@ pub trait ContextProvider {
         start_line: u32,
         end_line: u32,
     ) -> Result<Vec<DiffLine>>;
+
+    /// Return the total number of lines in the file at the revision used by
+    /// this provider. Returns `Ok(0)` when the file cannot be found.
+    fn file_line_count(
+        &self,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+        file_status: FileStatus,
+    ) -> Result<u32>;
 }
 
 /// Adapter over a `VcsBackend`. Picks the appropriate display path (new on
@@ -64,6 +73,20 @@ impl ContextProvider for VcsContextProvider<'_> {
             start_line,
             end_line,
         )
+    }
+
+    fn file_line_count(
+        &self,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+        file_status: FileStatus,
+    ) -> Result<u32> {
+        let path: &Path = match new_path.or(old_path) {
+            Some(p) => p.as_path(),
+            None => return Ok(0),
+        };
+        self.vcs
+            .file_line_count(path, file_status, self.ref_commit.as_deref())
     }
 }
 
@@ -118,6 +141,29 @@ impl ContextProvider for ForgeContextProvider<'_> {
             end_line,
         };
         self.forge.fetch_file_lines(request)
+    }
+
+    fn file_line_count(
+        &self,
+        old_path: Option<&PathBuf>,
+        new_path: Option<&PathBuf>,
+        file_status: FileStatus,
+    ) -> Result<u32> {
+        let side = ForgeFileLinesRequest::side_for_status(file_status);
+        let Some(path) = ForgeFileLinesRequest::path_for_side(side, old_path, new_path) else {
+            return Ok(0);
+        };
+        let request = ForgeFileLinesRequest {
+            repository: self.repository.clone(),
+            base_sha: self.base_sha.clone(),
+            head_sha: self.head_sha.clone(),
+            path,
+            status: file_status,
+            side,
+            start_line: 0,
+            end_line: 0,
+        };
+        self.forge.file_line_count(request)
     }
 }
 

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -415,6 +415,19 @@ where
         ))
     }
 
+    fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
+        let local_content = self
+            .local_checkout
+            .as_deref()
+            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
+        let content = if let Some(content) = local_content {
+            content
+        } else {
+            self.fetch_file_via_api(&request)?
+        };
+        Ok(content.lines().count() as u32)
+    }
+
     fn create_review(
         &self,
         pr: &PullRequestDetails,
@@ -538,15 +551,16 @@ fn slice_to_diff_lines(content: &str, start_line: u32, end_line: u32) -> Vec<Dif
     let mut result = Vec::new();
     for line_num in start_line..=end_line {
         let idx = (line_num - 1) as usize;
-        if idx < lines.len() {
-            result.push(DiffLine {
-                origin: LineOrigin::Context,
-                content: lines[idx].to_string(),
-                old_lineno: Some(line_num),
-                new_lineno: Some(line_num),
-                highlighted_spans: None,
-            });
+        if idx >= lines.len() {
+            break;
         }
+        result.push(DiffLine {
+            origin: LineOrigin::Context,
+            content: lines[idx].to_string(),
+            old_lineno: Some(line_num),
+            new_lineno: Some(line_num),
+            highlighted_spans: None,
+        });
     }
     result
 }

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -386,6 +386,19 @@ where
         ))
     }
 
+    fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
+        let local_content = self
+            .local_checkout
+            .as_deref()
+            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
+        let content = if let Some(content) = local_content {
+            content
+        } else {
+            self.fetch_file_via_api(&request)?
+        };
+        Ok(content.lines().count() as u32)
+    }
+
     fn create_review(
         &self,
         pr: &PullRequestDetails,
@@ -648,15 +661,16 @@ fn slice_to_diff_lines(content: &str, start_line: u32, end_line: u32) -> Vec<Dif
     let mut result = Vec::new();
     for line_num in start_line..=end_line {
         let idx = (line_num - 1) as usize;
-        if idx < lines.len() {
-            result.push(DiffLine {
-                origin: LineOrigin::Context,
-                content: lines[idx].to_string(),
-                old_lineno: Some(line_num),
-                new_lineno: Some(line_num),
-                highlighted_spans: None,
-            });
+        if idx >= lines.len() {
+            break;
         }
+        result.push(DiffLine {
+            origin: LineOrigin::Context,
+            content: lines[idx].to_string(),
+            old_lineno: Some(line_num),
+            new_lineno: Some(line_num),
+            highlighted_spans: None,
+        });
     }
     result
 }

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -357,6 +357,12 @@ pub trait ForgeBackend {
     /// Implementations may optimize by reading from a local checkout when
     /// available; the trait does not require that path.
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>>;
+    /// Return the total number of lines in a file at the revision described by
+    /// `request`. The `start_line` and `end_line` fields of the request are
+    /// ignored. Default returns `Ok(0)`; real forge backends override this.
+    fn file_line_count(&self, _request: ForgeFileLinesRequest) -> Result<u32> {
+        Ok(0)
+    }
     /// Fetch existing review discussions for a PR, including their resolved
     /// and outdated state. Implementations should return all threads in
     /// posted order; filtering by visibility happens in the App.

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -602,6 +602,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                     | DiffSource::StagedAndUnstaged
                     | DiffSource::StagedUnstagedAndCommits(_)
                     | DiffSource::CommitRange(_)
+                    | DiffSource::PullRequest(_)
             )
             && let Some(last_hunk) = file.hunks.last()
         {

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -951,6 +951,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                     | DiffSource::StagedAndUnstaged
                     | DiffSource::StagedUnstagedAndCommits(_)
                     | DiffSource::CommitRange(_)
+                    | DiffSource::PullRequest(_)
             )
             && let Some(last_hunk) = file.hunks.last()
         {


### PR DESCRIPTION
 This PR fixes #423

  ## Summary

  - Fix the missing expand row after the last hunk in PR review mode
  - Added `file_line_count` to `ForgeBackend` so the forge API is used directly to count lines
  - Fixed `slice_to_diff_lines` in both forge backends to break early instead of iterating up 