### PR TITLE
feat(comment): Alt+Enter accepts and Alt+Esc discards the vim comment

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -96,7 +96,10 @@ With `comment_vim = true` the box uses [`edtui`](https://github.com/preiter93/ed
 modal editing (Normal/Insert/Visual: `hjkl`, `w`/`b`/`e`, `dd`/`D`/`ciw`/`x`,
 `u`/`Ctrl-r`, visual `v`+`y`/`d`/`p`). From Normal mode `:w` (or `Enter` twice)
 saves and `:q` (or `Esc`/`q` twice) cancels — the first press arms the action
-and the header shows a confirm hint. `Tab` cycles the comment type in Normal
+and the header shows a confirm hint. `Alt-Enter` (Option+Enter) accepts and
+`Alt-Esc` discards directly (no double-press) — Alt is the one modified
+`Enter`/`Esc` that reaches the app across terminals, including browser/web
+terminals like zellij web. `Tab` cycles the comment type in Normal
 mode and inserts `comment_tab_width` spaces (default 4) in Insert mode; `Ctrl-s`
 also saves. Operator+motion combos like
 `dw`/`cw` aren't supported (edtui limitation).

--- a/src/main.rs
+++ b/src/main.rs
@@ -750,6 +750,25 @@ fn handle_comment_vim_key(app: &mut App, key: crossterm::event::KeyEvent) -> boo
         return true;
     }
 
+    // Alt+Enter (Option+Enter) accepts (save) and Alt+Esc discards (cancel)
+    // directly, in any mode — no double-press. Alt is the one modified Enter/Esc
+    // that reaches the app across terminals, including browser/web terminals
+    // like zellij web (where Shift/Cmd+Enter get stripped or grabbed). Plain
+    // Enter still inserts a newline in Insert mode, so Alt+Enter is free here.
+    if key.modifiers.contains(KeyModifiers::ALT) {
+        match key.code {
+            KeyCode::Enter => {
+                app.save_comment();
+                return true;
+            }
+            KeyCode::Esc => {
+                app.exit_comment_mode();
+                return true;
+            }
+            _ => {}
+        }
+    }
+
     let normal = app.comment_vim_in_normal_mode();
 
     // In Normal mode a first plain Enter/Esc arms a confirm (header shows the

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -152,7 +152,7 @@ pub fn format_comment_input_lines(
     // Top border with type label and hints. In vim mode the hints describe the
     // modal bindings and a `[MODE]` tag is shown after the type label.
     let hint = match vim_mode {
-        Some(_) => "(Tab/S-Tab:type i:insert Esc:normal :w save :q cancel)".to_string(),
+        Some(_) => "(i:insert  Alt-Enter:save  Esc:normal  :w save  :q discard)".to_string(),
         None => format!("(Tab/S-Tab:type Enter:save {newline_hint}:newline Esc:cancel)"),
     };
     let mut header_spans = vec![

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -525,7 +525,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw(if app.comment_vim_enabled {
-                "Vim modal editing ON (Esc:normal i/a:insert hjkl dd/ciw/x u; :w save :q cancel)"
+                "Vim ON (i/a:insert Esc:normal hjkl dd/ciw/x u; S-Enter:save S-Esc:discard :w/:q)"
             } else {
                 "Set comment_vim=true (or :vim) for vim modal editing"
             }),


### PR DESCRIPTION
## What

In the **vim comment editor** (`comment_vim = true`), a quick accept/discard with no double-press:

- **`Alt+Enter`** (Option+Enter) → accept (save the comment)
- **`Alt+Esc`** → discard (cancel)

This complements the existing ways to finish a comment: `:w`/`:q`, double-`Enter`/`Esc`, and `Ctrl-S`. The default (non-vim) comment box is unchanged — `Alt+Enter` stays a newline there.

## Implementation

- Handled in `handle_comment_vim_key` (vim box only): `Alt+Enter` → `save_comment`, `Alt+Esc` → `exit_comment_mode`.
- Header hint and `docs/KEYBINDINGS.md` updated.

## Testing

`cargo build`, `cargo fmt --check`, `cargo clippy --all-targets` (0 warnings), `cargo test` (0 failures). Manually confirmed `Alt+Enter` saves in zellij web.