### PR TITLE
Fix tree selection when collapsing directories

### DIFF
--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -104,6 +104,36 @@ fn app_with_root(root_path: PathBuf, files: Vec<DiffFile>) -> App {
 }
 
 #[test]
+fn collapsing_selected_directory_keeps_tree_selection() {
+    let mut app = app_with(vec![
+        file("README.md", vec![hunk(1, 1)]),
+        file("src/app.rs", vec![hunk(1, 1)]),
+        file("src/main.rs", vec![hunk(1, 1)]),
+    ]);
+    app.expand_all_dirs();
+
+    let tree_idx = app
+        .build_visible_items()
+        .iter()
+        .position(|item| {
+            matches!(
+                item,
+                FileTreeItem::Directory { path, .. } if path == "src"
+            )
+        })
+        .expect("src directory");
+    app.file_list_state.select(tree_idx);
+
+    app.toggle_directory("src");
+
+    assert_eq!(app.file_list_state.selected(), tree_idx);
+    assert!(matches!(
+        app.get_selected_tree_item(),
+        Some(FileTreeItem::Directory { path, .. }) if path == "src"
+    ));
+}
+
+#[test]
 fn editor_target_uses_selected_file_list_row() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("main.rs");

--- a/src/app/tree.rs
+++ b/src/app/tree.rs
@@ -210,7 +210,18 @@ impl App {
     pub fn toggle_directory(&mut self, dir_path: &str) {
         if self.expanded_dirs.contains(dir_path) {
             self.expanded_dirs.remove(dir_path);
-            self.ensure_valid_tree_selection();
+            if let Some(tree_idx) = self
+                .build_visible_items()
+                .iter()
+                .position(|item| match item {
+                    FileTreeItem::Directory { path, .. } => path == dir_path,
+                    FileTreeItem::File { .. } => false,
+                })
+            {
+                self.file_list_state.select(tree_idx);
+            } else {
+                self.ensure_valid_tree_selection();
+            }
         } else {
             self.expanded_dirs.insert(dir_path.to_string());
         }


### PR DESCRIPTION
Keep the selected directory row active when it is collapsed, even when the diff panel is showing a file elsewhere in the tree.

Adds regression coverage for the file-list selection behavior.

Fixes #57