### PR TITLE
feat(ui): detect light/dark theme from terminal background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2451,6 +2451,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal-colorsaurus"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46bb5364467da040298c573c8a95dbf9a512efc039630409a03126e3703e90"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio",
+ "terminal-trx",
+ "windows-sys 0.61.2",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3f27d9a8a177e57545481faec87acb45c6e854ed1e5a3658ad186c106f38ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2774,7 @@ dependencies = [
  "shlex 1.3.0",
  "syntect",
  "tempfile",
+ "terminal-colorsaurus",
  "thiserror 2.0.18",
  "toml",
  "tracing",
@@ -3445,6 +3472,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xterm-color"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7008a9d8ba97a7e47d9b2df63fcdb8dade303010c5a7cd5bf2469d4da6eba673"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,8 @@ sha1 = "0.10"
 syntect = "5.2"
 two-face = { version = "0.5", default-features = false, features = ["syntect-default-fancy"] }
 
+# Terminal background detection
+terminal-colorsaurus = "1"
+
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -1717,13 +1717,32 @@ fn resolve_appearance(appearance: AppearanceArg) -> ThemeArg {
         AppearanceArg::Light => ThemeArg::Light,
         AppearanceArg::Dark => ThemeArg::Dark,
         AppearanceArg::System => {
-            if is_system_dark_mode().unwrap_or(true) {
+            if is_dark_mode().unwrap_or(true) {
                 ThemeArg::Dark
             } else {
                 ThemeArg::Light
             }
         }
     }
+}
+
+fn is_dark_mode() -> Option<bool> {
+    is_terminal_background_dark().or_else(is_system_dark_mode)
+}
+
+#[cfg(not(test))]
+fn is_terminal_background_dark() -> Option<bool> {
+    use terminal_colorsaurus::{QueryOptions, background_color};
+
+    match background_color(QueryOptions::default()) {
+        Ok(color) => Some(color.perceived_lightness() < 0.5),
+        Err(_) => None,
+    }
+}
+
+#[cfg(test)]
+fn is_terminal_background_dark() -> Option<bool> {
+    None
 }
 
 #[cfg(target_os = "macos")]
@@ -2240,7 +2259,7 @@ pub fn resolve_theme_with_config(
             AppearanceArg::Dark => theme_dark,
             AppearanceArg::Light => theme_light,
             AppearanceArg::System => {
-                if is_system_dark_mode().unwrap_or(true) {
+                if is_dark_mode().unwrap_or(true) {
                     theme_dark
                 } else {
                     theme_light


### PR DESCRIPTION
**TL;DR** This should fix the default theme appearing unreadable on systems with a light theme and dark terminal:

Before
<img width="1086" height="611" alt="image" src="https://github.com/user-attachments/assets/cb84dc10-2133-4efb-8a68-a62628a63332" />

<img width="1121" height="633" alt="tuicr 1" src="https://github.com/user-attachments/assets/bc0f6363-e47d-447c-895f-bb0bd0d77b9c" />

After
<img width="1072" height="600" alt="image" src="https://github.com/user-attachments/assets/ef247a1e-60e2-4c3d-b3eb-cdac14144fbe" />

<img width="1123" height="633" alt="tuicr 2" src="https://github.com/user-attachments/assets/7b29b5c0-32d2-4f64-a7ca-efae2867b833" />

YMMV but I thought this might be helpful.

----

Prefer to query the terminal background color using terminal-colorsaurus, then fall back to the system theme.

terminal-colorsaurus was chosen due to its minimal added transitive dependencies, comprehensive documentation and Windows Terminal support.

Seems to fix light system theme & dark terminal rendering unreadable text on KDE + Konsole, Windows 11 + Windows Terminal.