### PR TITLE
fix: users can set diff.mnemonicPrefix = true in their git config which breaks diff parsing, override this setting in tuicr

### DIFF
--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -93,6 +93,12 @@ impl GitCliBackend {
         new_source: GitContentSource<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
+        // Force the traditional "a/" and "b/" path prefixes. The user's Git config
+        // can change this: diff.mnemonicPrefix emits mnemonic prefixes (i/, w/, c/,
+        // o/) and diff.noprefix drops prefixes entirely. The diff parser only strips
+        // "a/" and "b/", so these flags override the config to keep output parseable.
+        args.insert(1, "--src-prefix=a/".to_string());
+        args.insert(2, "--dst-prefix=b/".to_string());
         if self.whitespace_mode.ignores_all() {
             args.insert(1, "--ignore-all-space".to_string());
         }


### PR DESCRIPTION
I noticed that the tests were failing for me.

This turned out to be a config setting I had in git. This change sets the config setting to be the one tuicr expects, overriding user settings.
