### PR TITLE
feat: add search to help popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `g` / `G` | Top / bottom |
 | `{` / `}` | Previous / next file |
 | `[` / `]` | Previous / next hunk |
-| `/` | Search |
+| `/` | Search the diff, or search help while help is open (case-insensitive) |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |
 | `r` | Toggle file reviewed |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -19,12 +19,23 @@ Full reference. Press `?` inside tuicr for an in-app version of this list.
 | `{N}{motion}` | Vim-style count prefix — repeats `j` / `k` / `h` / `l` / `{` / `}` / `[` / `]` `N` times |
 | `{` / `}` | Jump to previous / next file |
 | `[` / `]` | Jump to previous / next hunk |
-| `/` | Search within diff |
+| `/` | Search within diff (case-insensitive) |
 | `n` / `N` | Next / previous search match |
 | `Enter` | Expand or collapse hidden context between hunks |
 | `zt` | Scroll cursor to top of screen |
 | `zz` | Center cursor on screen |
 | `zb` | Scroll cursor to bottom of screen |
+
+## Help
+
+Press `?` to open help.
+
+| Key | Action |
+|-----|--------|
+| `/` | Search within help (case-insensitive) |
+| `n` / `N` | Next / previous help search match |
+| `j` / `k` | Scroll down / up |
+| `q` / `?` / `Esc` | Close help |
 
 ## File tree
 

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -441,6 +441,7 @@ impl App {
             command_completion: None,
             search_buffer: String::new(),
             last_search_pattern: None,
+            search_return_mode: InputMode::Normal,
             comment_buffer: String::new(),
             comment_cursor: 0,
             comment_vim_enabled: false,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1008,6 +1008,7 @@ pub struct App {
     pub(crate) command_completion: Option<CommandCompletionState>,
     pub search_buffer: String,
     pub last_search_pattern: Option<String>,
+    pub(crate) search_return_mode: InputMode,
     pub comment_buffer: String,
     pub comment_cursor: usize,
     /// Config `comment_vim`: vim modal editing in the comment box.
@@ -1413,6 +1414,9 @@ pub struct HelpState {
     pub scroll_offset: usize,
     pub viewport_height: usize,
     pub total_lines: usize, // Set during render
+    pub(crate) searchable_lines: Vec<String>,
+    pub(crate) last_search_pattern: Option<String>,
+    pub(crate) current_match_line: Option<usize>,
 }
 
 /// Represents a comment location for deletion

--- a/src/app/modes.rs
+++ b/src/app/modes.rs
@@ -59,13 +59,18 @@ impl App {
     }
 
     pub fn enter_search_mode(&mut self) {
+        self.search_return_mode = self.input_mode;
         self.input_mode = InputMode::Search;
         self.search_buffer.clear();
     }
 
     pub fn exit_search_mode(&mut self) {
-        self.input_mode = InputMode::Normal;
+        self.input_mode = self.search_return_mode;
         self.search_buffer.clear();
+    }
+
+    pub fn searching_help(&self) -> bool {
+        self.input_mode == InputMode::Search && self.search_return_mode == InputMode::Help
     }
 
     pub fn toggle_help(&mut self) {

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -1,6 +1,109 @@
 use super::*;
 
+fn find_search_match(
+    total_lines: usize,
+    start_idx: usize,
+    forward: bool,
+    include_current: bool,
+    pattern: &str,
+    mut line_text: impl FnMut(usize) -> Option<String>,
+) -> Option<usize> {
+    if total_lines == 0 {
+        return None;
+    }
+
+    let normalized_pattern = pattern.to_lowercase();
+    let mut matches = |line_idx| {
+        line_text(line_idx).is_some_and(|text| text.to_lowercase().contains(&normalized_pattern))
+    };
+    let start_idx = start_idx.min(total_lines - 1);
+    if forward {
+        let first = if include_current {
+            start_idx
+        } else {
+            start_idx.saturating_add(1)
+        };
+        (first..total_lines).find(|&line_idx| matches(line_idx))
+    } else {
+        let first = if include_current {
+            Some(start_idx)
+        } else {
+            start_idx.checked_sub(1)
+        };
+        first.and_then(|line_idx| (0..=line_idx).rev().find(|&line_idx| matches(line_idx)))
+    }
+}
+
+impl HelpState {
+    fn search(&mut self, pattern: &str, forward: bool, include_current: bool) -> bool {
+        let start_idx = self.current_match_line.unwrap_or(self.scroll_offset);
+        let Some(line) = find_search_match(
+            self.searchable_lines.len(),
+            start_idx,
+            forward,
+            include_current,
+            pattern,
+            |line_idx| self.searchable_lines.get(line_idx).cloned(),
+        ) else {
+            return false;
+        };
+
+        self.current_match_line = Some(line);
+        let max_offset = self
+            .searchable_lines
+            .len()
+            .saturating_sub(self.viewport_height);
+        self.scroll_offset = line
+            .saturating_sub(self.viewport_height / 2)
+            .min(max_offset);
+        true
+    }
+}
+
 impl App {
+    pub fn search_in_help_from_scroll(&mut self) -> bool {
+        let pattern = self.search_buffer.clone();
+        if pattern.trim().is_empty() {
+            self.set_message("Search pattern is empty");
+            return false;
+        }
+
+        self.help_state.last_search_pattern = Some(pattern.clone());
+        self.help_state.current_match_line = None;
+        if self.help_state.search(&pattern, true, true) {
+            true
+        } else {
+            self.set_message(format!("No help matches for \"{pattern}\""));
+            false
+        }
+    }
+
+    pub fn search_next_in_help(&mut self) -> bool {
+        let Some(pattern) = self.help_state.last_search_pattern.clone() else {
+            self.set_message("No previous help search");
+            return false;
+        };
+        if self.help_state.search(&pattern, true, false) {
+            true
+        } else {
+            self.set_message(format!("No further help matches for \"{pattern}\""));
+            false
+        }
+    }
+
+    pub fn search_prev_in_help(&mut self) -> bool {
+        let Some(pattern) = self.help_state.last_search_pattern.clone() else {
+            self.set_message("No previous help search");
+            return false;
+        };
+        if self.help_state.search(&pattern, false, false) {
+            true
+        } else {
+            self.set_message(format!("No earlier help matches for \"{pattern}\""));
+            false
+        }
+    }
+
     pub fn search_in_diff_from_cursor(&mut self) -> bool {
         let pattern = self.search_buffer.clone();
         if pattern.trim().is_empty() {
@@ -41,47 +144,25 @@ impl App {
             return false;
         }
 
-        if forward {
-            let mut idx = start_idx.min(total_lines.saturating_sub(1));
-            if !include_current {
-                idx = idx.saturating_add(1);
-            }
-            for line_idx in idx..total_lines {
-                if let Some(text) = self.line_text_for_search(line_idx)
-                    && text.contains(pattern)
-                {
-                    self.diff_state.cursor_line = line_idx;
-                    self.ensure_cursor_visible();
-                    self.center_cursor();
-                    self.update_current_file_from_cursor();
-                    return true;
-                }
-            }
-        } else {
-            let mut idx = start_idx.min(total_lines.saturating_sub(1));
-            if !include_current {
-                idx = idx.saturating_sub(1);
-            }
-            let mut line_idx = idx;
-            loop {
-                if let Some(text) = self.line_text_for_search(line_idx)
-                    && text.contains(pattern)
-                {
-                    self.diff_state.cursor_line = line_idx;
-                    self.ensure_cursor_visible();
-                    self.center_cursor();
-                    self.update_current_file_from_cursor();
-                    return true;
-                }
-                if line_idx == 0 {
-                    break;
-                }
-                line_idx = line_idx.saturating_sub(1);
-            }
-        }
+        let matched_line = find_search_match(
+            total_lines,
+            start_idx,
+            forward,
+            include_current,
+            pattern,
+            |line_idx| self.line_text_for_search(line_idx),
+        );
 
-        self.set_message(format!("No matches for \"{pattern}\""));
-        false
+        let Some(line_idx) = matched_line else {
+            self.set_message(format!("No matches for \"{pattern}\""));
+            return false;
+        };
+
+        self.diff_state.cursor_line = line_idx;
+        self.ensure_cursor_visible();
+        self.center_cursor();
+        self.update_current_file_from_cursor();
+        true
     }
 
     fn line_text_for_search(&self, line_idx: usize) -> Option<String> {
@@ -204,5 +285,57 @@ impl App {
             }
             AnnotatedLine::Spacing => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HelpState;
+
+    fn help_state() -> HelpState {
+        HelpState {
+            viewport_height: 5,
+            searchable_lines: vec![
+                "Navigation".to_string(),
+                "Scroll down/up".to_string(),
+                "Review actions".to_string(),
+                "Add line comment".to_string(),
+                "Commands".to_string(),
+                "Reload comments".to_string(),
+                "Toggle this help".to_string(),
+            ],
+            ..HelpState::default()
+        }
+    }
+
+    #[test]
+    fn should_find_help_text_case_insensitively_and_center_it_in_the_viewport() {
+        let mut state = help_state();
+
+        assert!(state.search("COMMENT", true, true));
+        assert_eq!(state.current_match_line, Some(3));
+        assert_eq!(state.scroll_offset, 1);
+    }
+
+    #[test]
+    fn should_move_to_next_and_previous_help_matches() {
+        let mut state = help_state();
+        assert!(state.search("comment", true, true));
+
+        assert!(state.search("comment", true, false));
+        assert_eq!(state.current_match_line, Some(5));
+
+        assert!(state.search("comment", false, false));
+        assert_eq!(state.current_match_line, Some(3));
+    }
+
+    #[test]
+    fn should_keep_the_current_help_position_when_no_match_exists() {
+        let mut state = help_state();
+        state.scroll_offset = 2;
+
+        assert!(!state.search("missing", true, true));
+        assert_eq!(state.current_match_line, None);
+        assert_eq!(state.scroll_offset, 2);
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -485,6 +485,13 @@ pub fn handle_help_action(app: &mut App, action: Action) {
         Action::GoToBottom => app.help_scroll_to_bottom(),
         Action::MouseScrollDown(n) => app.help_scroll_down(n),
         Action::MouseScrollUp(n) => app.help_scroll_up(n),
+        Action::EnterSearchMode => app.enter_search_mode(),
+        Action::SearchNext => {
+            app.search_next_in_help();
+        }
+        Action::SearchPrev => {
+            app.search_prev_in_help();
+        }
         Action::ToggleHelp => app.toggle_help(),
         Action::Quit => app.should_quit = true,
         _ => {}
@@ -980,7 +987,11 @@ pub fn handle_search_action(app: &mut App, action: Action) {
         }
         Action::ExitMode => app.exit_search_mode(),
         Action::SubmitInput => {
-            app.search_in_diff_from_cursor();
+            if app.searching_help() {
+                app.search_in_help_from_scroll();
+            } else {
+                app.search_in_diff_from_cursor();
+            }
             app.exit_search_mode();
         }
         Action::Quit => app.should_quit = true,

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -341,6 +341,9 @@ fn map_help_mode(key: KeyEvent) -> Action {
         (KeyCode::PageUp, KeyModifiers::NONE) => Action::PageUp,
         (KeyCode::Char('g'), KeyModifiers::NONE) => Action::GoToTop,
         (KeyCode::Char('G'), _) => Action::GoToBottom,
+        (KeyCode::Char('/'), _) => Action::EnterSearchMode,
+        (KeyCode::Char('n'), KeyModifiers::NONE) => Action::SearchNext,
+        (KeyCode::Char('N'), _) => Action::SearchPrev,
         _ => Action::None,
     }
 }
@@ -475,6 +478,16 @@ mod tests {
     fn should_map_uppercase_g_to_go_to_bottom_in_normal_mode() {
         let action = map_normal_mode(key_shift('G'), DEFAULT_LEADER_KEY);
         assert_eq!(action, Action::GoToBottom);
+    }
+
+    #[test]
+    fn should_map_slash_and_match_navigation_in_help_mode() {
+        assert_eq!(
+            map_help_mode(key(KeyCode::Char('/'))),
+            Action::EnterSearchMode
+        );
+        assert_eq!(map_help_mode(key(KeyCode::Char('n'))), Action::SearchNext);
+        assert_eq!(map_help_mode(key_shift('N')), Action::SearchPrev);
     }
 
     #[test]

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -45,8 +45,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     status_bar::render_status_bar(frame, app, chunks[2]);
     status_bar::render_command_completion_popup(frame, app, chunks[2]);
 
-    // Render help popup on top if in help mode
-    if app.input_mode == InputMode::Help {
+    // Keep help visible while its search prompt is active.
+    if app.input_mode == InputMode::Help || app.searching_help() {
         help_popup::render_help(frame, app);
     }
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -21,7 +21,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(" Help (j/k to scroll) - Press ? or Esc to close ")
+        .title(" Help (j/k scroll, / search) - Press ? or Esc to close ")
         .borders(Borders::ALL)
         .style(styles::popup_style(theme))
         .border_style(styles::border_style(theme, true));
@@ -96,7 +96,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  /         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Search within diff"),
+            Span::raw("Search within diff (case-insensitive)"),
         ]),
         Line::from(vec![
             Span::styled(
@@ -770,6 +770,20 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         Line::from(""),
         Line::from(vec![
             Span::styled(
+                "  /         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Search within this help (case-insensitive)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  n/N       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Next/previous help search match"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  ?         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
@@ -782,6 +796,15 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
     let viewport_height = inner.height as usize;
     app.help_state.total_lines = total_lines;
     app.help_state.viewport_height = viewport_height;
+    app.help_state.searchable_lines = help_text
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect()
+        })
+        .collect();
 
     // Calculate if we can scroll
     let can_scroll_up = app.help_state.scroll_offset > 0;
@@ -790,8 +813,16 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
     // Apply scroll offset
     let visible_lines: Vec<Line> = help_text
         .into_iter()
+        .enumerate()
         .skip(app.help_state.scroll_offset)
         .take(viewport_height)
+        .map(|(line_idx, line)| {
+            if app.help_state.current_match_line == Some(line_idx) {
+                line.style(styles::selected_style(theme))
+            } else {
+                line
+            }
+        })
         .collect();
 
     let paragraph = Paragraph::new(visible_lines).style(styles::popup_style(theme));

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -279,7 +279,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
                 }
                 InputMode::Search => Cow::Borrowed("   \u{21b5} search \u{00b7} esc cancel"),
                 InputMode::Comment => Cow::Borrowed("   ctrl-s save \u{00b7} esc cancel"),
-                InputMode::Help => Cow::Borrowed("   q/?/esc close"),
+                InputMode::Help => Cow::Borrowed("   / search · n/N match · q/?/esc close"),
                 InputMode::Confirm => Cow::Borrowed("   y yes \u{00b7} n no"),
                 InputMode::CommitSelect => Cow::Borrowed(
                     "   j/k navigate \u{00b7} space select \u{00b7} \u{21b5} confirm \u{00b7} esc back",


### PR DESCRIPTION
The in-app help requires manual scrolling to find a keybinding or command. This lets `/` reuse the existing search prompt while keeping help open, then uses `n` and `N` for later or earlier matches. Matching is case-insensitive and shares one traversal implementation with diff search. The change was reviewed through tuicr; `cargo test` and `cargo clippy --all-targets -- -D warnings` pass.
