### PR TITLE
Fix tabify context lines

### DIFF
--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -9,10 +9,11 @@ use crate::forge::traits::{
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestListQuery,
     PullRequestListScope, PullRequestTarget,
 };
-use crate::model::{DiffLine, LineOrigin};
+use crate::model::DiffLine;
 use crate::process::{
     CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
 };
+use crate::vcs::slice_context_lines;
 
 use super::models::{GhPrCommit, GhPullRequestDetails, GhPullRequestSummary};
 use super::review_summaries::{
@@ -436,7 +437,7 @@ where
             self.fetch_file_via_api(&request)?
         };
 
-        Ok(slice_to_diff_lines(
+        Ok(slice_context_lines(
             &content,
             request.start_line,
             request.end_line,
@@ -580,25 +581,6 @@ where
         args.push(endpoint);
         self.run_gh(args, &request.repository.host)
     }
-}
-
-fn slice_to_diff_lines(content: &str, start_line: u32, end_line: u32) -> Vec<DiffLine> {
-    let lines: Vec<&str> = content.lines().collect();
-    let mut result = Vec::new();
-    for line_num in start_line..=end_line {
-        let idx = (line_num - 1) as usize;
-        if idx >= lines.len() {
-            break;
-        }
-        result.push(DiffLine {
-            origin: LineOrigin::Context,
-            content: lines[idx].to_string(),
-            old_lineno: Some(line_num),
-            new_lineno: Some(line_num),
-            highlighted_spans: None,
-        });
-    }
-    result
 }
 
 pub fn parse_pull_request_target(input: &str) -> Result<PullRequestTarget> {

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -12,10 +12,11 @@ use crate::forge::traits::{
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestListQuery,
     PullRequestListScope, PullRequestReviewMetadata, PullRequestReviewRecord, PullRequestTarget,
 };
-use crate::model::{DiffLine, LineOrigin};
+use crate::model::DiffLine;
 use crate::process::{
     CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
 };
+use crate::vcs::slice_context_lines;
 
 use super::models::{
     GlabApprovalState, GlabCommit, GlabDiscussion, GlabMrDetails, GlabMrSummary, GlabMrVersion,
@@ -531,7 +532,7 @@ where
             self.fetch_file_via_api(&request)?
         };
 
-        Ok(slice_to_diff_lines(
+        Ok(slice_context_lines(
             &content,
             request.start_line,
             request.end_line,
@@ -806,25 +807,6 @@ where
         args.push(endpoint);
         self.run_glab(args, &request.repository.host)
     }
-}
-
-fn slice_to_diff_lines(content: &str, start_line: u32, end_line: u32) -> Vec<DiffLine> {
-    let lines: Vec<&str> = content.lines().collect();
-    let mut result = Vec::new();
-    for line_num in start_line..=end_line {
-        let idx = (line_num - 1) as usize;
-        if idx >= lines.len() {
-            break;
-        }
-        result.push(DiffLine {
-            origin: LineOrigin::Context,
-            content: lines[idx].to_string(),
-            old_lineno: Some(line_num),
-            new_lineno: Some(line_num),
-            highlighted_spans: None,
-        });
-    }
-    result
 }
 
 /// Parse a pull request target string in GitLab format.

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -8,6 +8,7 @@ use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
 use crate::syntax::SyntaxHighlighter;
 
 use super::traits::{VcsBackend, VcsInfo, VcsType};
+use crate::vcs::slice_context_lines;
 
 /// A backend for reviewing files outside of a VCS repository (`--file`)
 /// and for the whole-repo `--all-files` mode.
@@ -329,23 +330,7 @@ impl VcsBackend for FileBackend {
         }
 
         let content = std::fs::read_to_string(&canonical)?;
-        let lines: Vec<&str> = content.lines().collect();
-        let mut result = Vec::new();
-
-        for line_num in start_line..=end_line {
-            let idx = (line_num - 1) as usize;
-            if idx < lines.len() {
-                result.push(DiffLine {
-                    origin: LineOrigin::Context,
-                    content: lines[idx].to_string(),
-                    old_lineno: Some(line_num),
-                    new_lineno: Some(line_num),
-                    highlighted_spans: None,
-                });
-            }
-        }
-
-        Ok(result)
+        Ok(slice_context_lines(&content, start_line, end_line))
     }
 
     fn file_line_count(

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -16,7 +16,9 @@ use crate::vcs::{
     ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget,
     VcsBackend, VcsChangeStatus, VcsInfo,
 };
-use crate::vcs::{container_file_paths, enhance_with_full_file_highlight, tabify};
+use crate::vcs::{
+    container_file_paths, enhance_with_full_file_highlight, slice_context_lines, tabify,
+};
 
 use super::{
     GitRepoMode, RevisionExpression, git_bool_config_enabled, git_command_error,
@@ -269,22 +271,7 @@ impl VcsBackend for GitCliBackend {
         }
 
         let content = self.read_file_content(file_path, file_status, ref_commit)?;
-
-        let lines: Vec<&str> = content.lines().collect();
-        let mut result = Vec::new();
-        for line_num in start_line..=end_line {
-            let idx = (line_num - 1) as usize;
-            if idx < lines.len() {
-                result.push(DiffLine {
-                    origin: LineOrigin::Context,
-                    content: lines[idx].to_string(),
-                    old_lineno: Some(line_num),
-                    new_lineno: Some(line_num),
-                    highlighted_spans: None,
-                });
-            }
-        }
-        Ok(result)
+        Ok(slice_context_lines(&content, start_line, end_line))
     }
 
     fn file_line_count(

--- a/src/vcs/git/context.rs
+++ b/src/vcs/git/context.rs
@@ -2,7 +2,8 @@ use git2::Repository;
 use std::path::Path;
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffLine, FileStatus, LineOrigin};
+use crate::model::{DiffLine, FileStatus};
+use crate::vcs::slice_context_lines;
 
 /// Fetch context lines from a file for gap expansion.
 ///
@@ -21,24 +22,7 @@ pub fn fetch_context_lines(
     }
 
     let content = read_file_content(repo, file_path, file_status, ref_commit)?;
-
-    let lines: Vec<&str> = content.lines().collect();
-    let mut result = Vec::new();
-
-    for line_num in start_line..=end_line {
-        let idx = (line_num - 1) as usize;
-        if idx < lines.len() {
-            result.push(DiffLine {
-                origin: LineOrigin::Context,
-                content: lines[idx].to_string(),
-                old_lineno: Some(line_num),
-                new_lineno: Some(line_num),
-                highlighted_spans: None,
-            });
-        }
-    }
-
-    Ok(result)
+    Ok(slice_context_lines(&content, start_line, end_line))
 }
 
 /// Get the total number of lines in a file.

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -6,14 +6,16 @@ use std::process::Command;
 use chrono::{TimeZone, Utc};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
+use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::traits::{
     CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsInfo,
     VcsType,
 };
-use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
+use crate::vcs::{
+    BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files, slice_context_lines,
+};
 
 /// Parse an hg description into (summary, optional body).
 fn parse_hg_description(desc: &str) -> (String, Option<String>) {
@@ -142,23 +144,7 @@ impl VcsBackend for HgBackend {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
 
-        let lines: Vec<&str> = content.lines().collect();
-        let mut result = Vec::new();
-
-        for line_num in start_line..=end_line {
-            let idx = (line_num - 1) as usize;
-            if idx < lines.len() {
-                result.push(DiffLine {
-                    origin: LineOrigin::Context,
-                    content: lines[idx].to_string(),
-                    old_lineno: Some(line_num),
-                    new_lineno: Some(line_num),
-                    highlighted_spans: None,
-                });
-            }
-        }
-
-        Ok(result)
+        Ok(slice_context_lines(&content, start_line, end_line))
     }
 
     fn file_line_count(
@@ -501,6 +487,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::LineOrigin;
     use crate::vcs::RevisionDiffTarget;
     use std::fs;
 

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -8,14 +8,16 @@ use std::process::Command;
 use chrono::{DateTime, Utc};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffLine, FileStatus, LineOrigin};
+use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
 use crate::vcs::diff_parser::{self, DiffFormat};
 use crate::vcs::traits::{
     CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsInfo,
     VcsType,
 };
-use crate::vcs::{BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files};
+use crate::vcs::{
+    BATCH_BOUNDARY, apply_container_full_file_highlight, parse_batched_files, slice_context_lines,
+};
 
 /// Parse a jj description into (summary, optional body).
 fn parse_description(desc: &str) -> (String, Option<String>) {
@@ -186,23 +188,7 @@ impl VcsBackend for JjBackend {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
 
-        let lines: Vec<&str> = content.lines().collect();
-        let mut result = Vec::new();
-
-        for line_num in start_line..=end_line {
-            let idx = (line_num - 1) as usize;
-            if idx < lines.len() {
-                result.push(DiffLine {
-                    origin: LineOrigin::Context,
-                    content: lines[idx].to_string(),
-                    old_lineno: Some(line_num),
-                    new_lineno: Some(line_num),
-                    highlighted_spans: None,
-                });
-            }
-        }
-
-        Ok(result)
+        Ok(slice_context_lines(&content, start_line, end_line))
     }
 
     fn file_line_count(
@@ -496,6 +482,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::LineOrigin;
     use crate::vcs::RevisionDiffTarget;
     use std::fs;
 

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -85,7 +85,7 @@ pub(crate) fn slice_context_lines(content: &str, start_line: u32, end_line: u32)
         }
         result.push(DiffLine {
             origin: LineOrigin::Context,
-            content: lines[idx].to_string(),
+            content: tabify(lines[idx]),
             old_lineno: Some(line_num),
             new_lineno: Some(line_num),
             highlighted_spans: None,
@@ -404,6 +404,16 @@ mod tests {
                 panic!("Unexpected error: {e:?}");
             }
         }
+    }
+
+    #[test]
+    fn slice_context_lines_expands_tabs() {
+        let content = "fn main() {\n\tprintln!(\"hi\");\n}";
+
+        let lines = slice_context_lines(content, 2, 2);
+
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].content, "    println!(\"hi\");");
     }
 
     fn vue_diff_file(

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, LineSide};
+use crate::model::{DiffFile, DiffLine, LineOrigin, LineSide};
 use crate::syntax::{
     HighlightedLines, HighlightedSpans, SyntaxHighlighter, needs_full_file_highlight,
 };
@@ -68,6 +68,30 @@ pub(crate) fn container_file_paths(files: &[DiffFile], side: LineSide) -> Vec<Pa
 /// with the displayed text in side-by-side and unified rendering.
 pub(crate) fn tabify(s: &str) -> String {
     s.replace('\t', "    ")
+}
+
+/// Slice `[start_line, end_line]` (1-indexed, inclusive) into `DiffLine`s.
+pub(crate) fn slice_context_lines(content: &str, start_line: u32, end_line: u32) -> Vec<DiffLine> {
+    if start_line > end_line || start_line == 0 {
+        return Vec::new();
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let mut result = Vec::new();
+    for line_num in start_line..=end_line {
+        let idx = (line_num - 1) as usize;
+        if idx >= lines.len() {
+            break;
+        }
+        result.push(DiffLine {
+            origin: LineOrigin::Context,
+            content: lines[idx].to_string(),
+            old_lineno: Some(line_num),
+            new_lineno: Some(line_num),
+            highlighted_spans: None,
+        });
+    }
+    result
 }
 
 /// Read a file from the working tree, returning `None` on any IO error.


### PR DESCRIPTION
Only the actual diffs are sanitized for tabs, not the context. Files
which use tabs are thus not indented at all in the context lines. Tabify
context lines as well.

Fixes: #452