### PR TITLE
feat: add show_commits config to control commit selector visibility on startup

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,6 +27,7 @@ theme_light = "gruvbox-light"
 diff_view = "side-by-side"
 ignore_whitespace = false
 show_file_list = true
+show_commits = true
 mouse = true
 leader = ","
 comment_vim = false
@@ -63,6 +64,7 @@ comment_type_prefix = true
 | `diff_view` | `unified` | `unified` or `side-by-side`. Toggle in-app with `:diff`. |
 | `ignore_whitespace` | `false` | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged. |
 | `show_file_list` | `true` | Whether the file list panel is visible on startup. Toggle with `<leader>e`. |
+| `show_commits` | (auto) | Whether the commit selector panel is shown on startup. Unset shows it automatically for multi-commit reviews. Toggle with `:set commits` / `:set nocommits` / `:set commits!`. |
 | `mouse` | `true` | Wheel scrolling, clicks, and drag-to-select. |
 | `leader` | `;` | Single-character prefix for panel focus, sidebar toggles, and review-comment shortcuts. Invalid multi-character values are ignored with a startup warning. |
 | `comment_vim` | `false` | Vim modal editing in the comment box; toggle at runtime with `:vim`. When off, default emacs/readline bindings. |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,6 +44,7 @@ pub struct AppConfig {
     pub backend: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
+    pub show_commits: Option<bool>,
     pub diff_view: Option<String>,
     pub ignore_whitespace: Option<bool>,
     pub wrap: Option<bool>,
@@ -83,6 +84,7 @@ const KNOWN_KEYS: &[&str] = &[
     "backend",
     "comment_types",
     "show_file_list",
+    "show_commits",
     "diff_view",
     "ignore_whitespace",
     "wrap",
@@ -289,6 +291,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             .get("comment_types")
             .and_then(|v| parse_comment_types(v, &mut warnings)),
         show_file_list: read_bool(table, "show_file_list", &mut warnings),
+        show_commits: read_bool(table, "show_commits", &mut warnings),
         diff_view: read_enum(
             table,
             "diff_view",
@@ -709,6 +712,28 @@ mod tests {
         let outcome = parse_config("show_file_list = \"no\"\n");
         assert_eq!(
             outcome.config.as_ref().and_then(|cfg| cfg.show_file_list),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+    }
+
+    // show_commits
+
+    #[test]
+    fn should_parse_show_commits_false() {
+        let outcome = parse_config("show_commits = false\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.show_commits),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_show_commits_with_invalid_type() {
+        let outcome = parse_config("show_commits = \"no\"\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.show_commits),
             None
         );
         assert_eq!(outcome.warnings.len(), 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,11 @@ fn main() -> anyhow::Result<()> {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
+        // Force the commit selector open/closed on startup when configured;
+        // unset preserves the >1-commit auto-default from App::new.
+        if let Some(show_commits) = cfg.show_commits {
+            app.show_commit_selector = show_commits;
+        }
         // Pristine mode has no diff, so side-by-side would render two
         // identical panes. Honor the config for every other mode.
         if cfg.diff_view.as_deref() == Some("side-by-side") && !app.is_pristine_mode {


### PR DESCRIPTION
## Description

Adds an optional `show_commits` config key mirroring `show_file_list`, controlling whether the commit selector panel is shown on startup.

- unset → current behavior: auto-shown for multi-commit reviews (>1 commit)
- false → starts collapsed
- true → starts open

Applied in the same startup config block as show_file_list in main.rs. Runtime toggles (`:set commits` / `:set nocommits` / `:set commits!`) are unchanged. Documented in `docs/CONFIG.md` with parse tests added.

## Rationale

I work on a 14 inch MacBook, and I typically review lots of commits at once. The file tree helps flow, the commit panel does not (I already know the scope I'm reviewing) and it takes valuable vertical space. I don't want to change the default setting, but I would love to have a config I can change so I don't have to run `:set nocommits` every time I open `tuicr`.