### PR TITLE
Add diff comment navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `g` / `G` | Top / bottom |
 | `{` / `}` | Previous / next file |
 | `[` / `]` | Previous / next hunk |
+| `m` / `M` | Next / previous comment |
 | `/` | Search the diff, or search help while help is open (case-insensitive) |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -19,6 +19,7 @@ Full reference. Press `?` inside tuicr for an in-app version of this list.
 | `{N}{motion}` | Vim-style count prefix — repeats `j` / `k` / `h` / `l` / `{` / `}` / `[` / `]` `N` times |
 | `{` / `}` | Jump to previous / next file |
 | `[` / `]` | Jump to previous / next hunk |
+| `m` / `M` | Jump to next / previous comment |
 | `/` | Search within diff (case-insensitive) |
 | `n` / `N` | Next / previous search match |
 | `Enter` | Expand or collapse hidden context between hunks |

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -238,10 +238,70 @@ impl App {
             self.set_message("No comments to navigate");
             return false;
         };
+        let file_idx = item.path.as_deref().and_then(|path| {
+            self.diff_files
+                .iter()
+                .position(|file| file.display_path() == Path::new(path))
+        });
         self.move_cursor_to_annotation(item.target_annotation);
+        if let Some(file_idx) = file_idx {
+            let file_changed = self.diff_state.current_file_idx != file_idx;
+            self.diff_state.current_file_idx = file_idx;
+            if self.is_single_file_view && file_changed {
+                self.rebuild_annotations();
+            }
+        }
         self.center_cursor();
         self.focused_panel = FocusedPanel::Diff;
         true
+    }
+
+    pub fn next_comment(&mut self) {
+        let items = self.build_comment_navigator_items();
+        if items.is_empty() {
+            self.set_message("No comments");
+            return;
+        }
+
+        let cursor = self
+            .diff_state
+            .cursor_line
+            .min(self.line_annotations.len().saturating_sub(1));
+        let target_idx = items
+            .iter()
+            .position(|item| item.target_annotation > cursor)
+            .unwrap_or(0);
+
+        self.comment_navigator_state.select(target_idx);
+        self.jump_to_selected_comment();
+        self.set_message(format!("Comment {}/{}", target_idx + 1, items.len()));
+    }
+
+    pub fn prev_comment(&mut self) {
+        let items = self.build_comment_navigator_items();
+        if items.is_empty() {
+            self.set_message("No comments");
+            return;
+        }
+
+        let cursor = self
+            .diff_state
+            .cursor_line
+            .min(self.line_annotations.len().saturating_sub(1));
+        let current_key = self
+            .line_annotations
+            .get(cursor)
+            .and_then(Self::comment_navigator_key);
+        let target_idx = items
+            .iter()
+            .rposition(|item| {
+                item.target_annotation < cursor && Some(&item.key) != current_key.as_ref()
+            })
+            .unwrap_or(items.len() - 1);
+
+        self.comment_navigator_state.select(target_idx);
+        self.jump_to_selected_comment();
+        self.set_message(format!("Comment {}/{}", target_idx + 1, items.len()));
     }
 
     /// True when the cursor sits on a local comment whose lifecycle state

--- a/src/app/tests/expand_gap_tests.rs
+++ b/src/app/tests/expand_gap_tests.rs
@@ -134,6 +134,160 @@ fn hunk_diff_line(app: &App, file_idx: usize, hunk_idx: usize) -> usize {
 }
 
 #[test]
+fn should_cycle_forward_through_review_file_and_line_comments() {
+    let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+    let mut app = build_app_with_files(vec![file], 20);
+    app.diff_state.viewport_height = 4;
+    app.session.review_comments.push(Comment::new(
+        "review".to_string(),
+        CommentType::from_id("note"),
+        None,
+    ));
+    let path = app.diff_files[0].display_path().clone();
+    let review = app.session.get_file_mut(&path).unwrap();
+    review.add_file_comment(Comment::new(
+        "file".to_string(),
+        CommentType::from_id("suggestion"),
+        None,
+    ));
+    review.add_line_comment(
+        2,
+        Comment::new(
+            "line".to_string(),
+            CommentType::from_id("issue"),
+            Some(LineSide::New),
+        ),
+    );
+    app.rebuild_annotations();
+
+    app.diff_state.cursor_line = 0;
+
+    app.next_comment();
+    let first_comment = app.diff_state.cursor_line;
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::ReviewComment { comment_idx: 0 })
+    ));
+
+    app.next_comment();
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::FileComment {
+            file_idx: 0,
+            comment_idx: 0
+        })
+    ));
+
+    app.next_comment();
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::LineComment {
+            file_idx: 0,
+            line: 2,
+            side: LineSide::New,
+            comment_idx: 0
+        })
+    ));
+
+    app.next_comment();
+    assert_eq!(app.diff_state.cursor_line, first_comment);
+}
+
+#[test]
+fn should_cycle_backward_and_skip_current_multiline_comment() {
+    let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+    let mut app = build_app_with_files(vec![file], 20);
+    app.session.review_comments.push(Comment::new(
+        "review".to_string(),
+        CommentType::from_id("note"),
+        None,
+    ));
+    let path = app.diff_files[0].display_path().clone();
+    let review = app.session.get_file_mut(&path).unwrap();
+    review.add_file_comment(Comment::new(
+        "file\nbody".to_string(),
+        CommentType::from_id("suggestion"),
+        None,
+    ));
+    review.add_line_comment(
+        2,
+        Comment::new(
+            "line".to_string(),
+            CommentType::from_id("issue"),
+            Some(LineSide::New),
+        ),
+    );
+    app.rebuild_annotations();
+
+    let file_comment = app
+        .line_annotations
+        .iter()
+        .position(|line| {
+            matches!(
+                line,
+                AnnotatedLine::FileComment {
+                    file_idx: 0,
+                    comment_idx: 0
+                }
+            )
+        })
+        .expect("missing annotation");
+    app.diff_state.cursor_line = file_comment + 2;
+
+    app.prev_comment();
+
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::ReviewComment { comment_idx: 0 })
+    ));
+}
+
+#[test]
+fn should_wrap_backward_to_last_comment() {
+    let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+    let mut app = build_app_with_files(vec![file], 20);
+    let path = app.diff_files[0].display_path().clone();
+    let review = app.session.get_file_mut(&path).unwrap();
+    review.add_file_comment(Comment::new(
+        "file".to_string(),
+        CommentType::from_id("suggestion"),
+        None,
+    ));
+    review.add_line_comment(
+        2,
+        Comment::new(
+            "line".to_string(),
+            CommentType::from_id("issue"),
+            Some(LineSide::New),
+        ),
+    );
+    app.rebuild_annotations();
+    app.diff_state.cursor_line = 0;
+
+    app.prev_comment();
+
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::LineComment {
+            file_idx: 0,
+            line: 2,
+            side: LineSide::New,
+            comment_idx: 0
+        })
+    ));
+}
+
+#[test]
+fn should_report_when_no_comments_exist() {
+    let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
+    let mut app = build_app_with_files(vec![file], 20);
+
+    app.next_comment();
+
+    assert_eq!(app.message.as_ref().unwrap().content, "No comments");
+}
+
+#[test]
 fn should_toggle_hunk_reviewed_from_header() {
     let file = make_file_with_hunks("test.rs", vec![make_hunk(1, 3)]);
     let mut app = build_app_with_files(vec![file], 20);
@@ -1150,6 +1304,104 @@ fn jump_to_selected_comment_uses_comment_annotation_target() {
     assert_eq!(app.diff_state.cursor_line, target);
     assert_eq!(app.diff_state.scroll_offset, expected_scroll);
     assert_eq!(app.focused_panel, FocusedPanel::Diff);
+}
+
+#[test]
+fn should_update_current_file_when_navigating_to_remote_comment() {
+    use crate::forge::remote_comments::{
+        RemoteCommentSide, RemoteReviewComment, RemoteReviewThread,
+    };
+
+    let files = vec![
+        make_file_with_hunks("a.rs", vec![make_hunk(1, 1)]),
+        make_file_with_hunks("b.rs", vec![make_hunk(1, 2)]),
+    ];
+    let mut app = build_app_with_files(files, 10);
+    app.forge_review_threads = vec![RemoteReviewThread {
+        id: "T1".into(),
+        path: "b.rs".into(),
+        line: Some(2),
+        side: RemoteCommentSide::Right,
+        is_resolved: false,
+        is_outdated: false,
+        comments: vec![RemoteReviewComment {
+            id: "C1".into(),
+            author: Some("alice".into()),
+            body: "remote-thread".into(),
+            created_at: None,
+            in_reply_to: None,
+            url: "https://example.com/c1".into(),
+        }],
+    }];
+    app.rebuild_annotations();
+    app.diff_state.current_file_idx = 0;
+    app.diff_state.cursor_line = 0;
+
+    app.next_comment();
+
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::RemoteThreadLine { thread_idx: 0 })
+    ));
+    assert_eq!(app.diff_state.current_file_idx, 1);
+
+    app.toggle_reviewed();
+
+    assert!(!app.session.is_file_reviewed(&PathBuf::from("a.rs")));
+    assert!(app.session.is_file_reviewed(&PathBuf::from("b.rs")));
+}
+
+#[test]
+fn should_rebuild_single_file_annotations_when_navigating_to_outdated_remote_comment() {
+    use crate::forge::remote_comments::{
+        PrCommentsVisibility, RemoteCommentSide, RemoteReviewComment, RemoteReviewThread,
+    };
+
+    let files = vec![
+        make_file_with_hunks("a.rs", vec![make_hunk(1, 1)]),
+        make_file_with_hunks("b.rs", vec![make_hunk(1, 2)]),
+    ];
+    let mut app = build_app_with_files(files, 10);
+    app.is_single_file_view = true;
+    app.diff_state.current_file_idx = 0;
+    app.session.remote_comments_visibility = PrCommentsVisibility::All;
+    app.forge_review_threads = vec![RemoteReviewThread {
+        id: "T1".into(),
+        path: "b.rs".into(),
+        line: None,
+        side: RemoteCommentSide::Right,
+        is_resolved: false,
+        is_outdated: true,
+        comments: vec![RemoteReviewComment {
+            id: "C1".into(),
+            author: Some("alice".into()),
+            body: "outdated-thread".into(),
+            created_at: None,
+            in_reply_to: None,
+            url: "https://example.com/c1".into(),
+        }],
+    }];
+    app.rebuild_annotations();
+    app.diff_state.cursor_line = 0;
+
+    app.next_comment();
+
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::RemoteThreadLine { thread_idx: 0 })
+    ));
+    assert_eq!(app.diff_state.current_file_idx, 1);
+    assert!(
+        app.line_annotations
+            .iter()
+            .any(|line| { matches!(line, AnnotatedLine::DiffLine { file_idx: 1, .. }) })
+    );
+    assert!(
+        !app.line_annotations
+            .iter()
+            .any(|line| { matches!(line, AnnotatedLine::DiffLine { file_idx: 0, .. }) })
+    );
+    assert_eq!(app.total_lines(), app.line_annotations.len());
 }
 
 #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1426,6 +1426,8 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
         Action::PrevFile => app.prev_file(),
         Action::NextHunk => app.next_hunk(),
         Action::PrevHunk => app.prev_hunk(),
+        Action::NextComment => app.next_comment(),
+        Action::PrevComment => app.prev_comment(),
         Action::ToggleReviewed => app.toggle_reviewed(),
         Action::ToggleHunkReviewed => app.toggle_hunk_reviewed(),
         Action::ToggleFocus => {

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -18,6 +18,8 @@ pub enum Action {
     PrevFile,
     NextHunk,
     PrevHunk,
+    NextComment,
+    PrevComment,
     PendingZCommand,
     PendingShiftZCommand,
     PendingLeaderCommand,
@@ -179,6 +181,8 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
         (KeyCode::Char('{'), _) => Action::PrevFile,
         (KeyCode::Char(']'), _) => Action::NextHunk,
         (KeyCode::Char('['), _) => Action::PrevHunk,
+        (KeyCode::Char('m'), KeyModifiers::NONE) => Action::NextComment,
+        (KeyCode::Char('M'), _) => Action::PrevComment,
         (KeyCode::Char(')'), _) => Action::CycleCommitNext,
         (KeyCode::Char('('), _) => Action::CycleCommitPrev,
 
@@ -515,6 +519,15 @@ mod tests {
     fn should_map_uppercase_r_to_toggle_hunk_reviewed_in_normal_mode() {
         let action = map_normal_mode(key_shift('R'), DEFAULT_LEADER_KEY);
         assert_eq!(action, Action::ToggleHunkReviewed);
+    }
+
+    #[test]
+    fn should_map_m_to_comment_navigation_in_normal_mode() {
+        let action = map_normal_mode(key(KeyCode::Char('m')), DEFAULT_LEADER_KEY);
+        assert_eq!(action, Action::NextComment);
+
+        let action = map_normal_mode(key_shift('M'), DEFAULT_LEADER_KEY);
+        assert_eq!(action, Action::PrevComment);
     }
 
     #[test]

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -93,6 +93,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  m/M       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Jump to next/previous comment"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  /         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -272,7 +272,7 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             match app.input_mode {
                 InputMode::Normal => Cow::Borrowed(
-                    "   j/k scroll \u{00b7} {/} file \u{00b7} r file \u{00b7} R hunk \u{00b7} c comment \u{00b7} ? help",
+                    "   j/k scroll \u{00b7} {/} file \u{00b7} m/M comment \u{00b7} r file \u{00b7} R hunk \u{00b7} c comment \u{00b7} ? help",
                 ),
                 InputMode::Command => {
                     Cow::Borrowed("   tab complete \u{00b7} \u{21b5} execute \u{00b7} esc cancel")


### PR DESCRIPTION
Allow normal mode to jump between rendered comments with m/M. The cycler walks review, file, and line comments in display order, wraps at the ends, and keeps multiline comments as a single target.

Document the keybindings in README, help, and status hints, and cover forward/backward cycling plus empty-review behavior in tests.