### PR TITLE
fix: route PR inline commit-range reload through the forge backend

### DIFF
--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -161,7 +161,7 @@ impl App {
 
             // Reload diff for the restored selection
             if self.commit_selection_range.is_some() {
-                self.reload_inline_selection()?;
+                self.reload_inline_selection_for_source()?;
             }
             return Ok(());
         }
@@ -844,5 +844,22 @@ impl App {
         self.rebuild_annotations();
 
         Ok(())
+    }
+
+    /// Reload the inline commit subrange diff via the backend appropriate for
+    /// the current review. PR reviews route through the forge `compare` API
+    /// (persisting the narrowed range so it survives a restart); local reviews
+    /// reload straight from the VCS. Callers that adjust the selection (toggle,
+    /// `(`/`)` cycling, restore-on-exit) must go through here so PR reviews
+    /// don't fall into the VCS path — the forge backend has no commit-range
+    /// diff support and would error with "Commit range diff not supported".
+    pub fn reload_inline_selection_for_source(&mut self) -> Result<()> {
+        if matches!(self.diff_source, DiffSource::PullRequest(_)) {
+            self.persist_pr_commit_selection_range();
+            self.reload_pr_inline_selection();
+            Ok(())
+        } else {
+            self.reload_inline_selection()
+        }
     }
 }

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -829,6 +829,52 @@ fn should_resolve_pr_range_to_pr_base_when_oldest_commit_selected() {
 }
 
 #[test]
+fn should_route_pr_inline_selection_reload_through_forge_not_vcs() {
+    // Regression for #462: narrowing a PR review to a commit subrange with
+    // `(`/`)` used to reload via the VCS `get_commit_range_diff`, which the
+    // forge-backed review has no support for — it errored with "Commit range
+    // diff not supported for this VCS". The reload must route through the
+    // forge `compare` API instead, exactly like the Enter/toggle path does.
+    let _reviews = TestReviewsDir::new();
+    let mut app = build_app();
+    app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));
+    app.pr_tab = PullRequestsTab::new(app.forge_repository.clone());
+    app.pr_tab.start_initial_load();
+    let summary = sample_pr(42, "cycle");
+    app.pr_tab
+        .apply_initial_load(Ok((vec![summary.clone()], false)));
+    let mut backend = FakeForgeBackend::open_pr_details(
+        test_pr_details(42, "cycle"),
+        crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+    );
+    backend.commits = vec![
+        sample_pr_commit("first11", "first"),
+        sample_pr_commit("middle2", "middle"),
+        sample_pr_commit("last333", "last"),
+    ];
+    app.open_pr_with_backend(&summary, Box::new(backend), None)
+        .unwrap();
+    // Default selection covers all three commits.
+    assert_eq!(app.commit_selection_range, Some((0, 2)));
+
+    // when — `(` narrows the selection to a strict subrange (all → first).
+    app.cycle_commit_prev();
+    assert_eq!(app.commit_selection_range, Some((0, 0)));
+    let result = app.reload_inline_selection_for_source();
+
+    // then — the reload succeeds (the VCS path would return
+    // UnsupportedOperation) and takes the forge range-reload route.
+    assert!(
+        result.is_ok(),
+        "PR inline reload must not hit the unsupported VCS path: {result:?}"
+    );
+    assert!(
+        app.pr_range_reload_state.is_some(),
+        "narrowing a PR review should spawn a forge range reload"
+    );
+}
+
+#[test]
 fn should_preserve_hunk_marks_hidden_by_pr_range_diff() {
     let mut app = build_app();
     app.forge_repository = Some(ForgeRepository::github("github.com", "agavra", "tuicr"));

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1200,13 +1200,10 @@ pub fn handle_commit_selector_action(app: &mut App, action: Action) {
         // Toggle + auto-advance so repeated presses sweep a contiguous run.
         Action::ToggleExpand | Action::ToggleCommitSelect | Action::SelectFile => {
             app.toggle_commit_selection_and_advance();
-            if matches!(app.diff_source, crate::app::DiffSource::PullRequest(_)) {
-                // PR mode reloads via the forge `compare` API on a
-                // background thread; persist the new range so it survives
-                // a restart.
-                app.persist_pr_commit_selection_range();
-                app.reload_pr_inline_selection();
-            } else if let Err(e) = app.reload_inline_selection() {
+            // PR mode reloads via the forge `compare` API on a background
+            // thread (persisting the new range so it survives a restart);
+            // local reviews reload from the VCS.
+            if let Err(e) = app.reload_inline_selection_for_source() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }
@@ -1501,13 +1498,13 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         }
         Action::CycleCommitNext if app.has_inline_commit_selector() => {
             app.cycle_commit_next();
-            if let Err(e) = app.reload_inline_selection() {
+            if let Err(e) = app.reload_inline_selection_for_source() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }
         Action::CycleCommitPrev if app.has_inline_commit_selector() => {
             app.cycle_commit_prev();
-            if let Err(e) = app.reload_inline_selection() {
+            if let Err(e) = app.reload_inline_selection_for_source() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }


### PR DESCRIPTION
Fixes #462. Narrowing a GitHub PR review to a commit subrange with `(`/`)` failed with "commit range diff not supported for this vcs", while selecting commits with `Enter`/click worked.