### PR TITLE
fix :edit on PR-s where you're forked

### DIFF
--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -780,14 +780,9 @@ impl App {
         // Use the local checkout for `.tuicrignore` only when it matches the
         // PR's target repository — using a foreign repo's checkout would
         // mis-filter the PR diff.
-        let local_checkout_for_target = local_repo_root.as_deref().and_then(|root| {
-            let detected = crate::forge::detect_forge_repository(root)?;
-            if detected == target_repo {
-                Some(root.to_path_buf())
-            } else {
-                None
-            }
-        });
+        let local_checkout_for_target = local_repo_root
+            .as_deref()
+            .and_then(|root| crate::forge::local_checkout_for_repo(root, &target_repo));
 
         let backend = create_forge_backend(&target_repo, local_checkout_for_target.clone());
         let highlighter = theme.syntax_highlighter();

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -899,7 +899,8 @@ impl App {
     ) -> Result<()> {
         use crate::forge::pr_open::prepare_open_pr;
 
-        let local_checkout = Some(self.vcs_info.root_path.clone());
+        let local_checkout =
+            crate::forge::local_checkout_for_repo(&self.vcs_info.root_path, &request.repository);
         let highlighter = self.theme.syntax_highlighter();
         let opened = prepare_open_pr(
             details.clone(),

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -813,7 +813,6 @@ impl App {
         use crate::forge::pr_open::fetch_pr_data;
         use crate::forge::traits::PullRequestTarget;
 
-        let local_checkout = Some(self.vcs_info.root_path.clone());
         let request = PrOpenRequest {
             repository: summary.repository.clone(),
             pr_number: summary.number,
@@ -826,9 +825,8 @@ impl App {
 
         let summary_repo = summary.repository.clone();
         let pr_number = summary.number;
-        let thread_local_checkout = local_checkout.clone();
         std::thread::spawn(move || {
-            let backend = create_forge_backend(&summary_repo, thread_local_checkout);
+            let backend = create_forge_backend(&summary_repo, None);
             let target =
                 PullRequestTarget::with_repository(summary_repo, pr_number, pr_number.to_string());
             let outcome = fetch_pr_data(backend.as_ref(), target).map_err(|e| e.to_string());

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -113,17 +113,24 @@ impl App {
         }
 
         let display_path = file.display_path().clone();
-        // PR mode uses a synthetic forge root when there is no local checkout
-        // to hand to an editor.
-        if !self.vcs_info.root_path.is_absolute() {
+        // PR mode's root_path is the synthetic forge:host/owner/repo
+        // identity, never a real directory.
+        let root = if self.vcs_info.root_path.is_absolute() {
+            Some(self.vcs_info.root_path.clone())
+        } else {
+            self.forge_backend
+                .as_deref()
+                .and_then(|backend| backend.local_checkout_path())
+        };
+        let Some(root) = root else {
             self.set_warning(format!(
                 "Cannot open {}: no local checkout",
                 display_path.display()
             ));
             return;
-        }
+        };
 
-        let path = self.vcs_info.root_path.join(&display_path);
+        let path = root.join(&display_path);
         // Deleted files and remote-only PR files have diff rows,
         // but no worktree file the external editor can open.
         if !path.exists() {

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -195,6 +195,111 @@ fn editor_target_warns_for_missing_local_file() {
     );
 }
 
+struct FakeForgeBackend {
+    local_checkout: Option<PathBuf>,
+}
+
+impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
+    fn list_pull_requests(
+        &self,
+        _query: crate::forge::traits::PullRequestListQuery,
+    ) -> crate::error::Result<crate::forge::traits::PagedPullRequests> {
+        unimplemented!()
+    }
+    fn get_pull_request(
+        &self,
+        _target: crate::forge::traits::PullRequestTarget,
+    ) -> crate::error::Result<crate::forge::traits::PullRequestDetails> {
+        unimplemented!()
+    }
+    fn get_pull_request_diff(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+    ) -> crate::error::Result<String> {
+        unimplemented!()
+    }
+    fn fetch_file_lines(
+        &self,
+        _request: crate::forge::traits::ForgeFileLinesRequest,
+    ) -> crate::error::Result<Vec<DiffLine>> {
+        unimplemented!()
+    }
+    fn list_review_threads(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+    ) -> crate::error::Result<Vec<crate::forge::remote_comments::RemoteReviewThread>> {
+        unimplemented!()
+    }
+    fn list_pull_request_commits(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+    ) -> crate::error::Result<Vec<crate::forge::traits::PullRequestCommit>> {
+        unimplemented!()
+    }
+    fn get_pull_request_commit_range_diff(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        _start_sha: &str,
+        _end_sha: &str,
+    ) -> crate::error::Result<String> {
+        unimplemented!()
+    }
+    fn create_review(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        _request: crate::forge::traits::CreateReviewRequest<'_>,
+    ) -> crate::error::Result<crate::forge::traits::GhCreateReviewResponse> {
+        unimplemented!()
+    }
+    fn local_checkout_path(&self) -> Option<PathBuf> {
+        self.local_checkout.clone()
+    }
+}
+
+#[test]
+fn editor_target_falls_back_to_forge_backend_checkout_in_pr_mode() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("main.rs");
+    fs::write(&path, "fn main() {}\n").expect("write file");
+
+    let mut app = app_with_root(
+        PathBuf::from("forge:github.com/agavra/tuicr"),
+        vec![file("main.rs", vec![hunk(1, 1)])],
+    );
+    app.forge_backend = Some(Box::new(FakeForgeBackend {
+        local_checkout: Some(dir.path().to_path_buf()),
+    }));
+    app.focused_panel = FocusedPanel::FileList;
+
+    app.queue_editor_for_focused_item();
+
+    let target = app.take_pending_editor_target().expect("editor target");
+    assert_eq!(target.path, path);
+}
+
+#[test]
+fn editor_target_warns_when_pr_mode_has_no_matching_checkout() {
+    let mut app = app_with_root(
+        PathBuf::from("forge:github.com/agavra/tuicr"),
+        vec![file("main.rs", vec![hunk(1, 1)])],
+    );
+    app.forge_backend = Some(Box::new(FakeForgeBackend {
+        local_checkout: None,
+    }));
+    app.focused_panel = FocusedPanel::FileList;
+
+    app.queue_editor_for_focused_item();
+
+    assert!(app.take_pending_editor_target().is_none());
+    assert!(
+        app.message
+            .as_ref()
+            .expect("warning")
+            .content
+            .contains("no local checkout")
+    );
+}
+
 #[test]
 fn toggle_preserves_file_position() {
     let files = vec![

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -95,40 +95,31 @@ fn remote_urls(repo_root: &Path) -> Vec<String> {
     all_urls
 }
 
-/// Detect the forge repository for the local checkout at `repo_root`.
+/// Parse `url` as a forge remote repository.
 ///
-/// Tries GitLab first (host must contain "gitlab"); falls back to GitHub,
-/// which accepts any host so GitHub Enterprise remotes whose hostname does
-/// not literally contain "github" are still detected. Returns `None` when
-/// no remote can be parsed.
-pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
-    let all_urls = remote_urls(repo_root);
+/// Tries GitLab first — its parser already filters to "gitlab" hosts, so
+/// trying it first won't claim GitHub Enterprise remotes — then falls back
+/// to GitHub, which accepts any host (covers github.com and GHE hosts whose
+/// hostname does not literally contain "github").
+fn parse_any_remote_url(url: &str) -> Option<ForgeRepository> {
+    parse_gitlab_remote_url(url).or_else(|| parse_github_remote_url(url))
+}
 
-    // GitLab parser already filters to "gitlab" hosts, so trying it first
-    // won't claim GitHub Enterprise remotes.
-    for url in &all_urls {
-        if let Some(parsed) = parse_gitlab_remote_url(url) {
-            return Some(parsed);
-        }
-    }
-    // GitHub fallback accepts any host (covers github.com and GHE hosts
-    // whose hostname does not literally contain "github").
-    for url in &all_urls {
-        if let Some(parsed) = parse_github_remote_url(url) {
-            return Some(parsed);
-        }
-    }
-    None
+/// Detect the forge repository for the local checkout at `repo_root`.
+/// Returns `None` when no remote can be parsed.
+pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
+    remote_urls(repo_root)
+        .iter()
+        .find_map(|url| parse_any_remote_url(url))
 }
 
 /// `root`'s local checkout, but only when one of its remotes — not
 /// necessarily `origin` — matches `target_repo`.
 pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Option<PathBuf> {
-    let matches = remote_urls(root).iter().any(|url| {
-        parse_gitlab_remote_url(url).as_ref() == Some(target_repo)
-            || parse_github_remote_url(url).as_ref() == Some(target_repo)
-    });
-    matches.then(|| root.to_path_buf())
+    remote_urls(root)
+        .iter()
+        .any(|url| parse_any_remote_url(url).as_ref() == Some(target_repo))
+        .then(|| root.to_path_buf())
 }
 
 #[cfg(test)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -71,14 +71,11 @@ pub fn detect_gitlab_repository(repo_root: &Path) -> Option<ForgeRepository> {
     None
 }
 
-/// Detect the forge repository for the local checkout at `repo_root`.
-///
-/// Tries GitLab first (host must contain "gitlab"); falls back to GitHub,
-/// which accepts any host so GitHub Enterprise remotes whose hostname does
-/// not literally contain "github" are still detected. Returns `None` when
-/// no remote can be parsed.
-pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
-    let repo = Repository::discover(repo_root).ok()?;
+/// `repo_root`'s remote URLs, `origin` first, then every other remote.
+fn remote_urls(repo_root: &Path) -> Vec<String> {
+    let Ok(repo) = Repository::discover(repo_root) else {
+        return Vec::new();
+    };
     let mut all_urls: Vec<String> = Vec::new();
 
     if let Ok(remote) = repo.find_remote("origin")
@@ -95,6 +92,17 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
             }
         }
     }
+    all_urls
+}
+
+/// Detect the forge repository for the local checkout at `repo_root`.
+///
+/// Tries GitLab first (host must contain "gitlab"); falls back to GitHub,
+/// which accepts any host so GitHub Enterprise remotes whose hostname does
+/// not literally contain "github" are still detected. Returns `None` when
+/// no remote can be parsed.
+pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
+    let all_urls = remote_urls(repo_root);
 
     // GitLab parser already filters to "gitlab" hosts, so trying it first
     // won't claim GitHub Enterprise remotes.
@@ -113,11 +121,14 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
     None
 }
 
-/// `root`'s local checkout, but only when its detected remote matches
-/// `target_repo`.
+/// `root`'s local checkout, but only when one of its remotes — not
+/// necessarily `origin` — matches `target_repo`.
 pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Option<PathBuf> {
-    let detected = detect_forge_repository(root)?;
-    (detected == *target_repo).then(|| root.to_path_buf())
+    let matches = remote_urls(root).iter().any(|url| {
+        parse_gitlab_remote_url(url).as_ref() == Some(target_repo)
+            || parse_github_remote_url(url).as_ref() == Some(target_repo)
+    });
+    matches.then(|| root.to_path_buf())
 }
 
 #[cfg(test)]
@@ -162,5 +173,19 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let target = ForgeRepository::github("github.com", "agavra", "tuicr");
         assert_eq!(local_checkout_for_repo(dir.path(), &target), None);
+    }
+
+    #[test]
+    fn local_checkout_matches_upstream_remote_in_fork_workflow() {
+        let dir = init_repo_with_origin("https://github.com/contributor/tuicr");
+        let repo = Repository::open(dir.path()).expect("open repo");
+        repo.remote("upstream", "https://github.com/agavra/tuicr")
+            .expect("add upstream");
+
+        let target = ForgeRepository::github("github.com", "agavra", "tuicr");
+        assert_eq!(
+            local_checkout_for_repo(dir.path(), &target),
+            Some(dir.path().to_path_buf())
+        );
     }
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -15,7 +15,7 @@ pub mod selector;
 pub mod submit;
 pub mod traits;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use git2::Repository;
 
@@ -111,4 +111,56 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
         }
     }
     None
+}
+
+/// `root`'s local checkout, but only when its detected remote matches
+/// `target_repo`.
+pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Option<PathBuf> {
+    let detected = detect_forge_repository(root)?;
+    (detected == *target_repo).then(|| root.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_repo_with_origin(url: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let repo = Repository::init(dir.path()).expect("init repo");
+        repo.remote("origin", url).expect("add origin");
+        dir
+    }
+
+    #[test]
+    fn detects_github_repository_from_origin() {
+        let dir = init_repo_with_origin("https://github.com/agavra/tuicr");
+        assert_eq!(
+            detect_forge_repository(dir.path()),
+            Some(ForgeRepository::github("github.com", "agavra", "tuicr"))
+        );
+    }
+
+    #[test]
+    fn local_checkout_matches_when_origin_equals_target() {
+        let dir = init_repo_with_origin("https://github.com/agavra/tuicr");
+        let target = ForgeRepository::github("github.com", "agavra", "tuicr");
+        assert_eq!(
+            local_checkout_for_repo(dir.path(), &target),
+            Some(dir.path().to_path_buf())
+        );
+    }
+
+    #[test]
+    fn local_checkout_rejects_mismatched_repo() {
+        let dir = init_repo_with_origin("https://github.com/contributor/tuicr");
+        let target = ForgeRepository::github("github.com", "agavra", "tuicr");
+        assert_eq!(local_checkout_for_repo(dir.path(), &target), None);
+    }
+
+    #[test]
+    fn local_checkout_returns_none_outside_a_repo() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let target = ForgeRepository::github("github.com", "agavra", "tuicr");
+        assert_eq!(local_checkout_for_repo(dir.path(), &target), None);
+    }
 }


### PR DESCRIPTION
This series fixes on issue where the `:edit` fails with no local checkout if you're operating on a fork-pr model.

Fixes: #451 