### PR TITLE
chore(deps): bump edtui and remove comment about `cw/dw` limitation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,9 +636,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "edtui"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4941adefb4c21c4a8a5bece220a24dc28d1cbb5d1e5875be4a575d5d1da172a"
+checksum = "9131e0e4f053070d7dd0ae21012e8378aaf914d77db72f63bbed5f8f5810ad01"
 dependencies = [
  "crossterm",
  "edtui-jagged",

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -101,8 +101,7 @@ and the header shows a confirm hint. `Alt-Enter` (Option+Enter) accepts and
 `Enter`/`Esc` that reaches the app across terminals, including browser/web
 terminals like zellij web. `Tab` cycles the comment type in Normal
 mode and inserts `comment_tab_width` spaces (default 4) in Insert mode; `Ctrl-s`
-also saves. Operator+motion combos like
-`dw`/`cw` aren't supported (edtui limitation).
+also saves.
 
 ## Commands
 


### PR DESCRIPTION
- v0.11.4 supports the cw/dw motions
- v0.11.5 supports the dot-repeat motion
- v0.11.6 supports forward/till motions (`f`|`t`|`df`|`dt`|...) and paste before (`P`)