### PR TITLE
Session Type Detection For Clipboard On Linux

### DIFF
--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -96,8 +96,20 @@ pub fn copy_text_to_clipboard(text: &str) -> Result<bool> {
 
 /// Try xclip (X11) then wl-copy (Wayland). Returns true if either succeeds.
 fn try_copy_via_subprocess(text: &str) -> bool {
-    try_clipboard_cmd("xclip", &["-selection", "clipboard"], text)
-        || try_clipboard_cmd("wl-copy", &[], text)
+    let session = std::env::var("XDG_SESSION_TYPE");
+    if session.is_err() {
+        // Session not specified
+        return false;
+    }
+    let session = session.unwrap();
+    if session == "wayland" {
+        try_clipboard_cmd("wl-copy", &[], text)
+    } else if session == "x11" {
+        try_clipboard_cmd("xclip", &["-selection", "clipboard"], text)
+    } else {
+        // Session type unsupported
+        false
+    }
 }
 
 /// Try copying via a CLI tool that forks into the background and holds


### PR DESCRIPTION
# Before

Clipboard would always run `xclip`, then, `wl-clipboard` (though because `xclip` doesn't fail on Wayland, `wl-clipboard` would never actually run).

# After

On Linux, `tuicr` will detect if `XDG_SESSION_TYPE` is `X11` or `Wayland`, then choose the proper clipboard tool to use.

# Tests

 - Tested on Hyprland (Wayland).
 - Tested on Openbox (X11).

 > Closes #434 
 
EDIT: Added Closes
EDIT: Added 'Tests' section