### PR TITLE
fix: stop Esc from hiding the file panel, fixes #467

### DIFF
--- a/src/app/tests/file_list_visibility_tests.rs
+++ b/src/app/tests/file_list_visibility_tests.rs
@@ -1,0 +1,129 @@
+use crate::app::*;
+use crate::handler::{handle_diff_action, handle_file_list_action};
+use crate::input::Action;
+use crate::model::FileStatus;
+use crate::vcs::traits::VcsType;
+
+struct DummyVcs {
+    info: VcsInfo,
+}
+
+impl VcsBackend for DummyVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.info
+    }
+
+    fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        Err(TuicrError::NoChanges)
+    }
+
+    fn fetch_context_lines(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start_line: u32,
+        _end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+
+    fn file_line_count(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        Ok(0)
+    }
+}
+
+fn build_app() -> App {
+    let file = DiffFile {
+        old_path: None,
+        new_path: Some(PathBuf::from("test.rs")),
+        status: FileStatus::Modified,
+        hunks: vec![],
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash: 0,
+    };
+
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: "abc".to_string(),
+        branch_name: Some("main".to_string()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+
+    App::build(
+        Box::new(DummyVcs {
+            info: vcs_info.clone(),
+        }),
+        vcs_info,
+        Theme::dark(),
+        None,
+        false,
+        vec![file],
+        session,
+        DiffSource::WorkingTree,
+        InputMode::Normal,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("failed to build test app")
+}
+
+#[test]
+fn escape_in_diff_panel_keeps_file_list_visible() {
+    let mut app = build_app();
+    app.show_file_list = true;
+    app.focused_panel = FocusedPanel::Diff;
+
+    handle_diff_action(&mut app, Action::ExitMode);
+
+    assert!(
+        app.show_file_list,
+        "Esc in the diff panel must not hide the file list"
+    );
+    assert_eq!(app.focused_panel, FocusedPanel::Diff);
+}
+
+#[test]
+fn escape_in_file_list_panel_keeps_file_list_visible_and_focuses_diff() {
+    let mut app = build_app();
+    app.show_file_list = true;
+    app.focused_panel = FocusedPanel::FileList;
+
+    handle_file_list_action(&mut app, Action::ExitMode);
+
+    assert!(
+        app.show_file_list,
+        "Esc in the file list panel must not hide the file list"
+    );
+    assert_eq!(
+        app.focused_panel,
+        FocusedPanel::Diff,
+        "Esc returns focus to the diff"
+    );
+}
+
+#[test]
+fn leader_e_toggle_still_hides_and_shows_the_file_list() {
+    let mut app = build_app();
+    app.show_file_list = true;
+
+    app.toggle_file_list();
+    assert!(!app.show_file_list, "toggle hides the file list");
+
+    app.toggle_file_list();
+    assert!(app.show_file_list, "toggle shows the file list again");
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -4,6 +4,7 @@ mod commit_selection_tests;
 mod decoration_skip_tests;
 mod diff_source_tests;
 mod expand_gap_tests;
+mod file_list_visibility_tests;
 mod find_source_line_tests;
 mod persistence_merge_tests;
 mod scroll_behavior_tests;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1402,7 +1402,6 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             }
         }
         Action::ExitMode => {
-            app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
         Action::HalfPageDown => app.scroll_down(app.diff_state.viewport_height / 2),


### PR DESCRIPTION
Esc in a normal-mode panel now only returns focus to the diff; it no
longer hides the file list. Visibility stays controlled by the explicit
toggles ;e / :e / <leader>e.

The hide-on-Esc behavior came from #373 (ADR FEAT-0016), which framed
Esc as "back to the diff, quiet the chrome". That assumed the file list
was transient chrome, but it has always defaulted to visible, so Esc
after leaving a comment box silently removed a panel the user never
asked to hide, with no discoverable way back.
