### PR TITLE
commit selector: toggle key, hidden cycling, and order/selection options

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -61,6 +61,8 @@ comment_type_prefix = true
 | `theme_dark` | (none) | Theme name for dark appearance (paired with `theme_light`). |
 | `theme_light` | (none) | Theme name for light appearance (paired with `theme_dark`). |
 | `diff_view` | `unified` | `unified` or `side-by-side`. Toggle in-app with `:diff`. |
+| `commit_order` | `descending` | Inline commit selector order: `descending` (newest on top, the default) or `ascending` (oldest on top). |
+| `initial_commit_selection` | `all` | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`. |
 | `ignore_whitespace` | `false` | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged. |
 | `show_file_list` | `true` | Whether the file list panel is visible on startup. Toggle with `<leader>e`. |
 | `mouse` | `true` | Wheel scrolling, clicks, and drag-to-select. |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -65,6 +65,7 @@ comment_type_prefix = true
 | `initial_commit_selection` | `all` | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`. |
 | `ignore_whitespace` | `false` | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged. |
 | `show_file_list` | `true` | Whether the file list panel is visible on startup. Toggle with `<leader>e`. |
+| `show_commits` | `true` | Whether the inline commit selector pane is visible on startup for multi-commit reviews. Toggle with `<leader>s` or `:set commits!`. |
 | `mouse` | `true` | Wheel scrolling, clicks, and drag-to-select. |
 | `leader` | `;` | Single-character prefix for panel focus, sidebar toggles, and review-comment shortcuts. Invalid multi-character values are ignored with a startup warning. |
 | `comment_vim` | `false` | Vim modal editing in the comment box; toggle at runtime with `:vim`. When off, default emacs/readline bindings. |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -56,6 +56,7 @@ Press `?` to open help.
 | `<leader>k` | Move focus up (comments to files, or diff/files to commit selector when visible) |
 | `<leader>j` | Move focus down (files to comments when visible, otherwise diff) |
 | `<leader>e` | Toggle file list visibility |
+| `<leader>s` | Toggle commit selector visibility (also `:set commits!`) |
 | `Enter` | Select file (when file list is focused) |
 
 ## Comment navigator

--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -1,6 +1,22 @@
 use super::*;
 
 impl App {
+    /// The commit-selection range a fresh multi-commit review opens with,
+    /// honoring the `initial_commit_selection` config. `review_commits` is stored
+    /// newest-first, so the oldest commit is the last index — that stays true
+    /// regardless of the `commit_order` display setting (which is presentation
+    /// only). Returns `None` for an empty list.
+    pub(in crate::app) fn initial_commit_range(
+        start: CommitSelectionStart,
+        n: usize,
+    ) -> Option<(usize, usize)> {
+        match (start, n) {
+            (_, 0) => None,
+            (CommitSelectionStart::Oldest, n) => Some((n - 1, n - 1)),
+            (CommitSelectionStart::All, n) => Some((0, n - 1)),
+        }
+    }
+
     pub(in crate::app) fn is_strict_commit_selection(
         range: Option<(usize, usize)>,
         total: usize,
@@ -38,13 +54,21 @@ impl App {
         let mut since_last_review_message = None;
         // Restore any persisted range scoped to this head SHA. If the
         // restored range exceeds the current commit count (e.g., the PR
-        // was rebased), fall back to "all". Only auto-scope to commits
-        // since last review when no explicit per-session range exists.
+        // was rebased), fall back to "all". A valid persisted range wins over
+        // both the `initial_commit_selection = oldest` opt-in and the
+        // since-last-review auto-scoping; `oldest` in turn takes precedence
+        // over since-last-review.
         if let Some(persisted) = self.session.commit_selection_range
             && persisted.1 < mapped.len()
             && persisted.0 <= persisted.1
         {
             range = persisted;
+        } else if self.commit_selection_start == CommitSelectionStart::Oldest {
+            if let Some(oldest) =
+                Self::initial_commit_range(CommitSelectionStart::Oldest, mapped.len())
+            {
+                range = oldest;
+            }
         } else if self.session.commit_selection_range.is_none()
             && let Some(selection) = since_last_review.as_ref()
         {
@@ -77,14 +101,39 @@ impl App {
             return None;
         }
         let rel = (screen_row - inner.y) as usize;
-        let idx = self.commit_list_scroll_offset + rel;
-        let total = match self.input_mode {
+        // Display row: the scroll offset is kept in display space for the
+        // inline pane (see the renderer), so this is the on-screen row index.
+        let display_idx = self.commit_list_scroll_offset + rel;
+        match self.input_mode {
             InputMode::CommitSelect => {
-                self.visible_commit_count + usize::from(self.can_show_more_commits())
+                let total = self.visible_commit_count + usize::from(self.can_show_more_commits());
+                (display_idx < total).then_some(display_idx)
             }
-            _ => self.review_commits.len(),
-        };
-        (idx < total).then_some(idx)
+            // Inline commit selector: map the display row back to a data index
+            // into `review_commits` (newest-first storage) for ascending order.
+            _ => {
+                let total = self.review_commits.len();
+                (display_idx < total).then_some(self.commit_data_index(display_idx))
+            }
+        }
+    }
+
+    /// Whether the inline commit selector renders oldest-first. Presentation
+    /// only — `review_commits` is always stored newest-first.
+    pub fn commits_ascending(&self) -> bool {
+        matches!(self.commit_order, CommitOrder::Ascending)
+    }
+
+    /// Convert between a data index into `review_commits` and its on-screen
+    /// display row (and back — the mapping is its own inverse). Identity in
+    /// descending order; mirrored (`n-1-i`) in ascending order.
+    pub fn commit_data_index(&self, index: usize) -> usize {
+        let n = self.review_commits.len();
+        if self.commits_ascending() && n > 0 {
+            n - 1 - index.min(n - 1)
+        } else {
+            index
+        }
     }
 
     /// Open the review target selector on a specific tab.
@@ -229,9 +278,27 @@ impl App {
 
     /// Whether the inline commit selector panel should be displayed.
     pub fn has_inline_commit_selector(&self) -> bool {
-        self.show_commit_selector
-            && self.review_commits.len() > 1
-            && !matches!(&self.diff_source, DiffSource::WorkingTree)
+        self.show_commit_selector && self.has_review_commits()
+    }
+
+    /// Whether the current review has a multi-commit selection that `(` / `)`
+    /// can cycle through. Unlike [`has_inline_commit_selector`], this ignores
+    /// pane visibility so cycling still works while the pane is hidden (the
+    /// status bar shows the `{n}/{total} commits` count as feedback).
+    pub fn has_review_commits(&self) -> bool {
+        self.review_commits.len() > 1 && !matches!(&self.diff_source, DiffSource::WorkingTree)
+    }
+
+    /// Toggle the inline commit selector's visibility. When hiding it while it
+    /// is focused, move focus back to the diff so input keeps flowing.
+    pub fn toggle_commit_selector(&mut self) {
+        let visible = !self.show_commit_selector;
+        self.show_commit_selector = visible;
+        if !visible && self.focused_panel == FocusedPanel::CommitSelector {
+            self.focused_panel = FocusedPanel::Diff;
+        }
+        let status = if visible { "visible" } else { "hidden" };
+        self.set_message(format!("Commit selector: {status}"));
     }
 
     // Commit selection methods
@@ -685,12 +752,10 @@ impl App {
         self.review_commits = selected_commits.iter().rev().cloned().collect();
         self.range_diff_files = Some(self.diff_files.clone());
         self.commit_list = self.review_commits.clone();
-        self.commit_list_cursor = 0;
-        self.commit_selection_range = if self.review_commits.is_empty() {
-            None
-        } else {
-            Some((0, self.review_commits.len() - 1))
-        };
+        let range =
+            Self::initial_commit_range(self.commit_selection_start, self.review_commits.len());
+        self.commit_selection_range = range;
+        self.commit_list_cursor = range.map(|(start, _)| start).unwrap_or(0);
         self.commit_list_scroll_offset = 0;
         self.visible_commit_count = self.review_commits.len();
         self.has_more_commit = false;
@@ -698,9 +763,16 @@ impl App {
         self.commit_diff_cache.clear();
         self.saved_inline_selection = None;
 
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        // `initial_commit_selection = oldest` opens scoped to a single commit; narrow
+        // the loaded diff to it. Otherwise finalize the full-range diff.
+        if Self::is_strict_commit_selection(self.commit_selection_range, self.review_commits.len())
+        {
+            self.reload_inline_selection()?;
+        } else {
+            self.sort_files_by_directory(true);
+            self.expand_all_dirs();
+            self.rebuild_annotations();
+        }
 
         Ok(())
     }

--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -136,6 +136,29 @@ impl App {
         }
     }
 
+    /// Status-bar description of the current inline commit selection, or `None`
+    /// when the whole range is selected (the caller shows the plain total).
+    /// A single selected commit reports its 1-based display position — so the
+    /// value changes as `(` / `)` cycle — while a multi-commit subrange reports
+    /// the selected count.
+    pub fn commit_selection_summary(&self) -> Option<String> {
+        let total = self.review_commits.len();
+        let (start, end) = self.commit_selection_range?;
+        let selected = end.saturating_sub(start) + 1;
+        if total <= 1 || selected >= total {
+            return None;
+        }
+        if start == end {
+            Some(format!(
+                "commit {}/{}",
+                self.commit_data_index(start) + 1,
+                total
+            ))
+        } else {
+            Some(format!("{selected} of {total} commits"))
+        }
+    }
+
     /// Open the review target selector on a specific tab.
     ///
     /// `Local` loads the recent-commits list (same as the historical commit

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -671,12 +671,10 @@ impl App {
         self.review_commits = selected_commits.into_iter().rev().collect();
         self.range_diff_files = Some(self.diff_files.clone());
         self.commit_list = self.review_commits.clone();
-        self.commit_list_cursor = 0;
-        self.commit_selection_range = if self.review_commits.is_empty() {
-            None
-        } else {
-            Some((0, self.review_commits.len() - 1))
-        };
+        let range =
+            Self::initial_commit_range(self.commit_selection_start, self.review_commits.len());
+        self.commit_selection_range = range;
+        self.commit_list_cursor = range.map(|(start, _)| start).unwrap_or(0);
         self.commit_list_scroll_offset = 0;
         self.visible_commit_count = self.review_commits.len();
         self.has_more_commit = false;
@@ -684,10 +682,17 @@ impl App {
         self.commit_diff_cache.clear();
         self.saved_inline_selection = None;
 
-        self.insert_commit_message_if_single();
-        self.sort_files_by_directory(true);
-        self.expand_all_dirs();
-        self.rebuild_annotations();
+        // `initial_commit_selection = oldest` opens scoped to a single commit; narrow
+        // the loaded diff to it. Otherwise finalize the full-range diff.
+        if Self::is_strict_commit_selection(self.commit_selection_range, self.review_commits.len())
+        {
+            self.reload_inline_selection()?;
+        } else {
+            self.insert_commit_message_if_single();
+            self.sort_files_by_directory(true);
+            self.expand_all_dirs();
+            self.rebuild_annotations();
+        }
         Ok(())
     }
 }

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -17,6 +17,7 @@ impl App {
                 output_to_stdout,
                 target,
                 options.repo_url_override.clone(),
+                options.commit_selection,
             );
         }
 
@@ -198,22 +199,28 @@ impl App {
 
                 app.range_diff_files = Some(app.diff_files.clone());
                 app.commit_list = all_commits.clone();
-                app.commit_list_cursor = 0;
-                app.commit_selection_range = if all_commits.is_empty() {
-                    None
-                } else {
-                    Some((0, all_commits.len() - 1))
-                };
+                let range = Self::initial_commit_range(options.commit_selection, all_commits.len());
+                app.commit_selection_range = range;
+                app.commit_list_cursor = range.map(|(start, _)| start).unwrap_or(0);
                 app.commit_list_scroll_offset = 0;
                 app.visible_commit_count = all_commits.len();
                 app.has_more_commit = false;
                 app.show_commit_selector = all_commits.len() > 1;
                 app.commit_diff_cache.clear();
                 app.review_commits = all_commits;
-                app.insert_commit_message_if_single();
-                app.sort_files_by_directory(true);
-                app.expand_all_dirs();
-                app.rebuild_annotations();
+                // `initial_commit_selection = oldest` scopes the review to a single
+                // commit; narrow the loaded diff to it.
+                if Self::is_strict_commit_selection(
+                    app.commit_selection_range,
+                    app.review_commits.len(),
+                ) {
+                    app.reload_inline_selection()?;
+                } else {
+                    app.insert_commit_message_if_single();
+                    app.sort_files_by_directory(true);
+                    app.expand_all_dirs();
+                    app.rebuild_annotations();
+                }
 
                 return Ok(app);
             }
@@ -255,8 +262,10 @@ impl App {
             if review_commits.len() > 1 {
                 app.range_diff_files = Some(app.diff_files.clone());
                 app.commit_list = review_commits.clone();
-                app.commit_list_cursor = 0;
-                app.commit_selection_range = Some((0, review_commits.len() - 1));
+                let range =
+                    Self::initial_commit_range(options.commit_selection, review_commits.len());
+                app.commit_selection_range = range;
+                app.commit_list_cursor = range.map(|(start, _)| start).unwrap_or(0);
                 app.commit_list_scroll_offset = 0;
                 app.visible_commit_count = review_commits.len();
                 app.has_more_commit = false;
@@ -264,10 +273,20 @@ impl App {
                 app.commit_diff_cache.clear();
             }
             app.review_commits = review_commits;
-            app.insert_commit_message_if_single();
-            app.sort_files_by_directory(true);
-            app.expand_all_dirs();
-            app.rebuild_annotations();
+            // `initial_commit_selection = oldest` opens the review scoped to a single
+            // commit; narrow the loaded diff to it. Otherwise finalize the
+            // full-range diff already loaded above.
+            if Self::is_strict_commit_selection(
+                app.commit_selection_range,
+                app.review_commits.len(),
+            ) {
+                app.reload_inline_selection()?;
+            } else {
+                app.insert_commit_message_if_single();
+                app.sort_files_by_directory(true);
+                app.expand_all_dirs();
+                app.rebuild_annotations();
+            }
 
             Ok(app)
         } else if options.working_tree {
@@ -532,6 +551,8 @@ impl App {
             pr_range_reload_state: None,
             pr_range_reload_rx: None,
             show_commit_selector: false,
+            commit_order: CommitOrder::default(),
+            commit_selection_start: CommitSelectionStart::default(),
             commit_diff_cache: HashMap::new(),
             range_diff_files: None,
             saved_inline_selection: None,
@@ -730,6 +751,7 @@ impl App {
         output_to_stdout: bool,
         target: &str,
         repo_url_override: Option<ForgeRepository>,
+        commit_selection: CommitSelectionStart,
     ) -> Result<Self> {
         use crate::forge::github::gh::parse_pull_request_target;
         use crate::forge::gitlab::glab::parse_pull_request_target_gitlab;
@@ -840,6 +862,7 @@ impl App {
         // the user came straight from CLI into PR diff mode).
         app.canonical_resolved = true;
         app.current_pr_head = Some(details_for_threads.head_sha.clone());
+        app.commit_selection_start = commit_selection;
         let since_last_review_message =
             app.apply_pr_commit_selector(commits_for_selector, review_metadata);
         if matches!(&app.diff_source, DiffSource::PullRequest(_))

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -923,6 +923,28 @@ pub enum DiffViewMode {
     SideBySide,
 }
 
+/// Display order for the inline commit selector. The stored `review_commits`
+/// list is always newest-first; this only flips presentation (render + input
+/// mapping), never the underlying data model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CommitOrder {
+    /// Newest commit at the top (the historical default).
+    #[default]
+    Descending,
+    /// Oldest commit at the top.
+    Ascending,
+}
+
+/// Which commits are selected when a multi-commit review first opens.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CommitSelectionStart {
+    /// Select the whole range (the historical default).
+    #[default]
+    All,
+    /// Select only the oldest commit, for a walk-forward per-commit review.
+    Oldest,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MessageType {
     Info,
@@ -1239,6 +1261,10 @@ pub struct App {
     pub pr_range_reload_rx: Option<std::sync::mpsc::Receiver<PrRangeReloadEvent>>,
     /// Whether the inline commit selector panel is visible
     pub show_commit_selector: bool,
+    /// Display order for the inline commit selector (presentation only).
+    pub commit_order: CommitOrder,
+    /// Which commits are selected when a multi-commit review first opens.
+    pub commit_selection_start: CommitSelectionStart,
     /// Cached individual/subrange diffs keyed by (start_idx, end_idx) into review_commits
     pub commit_diff_cache: HashMap<(usize, usize), Vec<DiffFile>>,
     /// The combined "all selected" diff, cached for quick restoration
@@ -1446,6 +1472,8 @@ pub struct AppStartupOptions<'a> {
     pub all_files: bool,
     pub git_backend_preference: GitBackendPreference,
     pub diff_whitespace_mode: DiffWhitespaceMode,
+    /// Which commits are selected when a multi-commit review first opens.
+    pub commit_selection: CommitSelectionStart,
     /// Direct PR target (`tuicr pr <target>`). Mutually exclusive with the
     /// other selectors above; the binary validates that before reaching here.
     pub pr_target: Option<&'a str>,

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -130,3 +130,94 @@ fn toggle_commit_selection_keeps_partial_range_shrink_behavior() {
 
     assert_eq!(app.commit_selection_range, Some((1, 1)));
 }
+
+#[test]
+fn initial_commit_range_all_selects_full_span() {
+    assert_eq!(
+        App::initial_commit_range(CommitSelectionStart::All, 4),
+        Some((0, 3))
+    );
+}
+
+#[test]
+fn initial_commit_range_oldest_selects_last_index() {
+    // review_commits is stored newest-first, so the oldest commit is the last
+    // index regardless of the display order.
+    assert_eq!(
+        App::initial_commit_range(CommitSelectionStart::Oldest, 4),
+        Some((3, 3))
+    );
+}
+
+#[test]
+fn initial_commit_range_empty_is_none() {
+    assert_eq!(
+        App::initial_commit_range(CommitSelectionStart::Oldest, 0),
+        None
+    );
+    assert_eq!(
+        App::initial_commit_range(CommitSelectionStart::All, 0),
+        None
+    );
+}
+
+#[test]
+fn commit_data_index_is_identity_when_descending() {
+    let mut app = build_app(vec![
+        normal_commit("a"),
+        normal_commit("b"),
+        normal_commit("c"),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_order = CommitOrder::Descending;
+    for i in 0..3 {
+        assert_eq!(app.commit_data_index(i), i);
+    }
+}
+
+#[test]
+fn commit_data_index_mirrors_and_round_trips_when_ascending() {
+    let mut app = build_app(vec![
+        normal_commit("a"),
+        normal_commit("b"),
+        normal_commit("c"),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_order = CommitOrder::Ascending;
+    assert_eq!(app.commit_data_index(0), 2);
+    assert_eq!(app.commit_data_index(2), 0);
+    // The mapping is its own inverse (data <-> display row).
+    for i in 0..3 {
+        assert_eq!(app.commit_data_index(app.commit_data_index(i)), i);
+    }
+}
+
+#[test]
+fn toggle_commit_selector_flips_visibility_and_drops_focus() {
+    let mut app = build_app(vec![normal_commit("a"), normal_commit("b")]);
+    app.show_commit_selector = true;
+    app.focused_panel = FocusedPanel::CommitSelector;
+
+    app.toggle_commit_selector();
+    assert!(!app.show_commit_selector);
+    // Hiding the focused pane returns focus to the diff.
+    assert_eq!(app.focused_panel, FocusedPanel::Diff);
+
+    app.toggle_commit_selector();
+    assert!(app.show_commit_selector);
+}
+
+#[test]
+fn has_review_commits_ignores_visibility_but_requires_multiple_non_worktree() {
+    let mut app = build_app(vec![normal_commit("a"), normal_commit("b")]);
+    app.review_commits = app.commit_list.clone();
+    app.diff_source = DiffSource::CommitRange(vec!["a".to_string(), "b".to_string()]);
+
+    app.show_commit_selector = false;
+    assert!(app.has_review_commits());
+    assert!(!app.has_inline_commit_selector());
+
+    // Working-tree reviews never cycle commits.
+    app.diff_source = DiffSource::WorkingTree;
+    assert!(!app.has_review_commits());
+}

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -221,3 +221,51 @@ fn has_review_commits_ignores_visibility_but_requires_multiple_non_worktree() {
     app.diff_source = DiffSource::WorkingTree;
     assert!(!app.has_review_commits());
 }
+
+#[test]
+fn commit_selection_summary_shows_position_for_single_and_count_for_range() {
+    let mut app = build_app(vec![
+        normal_commit("a"),
+        normal_commit("b"),
+        normal_commit("c"),
+    ]);
+    app.review_commits = app.commit_list.clone();
+
+    // Whole range selected -> no summary (caller shows the plain total).
+    app.commit_selection_range = Some((0, 2));
+    assert_eq!(app.commit_selection_summary(), None);
+
+    // Single commit, descending: position == data index + 1, so cycling moves it.
+    app.commit_order = CommitOrder::Descending;
+    app.commit_selection_range = Some((0, 0));
+    assert_eq!(
+        app.commit_selection_summary().as_deref(),
+        Some("commit 1/3")
+    );
+    app.commit_selection_range = Some((2, 2));
+    assert_eq!(
+        app.commit_selection_summary().as_deref(),
+        Some("commit 3/3")
+    );
+
+    // Single commit, ascending: display position is mirrored (top row == 1).
+    app.commit_order = CommitOrder::Ascending;
+    app.commit_selection_range = Some((0, 0)); // newest -> bottom row
+    assert_eq!(
+        app.commit_selection_summary().as_deref(),
+        Some("commit 3/3")
+    );
+    app.commit_selection_range = Some((2, 2)); // oldest -> top row
+    assert_eq!(
+        app.commit_selection_summary().as_deref(),
+        Some("commit 1/3")
+    );
+
+    // Multi-commit subrange -> selected count.
+    app.commit_order = CommitOrder::Descending;
+    app.commit_selection_range = Some((0, 1));
+    assert_eq!(
+        app.commit_selection_summary().as_deref(),
+        Some("2 of 3 commits")
+    );
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,6 +44,10 @@ pub struct AppConfig {
     pub backend: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
+    /// Whether the inline commit selector pane is visible on startup for
+    /// multi-commit reviews. Defaults to true; toggle at runtime with
+    /// `<leader>s` or `:set commits!`.
+    pub show_commits: Option<bool>,
     pub diff_view: Option<String>,
     /// Inline commit selector display order: `"descending"` (newest-first,
     /// the default) or `"ascending"` (oldest-first).
@@ -90,6 +94,7 @@ const KNOWN_KEYS: &[&str] = &[
     "backend",
     "comment_types",
     "show_file_list",
+    "show_commits",
     "diff_view",
     "commit_order",
     "initial_commit_selection",
@@ -298,6 +303,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             .get("comment_types")
             .and_then(|v| parse_comment_types(v, &mut warnings)),
         show_file_list: read_bool(table, "show_file_list", &mut warnings),
+        show_commits: read_bool(table, "show_commits", &mut warnings),
         diff_view: read_enum(
             table,
             "diff_view",
@@ -730,6 +736,28 @@ mod tests {
         let outcome = parse_config("show_file_list = \"no\"\n");
         assert_eq!(
             outcome.config.as_ref().and_then(|cfg| cfg.show_file_list),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+    }
+
+    // show_commits
+
+    #[test]
+    fn should_parse_show_commits_false() {
+        let outcome = parse_config("show_commits = false\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.show_commits),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_show_commits_with_invalid_type() {
+        let outcome = parse_config("show_commits = \"no\"\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.show_commits),
             None
         );
         assert_eq!(outcome.warnings.len(), 1);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -45,6 +45,13 @@ pub struct AppConfig {
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
     pub diff_view: Option<String>,
+    /// Inline commit selector display order: `"descending"` (newest-first,
+    /// the default) or `"ascending"` (oldest-first).
+    pub commit_order: Option<String>,
+    /// Which commits are selected when a multi-commit review first opens:
+    /// `"all"` (the default) or `"oldest"` (only the oldest commit, for a
+    /// walk-forward per-commit review).
+    pub initial_commit_selection: Option<String>,
     pub ignore_whitespace: Option<bool>,
     pub wrap: Option<bool>,
     pub export_legend: Option<bool>,
@@ -84,6 +91,8 @@ const KNOWN_KEYS: &[&str] = &[
     "comment_types",
     "show_file_list",
     "diff_view",
+    "commit_order",
+    "initial_commit_selection",
     "ignore_whitespace",
     "wrap",
     "export_legend",
@@ -293,6 +302,18 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             table,
             "diff_view",
             &["unified", "side-by-side"],
+            &mut warnings,
+        ),
+        commit_order: read_enum(
+            table,
+            "commit_order",
+            &["descending", "ascending"],
+            &mut warnings,
+        ),
+        initial_commit_selection: read_enum(
+            table,
+            "initial_commit_selection",
+            &["all", "oldest"],
             &mut warnings,
         ),
         ignore_whitespace: read_bool(table, "ignore_whitespace", &mut warnings),
@@ -740,6 +761,62 @@ mod tests {
             Some("unified")
         );
         assert!(outcome.warnings.is_empty());
+    }
+
+    // commit_order / initial_commit_selection
+
+    #[test]
+    fn should_parse_commit_order_ascending() {
+        let outcome = parse_config("commit_order = \"ascending\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.commit_order.as_deref()),
+            Some("ascending")
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_commit_order_with_invalid_value() {
+        let outcome = parse_config("commit_order = \"sideways\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.commit_order.as_deref()),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(outcome.warnings[0].contains("\"descending\" or \"ascending\""));
+    }
+
+    #[test]
+    fn should_parse_initial_commit_selection_oldest() {
+        let outcome = parse_config("initial_commit_selection = \"oldest\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.initial_commit_selection.as_deref()),
+            Some("oldest")
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_initial_commit_selection_with_invalid_value() {
+        let outcome = parse_config("initial_commit_selection = \"newest\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.initial_commit_selection.as_deref()),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(outcome.warnings[0].contains("\"all\" or \"oldest\""));
     }
 
     #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -277,6 +277,15 @@ pub fn clear_visual_if_cursor_offscreen(app: &mut App) {
 /// The list is short and selection-oriented, so each tick moves the cursor
 /// rather than the viewport, matching how arrow keys behave.
 fn wheel_commit_list(app: &mut App, scroll_up: bool) {
+    // Match screen direction: the inline pane (Normal mode) reverses its
+    // display in ascending order, so wheel-up moves toward newer (lower) data
+    // indices there. The full-screen picker (CommitSelect) is always
+    // newest-first.
+    let scroll_up = if app.input_mode == InputMode::Normal && app.commits_ascending() {
+        !scroll_up
+    } else {
+        scroll_up
+    };
     for _ in 0..WHEEL_LINES {
         if scroll_up {
             app.commit_select_up();
@@ -798,7 +807,7 @@ fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
             CommandAfterDispatch::ExitCommandMode
         }
         CommandKind::ToggleCommits => {
-            set_commit_selector_visible(app, !app.show_commit_selector);
+            app.toggle_commit_selector();
             CommandAfterDispatch::ExitCommandMode
         }
         CommandKind::Diff => {
@@ -1206,8 +1215,23 @@ fn handle_pr_filter_action(app: &mut App, action: Action) {
 /// Handle actions when inline commit selector panel is focused
 pub fn handle_commit_selector_action(app: &mut App, action: Action) {
     match action {
-        Action::CursorDown(_) => app.commit_select_down(),
-        Action::CursorUp(_) => app.commit_select_up(),
+        // `j`/`k` track screen direction: in ascending (oldest-first) order the
+        // display is reversed, so moving down the screen moves toward newer
+        // (lower) data indices.
+        Action::CursorDown(_) => {
+            if app.commits_ascending() {
+                app.commit_select_up();
+            } else {
+                app.commit_select_down();
+            }
+        }
+        Action::CursorUp(_) => {
+            if app.commits_ascending() {
+                app.commit_select_down();
+            } else {
+                app.commit_select_up();
+            }
+        }
         // Toggle + auto-advance so repeated presses sweep a contiguous run.
         Action::ToggleExpand | Action::ToggleCommitSelect | Action::SelectFile => {
             app.toggle_commit_selection_and_advance();
@@ -1507,14 +1531,25 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 app.set_message("Move cursor to a diff line to start visual selection");
             }
         }
-        Action::CycleCommitNext if app.has_inline_commit_selector() => {
-            app.cycle_commit_next();
+        // `(` moves toward the top row, `)` toward the bottom row. The cycle
+        // methods walk data indices (newest-first), so ascending display order
+        // swaps which one runs to keep the on-screen direction stable.
+        Action::CycleCommitNext if app.has_review_commits() => {
+            if app.commits_ascending() {
+                app.cycle_commit_prev();
+            } else {
+                app.cycle_commit_next();
+            }
             if let Err(e) = app.reload_inline_selection_for_source() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }
-        Action::CycleCommitPrev if app.has_inline_commit_selector() => {
-            app.cycle_commit_prev();
+        Action::CycleCommitPrev if app.has_review_commits() => {
+            if app.commits_ascending() {
+                app.cycle_commit_next();
+            } else {
+                app.cycle_commit_prev();
+            }
             if let Err(e) = app.reload_inline_selection_for_source() {
                 app.set_error(format!("Failed to load diff: {e}"));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,14 @@ fn main() -> anyhow::Result<()> {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
+        // Start with the commit selector pane hidden. `(` / `)` still cycle the
+        // selected commit while hidden; `<leader>s` / `:set commits!` reveal it.
+        if cfg.show_commits == Some(false) {
+            app.show_commit_selector = false;
+            if app.focused_panel == FocusedPanel::CommitSelector {
+                app.focused_panel = FocusedPanel::Diff;
+            }
+        }
         // Pristine mode has no diff, so side-by-side would render two
         // identical panes. Honor the config for every other mode.
         if cfg.diff_view.as_deref() == Some("side-by-side") && !app.is_pristine_mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,23 @@ fn main() -> anyhow::Result<()> {
         DiffWhitespaceMode::Normal
     };
 
+    let commit_order = match config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.commit_order.as_deref())
+    {
+        Some("ascending") => app::CommitOrder::Ascending,
+        _ => app::CommitOrder::Descending,
+    };
+    let commit_selection = match config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.initial_commit_selection.as_deref())
+    {
+        Some("oldest") => app::CommitSelectionStart::Oldest,
+        _ => app::CommitSelectionStart::All,
+    };
+
     let mut app = match profile::time("startup.app_init", || {
         App::new(
             theme,
@@ -163,6 +180,7 @@ fn main() -> anyhow::Result<()> {
                 all_files: cli_args.all_files,
                 git_backend_preference,
                 diff_whitespace_mode,
+                commit_selection,
                 pr_target: cli_args.pr_target.as_deref(),
                 repo_url_override: cli_args
                     .repo_url
@@ -216,6 +234,12 @@ fn main() -> anyhow::Result<()> {
             std::process::exit(1);
         }
     };
+
+    // Commit selector presentation/behavior prefs. `initial_commit_selection`
+    // also fed `App::new` for the initial `-r`/PR range; keep it on the app so
+    // re-selections during the session (target selector, PR reload) honor it.
+    app.commit_order = commit_order;
+    app.commit_selection_start = commit_selection;
 
     if let Err(e) = app.ensure_ephemeral_session_file() {
         startup_warnings.push(format!("Failed to initialize review session file: {e}"));
@@ -522,6 +546,11 @@ fn main() -> anyhow::Result<()> {
                             }
                             crossterm::event::KeyCode::Char('c') => {
                                 app.enter_review_comment_mode();
+                                continue;
+                            }
+                            // `<leader>s` toggles the commit selector pane.
+                            crossterm::event::KeyCode::Char('s') => {
+                                app.toggle_commit_selector();
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('f') => {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -149,6 +149,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                format!("  {}s        ", app.leader_key),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Toggle commit selector visibility (also `:set commits!`)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 format!("  {}f        ", app.leader_key),
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/inline_commit_selector.rs
+++ b/src/ui/inline_commit_selector.rs
@@ -25,7 +25,9 @@ pub(super) fn render_inline_commit_selector(frame: &mut Frame, app: &mut App, ar
     app.commit_list_viewport_height = inner.height as usize;
     app.commit_list_inner_area = Some(inner);
 
-    let items: Vec<Line> = app
+    // Rows are built in data order (index into newest-first `review_commits`),
+    // then reversed for ascending display so the oldest commit sits on top.
+    let mut items: Vec<Line> = app
         .review_commits
         .iter()
         .enumerate()
@@ -40,10 +42,31 @@ pub(super) fn render_inline_commit_selector(frame: &mut Frame, app: &mut App, ar
         })
         .collect();
 
+    let height = inner.height as usize;
+    let n = app.review_commits.len();
+    if app.commits_ascending() {
+        items.reverse();
+        // The renderer owns the scroll offset in display space for ascending
+        // order (descending order lets commit_select_up/down maintain it):
+        // clamp it so the cursor's display row stays visible.
+        if n > 0 && height > 0 {
+            let cursor_row = app.commit_data_index(app.commit_list_cursor);
+            let offset = app.commit_list_scroll_offset;
+            let offset = if cursor_row < offset {
+                cursor_row
+            } else if cursor_row >= offset + height {
+                cursor_row + 1 - height
+            } else {
+                offset
+            };
+            app.commit_list_scroll_offset = offset.min(n.saturating_sub(1));
+        }
+    }
+
     let visible_items: Vec<Line> = items
         .into_iter()
         .skip(app.commit_list_scroll_offset)
-        .take(inner.height as usize)
+        .take(height)
         .collect();
 
     frame.render_widget(

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -170,12 +170,10 @@ fn header_source_chunk(app: &App) -> Option<String> {
             if commits.len() == 1 {
                 Some(format!("commit {}", &commits[0][..7.min(commits[0].len())]))
             } else {
-                match app.commit_selection_range {
-                    Some((start, end)) if end - start + 1 < app.review_commits.len() => Some(
-                        format!("{}/{} commits", end - start + 1, app.review_commits.len()),
-                    ),
-                    _ => Some(format!("{} commits", commits.len())),
-                }
+                Some(
+                    app.commit_selection_summary()
+                        .unwrap_or_else(|| format!("{} commits", commits.len())),
+                )
             }
         }
         DiffSource::StagedUnstagedAndCommits(commits) => {
@@ -200,14 +198,10 @@ fn header_source_chunk(app: &App) -> Option<String> {
                 "{slug}#{number} \u{00b7} {trimmed_title}",
                 number = pr.key.number
             );
-            let total = app.pr_commits.len();
-            if total > 1
-                && let Some((start, end)) = app.commit_selection_range
+            if app.pr_commits.len() > 1
+                && let Some(summary) = app.commit_selection_summary()
             {
-                let selected = end - start + 1;
-                if selected < total {
-                    s.push_str(&format!(" \u{00b7} {selected} of {total} commits"));
-                }
+                s.push_str(&format!(" \u{00b7} {summary}"));
             }
             Some(s)
         }
@@ -721,19 +715,47 @@ mod pr_header_snapshot_tests {
 
     #[test]
     fn should_render_n_of_m_commits_when_subset_selected() {
-        // given a 3-commit PR with the middle commit selected
+        // given a 3-commit PR with a two-commit subrange selected
         let mut app = build_pr_app(pr_source(false, false));
         app.pr_commits = vec![
             fake_pr_commit("aaaaaaa1", "third"),
             fake_pr_commit("bbbbbbb2", "second"),
             fake_pr_commit("ccccccc3", "first"),
         ];
+        app.review_commits = app
+            .pr_commits
+            .iter()
+            .map(crate::app::pr_commit_to_commit_info)
+            .collect();
+        app.commit_selection_range = Some((0, 1));
+        // when
+        let buffer = draw_header(&app);
+        // then
+        let line = row_text(&buffer, 0);
+        assert!(line.contains("2 of 3 commits"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_render_commit_position_when_single_commit_selected() {
+        // given a 3-commit PR with a single commit selected, the header shows
+        // its position (not "1 of 3") so it changes as ( / ) cycle.
+        let mut app = build_pr_app(pr_source(false, false));
+        app.pr_commits = vec![
+            fake_pr_commit("aaaaaaa1", "third"),
+            fake_pr_commit("bbbbbbb2", "second"),
+            fake_pr_commit("ccccccc3", "first"),
+        ];
+        app.review_commits = app
+            .pr_commits
+            .iter()
+            .map(crate::app::pr_commit_to_commit_info)
+            .collect();
         app.commit_selection_range = Some((1, 1));
         // when
         let buffer = draw_header(&app);
         // then
         let line = row_text(&buffer, 0);
-        assert!(line.contains("1 of 3 commits"), "got: {line:?}");
+        assert!(line.contains("commit 2/3"), "got: {line:?}");
     }
 
     #[test]


### PR DESCRIPTION
Improvements to the inline commit selector for multi-commit reviews:

- `<leader>s` toggles the pane (alongside `:set commits!`), and `( / )` keep cycling the selected commit while it is hidden.
- `show_commits = false` starts with the pane hidden, paralleling `show_file_list`.
- `commit_order = ascending` renders the pane oldest-first (presentation only; selection, persistence and since-last-review logic untouched).
- `commit_selection = oldest` opens the review scoped to the oldest commit for a walk-forward per-commit review.
- The status bar now shows the selected commit's position (e.g. `commit 2/3`) instead of a constant `1/N` when a single commit is selected.