### PR TITLE
fix(ui): make scroll and cursor jumps wrap-aware

### DIFF
--- a/src/app/gaps.rs
+++ b/src/app/gaps.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 impl App {
-    pub(in crate::app) fn gap_size(&self, gap_id: &GapId) -> Option<u32> {
+    pub(crate) fn gap_size(&self, gap_id: &GapId) -> Option<u32> {
         let file = self.diff_files.get(gap_id.file_idx)?;
 
         if gap_id.hunk_idx == file.hunks.len() {

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ui::row_height::annotation_row_height;
 
 impl App {
     pub fn cursor_down(&mut self, lines: usize) {
@@ -223,14 +224,54 @@ impl App {
         }
     }
 
+    pub(in crate::app) fn scroll_offset_for_rows_above(
+        &self,
+        anchor: usize,
+        row_budget: usize,
+    ) -> usize {
+        let mut result = anchor;
+        let mut acc: usize = 0;
+        let mut k = anchor;
+        while k > 0 {
+            k -= 1;
+            let h = annotation_row_height(self, k);
+            if acc + h > row_budget {
+                break;
+            }
+            acc += h;
+            result = k;
+        }
+        result
+    }
+
+    pub(crate) fn page_lines_down(&self, row_budget: usize) -> usize {
+        let anchor = self.diff_state.cursor_line;
+        let total = self.line_annotations.len();
+        let mut acc: usize = 0;
+        let mut count: usize = 0;
+        let mut k = anchor + 1;
+        while k < total {
+            let h = annotation_row_height(self, k);
+            if acc + h > row_budget {
+                break;
+            }
+            acc += h;
+            count += 1;
+            k += 1;
+        }
+        count.max(1)
+    }
+
+    pub(crate) fn page_lines_up(&self, row_budget: usize) -> usize {
+        let anchor = self.diff_state.cursor_line;
+        (anchor - self.scroll_offset_for_rows_above(anchor, row_budget)).max(1)
+    }
+
     pub fn center_cursor(&mut self) {
         let viewport = self.diff_state.viewport_height.max(1);
-        let half_viewport = viewport / 2;
         let max_scroll = self.max_scroll_offset();
         self.diff_state.scroll_offset = self
-            .diff_state
-            .cursor_line
-            .saturating_sub(half_viewport)
+            .scroll_offset_for_rows_above(self.diff_state.cursor_line, viewport / 2)
             .min(max_scroll);
     }
 
@@ -238,20 +279,18 @@ impl App {
         let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
         let max_scroll = self.max_scroll_offset();
         self.diff_state.scroll_offset = self
-            .diff_state
-            .cursor_line
-            .saturating_sub(scroll_margin)
+            .scroll_offset_for_rows_above(self.diff_state.cursor_line, scroll_margin)
             .min(max_scroll);
     }
 
     pub fn cursor_to_bottom(&mut self) {
-        let visible_lines = self.diff_state.effective_visible_lines();
+        let viewport = self.diff_state.viewport_height.max(1);
         let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
+        let cursor = self.diff_state.cursor_line;
+        let budget = viewport.saturating_sub(scroll_margin + annotation_row_height(self, cursor));
         let max_scroll = self.max_scroll_offset();
         self.diff_state.scroll_offset = self
-            .diff_state
-            .cursor_line
-            .saturating_sub(visible_lines.saturating_sub(1 + scroll_margin))
+            .scroll_offset_for_rows_above(cursor, budget)
             .min(max_scroll);
     }
 
@@ -381,8 +420,14 @@ impl App {
         let viewport = self.diff_state.viewport_height.max(1);
         if idx < self.diff_state.scroll_offset {
             self.diff_state.scroll_offset = idx;
-        } else if idx >= self.diff_state.scroll_offset + viewport {
-            self.diff_state.scroll_offset = idx + 1 - viewport;
+        } else {
+            let bottom_start = self.scroll_offset_for_rows_above(
+                idx,
+                viewport.saturating_sub(annotation_row_height(self, idx)),
+            );
+            if self.diff_state.scroll_offset < bottom_start {
+                self.diff_state.scroll_offset = bottom_start;
+            }
         }
     }
 
@@ -625,7 +670,10 @@ impl App {
         self.diff_state.cursor_line = max_line;
         // Position so the last navigable line is at the bottom of the viewport
         let viewport = self.diff_state.viewport_height.max(1);
-        self.diff_state.scroll_offset = (max_line + 1).saturating_sub(viewport);
+        self.diff_state.scroll_offset = self.scroll_offset_for_rows_above(
+            max_line,
+            viewport.saturating_sub(annotation_row_height(self, max_line)),
+        );
         self.update_current_file_from_cursor();
     }
 

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -170,11 +170,7 @@ impl App {
         let first = scroll;
         let last = self.last_fully_visible_annotation(first);
         let mut cursor = cursor.clamp(first, last);
-        if self
-            .line_annotations
-            .get(cursor)
-            .is_some_and(is_decoration)
-        {
+        if self.line_annotations.get(cursor).is_some_and(is_decoration) {
             cursor = if moving_down {
                 let forward = skip_decoration_forward(&self.line_annotations, cursor, last);
                 if self

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -133,6 +133,92 @@ impl App {
         self.update_current_file_from_cursor();
     }
 
+    pub fn page_down(&mut self, row_budget: usize) {
+        let cursor_lines = self.page_lines_down(row_budget);
+        let viewport_lines = self.page_view_lines_down(row_budget);
+        let max_line = self.max_cursor_line();
+        let cursor = skip_decoration_forward(
+            &self.line_annotations,
+            (self.diff_state.cursor_line + cursor_lines).min(max_line),
+            max_line,
+        );
+        let scroll = (self.diff_state.scroll_offset + viewport_lines).min(self.max_scroll_offset());
+        self.apply_page_position(cursor, scroll, true);
+    }
+
+    pub fn page_up(&mut self, row_budget: usize) {
+        let cursor_lines = self.page_lines_up(row_budget);
+        let viewport_lines = self.page_view_lines_up(row_budget);
+        let cursor = skip_decoration_backward(
+            &self.line_annotations,
+            self.diff_state.cursor_line.saturating_sub(cursor_lines),
+        );
+        let scroll = self.diff_state.scroll_offset.saturating_sub(viewport_lines);
+        self.apply_page_position(cursor, scroll, false);
+    }
+
+    fn apply_page_position(&mut self, cursor: usize, scroll: usize, moving_down: bool) {
+        // A trailing Spacing annotation is not a valid cursor row. Do not let
+        // a page motion leave it alone at the top with the cursor off-screen.
+        let scroll = scroll.min(self.max_cursor_line());
+        self.diff_state.scroll_offset = scroll;
+
+        // Cursor and viewport consume their row budgets from different
+        // anchors. If a tall row causes their greedy walks to land on
+        // opposite sides of a wrap boundary, keep the independently
+        // calculated viewport position and clamp the cursor into it.
+        let first = scroll;
+        let last = self.last_fully_visible_annotation(first);
+        let mut cursor = cursor.clamp(first, last);
+        if self
+            .line_annotations
+            .get(cursor)
+            .is_some_and(is_decoration)
+        {
+            cursor = if moving_down {
+                let forward = skip_decoration_forward(&self.line_annotations, cursor, last);
+                if self
+                    .line_annotations
+                    .get(forward)
+                    .is_some_and(|annotation| !is_decoration(annotation))
+                {
+                    forward
+                } else {
+                    skip_decoration_backward(&self.line_annotations, last).max(first)
+                }
+            } else {
+                let backward = skip_decoration_backward(&self.line_annotations, cursor).max(first);
+                if self
+                    .line_annotations
+                    .get(backward)
+                    .is_some_and(|annotation| !is_decoration(annotation))
+                {
+                    backward
+                } else {
+                    skip_decoration_forward(&self.line_annotations, first, last)
+                }
+            };
+        }
+
+        self.diff_state.cursor_line = cursor;
+        self.update_current_file_from_cursor();
+    }
+
+    fn last_fully_visible_annotation(&self, start: usize) -> usize {
+        let viewport = self.diff_state.viewport_height.max(1);
+        let mut used = 0;
+        let mut last = start;
+        for idx in start..self.line_annotations.len() {
+            let height = annotation_row_height(self, idx);
+            if used + height > viewport {
+                break;
+            }
+            used += height;
+            last = idx;
+        }
+        last
+    }
+
     pub fn scroll_view_down(&mut self, lines: usize) {
         let max_scroll = self.max_scroll_offset();
         self.diff_state.scroll_offset = (self.diff_state.scroll_offset + lines).min(max_scroll);
@@ -264,6 +350,28 @@ impl App {
 
     pub(crate) fn page_lines_up(&self, row_budget: usize) -> usize {
         let anchor = self.diff_state.cursor_line;
+        (anchor - self.scroll_offset_for_rows_above(anchor, row_budget)).max(1)
+    }
+
+    pub(crate) fn page_view_lines_down(&self, row_budget: usize) -> usize {
+        let total = self.line_annotations.len();
+        let mut used = 0;
+        let mut count = 0;
+        let mut idx = self.diff_state.scroll_offset;
+        while idx < total {
+            let height = annotation_row_height(self, idx);
+            if used + height > row_budget {
+                break;
+            }
+            used += height;
+            count += 1;
+            idx += 1;
+        }
+        count.max(1)
+    }
+
+    pub(crate) fn page_view_lines_up(&self, row_budget: usize) -> usize {
+        let anchor = self.diff_state.scroll_offset;
         (anchor - self.scroll_offset_for_rows_above(anchor, row_budget)).max(1)
     }
 

--- a/src/app/tests/scroll_behavior_tests.rs
+++ b/src/app/tests/scroll_behavior_tests.rs
@@ -1,5 +1,6 @@
 use crate::app::*;
 use crate::model::FileStatus;
+use crate::ui::row_height::annotation_row_height;
 use crate::vcs::traits::VcsType;
 
 struct DummyVcs {
@@ -390,4 +391,262 @@ fn scroll_offset_zero_means_no_margin() {
     };
     let margin = state.effective_scroll_margin(0);
     assert_eq!(margin, 0, "margin should be 0 when scroll_offset is 0");
+}
+
+#[test]
+fn scroll_offset_for_rows_above_wrap_off_matches_saturating_sub() {
+    let mut app = build_scroll_app(40, 20, 5);
+    app.diff_state.wrap_lines = false;
+    for anchor in [0usize, 1, 5, 20, 43] {
+        for n in [0usize, 1, 3, 10, 100] {
+            assert_eq!(
+                app.scroll_offset_for_rows_above(anchor, n),
+                anchor.saturating_sub(n),
+                "anchor={anchor} n={n}"
+            );
+        }
+    }
+}
+
+/// Build a scroll app whose diff lines are long enough that each wraps
+/// to multiple visual rows at the given viewport_width.
+fn build_wrapping_scroll_app(n: usize, viewport: usize, viewport_width: usize) -> App {
+    let contents: Vec<String> = (0..n).map(|_| "L".repeat(viewport_width * 4)).collect();
+    build_wrapping_scroll_app_with_contents(&contents, viewport, viewport_width)
+}
+
+/// Variant that lets callers set per-line diff content, so heterogeneous
+/// heights can be arranged without duplicating the fixture.
+fn build_wrapping_scroll_app_with_contents(
+    contents: &[String],
+    viewport: usize,
+    viewport_width: usize,
+) -> App {
+    let mut app = build_scroll_app(contents.len(), viewport, 0);
+    for (line, content) in app.diff_files[0].hunks[0]
+        .lines
+        .iter_mut()
+        .zip(contents.iter())
+    {
+        line.content = content.clone();
+    }
+    app.diff_state.wrap_lines = true;
+    app.rebuild_annotations();
+    app.sync_viewport_width(viewport_width);
+    app
+}
+
+#[test]
+fn center_cursor_wrap_on_walks_maximally() {
+    let mut app = build_wrapping_scroll_app(40, 20, 20);
+    let cursor = 30usize;
+    app.diff_state.cursor_line = cursor;
+    app.center_cursor();
+
+    let scroll = app.diff_state.scroll_offset;
+    let budget = app.diff_state.viewport_height / 2;
+    let sum: usize = (scroll..cursor)
+        .map(|k| annotation_row_height(&app, k))
+        .sum();
+    assert!(
+        sum <= budget,
+        "sum of heights [{scroll}..{cursor}) = {sum} must be <= budget {budget}"
+    );
+    let max_scroll = app.max_scroll_offset();
+    if scroll > 0 && scroll <= max_scroll {
+        let next = sum + annotation_row_height(&app, scroll - 1);
+        assert!(
+            next > budget,
+            "walk should be maximal: adding row {} (height {}) yields {next}, budget {budget}",
+            scroll - 1,
+            annotation_row_height(&app, scroll - 1)
+        );
+    }
+}
+
+#[test]
+fn cursor_to_bottom_wrap_on_walks_maximally() {
+    let mut app = build_wrapping_scroll_app(40, 20, 20);
+    let cursor = 30usize;
+    app.diff_state.cursor_line = cursor;
+    let viewport = app.diff_state.viewport_height;
+    let margin = app.diff_state.effective_scroll_margin(app.scroll_offset);
+    let cursor_h = annotation_row_height(&app, cursor);
+    let budget = viewport.saturating_sub(margin + cursor_h);
+
+    app.cursor_to_bottom();
+
+    let scroll = app.diff_state.scroll_offset;
+    let sum: usize = (scroll..cursor)
+        .map(|k| annotation_row_height(&app, k))
+        .sum();
+    let total = sum + cursor_h;
+    assert!(
+        total + margin <= viewport,
+        "sum over [{scroll}..={cursor}] = {total} plus margin {margin} must be <= viewport {viewport}"
+    );
+    let max_scroll = app.max_scroll_offset();
+    if scroll > 0 && scroll <= max_scroll {
+        let next = sum + annotation_row_height(&app, scroll - 1);
+        assert!(
+            next > budget,
+            "walk should be maximal: adding row {} (height {}) yields {next}, budget {budget}",
+            scroll - 1,
+            annotation_row_height(&app, scroll - 1)
+        );
+    }
+}
+
+#[test]
+fn page_lines_wrap_off_equals_row_budget() {
+    let mut app = build_scroll_app(40, 20, 0);
+    app.diff_state.wrap_lines = false;
+    app.diff_state.cursor_line = 20;
+    assert_eq!(app.page_lines_down(5), 5);
+    assert_eq!(app.page_lines_up(5), 5);
+}
+
+#[test]
+fn page_lines_down_wrap_on_counts_visual_rows() {
+    let mut app = build_wrapping_scroll_app(40, 20, 20);
+    let cursor = 5usize;
+    app.diff_state.cursor_line = cursor;
+    let budget = 10usize;
+    let count = app.page_lines_down(budget);
+    assert!(count >= 1);
+    let sum: usize = (cursor + 1..=cursor + count)
+        .map(|k| annotation_row_height(&app, k))
+        .sum();
+    assert!(
+        sum <= budget,
+        "sum of heights {sum} must be <= budget {budget}"
+    );
+    let next_idx = cursor + count + 1;
+    if next_idx < app.line_annotations.len() {
+        let next_h = annotation_row_height(&app, next_idx);
+        assert!(
+            sum + next_h > budget,
+            "walk should be maximal: adding next height {next_h} to {sum} would fit in {budget}"
+        );
+    }
+}
+
+#[test]
+fn scroll_offset_for_rows_above_wrap_on_heterogeneous_heights() {
+    // Alternating short (1-row) and long (3-row) diff lines at
+    // viewport_width=20. Prefix width for a DiffLine at lw=1 is 5
+    // (indicator + "n " + prefix + " "). Short content "x" -> 6 chars
+    // total -> 1 row. Long content "L"*36 -> 41 chars total -> 3 rows.
+    let contents: Vec<String> = (0..8)
+        .map(|i| {
+            if i % 2 == 0 {
+                "x".to_string()
+            } else {
+                "L".repeat(36)
+            }
+        })
+        .collect();
+    let app = build_wrapping_scroll_app_with_contents(&contents, 20, 20);
+
+    // Locate the first DiffLine annotation and pin the heights so the
+    // test is self-documenting. Indices [first_diff..first_diff+8]
+    // correspond to contents[0..8], alternating 1, 3, 1, 3, ...
+    let first_diff = app
+        .line_annotations
+        .iter()
+        .position(|a| matches!(a, AnnotatedLine::DiffLine { .. }))
+        .expect("a diff line annotation must exist");
+    for i in 0..8 {
+        let expected = if i % 2 == 0 { 1 } else { 3 };
+        let got = annotation_row_height(&app, first_diff + i);
+        assert_eq!(
+            got,
+            expected,
+            "height mismatch at content {i} (annotation {}): got {got}, want {expected}",
+            first_diff + i
+        );
+    }
+
+    // Anchor at content index 6 (short, height 1). Walk backwards:
+    //   k = anchor-1 (idx 5, long,  h=3): acc=3 <=5, keep
+    //   k = anchor-2 (idx 4, short, h=1): acc=4 <=5, keep
+    //   k = anchor-3 (idx 3, long,  h=3): acc=7  >5, break
+    // Expected offset = anchor-2.
+    //
+    // Off-by-one bug (reading height(k+1) or height(k-1) instead of k)
+    // would misroute the walk at k=anchor-1, yielding anchor-3.
+    let anchor = first_diff + 6;
+    let budget = 5usize;
+    assert_eq!(
+        app.scroll_offset_for_rows_above(anchor, budget),
+        anchor - 2,
+        "walk must consume heights[anchor-1..anchor] correctly"
+    );
+}
+
+#[test]
+fn page_lines_return_at_least_one() {
+    let mut app = build_scroll_app(40, 20, 0);
+    app.diff_state.wrap_lines = false;
+    app.diff_state.cursor_line = 10;
+    assert_eq!(app.page_lines_down(0), 1);
+    assert_eq!(app.page_lines_up(0), 1);
+
+    let last = app.line_annotations.len().saturating_sub(1);
+    app.diff_state.cursor_line = last;
+    assert_eq!(app.page_lines_down(10), 1);
+}
+
+#[test]
+fn jump_to_bottom_wrap_on_keeps_last_line_fully_visible() {
+    let mut app = build_wrapping_scroll_app(40, 20, 20);
+    app.jump_to_bottom();
+
+    let scroll = app.diff_state.scroll_offset;
+    let max_line = app.max_cursor_line();
+    let viewport = app.diff_state.viewport_height;
+
+    let total: usize = (scroll..=max_line)
+        .map(|k| annotation_row_height(&app, k))
+        .sum();
+    assert!(
+        total <= viewport,
+        "rows over [{scroll}..={max_line}] = {total} must fit viewport {viewport}"
+    );
+    assert_eq!(app.diff_state.cursor_line, max_line);
+    if scroll > 0 {
+        let with_prev = total + annotation_row_height(&app, scroll - 1);
+        assert!(
+            with_prev > viewport,
+            "walk should be maximal: adding row {} yields {with_prev}, viewport {viewport}",
+            scroll - 1
+        );
+    }
+}
+
+#[test]
+fn move_cursor_to_annotation_wrap_on_scrolls_target_fully_into_view() {
+    let mut app = build_wrapping_scroll_app(40, 20, 20);
+    app.diff_state.scroll_offset = 0;
+    let target = app.max_cursor_line();
+
+    app.move_cursor_to_annotation(target);
+
+    let scroll = app.diff_state.scroll_offset;
+    let viewport = app.diff_state.viewport_height;
+    let total: usize = (scroll..=target)
+        .map(|k| annotation_row_height(&app, k))
+        .sum();
+    assert!(
+        total <= viewport,
+        "target must be fully visible: rows over [{scroll}..={target}] = {total}, viewport {viewport}"
+    );
+    assert_eq!(app.diff_state.cursor_line, target);
+
+    let scroll_before = app.diff_state.scroll_offset;
+    app.move_cursor_to_annotation(target);
+    assert_eq!(
+        app.diff_state.scroll_offset, scroll_before,
+        "already-visible target should not change scroll_offset"
+    );
 }

--- a/src/app/tests/scroll_behavior_tests.rs
+++ b/src/app/tests/scroll_behavior_tests.rs
@@ -502,8 +502,11 @@ fn page_lines_wrap_off_equals_row_budget() {
     let mut app = build_scroll_app(40, 20, 0);
     app.diff_state.wrap_lines = false;
     app.diff_state.cursor_line = 20;
+    app.diff_state.scroll_offset = 10;
     assert_eq!(app.page_lines_down(5), 5);
     assert_eq!(app.page_lines_up(5), 5);
+    assert_eq!(app.page_view_lines_down(5), 5);
+    assert_eq!(app.page_view_lines_up(5), 5);
 }
 
 #[test]
@@ -529,6 +532,78 @@ fn page_lines_down_wrap_on_counts_visual_rows() {
             "walk should be maximal: adding next height {next_h} to {sum} would fit in {budget}"
         );
     }
+}
+
+#[test]
+fn page_down_uses_viewport_relative_row_heights() {
+    let mut contents = vec!["x".to_string(); 16];
+    // Diff-row prefix is 5 cells at this fixture's line-number width, so
+    // 56 unbroken content cells produce a four-row annotation at width 20.
+    contents[0] = "L".repeat(56);
+    let mut app = build_wrapping_scroll_app_with_contents(&contents, 5, 20);
+    let first_diff = app
+        .line_annotations
+        .iter()
+        .position(|a| matches!(a, AnnotatedLine::DiffLine { .. }))
+        .expect("a diff line annotation must exist");
+    assert_eq!(annotation_row_height(&app, first_diff), 4);
+    assert_eq!(annotation_row_height(&app, first_diff + 1), 1);
+
+    app.diff_state.scroll_offset = first_diff;
+    app.diff_state.cursor_line = first_diff + 1;
+
+    assert_eq!(app.page_lines_down(5), 5);
+    assert_eq!(
+        app.page_view_lines_down(5),
+        2,
+        "the viewport must spend four rows on its tall top annotation"
+    );
+
+    app.page_down(5);
+
+    assert_eq!(app.diff_state.scroll_offset, first_diff + 2);
+    assert_eq!(app.diff_state.cursor_line, first_diff + 6);
+    let advanced_rows: usize = (first_diff..app.diff_state.scroll_offset)
+        .map(|idx| annotation_row_height(&app, idx))
+        .sum();
+    assert_eq!(advanced_rows, 5);
+}
+
+#[test]
+fn page_up_uses_viewport_relative_row_heights() {
+    let mut contents = vec!["x".to_string(); 20];
+    contents[5] = "L".repeat(56);
+    let mut app = build_wrapping_scroll_app_with_contents(&contents, 5, 20);
+    let first_diff = app
+        .line_annotations
+        .iter()
+        .position(|a| matches!(a, AnnotatedLine::DiffLine { .. }))
+        .expect("a diff line annotation must exist");
+    assert_eq!(annotation_row_height(&app, first_diff + 5), 4);
+
+    let old_scroll = first_diff + 6;
+    app.diff_state.scroll_offset = old_scroll;
+    app.diff_state.cursor_line = first_diff + 10;
+
+    assert_eq!(app.page_lines_up(5), 4);
+    assert_eq!(
+        app.page_view_lines_up(5),
+        2,
+        "the viewport must spend four rows on the tall annotation above it"
+    );
+
+    app.page_up(5);
+
+    assert_eq!(app.diff_state.scroll_offset, first_diff + 4);
+    let advanced_rows: usize = (app.diff_state.scroll_offset..old_scroll)
+        .map(|idx| annotation_row_height(&app, idx))
+        .sum();
+    assert_eq!(advanced_rows, 5);
+    assert_eq!(
+        app.diff_state.cursor_line,
+        first_diff + 5,
+        "cursor should clamp to the last fully visible annotation without moving the viewport"
+    );
 }
 
 #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1256,10 +1256,12 @@ pub fn handle_visual_action(app: &mut App, action: Action) {
         Action::Quit => app.should_quit = true,
         Action::ScrollViewDown(n) | Action::MouseScrollDown(n) => app.scroll_view_down(n),
         Action::ScrollViewUp(n) | Action::MouseScrollUp(n) => app.scroll_view_up(n),
-        Action::HalfPageDown => app.scroll_down(app.diff_state.viewport_height / 2),
-        Action::HalfPageUp => app.scroll_up(app.diff_state.viewport_height / 2),
-        Action::PageDown => app.scroll_down(app.diff_state.viewport_height),
-        Action::PageUp => app.scroll_up(app.diff_state.viewport_height),
+        Action::HalfPageDown => {
+            app.scroll_down(app.page_lines_down(app.diff_state.viewport_height / 2))
+        }
+        Action::HalfPageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height / 2)),
+        Action::PageDown => app.scroll_down(app.page_lines_down(app.diff_state.viewport_height)),
+        Action::PageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height)),
         _ => {}
     }
     clear_visual_if_cursor_offscreen(app);
@@ -1416,10 +1418,12 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
-        Action::HalfPageDown => app.scroll_down(app.diff_state.viewport_height / 2),
-        Action::HalfPageUp => app.scroll_up(app.diff_state.viewport_height / 2),
-        Action::PageDown => app.scroll_down(app.diff_state.viewport_height),
-        Action::PageUp => app.scroll_up(app.diff_state.viewport_height),
+        Action::HalfPageDown => {
+            app.scroll_down(app.page_lines_down(app.diff_state.viewport_height / 2))
+        }
+        Action::HalfPageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height / 2)),
+        Action::PageDown => app.scroll_down(app.page_lines_down(app.diff_state.viewport_height)),
+        Action::PageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height)),
         Action::GoToTop => app.jump_to_file(0),
         Action::GoToBottom => app.jump_to_bottom(),
         Action::NextFile => app.next_file(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1256,12 +1256,10 @@ pub fn handle_visual_action(app: &mut App, action: Action) {
         Action::Quit => app.should_quit = true,
         Action::ScrollViewDown(n) | Action::MouseScrollDown(n) => app.scroll_view_down(n),
         Action::ScrollViewUp(n) | Action::MouseScrollUp(n) => app.scroll_view_up(n),
-        Action::HalfPageDown => {
-            app.scroll_down(app.page_lines_down(app.diff_state.viewport_height / 2))
-        }
-        Action::HalfPageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height / 2)),
-        Action::PageDown => app.scroll_down(app.page_lines_down(app.diff_state.viewport_height)),
-        Action::PageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height)),
+        Action::HalfPageDown => app.page_down(app.diff_state.viewport_height / 2),
+        Action::HalfPageUp => app.page_up(app.diff_state.viewport_height / 2),
+        Action::PageDown => app.page_down(app.diff_state.viewport_height),
+        Action::PageUp => app.page_up(app.diff_state.viewport_height),
         _ => {}
     }
     clear_visual_if_cursor_offscreen(app);
@@ -1418,12 +1416,10 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
-        Action::HalfPageDown => {
-            app.scroll_down(app.page_lines_down(app.diff_state.viewport_height / 2))
-        }
-        Action::HalfPageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height / 2)),
-        Action::PageDown => app.scroll_down(app.page_lines_down(app.diff_state.viewport_height)),
-        Action::PageUp => app.scroll_up(app.page_lines_up(app.diff_state.viewport_height)),
+        Action::HalfPageDown => app.page_down(app.diff_state.viewport_height / 2),
+        Action::HalfPageUp => app.page_up(app.diff_state.viewport_height / 2),
+        Action::PageDown => app.page_down(app.diff_state.viewport_height),
+        Action::PageUp => app.page_up(app.diff_state.viewport_height),
         Action::GoToTop => app.jump_to_file(0),
         Action::GoToBottom => app.jump_to_bottom(),
         Action::NextFile => app.next_file(),

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -247,7 +247,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 styles::current_line_indicator_style(&app.theme),
             ),
             Span::styled(
-                "═══ Review Comments ",
+                crate::ui::diff_view::REVIEW_COMMENTS_HEADER_PREFIX,
                 styles::file_header_style(&app.theme),
             ),
             Span::styled(
@@ -389,17 +389,11 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             continue;
         }
         let path = file.display_path();
-        let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);
 
         if !app.is_single_file_view {
             let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
-            let review_mark = if is_reviewed { "✓ " } else { "" };
-            let header_text = if file.is_commit_message {
-                format!("═══ {}{} ", review_mark, path.display())
-            } else {
-                format!("═══ {}{} [{}] ", review_mark, path.display(), status)
-            };
+            let header_text = crate::ui::diff_view::file_header_prefix_text(app, file);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(header_text, styles::file_header_style(&app.theme)),
@@ -536,25 +530,14 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             }
         }
 
-        if file.is_too_large {
+        if file.is_too_large || file.is_binary || file.hunks.is_empty() {
             let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled("(file too large to display)", styles::dim_style(&app.theme)),
-            ]));
-            line_idx += 1;
-        } else if file.is_binary {
-            let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
-            lines.push(Line::from(vec![
-                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled("(binary file)", styles::dim_style(&app.theme)),
-            ]));
-            line_idx += 1;
-        } else if file.hunks.is_empty() {
-            let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
-            lines.push(Line::from(vec![
-                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled("(no changes)", styles::dim_style(&app.theme)),
+                Span::styled(
+                    crate::ui::diff_view::binary_or_empty_label(file),
+                    styles::dim_style(&app.theme),
+                ),
             ]));
             line_idx += 1;
         } else {

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -87,7 +87,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 styles::current_line_indicator_style(&app.theme),
             ),
             Span::styled(
-                "═══ Review Comments ",
+                crate::ui::diff_view::REVIEW_COMMENTS_HEADER_PREFIX,
                 styles::file_header_style(&app.theme),
             ),
             Span::styled(
@@ -231,7 +231,6 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             continue;
         }
         let path = file.display_path();
-        let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);
 
         // The `═══ filename ═══` separator is redundant in single-file
@@ -239,16 +238,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         // the wide bar of `═` characters confuses horizontal scrolling.
         if !app.is_single_file_view {
             let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
-            let review_mark = if is_reviewed { "✓ " } else { "" };
-            let header_text = if file.is_commit_message {
-                format!("═══ {}{} ", review_mark, path.display())
-            } else if app.is_pristine_mode {
-                // Pristine mode reviews unchanged code; the M/A/D badge would
-                // mislead. Render the header without it.
-                format!("═══ {}{} ", review_mark, path.display())
-            } else {
-                format!("═══ {}{} [{}] ", review_mark, path.display(), status)
-            };
+            let header_text = crate::ui::diff_view::file_header_prefix_text(app, file);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(header_text, styles::file_header_style(&app.theme)),
@@ -389,25 +379,14 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             }
         }
 
-        if file.is_too_large {
+        if file.is_too_large || file.is_binary || file.hunks.is_empty() {
             let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled("(file too large to display)", styles::dim_style(&app.theme)),
-            ]));
-            line_idx += 1;
-        } else if file.is_binary {
-            let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
-            lines.push(Line::from(vec![
-                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled("(binary file)", styles::dim_style(&app.theme)),
-            ]));
-            line_idx += 1;
-        } else if file.hunks.is_empty() {
-            let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
-            lines.push(Line::from(vec![
-                Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
-                Span::styled("(no changes)", styles::dim_style(&app.theme)),
+                Span::styled(
+                    crate::ui::diff_view::binary_or_empty_label(file),
+                    styles::dim_style(&app.theme),
+                ),
             ]));
             line_idx += 1;
         } else {
@@ -560,36 +539,20 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         lines.push(Line::default());
                         line_idx += 1;
                     } else {
-                        let (prefix, base_style) = match diff_line.origin {
-                            LineOrigin::Addition => ("▌", styles::diff_add_style(&app.theme)),
-                            LineOrigin::Deletion => ("▌", styles::diff_del_style(&app.theme)),
-                            LineOrigin::Context => (" ", styles::diff_context_style(&app.theme)),
+                        let base_style = match diff_line.origin {
+                            LineOrigin::Addition => styles::diff_add_style(&app.theme),
+                            LineOrigin::Deletion => styles::diff_del_style(&app.theme),
+                            LineOrigin::Context => styles::diff_context_style(&app.theme),
                         };
-
                         let style = base_style;
-
-                        let blank = " ".repeat(lw + 1);
                         // A commit message is prose, not code: render it without
                         // line numbers, matching the side-by-side view.
                         let line_num_str = if file.is_commit_message {
-                            blank
+                            " ".repeat(lw + 1)
                         } else {
-                            match diff_line.origin {
-                                LineOrigin::Addition => diff_line
-                                    .new_lineno
-                                    .map(|n| format!("{n:>lw$} "))
-                                    .unwrap_or_else(|| blank.clone()),
-                                LineOrigin::Deletion => diff_line
-                                    .old_lineno
-                                    .map(|n| format!("{n:>lw$} "))
-                                    .unwrap_or_else(|| blank.clone()),
-                                _ => diff_line
-                                    .new_lineno
-                                    .or(diff_line.old_lineno)
-                                    .map(|n| format!("{n:>lw$} "))
-                                    .unwrap_or_else(|| blank),
-                            }
+                            crate::ui::diff_view::unified_line_number_field(diff_line, lw)
                         };
+                        let prefix = crate::ui::diff_view::unified_line_origin_marker(diff_line);
 
                         let indicator = cursor_indicator(line_idx, current_line_idx);
 
@@ -1075,7 +1038,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(
-                    format!("  \u{2193}  {next_path}"),
+                    crate::ui::diff_view::spacing_next_file_hint_text(&next_path),
                     Style::default()
                         .fg(app.theme.fg_secondary)
                         .add_modifier(Modifier::DIM),
@@ -1342,10 +1305,7 @@ fn render_expanded_context_line(
     lw: usize,
 ) {
     let indicator = cursor_indicator(*line_idx, current_line_idx);
-    let line_num = expanded_line
-        .new_lineno
-        .map(|n| format!("{n:>lw$} "))
-        .unwrap_or_else(|| " ".repeat(lw + 1));
+    let line_num = crate::ui::diff_view::expanded_context_lineno_field(expanded_line, lw);
     let line_spans = vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
         Span::styled(line_num, styles::expanded_context_style(theme)),

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use crate::app::{
     AnnotatedLine, App, DiffViewMode, ExpandDirection, GAP_EXPAND_BATCH, VisualSelection,
 };
-use crate::model::{Comment, DiffHunk, LineSide};
+use crate::model::{Comment, DiffFile, DiffHunk, DiffLine, LineOrigin, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_side_by_side::render_side_by_side_diff;
@@ -18,6 +18,103 @@ use unicode_width::UnicodeWidthStr;
 
 /// Static header rule used for file/section headers; avoids `"═".repeat(40)` per frame.
 pub(super) const HEADER_RULE: &str = "════════════════════════════════════════";
+
+/// Shared text before `HEADER_RULE` for the synthetic review-comments banner.
+pub(super) const REVIEW_COMMENTS_HEADER_PREFIX: &str = "═══ Review Comments ";
+
+/// Text portion of a per-file section header, without the trailing
+/// `HEADER_RULE`. Callers concatenate `HEADER_RULE` themselves so the rule
+/// can be styled as a separate span (both renderers) or absorbed into a
+/// single width computation (`row_height`).
+pub(super) fn file_header_prefix_text(app: &App, file: &DiffFile) -> String {
+    let path = file.display_path();
+    let is_reviewed = app.session.is_file_reviewed(path);
+    let review_mark = if is_reviewed { "✓ " } else { "" };
+    if file.is_commit_message || app.is_pristine_mode {
+        format!("═══ {}{} ", review_mark, path.display())
+    } else {
+        format!(
+            "═══ {}{} [{}] ",
+            review_mark,
+            path.display(),
+            file.status.as_char()
+        )
+    }
+}
+
+/// Styled body text of the gap `expand (N lines)` row. Callers prepend a
+/// two-cell cursor indicator.
+pub(super) fn expander_body_text(direction: ExpandDirection, remaining: usize) -> String {
+    let arrow = match direction {
+        ExpandDirection::Down => "↓",
+        ExpandDirection::Up => "↑",
+        ExpandDirection::Both => "↕",
+    };
+    let count = remaining.min(GAP_EXPAND_BATCH);
+    format!("       ... {arrow} expand ({count} lines) ...")
+}
+
+/// Styled body text of the `N lines hidden` row.
+pub(super) fn hidden_lines_body_text(count: usize) -> String {
+    format!("       ... {count} lines hidden ...")
+}
+
+/// Unified-mode line-number gutter field for a diff line — a right-aligned
+/// number followed by a single space, or all spaces when the side is absent.
+pub(super) fn unified_line_number_field(dl: &DiffLine, lw: usize) -> String {
+    let blank = || " ".repeat(lw + 1);
+    let format_n = |n: u32| format!("{n:>lw$} ");
+    match dl.origin {
+        LineOrigin::Addition => dl.new_lineno.map(format_n).unwrap_or_else(blank),
+        LineOrigin::Deletion => dl.old_lineno.map(format_n).unwrap_or_else(blank),
+        LineOrigin::Context => dl
+            .new_lineno
+            .or(dl.old_lineno)
+            .map(format_n)
+            .unwrap_or_else(blank),
+    }
+}
+
+/// Single-cell origin marker for a unified diff line (`▌` for add/del,
+/// space for context). Callers append a trailing space of their own.
+pub(super) fn unified_line_origin_marker(dl: &DiffLine) -> &'static str {
+    match dl.origin {
+        LineOrigin::Addition | LineOrigin::Deletion => "▌",
+        LineOrigin::Context => " ",
+    }
+}
+
+/// Body text of the `Spacing` inter-file row in unified single-file view —
+/// a hint pointing at the file `j` would walk into next. Callers prepend the
+/// one-cell cursor indicator. Multi-file view and side-by-side always emit a
+/// bare indicator instead, so this builder is only used by the unified
+/// single-file branch (and by `row_height` mirroring it).
+pub(super) fn spacing_next_file_hint_text(next_path: &str) -> String {
+    format!("  \u{2193}  {next_path}")
+}
+
+/// Label text for a `BinaryOrEmpty` row (unified & SBS both render this
+/// verbatim after the two-cell cursor indicator). Empty string means the
+/// file doesn't fall into any of the three known non-diff cases.
+pub(super) fn binary_or_empty_label(file: &DiffFile) -> &'static str {
+    if file.is_too_large {
+        "(file too large to display)"
+    } else if file.is_binary {
+        "(binary file)"
+    } else if file.hunks.is_empty() {
+        "(no changes)"
+    } else {
+        ""
+    }
+}
+
+/// Line-number gutter field for an expanded-context row (uses new-side
+/// numbers only).
+pub(super) fn expanded_context_lineno_field(dl: &DiffLine, lw: usize) -> String {
+    dl.new_lineno
+        .map(|n| format!("{n:>lw$} "))
+        .unwrap_or_else(|| " ".repeat(lw + 1))
+}
 
 /// Shared empty map so we can borrow `line_comments` without cloning per file per frame.
 pub(super) static EMPTY_LINE_COMMENTS: std::sync::LazyLock<
@@ -170,17 +267,11 @@ pub(super) fn render_expander_line(
     remaining: usize,
     theme: &Theme,
 ) {
-    let arrow = match direction {
-        ExpandDirection::Down => "↓",
-        ExpandDirection::Up => "↑",
-        ExpandDirection::Both => "↕",
-    };
-    let count = remaining.min(GAP_EXPAND_BATCH);
     let indicator = cursor_indicator_spaced(*line_idx, current_line_idx);
     lines.push(Line::from(vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
         Span::styled(
-            format!("       ... {arrow} expand ({count} lines) ..."),
+            expander_body_text(direction, remaining),
             styles::dim_style(theme),
         ),
     ]));
@@ -198,10 +289,7 @@ pub(super) fn render_hidden_lines(
     let indicator = cursor_indicator_spaced(*line_idx, current_line_idx);
     lines.push(Line::from(vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
-        Span::styled(
-            format!("       ... {count} lines hidden ..."),
-            styles::dim_style(theme),
-        ),
+        Span::styled(hidden_lines_body_text(count), styles::dim_style(theme)),
     ]));
     *line_idx += 1;
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,6 +8,7 @@ pub mod diff_view;
 pub mod file_list;
 pub mod help_popup;
 pub mod inline_commit_selector;
+pub mod row_height;
 pub mod selector;
 pub mod status_bar;
 pub mod styles;

--- a/src/ui/row_height.rs
+++ b/src/ui/row_height.rs
@@ -1,0 +1,777 @@
+//! Wrap-aware visual row-height helper for a single annotation.
+//!
+//! `annotation_row_height(app, idx)` returns the same number of terminal
+//! rows the diff renderer will emit for `line_annotations[idx]` at the
+//! current `viewport_width` and `wrap_lines`. It mirrors the renderer's
+//! single wrap pass logical-line by logical-line so that jumps (zz, G,
+//! paging) can sum heights without re-running the renderer.
+//!
+//! Every rendered-body format string used to reconstruct a row lives
+//! once, in the renderer's shared text builders in `ui::diff_view`; this
+//! module only calls them and concatenates the parts (cursor-indicator
+//! spacing is the sole literal kept locally, since the renderer
+//! constructs it as a styled span rather than as a shared string).
+//! Comment-box annotations are pre-wrapped by `format_comment_lines`, so
+//! each is exactly one row.
+
+use ratatui::text::Span;
+
+use crate::app::{AnnotatedLine, App, DiffViewMode, sbs_overhead};
+use crate::ui::diff_view;
+use crate::ui::text_utils::wrap_spans;
+
+pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
+    if !app.diff_state.wrap_lines {
+        return 1;
+    }
+    let viewport_width = app.diff_state.viewport_width;
+    if viewport_width == 0 {
+        return 1;
+    }
+    // SBS parity: the renderer disables the entire wrap pass (including
+    // non-content rows) when the per-side content width is 0, falling back
+    // to height 1 for every row.
+    if app.diff_view_mode == DiffViewMode::SideBySide && sbs_content_width(app, viewport_width) == 0
+    {
+        return 1;
+    }
+    let Some(annotation) = app.line_annotations.get(idx) else {
+        return 1;
+    };
+
+    match annotation {
+        // Pre-wrapped by comment_panel::wrap_segments to inner width - 1.
+        AnnotatedLine::ReviewComment { .. }
+        | AnnotatedLine::RemoteReviewSummaryLine { .. }
+        | AnnotatedLine::FileComment { .. }
+        | AnnotatedLine::LineComment { .. }
+        | AnnotatedLine::RemoteThreadLine { .. } => 1,
+
+        AnnotatedLine::SideBySideLine {
+            file_idx,
+            hunk_idx,
+            del_line_idx,
+            add_line_idx,
+            ..
+        } if app.diff_view_mode == DiffViewMode::SideBySide => {
+            let content_width = sbs_content_width(app, viewport_width);
+            let (left, right) =
+                sbs_row_contents(app, *file_idx, *hunk_idx, *del_line_idx, *add_line_idx);
+            wrap_side_max(&left, &right, content_width)
+        }
+
+        AnnotatedLine::ExpandedContext {
+            gap_id,
+            line_idx: li,
+        } if app.diff_view_mode == DiffViewMode::SideBySide => {
+            let content = expanded_line_content(app, gap_id, *li).unwrap_or_default();
+            let content_width = sbs_content_width(app, viewport_width);
+            wrap_side_max(&content, &content, content_width)
+        }
+
+        _ => {
+            let text = full_row_text(app, annotation);
+            wrap_len(&text, viewport_width)
+        }
+    }
+}
+
+fn wrap_len(text: &str, width: usize) -> usize {
+    wrap_spans(&[Span::raw(text.to_string())], width).len()
+}
+
+fn wrap_side_max(left: &str, right: &str, content_width: usize) -> usize {
+    let l = wrap_len(left, content_width);
+    let r = wrap_len(right, content_width);
+    l.max(r).max(1)
+}
+
+fn sbs_content_width(app: &App, viewport_width: usize) -> usize {
+    let lw = app.lineno_width();
+    let overhead = sbs_overhead(lw) as usize;
+    viewport_width.saturating_sub(overhead) / 2
+}
+
+fn sbs_row_contents(
+    app: &App,
+    file_idx: usize,
+    hunk_idx: usize,
+    del_line_idx: Option<usize>,
+    add_line_idx: Option<usize>,
+) -> (String, String) {
+    let hunk = app
+        .diff_files
+        .get(file_idx)
+        .and_then(|f| f.hunks.get(hunk_idx));
+    let get = |i: Option<usize>| -> String {
+        i.and_then(|idx| hunk.and_then(|h| h.lines.get(idx)))
+            .map(|dl| dl.content.clone())
+            .unwrap_or_default()
+    };
+    (get(del_line_idx), get(add_line_idx))
+}
+
+fn expanded_line_content(app: &App, gap_id: &crate::app::GapId, idx: usize) -> Option<String> {
+    let top = app.expanded_top.get(gap_id);
+    let top_len = top.map_or(0, |v| v.len());
+    if idx < top_len {
+        top?.get(idx).map(|dl| dl.content.clone())
+    } else {
+        app.expanded_bottom
+            .get(gap_id)?
+            .get(idx - top_len)
+            .map(|dl| dl.content.clone())
+    }
+}
+
+/// Reconstruct the concatenated text of a rendered logical line by calling
+/// the same text builders the renderer uses. Used for the "wrap at full
+/// inner width" branch: unified mode, and SBS non-content rows.
+fn full_row_text(app: &App, annotation: &AnnotatedLine) -> String {
+    let lw = app.lineno_width();
+    let indicator = " ";
+    let indicator_spaced = "  ";
+
+    match annotation {
+        AnnotatedLine::ReviewCommentsHeader => {
+            format!(
+                "{indicator_spaced}{}{}",
+                diff_view::REVIEW_COMMENTS_HEADER_PREFIX,
+                diff_view::HEADER_RULE
+            )
+        }
+
+        AnnotatedLine::FileHeader { file_idx } => match app.diff_files.get(*file_idx) {
+            Some(file) => format!(
+                "{indicator_spaced}{}{}",
+                diff_view::file_header_prefix_text(app, file),
+                diff_view::HEADER_RULE
+            ),
+            None => indicator_spaced.to_string(),
+        },
+
+        AnnotatedLine::HunkHeader { file_idx, hunk_idx } => {
+            let text = app
+                .diff_files
+                .get(*file_idx)
+                .and_then(|f| f.hunks.get(*hunk_idx))
+                .map(|h| {
+                    diff_view::hunk_header_text_and_style(
+                        &app.theme,
+                        h,
+                        app.is_hunk_reviewed(*file_idx, *hunk_idx),
+                    )
+                    .0
+                })
+                .unwrap_or_default();
+            format!("{indicator_spaced}{text}")
+        }
+
+        AnnotatedLine::Expander { gap_id, direction } => {
+            // Mirror the renderer's `remaining` computation at the call site;
+            // the annotation itself doesn't carry it.
+            let remaining = match app.gap_size(gap_id) {
+                Some(gap) => {
+                    let top_len = app.expanded_top.get(gap_id).map_or(0, |v| v.len());
+                    let bot_len = app.expanded_bottom.get(gap_id).map_or(0, |v| v.len());
+                    (gap as usize).saturating_sub(top_len + bot_len)
+                }
+                None => 1,
+            };
+            format!(
+                "{indicator_spaced}{}",
+                diff_view::expander_body_text(*direction, remaining)
+            )
+        }
+
+        AnnotatedLine::HiddenLines { count, .. } => {
+            format!(
+                "{indicator_spaced}{}",
+                diff_view::hidden_lines_body_text(*count)
+            )
+        }
+
+        AnnotatedLine::ExpandedContext { gap_id, line_idx } => {
+            // Unified branch; SBS is handled by the outer match.
+            let dl = expanded_diff_line(app, gap_id, *line_idx);
+            let (lineno, content) = match dl {
+                Some(dl) => (
+                    diff_view::expanded_context_lineno_field(&dl, lw),
+                    dl.content,
+                ),
+                None => (" ".repeat(lw + 1), String::new()),
+            };
+            format!("{indicator}{lineno}  {content}")
+        }
+
+        AnnotatedLine::DiffLine {
+            file_idx,
+            hunk_idx,
+            line_idx,
+            ..
+        } => {
+            let dl = app
+                .diff_files
+                .get(*file_idx)
+                .and_then(|f| f.hunks.get(*hunk_idx))
+                .and_then(|h| h.lines.get(*line_idx));
+            match dl {
+                Some(dl) => {
+                    let lineno = diff_view::unified_line_number_field(dl, lw);
+                    let prefix = diff_view::unified_line_origin_marker(dl);
+                    format!("{indicator}{lineno}{prefix} {}", dl.content)
+                }
+                None => format!("{indicator}{}", " ".repeat(lw + 1)),
+            }
+        }
+
+        // Defensive: SBS annotation seen while in Unified mode. The renderer
+        // wouldn't emit this; concatenate both sides at full width as a best
+        // effort so we still return a sensible row count.
+        AnnotatedLine::SideBySideLine {
+            file_idx,
+            hunk_idx,
+            del_line_idx,
+            add_line_idx,
+            ..
+        } => {
+            let (l, r) = sbs_row_contents(app, *file_idx, *hunk_idx, *del_line_idx, *add_line_idx);
+            format!("{indicator}{l} {r}")
+        }
+
+        AnnotatedLine::BinaryOrEmpty { file_idx } => {
+            let text = app
+                .diff_files
+                .get(*file_idx)
+                .map(diff_view::binary_or_empty_label)
+                .unwrap_or("");
+            format!("{indicator_spaced}{text}")
+        }
+
+        AnnotatedLine::Spacing => {
+            // The SBS renderer always emits a bare-indicator spacing row;
+            // only unified single-file view emits the `↓ next-file` hint.
+            if app.diff_view_mode == DiffViewMode::Unified
+                && app.is_single_file_view
+                && let Some(f) = app.diff_files.get(app.diff_state.current_file_idx + 1)
+            {
+                let path = f.display_path().display().to_string();
+                format!(
+                    "{indicator}{}",
+                    diff_view::spacing_next_file_hint_text(&path)
+                )
+            } else {
+                indicator.to_string()
+            }
+        }
+
+        // Comment-ish rows are pre-wrapped and handled by the outer match.
+        AnnotatedLine::ReviewComment { .. }
+        | AnnotatedLine::RemoteReviewSummaryLine { .. }
+        | AnnotatedLine::FileComment { .. }
+        | AnnotatedLine::LineComment { .. }
+        | AnnotatedLine::RemoteThreadLine { .. } => indicator.to_string(),
+    }
+}
+
+fn expanded_diff_line(
+    app: &App,
+    gap_id: &crate::app::GapId,
+    idx: usize,
+) -> Option<crate::model::DiffLine> {
+    let top = app.expanded_top.get(gap_id);
+    let top_len = top.map_or(0, |v| v.len());
+    if idx < top_len {
+        top?.get(idx).cloned()
+    } else {
+        app.expanded_bottom.get(gap_id)?.get(idx - top_len).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Parity: for every fully visible logical line after render, the visual
+    //! row count derived from `diff_row_to_annotation` must match
+    //! `annotation_row_height`. The fixture also asserts coverage across all
+    //! annotation variants so future edits can't silently drop branches.
+    use super::*;
+    use crate::app::{
+        App, DiffSource, DiffViewMode, ExpandDirection, GapId, InputMode, PullRequestDiffSource,
+    };
+    use crate::error::Result as TuicrResult;
+    use crate::error::TuicrError;
+    use crate::forge::traits::{ForgeRepository, PrSessionKey};
+    use crate::model::{
+        Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide,
+        ReviewSession, SessionDiffSource,
+    };
+    use crate::syntax::SyntaxHighlighter;
+    use crate::theme::Theme;
+    use crate::vcs::traits::{VcsBackend, VcsChangeStatus, VcsInfo, VcsType};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::layout::Rect;
+    use std::path::{Path, PathBuf};
+
+    struct StubVcs {
+        info: VcsInfo,
+    }
+    impl VcsBackend for StubVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.info
+        }
+        fn get_working_tree_diff(
+            &self,
+            _highlighter: &SyntaxHighlighter,
+        ) -> TuicrResult<Vec<DiffFile>> {
+            Err(TuicrError::NoChanges)
+        }
+        fn fetch_context_lines(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+            start_line: u32,
+            end_line: u32,
+        ) -> TuicrResult<Vec<DiffLine>> {
+            // Synthetic context so `expand_gap` can populate ExpandedContext
+            // annotations in tests.
+            Ok((start_line..=end_line)
+                .map(|n| DiffLine {
+                    origin: LineOrigin::Context,
+                    content: format!("ctx line {n}"),
+                    old_lineno: Some(n),
+                    new_lineno: Some(n),
+                    highlighted_spans: None,
+                })
+                .collect())
+        }
+        fn get_change_status(&self) -> TuicrResult<VcsChangeStatus> {
+            Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            })
+        }
+        fn file_line_count(
+            &self,
+            _file_path: &Path,
+            _file_status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> TuicrResult<u32> {
+            // Non-zero so EOF gaps and top-of-file gaps get expander/hidden
+            // annotations built.
+            Ok(500)
+        }
+    }
+
+    fn code_file() -> DiffFile {
+        let long_left = "L".repeat(140);
+        let long_right = "R".repeat(90);
+        // Hunk 1 starts at line 30 (gap-of-29 before it → HiddenLines + Expander(Up)).
+        // Hunk 2 starts at line 100 (gap of ~66 between hunks → Expander(Down) +
+        // HiddenLines + Expander(Up)).
+        let hunk1 = DiffHunk {
+            header: "@@ -30,2 +30,3 @@ fn foo".to_string(),
+            lines: vec![
+                DiffLine {
+                    origin: LineOrigin::Context,
+                    content: "context short".to_string(),
+                    old_lineno: Some(30),
+                    new_lineno: Some(30),
+                    highlighted_spans: None,
+                },
+                DiffLine {
+                    origin: LineOrigin::Deletion,
+                    content: long_left,
+                    old_lineno: Some(31),
+                    new_lineno: None,
+                    highlighted_spans: None,
+                },
+                DiffLine {
+                    origin: LineOrigin::Addition,
+                    content: long_right,
+                    old_lineno: None,
+                    new_lineno: Some(31),
+                    highlighted_spans: None,
+                },
+                DiffLine {
+                    origin: LineOrigin::Addition,
+                    content: "y".to_string(),
+                    old_lineno: None,
+                    new_lineno: Some(32),
+                    highlighted_spans: None,
+                },
+            ],
+            old_start: 30,
+            old_count: 2,
+            new_start: 30,
+            new_count: 3,
+        };
+        let hunk2 = DiffHunk {
+            header: "@@ -100,1 +100,1 @@ fn bar".to_string(),
+            lines: vec![DiffLine {
+                origin: LineOrigin::Context,
+                content: "tail".to_string(),
+                old_lineno: Some(100),
+                new_lineno: Some(100),
+                highlighted_spans: None,
+            }],
+            old_start: 100,
+            old_count: 1,
+            new_start: 100,
+            new_count: 1,
+        };
+        let hunks = vec![hunk1, hunk2];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: Some(PathBuf::from("src/lib.rs")),
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    fn binary_file() -> DiffFile {
+        DiffFile {
+            old_path: Some(PathBuf::from("assets/logo.png")),
+            new_path: Some(PathBuf::from("assets/logo.png")),
+            status: FileStatus::Modified,
+            hunks: Vec::new(),
+            is_binary: true,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash: 0,
+        }
+    }
+
+    fn make_app() -> App {
+        let repo = ForgeRepository::github("github.com", "test", "tuicr");
+        let pr = PullRequestDiffSource {
+            key: PrSessionKey::new(repo, 1, "headsha".to_string()),
+            base_sha: "base".to_string(),
+            title: "t".to_string(),
+            url: "u".to_string(),
+            head_ref_name: "feat".to_string(),
+            base_ref_name: "main".to_string(),
+            state: "OPEN".to_string(),
+            closed: false,
+            merged: false,
+        };
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("forge:github.com/test/tuicr"),
+            head_commit: "headsha".to_string(),
+            branch_name: Some("feat".to_string()),
+            vcs_type: VcsType::File,
+        };
+        let mut session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            "headsha".to_string(),
+            Some("feat".to_string()),
+            SessionDiffSource::PullRequest,
+        );
+        session.pr_session_key = Some(pr.key.clone());
+        let mut app = App::build(
+            Box::new(StubVcs {
+                info: vcs_info.clone(),
+            }),
+            vcs_info,
+            Theme::dark(),
+            None,
+            false,
+            vec![code_file(), binary_file()],
+            session,
+            DiffSource::PullRequest(Box::new(pr)),
+            InputMode::Normal,
+            Vec::new(),
+            None,
+            None,
+        )
+        .expect("build app");
+        let path = PathBuf::from("src/lib.rs");
+        let review = app.session.get_file_mut(&path).expect("file registered");
+        review.add_line_comment(
+            31,
+            Comment::new(
+                "this line is important".to_string(),
+                CommentType::from_id("note"),
+                Some(LineSide::New),
+            ),
+        );
+        review.add_file_comment(Comment::new(
+            "overall the file looks good".to_string(),
+            CommentType::from_id("praise"),
+            None,
+        ));
+        // `sort_files_by_directory` reorders diff_files by parent directory,
+        // so `assets/logo.png` lands before `src/lib.rs`; find the code file
+        // by path rather than assuming its post-sort index.
+        let code_idx = app
+            .diff_files
+            .iter()
+            .position(|f| f.display_path().as_path() == Path::new("src/lib.rs"))
+            .expect("code file present");
+        // Partially expand the gap between hunk 1 and hunk 2 so we get both
+        // an Expander row and ExpandedContext rows.
+        app.expand_gap(
+            GapId {
+                file_idx: code_idx,
+                hunk_idx: 1,
+            },
+            ExpandDirection::Down,
+            Some(2),
+        )
+        .expect("expand gap");
+        app
+    }
+
+    fn render_diff(app: &mut App, mode: DiffViewMode, w: u16, h: u16) {
+        app.diff_view_mode = mode;
+        app.rebuild_annotations();
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| match mode {
+                DiffViewMode::Unified => {
+                    crate::ui::diff_unified::render_unified_diff(frame, app, Rect::new(0, 0, w, h));
+                }
+                DiffViewMode::SideBySide => {
+                    crate::ui::diff_side_by_side::render_side_by_side_diff(
+                        frame,
+                        app,
+                        Rect::new(0, 0, w, h),
+                    );
+                }
+            })
+            .expect("draw");
+    }
+
+    /// Group consecutive identical annotation indices in `diff_row_to_annotation`
+    /// into (annotation_idx, visible_row_count) pairs. Skips the final group
+    /// because the renderer may have truncated it at the viewport bottom.
+    fn observed_heights(app: &App) -> Vec<(usize, usize)> {
+        let map = &app.diff_row_to_annotation;
+        let mut groups: Vec<(usize, usize)> = Vec::new();
+        for &ann in map {
+            match groups.last_mut() {
+                Some(g) if g.0 == ann => g.1 += 1,
+                _ => groups.push((ann, 1)),
+            }
+        }
+        if !groups.is_empty() {
+            groups.pop();
+        }
+        groups
+    }
+
+    fn assert_parity(app: &App) {
+        let obs = observed_heights(app);
+        assert!(
+            !obs.is_empty(),
+            "no fully visible annotations captured; increase viewport height"
+        );
+        for (ann_idx, observed) in obs {
+            let computed = annotation_row_height(app, ann_idx);
+            assert_eq!(
+                observed,
+                computed,
+                "annotation {ann_idx} ({:?}): renderer produced {observed} rows, helper computed {computed}",
+                app.line_annotations.get(ann_idx)
+            );
+        }
+    }
+
+    /// Bin an annotation into one of the coverage buckets. Returns `None` for
+    /// variants we don't require the fixture to exercise.
+    fn variant_bucket(ann: &AnnotatedLine) -> Option<&'static str> {
+        match ann {
+            AnnotatedLine::FileHeader { .. } => Some("FileHeader"),
+            AnnotatedLine::HunkHeader { .. } => Some("HunkHeader"),
+            AnnotatedLine::DiffLine { .. } => Some("DiffLine"),
+            AnnotatedLine::SideBySideLine { .. } => Some("SideBySideLine"),
+            AnnotatedLine::Expander { .. } => Some("Expander"),
+            AnnotatedLine::HiddenLines { .. } => Some("HiddenLines"),
+            AnnotatedLine::ExpandedContext { .. } => Some("ExpandedContext"),
+            AnnotatedLine::LineComment { .. } => Some("LineComment"),
+            AnnotatedLine::FileComment { .. } => Some("FileComment"),
+            AnnotatedLine::Spacing => Some("Spacing"),
+            AnnotatedLine::BinaryOrEmpty { .. } => Some("BinaryOrEmpty"),
+            _ => None,
+        }
+    }
+
+    fn assert_coverage(app: &App, mode: DiffViewMode) {
+        use std::collections::BTreeSet;
+        // Derive coverage from the parity-verified set (i.e. the same
+        // groups `assert_parity` iterates over) so every counted variant
+        // is guaranteed to have been height-checked. The final possibly-
+        // truncated group that `observed_heights` drops is excluded here
+        // for the same reason.
+        let mut seen: BTreeSet<&'static str> = BTreeSet::new();
+        for (ann_idx, _) in observed_heights(app) {
+            if let Some(a) = app.line_annotations.get(ann_idx)
+                && let Some(bucket) = variant_bucket(a)
+            {
+                seen.insert(bucket);
+            }
+        }
+        let mut required: BTreeSet<&'static str> = [
+            "FileHeader",
+            "HunkHeader",
+            "Expander",
+            "HiddenLines",
+            "ExpandedContext",
+            "LineComment",
+            "FileComment",
+            "Spacing",
+            "BinaryOrEmpty",
+        ]
+        .into_iter()
+        .collect();
+        required.insert(match mode {
+            DiffViewMode::Unified => "DiffLine",
+            DiffViewMode::SideBySide => "SideBySideLine",
+        });
+        let missing: Vec<_> = required.difference(&seen).copied().collect();
+        assert!(
+            missing.is_empty(),
+            "parity fixture missing coverage for: {missing:?} (mode {mode:?}); saw {seen:?}"
+        );
+    }
+
+    #[test]
+    fn parity_unified_with_wrap() {
+        let mut app = make_app();
+        app.set_diff_wrap(true);
+        // Tall viewport so every logical line, including BinaryOrEmpty on the
+        // second file, is fully visible and captured by `observed_heights`.
+        render_diff(&mut app, DiffViewMode::Unified, 40, 200);
+        assert_coverage(&app, DiffViewMode::Unified);
+        assert_parity(&app);
+    }
+
+    #[test]
+    fn parity_side_by_side_with_wrap() {
+        let mut app = make_app();
+        app.set_diff_wrap(true);
+        render_diff(&mut app, DiffViewMode::SideBySide, 60, 200);
+        assert_coverage(&app, DiffViewMode::SideBySide);
+        assert_parity(&app);
+    }
+
+    #[test]
+    fn parity_unified_wrap_on_single_file_view_next_hint_wraps() {
+        // Single-file view emits a `↓ <next-file-path>` hint on the
+        // inter-file Spacing row. Pick a long path + narrow viewport so
+        // the hint wraps, and assert parity still holds for that row.
+        let mut app = make_app();
+        app.set_diff_wrap(true);
+        // Replace the second file with one whose display path is long
+        // enough to wrap at the chosen viewport width.
+        // Rename the file that follows the current one in sort order so
+        // its display path is long enough to wrap at the chosen viewport
+        // width, then focus the file just before it in single-file view
+        // so the Spacing row after it renders the next-file hint.
+        let long_name = format!("{}.txt", "a".repeat(120));
+        let long_path = PathBuf::from("src").join(long_name);
+        // In the parity fixture there are exactly two diff files; after
+        // `sort_files_by_directory` the code file lands second, so focus
+        // index 0 and rewrite index 1's path to be long.
+        assert_eq!(app.diff_files.len(), 2);
+        app.diff_files[1].old_path = Some(long_path.clone());
+        app.diff_files[1].new_path = Some(long_path);
+        app.diff_state.current_file_idx = 0;
+        app.is_single_file_view = true;
+        app.rebuild_annotations();
+        render_diff(&mut app, DiffViewMode::Unified, 40, 400);
+
+        // Locate the Spacing annotation and confirm it wrapped to > 1 row.
+        // In single-file view Spacing is the very last logical line, which
+        // `observed_heights` drops on principle, so count its visible rows
+        // directly against the row-to-annotation map instead.
+        let spacing_idx = app
+            .line_annotations
+            .iter()
+            .position(|a| matches!(a, AnnotatedLine::Spacing))
+            .expect("Spacing annotation present");
+        let observed_spacing_rows = app
+            .diff_row_to_annotation
+            .iter()
+            .filter(|&&idx| idx == spacing_idx)
+            .count();
+        let computed = annotation_row_height(&app, spacing_idx);
+        assert!(
+            computed > 1,
+            "expected next-file hint to wrap, computed {computed} rows"
+        );
+        assert_eq!(
+            observed_spacing_rows, computed,
+            "Spacing parity: renderer produced {observed_spacing_rows} rows, helper computed {computed}"
+        );
+        assert_parity(&app);
+    }
+
+    #[test]
+    fn parity_side_by_side_single_file_view_spacing_is_bare() {
+        // SBS always emits a bare-indicator Spacing row, even in
+        // single-file view. Use the same long next-file path as the
+        // unified test to prove it does NOT wrap here.
+        let mut app = make_app();
+        app.set_diff_wrap(true);
+        let long_name = format!("{}.txt", "a".repeat(120));
+        let long_path = PathBuf::from("src").join(long_name);
+        assert_eq!(app.diff_files.len(), 2);
+        app.diff_files[1].old_path = Some(long_path.clone());
+        app.diff_files[1].new_path = Some(long_path);
+        app.diff_state.current_file_idx = 0;
+        app.is_single_file_view = true;
+        app.rebuild_annotations();
+        render_diff(&mut app, DiffViewMode::SideBySide, 60, 400);
+
+        let spacing_idx = app
+            .line_annotations
+            .iter()
+            .position(|a| matches!(a, AnnotatedLine::Spacing))
+            .expect("Spacing annotation present");
+        let observed_spacing_rows = app
+            .diff_row_to_annotation
+            .iter()
+            .filter(|&&idx| idx == spacing_idx)
+            .count();
+        assert_eq!(
+            observed_spacing_rows, 1,
+            "SBS Spacing row must stay 1 row even in single-file view"
+        );
+        assert_eq!(annotation_row_height(&app, spacing_idx), 1);
+        assert_parity(&app);
+    }
+
+    #[test]
+    fn parity_unified_wrap_off_all_ones() {
+        let mut app = make_app();
+        app.set_diff_wrap(false);
+        render_diff(&mut app, DiffViewMode::Unified, 40, 200);
+        for (_, h) in observed_heights(&app) {
+            assert_eq!(h, 1);
+        }
+        for i in 0..app.line_annotations.len() {
+            assert_eq!(annotation_row_height(&app, i), 1);
+        }
+    }
+
+    #[test]
+    fn parity_side_by_side_wrap_off_all_ones() {
+        let mut app = make_app();
+        app.set_diff_wrap(false);
+        render_diff(&mut app, DiffViewMode::SideBySide, 60, 200);
+        for (_, h) in observed_heights(&app) {
+            assert_eq!(h, 1);
+        }
+        for i in 0..app.line_annotations.len() {
+            assert_eq!(annotation_row_height(&app, i), 1);
+        }
+    }
+}

--- a/src/ui/row_height.rs
+++ b/src/ui/row_height.rs
@@ -11,14 +11,16 @@
 //! module only calls them and concatenates the parts (cursor-indicator
 //! spacing is the sole literal kept locally, since the renderer
 //! constructs it as a styled span rather than as a shared string).
-//! Comment-box annotations are pre-wrapped by `format_comment_lines`, so
-//! each is exactly one row.
+//! Local comment-box annotations are pre-wrapped by `format_comment_lines`,
+//! so each is exactly one row. Remote comment rows are not pre-wrapped; their
+//! formatted spans are measured here with the same outer wrap pass used by
+//! the renderers.
 
-use ratatui::text::Span;
+use ratatui::text::{Line, Span};
 
 use crate::app::{AnnotatedLine, App, DiffViewMode, sbs_overhead};
-use crate::ui::diff_view;
 use crate::ui::text_utils::wrap_spans;
+use crate::ui::{comment_panel, diff_view};
 
 pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
     if !app.diff_state.wrap_lines {
@@ -40,12 +42,37 @@ pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
     };
 
     match annotation {
+        AnnotatedLine::RemoteReviewSummaryLine { summary_idx } => app
+            .forge_review_summaries
+            .get(*summary_idx)
+            .and_then(|summary| {
+                let row = repeated_annotation_row(app, idx, annotation);
+                comment_panel::format_remote_review_summary_lines(&app.theme, summary)
+                    .into_iter()
+                    .nth(row)
+            })
+            .map_or(1, |line| formatted_line_height(line, viewport_width)),
+
+        AnnotatedLine::RemoteThreadLine { thread_idx } => app
+            .forge_review_threads
+            .get(*thread_idx)
+            .and_then(|thread| {
+                let muted = app
+                    .session
+                    .remote_comments_visibility
+                    .render_decision(thread)
+                    .unwrap_or(false);
+                let row = repeated_annotation_row(app, idx, annotation);
+                comment_panel::format_remote_thread_lines(&app.theme, thread, muted)
+                    .into_iter()
+                    .nth(row)
+            })
+            .map_or(1, |line| formatted_line_height(line, viewport_width)),
+
         // Pre-wrapped by comment_panel::wrap_segments to inner width - 1.
         AnnotatedLine::ReviewComment { .. }
-        | AnnotatedLine::RemoteReviewSummaryLine { .. }
         | AnnotatedLine::FileComment { .. }
-        | AnnotatedLine::LineComment { .. }
-        | AnnotatedLine::RemoteThreadLine { .. } => 1,
+        | AnnotatedLine::LineComment { .. } => 1,
 
         AnnotatedLine::SideBySideLine {
             file_idx,
@@ -74,6 +101,35 @@ pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
             wrap_len(&text, viewport_width)
         }
     }
+}
+
+fn repeated_annotation_row(app: &App, idx: usize, annotation: &AnnotatedLine) -> usize {
+    app.line_annotations[..idx]
+        .iter()
+        .rev()
+        .take_while(|candidate| match (candidate, annotation) {
+            (
+                AnnotatedLine::RemoteReviewSummaryLine {
+                    summary_idx: candidate,
+                },
+                AnnotatedLine::RemoteReviewSummaryLine { summary_idx },
+            ) => candidate == summary_idx,
+            (
+                AnnotatedLine::RemoteThreadLine {
+                    thread_idx: candidate,
+                },
+                AnnotatedLine::RemoteThreadLine { thread_idx },
+            ) => candidate == thread_idx,
+            _ => false,
+        })
+        .count()
+}
+
+fn formatted_line_height(mut line: Line<'static>, viewport_width: usize) -> usize {
+    // Both renderers prepend a one-cell cursor indicator before passing the
+    // logical line through their full-width outer wrap pass.
+    line.spans.insert(0, Span::raw(" "));
+    wrap_spans(&line.spans, viewport_width).len()
 }
 
 fn wrap_len(text: &str, width: usize) -> usize {
@@ -300,6 +356,10 @@ mod tests {
     };
     use crate::error::Result as TuicrResult;
     use crate::error::TuicrError;
+    use crate::forge::remote_comments::{
+        RemoteCommentSide, RemoteReviewComment, RemoteReviewState, RemoteReviewSummary,
+        RemoteReviewThread,
+    };
     use crate::forge::traits::{ForgeRepository, PrSessionKey};
     use crate::model::{
         Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide,
@@ -506,6 +566,30 @@ mod tests {
             CommentType::from_id("praise"),
             None,
         ));
+        app.forge_review_summaries = vec![RemoteReviewSummary {
+            id: "summary-1".to_string(),
+            author: Some("reviewer".to_string()),
+            body: "a long review summary ".repeat(12),
+            state: RemoteReviewState::ChangesRequested,
+            created_at: None,
+            url: "https://example.com/review".to_string(),
+        }];
+        app.forge_review_threads = vec![RemoteReviewThread {
+            id: "thread-1".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(31),
+            side: RemoteCommentSide::Right,
+            is_resolved: false,
+            is_outdated: false,
+            comments: vec![RemoteReviewComment {
+                id: "comment-1".to_string(),
+                author: Some("reviewer".to_string()),
+                body: "a long inline review comment ".repeat(12),
+                created_at: None,
+                in_reply_to: None,
+                url: "https://example.com/comment".to_string(),
+            }],
+        }];
         // `sort_files_by_directory` reorders diff_files by parent directory,
         // so `assets/logo.png` lands before `src/lib.rs`; find the code file
         // by path rather than assuming its post-sort index.
@@ -595,8 +679,10 @@ mod tests {
             AnnotatedLine::Expander { .. } => Some("Expander"),
             AnnotatedLine::HiddenLines { .. } => Some("HiddenLines"),
             AnnotatedLine::ExpandedContext { .. } => Some("ExpandedContext"),
+            AnnotatedLine::RemoteReviewSummaryLine { .. } => Some("RemoteReviewSummaryLine"),
             AnnotatedLine::LineComment { .. } => Some("LineComment"),
             AnnotatedLine::FileComment { .. } => Some("FileComment"),
+            AnnotatedLine::RemoteThreadLine { .. } => Some("RemoteThreadLine"),
             AnnotatedLine::Spacing => Some("Spacing"),
             AnnotatedLine::BinaryOrEmpty { .. } => Some("BinaryOrEmpty"),
             _ => None,
@@ -624,8 +710,10 @@ mod tests {
             "Expander",
             "HiddenLines",
             "ExpandedContext",
+            "RemoteReviewSummaryLine",
             "LineComment",
             "FileComment",
+            "RemoteThreadLine",
             "Spacing",
             "BinaryOrEmpty",
         ]
@@ -642,6 +730,24 @@ mod tests {
         );
     }
 
+    fn assert_remote_rows_wrap(app: &App) {
+        for label in ["summary", "thread"] {
+            let wrapped = app
+                .line_annotations
+                .iter()
+                .enumerate()
+                .filter(|(_, annotation)| match label {
+                    "summary" => {
+                        matches!(annotation, AnnotatedLine::RemoteReviewSummaryLine { .. })
+                    }
+                    "thread" => matches!(annotation, AnnotatedLine::RemoteThreadLine { .. }),
+                    _ => false,
+                })
+                .any(|(idx, _)| annotation_row_height(app, idx) > 1);
+            assert!(wrapped, "expected at least one remote {label} row to wrap");
+        }
+    }
+
     #[test]
     fn parity_unified_with_wrap() {
         let mut app = make_app();
@@ -650,6 +756,7 @@ mod tests {
         // second file, is fully visible and captured by `observed_heights`.
         render_diff(&mut app, DiffViewMode::Unified, 40, 200);
         assert_coverage(&app, DiffViewMode::Unified);
+        assert_remote_rows_wrap(&app);
         assert_parity(&app);
     }
 
@@ -659,6 +766,7 @@ mod tests {
         app.set_diff_wrap(true);
         render_diff(&mut app, DiffViewMode::SideBySide, 60, 200);
         assert_coverage(&app, DiffViewMode::SideBySide);
+        assert_remote_rows_wrap(&app);
         assert_parity(&app);
     }
 


### PR DESCRIPTION
Follow up to #450.

That PR made word wrap real: one logical diff line can now span multiple
screen rows. However, all scroll/cursor math still assumed 1 logical line
equals 1 screen row.

With wrapped lines on screen:

* `zz`/`zt`/`zb` center on the wrong row
* `G` overshoots
* PageUp/PageDown skip or repeat content
* comment navigator jumps land the viewport in the wrong place

## Fix

Introduce `ui/row_height.rs`. `annotation_row_height(app, idx)` mirrors the
renderers' wrap pass to compute the exact visual row count of one annotation
without rendering.

All jump functions are rewritten on top of a single primitive,
`scroll_offset_for_rows_above`, which walks backward from an anchor spending
a screen row budget. Page keys now convert their row budget into a logical
line count first.

To keep the height mirror from drifting:

* every row format string is extracted into shared builders in
  `ui/diff_view.rs`, the single source for both renderers and the height
  oracle
* parity tests render into a `TestBackend` and compare observed per
  annotation heights
* a coverage assert forces every `AnnotatedLine` variant to be exercised