### PR TITLE
feat(ui): filter the file tree by include/exclude regex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@ src/
 ├── config/
 │   └── mod.rs           # User config loading (XDG on Unix, %APPDATA% on Windows)
 ├── app.rs               # Application state (App struct, InputMode, etc.)
+│   └── file_filter.rs   # File-tree include/exclude regex filters + `/` path search
 ├── error.rs             # Error types (TuicrError enum)
 ├── editor.rs            # External $EDITOR command construction and launch helpers
 ├── review_store.rs      # Library API for session listing/loading and shared comment insertion
@@ -116,6 +117,19 @@ Repository-managed agent integrations:
 - Capability hooks: `supports_sparse_checkout()` advertises whether the selected backend can operate on Git sparse-checkout repos
 - Implementations: `GitBackend`, `HgBackend`, `JjBackend` (all always compiled)
 
+**FileTreeFilter** (`src/app/mod.rs`, impls in `src/app/file_filter.rs`):
+- File-tree `i` include / `e` exclude regex filters plus the `/` path search
+- A filter is a *view* over `diff_files`, never a mutation: `file_idx` stays an absolute
+  index, so nothing downstream needs remapping. `App::file_passes_filter()` is the single
+  predicate, consulted by `build_visible_items`, `rebuild_annotations`,
+  `file_render_height`/`effective_file_height` (0 lines for hidden files), `hunk_positions`,
+  and both diff renderers. Add a gate anywhere a new loop walks `diff_files`.
+- `file_filter.draft` makes the tree a text-input sub-state of `InputMode::Normal`, the same
+  shape as `pr_filter_draft` for the target selector; `main.rs` routes to
+  `map_file_tree_prompt_mode` while it is `Some`
+- Keys are focus-scoped via `map_file_tree_mode`: the tree claims `i`/`e`/`I`/`E`/`/`, the
+  diff keeps `i` = edit comment and `/` = search diff
+
 **InputMode** (`src/app.rs`):
 - `Normal` - default navigation mode
 - `Command` - after pressing `:`, vim-style commands
@@ -160,6 +174,9 @@ Repository-managed agent integrations:
 - **Clipboard**: Uses `arboard` crate for cross-platform clipboard support
 - **Hunk navigation**: `next_hunk()`/`prev_hunk()` calculate positions by iterating through files
 - **Ignore filtering**: `.tuicrignore` is applied whenever diffs are loaded/reloaded
+- **File-tree filters**: `i`/`e` regex filters narrow the tree *and* the diff at render/measure
+  time (`App::file_passes_filter`), unlike `.tuicrignore` which drops files at load time. They
+  are session-local and never persisted
 
 ### Dependencies
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,7 @@ dependencies = [
  "git2",
  "ignore",
  "ratatui",
+ "regex",
  "self-replace",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,8 @@ uuid = { version = "1.0", features = ["v4"] }
 arboard = { version = "3.4", features = ["wayland-data-control"] }
 base64 = "0.22"
 ignore = "0.4"
+# User-supplied include/exclude patterns for the file tree filter.
+regex = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 shlex = "1.3"

--- a/README.md
+++ b/README.md
@@ -244,7 +244,9 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `{` / `}` | Previous / next file |
 | `[` / `]` | Previous / next hunk |
 | `m` / `M` | Next / previous comment |
-| `/` | Search the diff, or search help while help is open (case-insensitive) |
+| `/` | Search the diff, the file tree, or help — whichever is focused/open (case-insensitive) |
+| `i` / `e` (file tree) | Filter files in / out by regex; narrows the tree **and** the diff |
+| `I` / `E` (file tree) | Clear the include / exclude filter |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |
 | `r` | Toggle file reviewed |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -46,6 +46,42 @@ Press `?` to open help.
 | `Enter` | Expand directory / jump to file in diff |
 | `o` | Expand all directories |
 | `O` | Collapse all directories |
+| `i` | Filter to files matching a regex (include) |
+| `e` | Filter out files matching a regex (exclude) |
+| `I` | Clear the include filter |
+| `E` | Clear the exclude filter |
+| `/` | Search file paths (substring) |
+| `n` / `N` | Next / previous file-path match |
+
+These keys are only active while the file tree is focused — in the diff, `i` still
+edits the comment at the cursor and `/` still searches the diff.
+
+### Filtering
+
+`i` and `e` take case-insensitive regexes matched against each file's **full
+relative path** (`^src/`, `\.rs$`, `test|spec`). Both can be active at once:
+include runs first, then exclude removes from what's left.
+
+A filter is not just a tree view — hidden files also disappear from the diff
+pane, from `{`/`}` file navigation, `[`/`]` hunk navigation, and from the file
+and `+/-` counts in the header. The tree title reports how much is hidden
+(`Files · 2/12 · 12 of 58`), and the active patterns show in its bottom border.
+
+Enter applies, `Esc` cancels, `Ctrl-u` clears the line. Reopening a prompt
+pre-fills the pattern already applied, so submitting an emptied buffer is the
+same as `I` / `E`. An invalid regex reports the error and leaves the prompt open
+so it can be fixed. Comments on hidden files are not deleted and still export —
+filters are a view, not an edit.
+
+Filters are session-local: they are not written to the review session and reset
+when tuicr restarts, but they survive a `:e` reload.
+
+### Search
+
+`/` moves only the tree selection to the next matching path, expanding collapsed
+parents as needed, and leaves the diff viewport where it was — press `Enter` to
+jump the diff there. `n` / `N` step matches and wrap around. Search only ever
+considers files that pass the active filters.
 
 ## Panel focus
 

--- a/src/app/annotations.rs
+++ b/src/app/annotations.rs
@@ -123,6 +123,11 @@ impl App {
             if self.is_single_file_view && file_idx != self.diff_state.current_file_idx {
                 continue;
             }
+            // Hidden by an include/exclude filter: emit no annotations, the
+            // same way the renderers emit no lines.
+            if !self.file_passes_filter(file) {
+                continue;
+            }
             let path = file.display_path();
 
             // File header (only when shown — same gate as the renderer).

--- a/src/app/file_filter.rs
+++ b/src/app/file_filter.rs
@@ -1,0 +1,437 @@
+//! File-tree include/exclude filters and `/` search.
+//!
+//! Filters are a *view* over `diff_files`, not a mutation of it: `file_idx`
+//! stays an absolute index into `diff_files`, so nothing downstream needs
+//! remapping. Every consumer that walks files asks `file_passes_filter`:
+//!
+//! - `build_visible_items` (tree, and therefore `}`/`{` file nav)
+//! - `rebuild_annotations` (diff content, comment navigator)
+//! - `file_render_height` / `effective_file_height` (scroll math -> 0 lines)
+//! - `hunk_positions` (`]`/`[`)
+//! - both diff renderers
+//!
+//! Search is deliberately weaker: it only moves the tree selection, leaving
+//! the diff viewport where the user left it.
+
+use super::*;
+use regex::RegexBuilder;
+
+impl App {
+    /// True when a filtered-out file should be hidden from the tree, the
+    /// diff, and the navigation/scroll math.
+    ///
+    /// Commit-message pseudo-files are matched like any other row: their
+    /// display path is `Commit Message (<sha>)`, so `i \.rs$` hides them
+    /// along with every other non-Rust entry. That keeps "include" meaning
+    /// exactly what it says instead of carving out a silent exception.
+    pub fn file_passes_filter(&self, file: &DiffFile) -> bool {
+        let path = file.display_path().to_string_lossy().to_string();
+        if let Some(include) = &self.file_filter.include
+            && !include.regex.is_match(&path)
+        {
+            return false;
+        }
+        if let Some(exclude) = &self.file_filter.exclude
+            && exclude.regex.is_match(&path)
+        {
+            return false;
+        }
+        true
+    }
+
+    /// `file_passes_filter` by index, for the loops that only carry an index.
+    pub fn file_idx_passes_filter(&self, file_idx: usize) -> bool {
+        self.diff_files
+            .get(file_idx)
+            .is_none_or(|file| self.file_passes_filter(file))
+    }
+
+    pub fn file_filter_active(&self) -> bool {
+        self.file_filter.include.is_some() || self.file_filter.exclude.is_some()
+    }
+
+    /// Indices of the files surviving the current filters, in tree order.
+    pub fn filtered_file_indices(&self) -> Vec<usize> {
+        self.diff_files
+            .iter()
+            .enumerate()
+            .filter(|(_, file)| self.file_passes_filter(file))
+            .map(|(idx, _)| idx)
+            .collect()
+    }
+
+    // ---- prompt lifecycle -------------------------------------------------
+
+    /// Open one of the three file-tree prompts, pre-seeded with the value
+    /// already applied so the user can refine rather than retype.
+    pub fn begin_file_tree_prompt(&mut self, prompt: FileTreePrompt) {
+        let buffer = match prompt {
+            FileTreePrompt::Include => self
+                .file_filter
+                .include
+                .as_ref()
+                .map(|p| p.source.clone())
+                .unwrap_or_default(),
+            FileTreePrompt::Exclude => self
+                .file_filter
+                .exclude
+                .as_ref()
+                .map(|p| p.source.clone())
+                .unwrap_or_default(),
+            FileTreePrompt::Search => self.file_filter.search.clone().unwrap_or_default(),
+        };
+        self.file_filter.draft = Some(FileTreeDraft { prompt, buffer });
+    }
+
+    /// True while a file-tree prompt owns keyboard input. `main.rs` checks
+    /// this before mapping keys so typed characters reach the buffer instead
+    /// of driving tree navigation.
+    pub fn file_tree_prompt_editing(&self) -> bool {
+        self.file_filter.draft.is_some()
+    }
+
+    pub fn file_tree_draft(&self) -> Option<&FileTreeDraft> {
+        self.file_filter.draft.as_ref()
+    }
+
+    pub fn file_tree_prompt_insert_char(&mut self, ch: char) {
+        if let Some(draft) = self.file_filter.draft.as_mut() {
+            draft.buffer.push(ch);
+        }
+    }
+
+    pub fn file_tree_prompt_insert_str(&mut self, text: &str) {
+        if let Some(draft) = self.file_filter.draft.as_mut() {
+            for ch in text.chars() {
+                if !matches!(ch, '\n' | '\r') {
+                    draft.buffer.push(ch);
+                }
+            }
+        }
+    }
+
+    pub fn file_tree_prompt_delete_char(&mut self) {
+        if let Some(draft) = self.file_filter.draft.as_mut() {
+            draft.buffer.pop();
+        }
+    }
+
+    pub fn file_tree_prompt_delete_word(&mut self) {
+        if let Some(draft) = self.file_filter.draft.as_mut() {
+            while draft
+                .buffer
+                .chars()
+                .next_back()
+                .is_some_and(char::is_whitespace)
+            {
+                draft.buffer.pop();
+            }
+            while draft
+                .buffer
+                .chars()
+                .next_back()
+                .is_some_and(|c| !c.is_whitespace())
+            {
+                draft.buffer.pop();
+            }
+        }
+    }
+
+    pub fn file_tree_prompt_clear_line(&mut self) {
+        if let Some(draft) = self.file_filter.draft.as_mut() {
+            draft.buffer.clear();
+        }
+    }
+
+    pub fn cancel_file_tree_prompt(&mut self) {
+        self.file_filter.draft = None;
+    }
+
+    /// Apply the draft. An empty buffer clears that filter, so `i`+Enter is
+    /// the same as `I`. An invalid regex leaves the prompt open with an
+    /// error so the pattern can be fixed instead of retyped.
+    pub fn commit_file_tree_prompt(&mut self) {
+        let Some(draft) = self.file_filter.draft.clone() else {
+            return;
+        };
+        let pattern = draft.buffer.trim().to_string();
+
+        match draft.prompt {
+            FileTreePrompt::Search => {
+                self.file_filter.draft = None;
+                if pattern.is_empty() {
+                    self.file_filter.search = None;
+                    return;
+                }
+                self.file_filter.search = Some(pattern);
+                self.step_file_tree_search(true, true);
+            }
+            FileTreePrompt::Include | FileTreePrompt::Exclude => {
+                if pattern.is_empty() {
+                    self.file_filter.draft = None;
+                    match draft.prompt {
+                        FileTreePrompt::Include => self.clear_include_filter(),
+                        _ => self.clear_exclude_filter(),
+                    }
+                    return;
+                }
+                let compiled = match RegexBuilder::new(&pattern).case_insensitive(true).build() {
+                    Ok(regex) => FilePattern {
+                        source: pattern,
+                        regex,
+                    },
+                    Err(err) => {
+                        // Keep the draft open: the user is mid-pattern and
+                        // retyping from scratch would be worse than fixing it.
+                        self.set_error(format!(
+                            "Invalid regex: {}",
+                            regex_reason(&err.to_string())
+                        ));
+                        return;
+                    }
+                };
+                self.file_filter.draft = None;
+                let label = draft.prompt.label();
+                let source = compiled.source.clone();
+                match draft.prompt {
+                    FileTreePrompt::Include => self.file_filter.include = Some(compiled),
+                    _ => self.file_filter.exclude = Some(compiled),
+                }
+                self.apply_file_filter_change();
+                let matched = self.filtered_file_indices().len();
+                if matched == 0 {
+                    self.set_warning(format!(
+                        "No files match {label} \"{source}\" \u{2014} I clears include, E clears exclude"
+                    ));
+                } else {
+                    let total = self.diff_files.len();
+                    self.set_message(format!(
+                        "Filter {label} \"{source}\" \u{00b7} {matched}/{total} files"
+                    ));
+                }
+            }
+        }
+    }
+
+    pub fn clear_include_filter(&mut self) {
+        if self.file_filter.include.take().is_none() {
+            self.set_message("No include filter set");
+            return;
+        }
+        self.apply_file_filter_change();
+        self.report_filter_cleared("include");
+    }
+
+    pub fn clear_exclude_filter(&mut self) {
+        if self.file_filter.exclude.take().is_none() {
+            self.set_message("No exclude filter set");
+            return;
+        }
+        self.apply_file_filter_change();
+        self.report_filter_cleared("exclude");
+    }
+
+    fn report_filter_cleared(&mut self, label: &str) {
+        let shown = self.filtered_file_indices().len();
+        let total = self.diff_files.len();
+        if shown == total {
+            self.set_message(format!("Cleared {label} filter \u{00b7} {total} files"));
+        } else {
+            self.set_message(format!(
+                "Cleared {label} filter \u{00b7} {shown}/{total} files"
+            ));
+        }
+    }
+
+    /// Re-derive everything that depends on which files are visible, then
+    /// make sure the cursor and tree selection aren't parked on a file that
+    /// just disappeared.
+    fn apply_file_filter_change(&mut self) {
+        self.rebuild_annotations();
+
+        let visible = self.filtered_file_indices();
+        if visible.is_empty() {
+            // Nothing to focus. Park at the overview so the diff pane shows
+            // its empty state instead of a stale offset into hidden content.
+            self.diff_state.current_file_idx = 0;
+            self.diff_state.cursor_line = 0;
+            self.diff_state.scroll_offset = 0;
+            self.file_list_state.select(0);
+            return;
+        }
+
+        if visible.contains(&self.diff_state.current_file_idx) {
+            // Same file, but its render offset moved because earlier files
+            // may now be hidden.
+            self.jump_to_file(self.diff_state.current_file_idx);
+        } else {
+            self.jump_to_file(visible[0]);
+        }
+    }
+
+    // ---- `/` search -------------------------------------------------------
+
+    pub fn file_tree_search_active(&self) -> bool {
+        self.file_filter.search.is_some()
+    }
+
+    pub fn file_tree_search_next(&mut self) {
+        self.step_file_tree_search(true, false);
+    }
+
+    pub fn file_tree_search_prev(&mut self) {
+        self.step_file_tree_search(false, false);
+    }
+
+    /// Move the tree selection to the next/previous file whose path contains
+    /// the query (case-insensitive), wrapping around. Only the selection
+    /// moves: the diff viewport stays put until the user presses Enter.
+    ///
+    /// `include_current` lets a freshly submitted query match the file that
+    /// is already selected instead of skipping past it.
+    fn step_file_tree_search(&mut self, forward: bool, include_current: bool) {
+        let Some(query) = self.file_filter.search.clone() else {
+            self.set_message("No file tree search active");
+            return;
+        };
+        let needle = query.to_lowercase();
+
+        let candidates: Vec<usize> = self
+            .filtered_file_indices()
+            .into_iter()
+            .filter(|&idx| {
+                self.diff_files[idx]
+                    .display_path()
+                    .to_string_lossy()
+                    .to_lowercase()
+                    .contains(&needle)
+            })
+            .collect();
+
+        if candidates.is_empty() {
+            self.set_message(format!("No files matching \"{query}\""));
+            return;
+        }
+
+        let anchor = self.selected_tree_file_idx();
+        let target = if forward {
+            candidates
+                .iter()
+                .find(|&&idx| {
+                    if include_current {
+                        idx >= anchor
+                    } else {
+                        idx > anchor
+                    }
+                })
+                .copied()
+                .unwrap_or(candidates[0])
+        } else {
+            candidates
+                .iter()
+                .rev()
+                .find(|&&idx| {
+                    if include_current {
+                        idx <= anchor
+                    } else {
+                        idx < anchor
+                    }
+                })
+                .copied()
+                .unwrap_or(*candidates.last().expect("candidates is non-empty"))
+        };
+
+        self.select_file_in_tree(target);
+        let path = self.diff_files[target].display_path().display().to_string();
+        let position = candidates
+            .iter()
+            .position(|&idx| idx == target)
+            .unwrap_or(0)
+            + 1;
+        self.set_message(format!(
+            "{path} \u{00b7} {position}/{} for \"{query}\"",
+            candidates.len()
+        ));
+    }
+
+    /// The file the tree selection is sitting on, or the diff's current file
+    /// when a directory row is selected.
+    fn selected_tree_file_idx(&self) -> usize {
+        match self.get_selected_tree_item() {
+            Some(FileTreeItem::File { file_idx, .. }) => file_idx,
+            _ => self.diff_state.current_file_idx,
+        }
+    }
+
+    /// Expand the ancestors of `file_idx` and select its row, without
+    /// touching the diff viewport.
+    pub(in crate::app) fn select_file_in_tree(&mut self, file_idx: usize) {
+        use std::path::Path;
+
+        let Some(file) = self.diff_files.get(file_idx) else {
+            return;
+        };
+        let path = file.display_path().clone();
+        let mut current = path.parent();
+        while let Some(parent) = current {
+            if parent != Path::new("") {
+                self.expanded_dirs
+                    .insert(parent.to_string_lossy().to_string());
+            }
+            current = parent.parent();
+        }
+        if let Some(tree_idx) = self.file_idx_to_tree_idx(file_idx) {
+            self.file_list_state.select(tree_idx);
+        }
+    }
+}
+
+/// Reduce a `regex` parse error to the one line worth showing in the status
+/// bar. The crate renders errors as:
+///
+/// ```text
+/// regex parse error:
+///     [unclosed
+///     ^
+/// error: unclosed character class
+/// ```
+///
+/// The first line is a useless header, so prefer the trailing `error:` line
+/// (which carries the actual reason) and fall back to a flattened message.
+fn regex_reason(message: &str) -> String {
+    if let Some(reason) = message
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| line.strip_prefix("error:"))
+        .next_back()
+    {
+        return reason.trim().to_string();
+    }
+    message
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::regex_reason;
+
+    #[test]
+    fn should_take_the_trailing_reason_line_over_the_header() {
+        // Shape of a real `regex` parse error. The end-to-end assertion
+        // against the live crate output lives in
+        // `app::tests::file_filter_tests`, which reaches the compiler through
+        // the prompt instead of a literal clippy can lint.
+        let raw = "regex parse error:\n    [unclosed\n    ^\nerror: unclosed character class";
+
+        assert_eq!(regex_reason(raw), "unclosed character class");
+    }
+
+    #[test]
+    fn should_flatten_errors_that_carry_no_reason_line() {
+        assert_eq!(regex_reason("something\n  broke"), "something broke");
+    }
+}

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -456,6 +456,7 @@ impl App {
             comment_navigator_state: CommentNavigatorState::default(),
             diff_state: DiffState::default(),
             help_state: HelpState::default(),
+            file_filter: FileTreeFilter::default(),
             command_buffer: String::new(),
             command_completion: None,
             search_buffer: String::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1026,6 +1026,8 @@ pub struct App {
     pub comment_navigator_state: CommentNavigatorState,
     pub diff_state: DiffState,
     pub help_state: HelpState,
+    /// File-tree include/exclude filters and `/` search.
+    pub file_filter: FileTreeFilter,
     pub command_buffer: String,
     pub(crate) command_completion: Option<CommandCompletionState>,
     pub search_buffer: String,
@@ -1435,6 +1437,67 @@ impl Default for DiffState {
     }
 }
 
+/// Which file-tree prompt is currently collecting input. All three share
+/// one draft buffer because only one can be open at a time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileTreePrompt {
+    /// `i` — keep only files whose path matches (regex).
+    Include,
+    /// `e` — drop files whose path matches (regex).
+    Exclude,
+    /// `/` — jump the tree selection to a matching file (substring).
+    Search,
+}
+
+impl FileTreePrompt {
+    /// Prefix shown before the buffer in the prompt line, mirroring the
+    /// key that opened it.
+    pub fn sigil(self) -> char {
+        match self {
+            FileTreePrompt::Include => 'i',
+            FileTreePrompt::Exclude => 'e',
+            FileTreePrompt::Search => '/',
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            FileTreePrompt::Include => "include",
+            FileTreePrompt::Exclude => "exclude",
+            FileTreePrompt::Search => "search",
+        }
+    }
+}
+
+/// An in-progress prompt. `Some` in `FileTreeFilter::draft` makes the file
+/// tree a text-input sub-state of `InputMode::Normal`, the same way
+/// `pr_filter_draft` does for the target selector.
+#[derive(Debug, Clone)]
+pub struct FileTreeDraft {
+    pub prompt: FileTreePrompt,
+    pub buffer: String,
+}
+
+/// An applied regex filter plus the pattern the user typed, kept so the
+/// prompt can be reopened pre-seeded and the UI can echo the source.
+pub struct FilePattern {
+    pub source: String,
+    pub regex: regex::Regex,
+}
+
+/// Include/exclude/search state for the file tree. Filters narrow both the
+/// tree and the diff pane (see `App::file_passes_filter`); search only moves
+/// the tree selection.
+#[derive(Default)]
+pub struct FileTreeFilter {
+    pub include: Option<FilePattern>,
+    pub exclude: Option<FilePattern>,
+    /// Applied `/` query. Persists after the prompt closes so `n`/`N` can
+    /// keep stepping matches.
+    pub search: Option<String>,
+    pub draft: Option<FileTreeDraft>,
+}
+
 #[derive(Debug, Default)]
 pub struct HelpState {
     pub scroll_offset: usize,
@@ -1488,6 +1551,7 @@ mod comment_vim;
 mod comments;
 mod commits;
 mod diff_load;
+mod file_filter;
 mod gaps;
 mod init;
 mod modes;

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -682,6 +682,9 @@ impl App {
             if single && file_idx != current_idx {
                 continue;
             }
+            if !self.file_passes_filter(file) {
+                continue;
+            }
             let path = file.display_path();
             let is_reviewed = self.session.is_file_reviewed(path);
 
@@ -733,8 +736,11 @@ impl App {
         // into the next file's first hunk so `]` can step the codebase
         // hunk-by-hunk without breaking on file boundaries.
         if self.is_single_file_view {
-            let next_idx = self.diff_state.current_file_idx + 1;
-            if next_idx < self.diff_files.len() {
+            // Step over files hidden by a file-tree filter: they render
+            // nothing, so landing on one would show an empty pane.
+            let next_idx = ((self.diff_state.current_file_idx + 1)..self.diff_files.len())
+                .find(|&idx| self.file_idx_passes_filter(idx));
+            if let Some(next_idx) = next_idx {
                 self.jump_to_file(next_idx);
                 if let Some(&first) = self.hunk_positions().first() {
                     self.diff_state.cursor_line = first;
@@ -762,8 +768,11 @@ impl App {
         // Symmetric to next_hunk: in single-file view, fall through to the
         // previous file's last hunk so `[` keeps stepping backward across
         // files.
-        if self.is_single_file_view && self.diff_state.current_file_idx > 0 {
-            let prev_idx = self.diff_state.current_file_idx - 1;
+        if self.is_single_file_view
+            && let Some(prev_idx) = (0..self.diff_state.current_file_idx)
+                .rev()
+                .find(|&idx| self.file_idx_passes_filter(idx))
+        {
             self.jump_to_file(prev_idx);
             if let Some(&last) = self.hunk_positions().last() {
                 self.diff_state.cursor_line = last;
@@ -826,6 +835,11 @@ impl App {
     }
 
     pub(in crate::app) fn file_render_height(&self, file_idx: usize, file: &DiffFile) -> usize {
+        // Filtered out: renders nothing, so it must occupy no render lines or
+        // every cumulative offset below it would drift.
+        if !self.file_passes_filter(file) {
+            return 0;
+        }
         if self.session.is_file_reviewed(file.display_path()) {
             return 1; // collapsed: header only
         }
@@ -1174,6 +1188,9 @@ impl App {
             return self.file_render_height(file_idx, file);
         }
         if file_idx != self.diff_state.current_file_idx {
+            return 0;
+        }
+        if !self.file_passes_filter(file) {
             return 0;
         }
         let banner = if self.session.is_file_reviewed(file.display_path()) {

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -270,24 +270,54 @@ impl App {
         }
     }
 
+    /// Files currently shown. Excludes anything hidden by the file-tree
+    /// include/exclude filters so the header and tree title describe what is
+    /// actually on screen.
     pub fn file_count(&self) -> usize {
+        if !self.file_filter_active() {
+            return self.diff_files.len();
+        }
+        self.filtered_file_indices().len()
+    }
+
+    /// Total files in the diff, ignoring filters. Used to report how much a
+    /// filter is hiding.
+    pub fn unfiltered_file_count(&self) -> usize {
         self.diff_files.len()
     }
 
     pub fn reviewed_count(&self) -> usize {
-        self.session.reviewed_count()
+        if !self.file_filter_active() {
+            return self.session.reviewed_count();
+        }
+        // Counting the whole session here would read as `12/5` next to a
+        // filtered total, so count only reviewed files that survive.
+        self.filtered_file_indices()
+            .into_iter()
+            .filter(|&idx| {
+                self.diff_files
+                    .get(idx)
+                    .is_some_and(|file| self.session.is_file_reviewed(file.display_path()))
+            })
+            .count()
     }
 
-    /// Returns `(total_files, total_additions, total_deletions)` across all diff files.
+    /// Returns `(total_files, total_additions, total_deletions)` across the
+    /// files currently shown (filters applied).
     pub fn diff_stat(&self) -> (usize, usize, usize) {
         let mut additions = 0;
         let mut deletions = 0;
+        let mut files = 0;
         for file in &self.diff_files {
+            if !self.file_passes_filter(file) {
+                continue;
+            }
+            files += 1;
             let (a, d) = file.stat();
             additions += a;
             deletions += d;
         }
-        (self.diff_files.len(), additions, deletions)
+        (files, additions, deletions)
     }
 
     /// Returns true when the cursor is in the review comments area above all files.

--- a/src/app/tests/file_filter_tests.rs
+++ b/src/app/tests/file_filter_tests.rs
@@ -1,0 +1,419 @@
+use crate::app::*;
+use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+use std::path::PathBuf;
+
+struct StubVcs(VcsInfo);
+impl VcsBackend for StubVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.0
+    }
+    fn get_working_tree_diff(
+        &self,
+        _hl: &crate::syntax::SyntaxHighlighter,
+    ) -> crate::error::Result<Vec<DiffFile>> {
+        Ok(Vec::new())
+    }
+    fn fetch_context_lines(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start: u32,
+        _end: u32,
+    ) -> crate::error::Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+    fn file_line_count(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> crate::error::Result<u32> {
+        Ok(0)
+    }
+}
+
+fn hunk() -> DiffHunk {
+    DiffHunk {
+        header: "@@ -1,2 +1,2 @@".to_string(),
+        lines: vec![
+            DiffLine {
+                origin: LineOrigin::Context,
+                content: "context".to_string(),
+                old_lineno: Some(1),
+                new_lineno: Some(1),
+                highlighted_spans: None,
+            },
+            DiffLine {
+                origin: LineOrigin::Addition,
+                content: "added".to_string(),
+                old_lineno: None,
+                new_lineno: Some(2),
+                highlighted_spans: None,
+            },
+        ],
+        old_start: 1,
+        old_count: 1,
+        new_start: 1,
+        new_count: 2,
+    }
+}
+
+fn file(path: &str) -> DiffFile {
+    let hunks = vec![hunk()];
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+    DiffFile {
+        old_path: None,
+        new_path: Some(PathBuf::from(path)),
+        status: FileStatus::Modified,
+        hunks,
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash,
+    }
+}
+
+fn app_with(paths: &[&str]) -> App {
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: "head".into(),
+        branch_name: Some("main".into()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+    let mut app = App::build(
+        Box::new(StubVcs(vcs_info.clone())),
+        vcs_info,
+        crate::theme::Theme::dark(),
+        None,
+        false,
+        paths.iter().map(|p| file(p)).collect(),
+        session,
+        DiffSource::WorkingTree,
+        InputMode::Normal,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("build app");
+    // The tree starts collapsed; every assertion here is about which files
+    // survive the filter, not about expand state.
+    app.expand_all_dirs();
+    app
+}
+
+/// Paths of the file rows currently in the tree, in order.
+fn visible_paths(app: &App) -> Vec<String> {
+    app.build_visible_items()
+        .into_iter()
+        .filter_map(|item| match item {
+            FileTreeItem::File { file_idx, .. } => Some(
+                app.diff_files[file_idx]
+                    .display_path()
+                    .display()
+                    .to_string(),
+            ),
+            FileTreeItem::Directory { .. } => None,
+        })
+        .collect()
+}
+
+fn visible_dirs(app: &App) -> Vec<String> {
+    app.build_visible_items()
+        .into_iter()
+        .filter_map(|item| match item {
+            FileTreeItem::Directory { path, .. } => Some(path),
+            FileTreeItem::File { .. } => None,
+        })
+        .collect()
+}
+
+/// Type `pattern` into the prompt opened by `prompt` and press Enter.
+fn apply(app: &mut App, prompt: FileTreePrompt, pattern: &str) {
+    app.begin_file_tree_prompt(prompt);
+    for ch in pattern.chars() {
+        app.file_tree_prompt_insert_char(ch);
+    }
+    app.commit_file_tree_prompt();
+}
+
+#[test]
+fn should_keep_only_files_matching_the_include_pattern() {
+    let mut app = app_with(&["src/main.rs", "README.md", "src/app/tree.rs"]);
+
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+
+    assert_eq!(visible_paths(&app), vec!["src/main.rs", "src/app/tree.rs"]);
+}
+
+#[test]
+fn should_drop_files_matching_the_exclude_pattern() {
+    let mut app = app_with(&["src/main.rs", "tests/smoke.rs", "README.md"]);
+
+    apply(&mut app, FileTreePrompt::Exclude, "^tests/");
+
+    // Rows come back in tree order (root files first, then directories),
+    // not in the order the diff was loaded.
+    assert_eq!(visible_paths(&app), vec!["README.md", "src/main.rs"]);
+}
+
+#[test]
+fn should_intersect_include_and_exclude_patterns() {
+    let mut app = app_with(&["src/main.rs", "src/app/tree.rs", "tests/smoke.rs"]);
+
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+    apply(&mut app, FileTreePrompt::Exclude, "^tests/");
+
+    assert_eq!(visible_paths(&app), vec!["src/main.rs", "src/app/tree.rs"]);
+}
+
+#[test]
+fn should_match_patterns_case_insensitively() {
+    let mut app = app_with(&["src/Main.rs", "README.md"]);
+
+    apply(&mut app, FileTreePrompt::Include, "main");
+
+    assert_eq!(visible_paths(&app), vec!["src/Main.rs"]);
+}
+
+#[test]
+fn should_match_against_the_full_relative_path_not_just_the_file_name() {
+    let mut app = app_with(&["src/app/tree.rs", "src/ui/tree.rs"]);
+
+    apply(&mut app, FileTreePrompt::Include, "^src/ui/");
+
+    assert_eq!(visible_paths(&app), vec!["src/ui/tree.rs"]);
+}
+
+#[test]
+fn should_hide_directories_whose_children_are_all_filtered_out() {
+    let mut app = app_with(&["src/main.rs", "docs/guide.md"]);
+
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+
+    assert_eq!(visible_dirs(&app), vec!["src"]);
+}
+
+#[test]
+fn should_remove_filtered_files_from_the_diff_render_height() {
+    let mut app = app_with(&["src/main.rs", "README.md"]);
+    let unfiltered = app.total_lines();
+
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+
+    let filtered = app.total_lines();
+    assert!(
+        filtered < unfiltered,
+        "filtered diff should be shorter: {filtered} vs {unfiltered}"
+    );
+    // Filtering to 1 of 2 identical files removes exactly one file's worth
+    // of render lines.
+    let per_file = unfiltered - filtered;
+    assert_eq!(filtered, unfiltered - per_file);
+}
+
+#[test]
+fn should_exclude_filtered_files_from_counts_and_stats() {
+    let mut app = app_with(&["src/main.rs", "README.md", "docs/guide.md"]);
+    assert_eq!(app.file_count(), 3);
+
+    apply(&mut app, FileTreePrompt::Include, r"\.md$");
+
+    assert_eq!(app.file_count(), 2);
+    assert_eq!(app.unfiltered_file_count(), 3);
+    let (files, _, _) = app.diff_stat();
+    assert_eq!(files, 2);
+}
+
+#[test]
+fn should_move_the_current_file_off_a_row_the_filter_just_hid() {
+    let mut app = app_with(&["README.md", "src/main.rs"]);
+    app.jump_to_file(0);
+    assert_eq!(app.diff_state.current_file_idx, 0);
+
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+
+    assert_eq!(app.diff_state.current_file_idx, 1);
+}
+
+#[test]
+fn should_park_at_the_overview_when_nothing_matches() {
+    let mut app = app_with(&["src/main.rs", "README.md"]);
+
+    apply(&mut app, FileTreePrompt::Include, "no-such-file");
+
+    assert!(visible_paths(&app).is_empty());
+    assert_eq!(app.diff_state.cursor_line, 0);
+    assert_eq!(app.diff_state.scroll_offset, 0);
+}
+
+#[test]
+fn should_clear_only_the_requested_filter() {
+    let mut app = app_with(&["src/main.rs", "tests/smoke.rs", "README.md"]);
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+    apply(&mut app, FileTreePrompt::Exclude, "^tests/");
+
+    app.clear_include_filter();
+    assert_eq!(visible_paths(&app), vec!["README.md", "src/main.rs"]);
+
+    app.clear_exclude_filter();
+    assert_eq!(
+        visible_paths(&app),
+        vec!["README.md", "src/main.rs", "tests/smoke.rs"]
+    );
+    assert!(!app.file_filter_active());
+}
+
+#[test]
+fn should_treat_an_empty_pattern_as_clearing_the_filter() {
+    let mut app = app_with(&["src/main.rs", "README.md"]);
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+    assert_eq!(visible_paths(&app).len(), 1);
+
+    // Reopening seeds the buffer with the applied pattern, so emptying it
+    // (ctrl-u) is what expresses "no include filter".
+    app.begin_file_tree_prompt(FileTreePrompt::Include);
+    app.file_tree_prompt_clear_line();
+    app.commit_file_tree_prompt();
+
+    assert_eq!(visible_paths(&app).len(), 2);
+    assert!(!app.file_filter_active());
+}
+
+#[test]
+fn should_keep_the_prompt_open_and_apply_nothing_on_an_invalid_regex() {
+    let mut app = app_with(&["src/main.rs", "README.md"]);
+
+    apply(&mut app, FileTreePrompt::Include, "[unclosed");
+
+    assert!(
+        app.file_tree_prompt_editing(),
+        "prompt should stay open so the pattern can be fixed"
+    );
+    assert!(!app.file_filter_active());
+    assert_eq!(visible_paths(&app).len(), 2);
+    // The reason, not the `regex parse error:` header, is what reaches the
+    // status bar. Pinned against the live crate output.
+    let message = app.message.as_ref().expect("error message").content.clone();
+    assert_eq!(message, "Invalid regex: unclosed character class");
+}
+
+#[test]
+fn should_seed_the_prompt_with_the_pattern_already_applied() {
+    let mut app = app_with(&["src/main.rs"]);
+    apply(&mut app, FileTreePrompt::Include, r"\.rs$");
+
+    app.begin_file_tree_prompt(FileTreePrompt::Include);
+
+    assert_eq!(app.file_tree_draft().expect("draft").buffer, r"\.rs$");
+}
+
+#[test]
+fn should_discard_the_draft_when_the_prompt_is_cancelled() {
+    let mut app = app_with(&["src/main.rs", "README.md"]);
+    app.begin_file_tree_prompt(FileTreePrompt::Include);
+    app.file_tree_prompt_insert_char('x');
+
+    app.cancel_file_tree_prompt();
+
+    assert!(!app.file_tree_prompt_editing());
+    assert!(!app.file_filter_active());
+}
+
+#[test]
+fn should_select_the_matching_file_on_search_without_moving_the_diff() {
+    let mut app = app_with(&["README.md", "src/main.rs"]);
+    app.jump_to_file(0);
+    let cursor_before = app.diff_state.cursor_line;
+
+    apply(&mut app, FileTreePrompt::Search, "main");
+
+    let selected = app.get_selected_tree_item().expect("selection");
+    let FileTreeItem::File { file_idx, .. } = selected else {
+        panic!("expected a file row to be selected, got {selected:?}");
+    };
+    assert_eq!(
+        app.diff_files[file_idx]
+            .display_path()
+            .display()
+            .to_string(),
+        "src/main.rs"
+    );
+    assert_eq!(
+        app.diff_state.cursor_line, cursor_before,
+        "search should not move the diff viewport"
+    );
+    assert_eq!(app.diff_state.current_file_idx, 0);
+}
+
+#[test]
+fn should_step_and_wrap_through_search_matches() {
+    let mut app = app_with(&["a_test.rs", "b_test.rs", "README.md"]);
+
+    apply(&mut app, FileTreePrompt::Search, "_test");
+    assert_eq!(selected_path(&app), "a_test.rs");
+
+    app.file_tree_search_next();
+    assert_eq!(selected_path(&app), "b_test.rs");
+
+    // Past the last match, wrap to the first.
+    app.file_tree_search_next();
+    assert_eq!(selected_path(&app), "a_test.rs");
+
+    // And backwards off the front wraps to the last.
+    app.file_tree_search_prev();
+    assert_eq!(selected_path(&app), "b_test.rs");
+}
+
+#[test]
+fn should_expand_collapsed_parents_to_reveal_a_search_match() {
+    let mut app = app_with(&["src/deep/nested/target.rs", "README.md"]);
+    app.collapse_all_dirs();
+
+    apply(&mut app, FileTreePrompt::Search, "target");
+
+    assert_eq!(selected_path(&app), "src/deep/nested/target.rs");
+}
+
+#[test]
+fn should_not_search_into_files_hidden_by_a_filter() {
+    let mut app = app_with(&["src/main.rs", "tests/main.rs"]);
+    apply(&mut app, FileTreePrompt::Exclude, "^tests/");
+
+    apply(&mut app, FileTreePrompt::Search, "main");
+    assert_eq!(selected_path(&app), "src/main.rs");
+
+    // The only other "main" match is excluded, so stepping wraps back.
+    app.file_tree_search_next();
+    assert_eq!(selected_path(&app), "src/main.rs");
+}
+
+#[test]
+fn should_report_when_no_file_matches_the_search() {
+    let mut app = app_with(&["src/main.rs"]);
+
+    apply(&mut app, FileTreePrompt::Search, "nothing-here");
+
+    let message = app.message.as_ref().expect("message").content.clone();
+    assert!(
+        message.contains("nothing-here"),
+        "expected a no-match message, got: {message}"
+    );
+}
+
+fn selected_path(app: &App) -> String {
+    match app.get_selected_tree_item().expect("selection") {
+        FileTreeItem::File { file_idx, .. } => app.diff_files[file_idx]
+            .display_path()
+            .display()
+            .to_string(),
+        other => panic!("expected a file row, got {other:?}"),
+    }
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -4,6 +4,7 @@ mod commit_selection_tests;
 mod decoration_skip_tests;
 mod diff_source_tests;
 mod expand_gap_tests;
+mod file_filter_tests;
 mod find_source_line_tests;
 mod persistence_merge_tests;
 mod scroll_behavior_tests;

--- a/src/app/tree.rs
+++ b/src/app/tree.rs
@@ -264,6 +264,12 @@ impl App {
         let mut seen_dirs: HashSet<String> = HashSet::new();
 
         for (file_idx, file) in self.diff_files.iter().enumerate() {
+            // Filtered-out files contribute no row and no ancestor
+            // directories, so a directory whose children are all hidden
+            // disappears with them.
+            if !self.file_passes_filter(file) {
+                continue;
+            }
             let path = file.display_path();
 
             let mut ancestors: Vec<String> = Vec::new();

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -2,8 +2,8 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Position;
 
 use crate::app::{
-    self, App, CommandCompletionState, ExpandDirection, FileTreeItem, FocusedPanel, GapCursorHit,
-    InputMode, TargetTab, VisualSelection,
+    self, App, CommandCompletionState, ExpandDirection, FileTreeItem, FileTreePrompt, FocusedPanel,
+    GapCursorHit, InputMode, TargetTab, VisualSelection,
 };
 use crate::forge::remote_comments::PrCommentsVisibility;
 use crate::forge::submit::SubmitEvent;
@@ -1291,7 +1291,27 @@ pub fn handle_visual_action(app: &mut App, action: Action) {
 
 /// Handle actions when file list panel is focused
 pub fn handle_file_list_action(app: &mut App, action: Action) {
+    // An open `i`/`e`/`/` prompt owns keyboard input until it is submitted or
+    // cancelled. The wheel still scrolls the list underneath it.
+    if app.file_tree_prompt_editing()
+        && !matches!(
+            action,
+            Action::MouseScrollDown(_) | Action::MouseScrollUp(_)
+        )
+    {
+        handle_file_tree_prompt_action(app, action);
+        return;
+    }
     match action {
+        Action::FileTreeFilterInclude => app.begin_file_tree_prompt(FileTreePrompt::Include),
+        Action::FileTreeFilterExclude => app.begin_file_tree_prompt(FileTreePrompt::Exclude),
+        Action::FileTreeClearInclude => app.clear_include_filter(),
+        Action::FileTreeClearExclude => app.clear_exclude_filter(),
+        Action::FileTreeSearch => app.begin_file_tree_prompt(FileTreePrompt::Search),
+        // With a tree search active, n/N step file matches. Otherwise they
+        // fall through to the diff search so the shared binding still works.
+        Action::SearchNext if app.file_tree_search_active() => app.file_tree_search_next(),
+        Action::SearchPrev if app.file_tree_search_active() => app.file_tree_search_prev(),
         Action::CursorDown(n) => app.file_list_down(n),
         Action::CursorUp(n) => app.file_list_up(n),
         Action::ScrollLeft(n) => app.file_list_state.scroll_left(n),
@@ -1317,6 +1337,21 @@ pub fn handle_file_list_action(app: &mut App, action: Action) {
             }
         }
         _ => handle_shared_normal_action(app, action),
+    }
+}
+
+/// Handle input while a file-tree prompt (`i` include, `e` exclude, `/`
+/// search) is open. Mirrors `handle_pr_filter_action` for the target selector.
+fn handle_file_tree_prompt_action(app: &mut App, action: Action) {
+    match action {
+        Action::InsertChar(c) => app.file_tree_prompt_insert_char(c),
+        Action::Paste(text) => app.file_tree_prompt_insert_str(&text),
+        Action::DeleteChar => app.file_tree_prompt_delete_char(),
+        Action::DeleteWord => app.file_tree_prompt_delete_word(),
+        Action::ClearLine => app.file_tree_prompt_clear_line(),
+        Action::SubmitInput => app.commit_file_tree_prompt(),
+        Action::ExitMode => app.cancel_file_tree_prompt(),
+        _ => {}
     }
 }
 

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -134,6 +134,19 @@ pub enum Action {
     CollapseAll,
     SelectFileFull,
 
+    // File tree filters (only produced while the file tree is focused, see
+    // `map_file_tree_mode`)
+    /// `i` — open the include-regex prompt.
+    FileTreeFilterInclude,
+    /// `e` — open the exclude-regex prompt.
+    FileTreeFilterExclude,
+    /// `I` — drop the include filter.
+    FileTreeClearInclude,
+    /// `E` — drop the exclude filter.
+    FileTreeClearExclude,
+    /// `/` — open the file-tree search prompt.
+    FileTreeSearch,
+
     // No-op
     None,
 }
@@ -408,6 +421,44 @@ fn map_commit_select_mode(key: KeyEvent) -> Action {
     }
 }
 
+/// Key map used when the file tree holds focus in `InputMode::Normal`.
+///
+/// Only the keys the tree claims for itself are listed; everything else
+/// delegates to `map_normal_mode` so shared bindings keep working. `i` is the
+/// notable override — in the diff it edits the comment at the cursor, in the
+/// tree it opens the include filter.
+pub fn map_file_tree_mode(key: KeyEvent, leader_key: char) -> Action {
+    // The leader key wins: `;e` (toggle file list) must not be swallowed by
+    // the exclude-filter binding.
+    if key.code == KeyCode::Char(leader_key) && key.modifiers == KeyModifiers::NONE {
+        return map_normal_mode(key, leader_key);
+    }
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('i'), KeyModifiers::NONE) => Action::FileTreeFilterInclude,
+        (KeyCode::Char('e'), KeyModifiers::NONE) => Action::FileTreeFilterExclude,
+        (KeyCode::Char('I'), _) => Action::FileTreeClearInclude,
+        (KeyCode::Char('E'), _) => Action::FileTreeClearExclude,
+        (KeyCode::Char('/'), _) => Action::FileTreeSearch,
+        _ => map_normal_mode(key, leader_key),
+    }
+}
+
+/// Key map used while a file-tree prompt (`i`/`e`/`/`) is collecting input.
+/// A sub-state of `InputMode::Normal`; the dispatcher in `main.rs` routes here
+/// when `App::file_tree_prompt_editing()` is true.
+pub fn map_file_tree_prompt_mode(key: KeyEvent) -> Action {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitInput,
+        (KeyCode::Backspace, mods) if mods.contains(KeyModifiers::ALT) => Action::DeleteWord,
+        (KeyCode::Backspace, KeyModifiers::NONE) => Action::DeleteChar,
+        (KeyCode::Char('w'), KeyModifiers::CONTROL) => Action::DeleteWord,
+        (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::ClearLine,
+        (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT) => Action::InsertChar(c),
+        _ => Action::None,
+    }
+}
+
 /// Key map used while the user is editing the PR-tab local filter.
 /// This is a sub-state of `InputMode::CommitSelect`; the dispatcher in
 /// `main.rs` routes here when `App::pr_filter_editing()` is true.
@@ -451,6 +502,92 @@ mod tests {
 
     fn key_shift(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::SHIFT)
+    }
+
+    #[test]
+    fn should_map_filter_keys_when_the_file_tree_is_focused() {
+        assert_eq!(
+            map_file_tree_mode(key(KeyCode::Char('i')), DEFAULT_LEADER_KEY),
+            Action::FileTreeFilterInclude
+        );
+        assert_eq!(
+            map_file_tree_mode(key(KeyCode::Char('e')), DEFAULT_LEADER_KEY),
+            Action::FileTreeFilterExclude
+        );
+        assert_eq!(
+            map_file_tree_mode(key_shift('I'), DEFAULT_LEADER_KEY),
+            Action::FileTreeClearInclude
+        );
+        assert_eq!(
+            map_file_tree_mode(key_shift('E'), DEFAULT_LEADER_KEY),
+            Action::FileTreeClearExclude
+        );
+        assert_eq!(
+            map_file_tree_mode(key(KeyCode::Char('/')), DEFAULT_LEADER_KEY),
+            Action::FileTreeSearch
+        );
+    }
+
+    #[test]
+    fn should_leave_diff_bindings_alone_when_the_tree_is_not_focused() {
+        // `i` edits the comment at the cursor in the diff; only the tree
+        // reinterprets it as the include filter.
+        assert_eq!(
+            map_normal_mode(key(KeyCode::Char('i')), DEFAULT_LEADER_KEY),
+            Action::EditComment
+        );
+        assert_eq!(
+            map_normal_mode(key(KeyCode::Char('/')), DEFAULT_LEADER_KEY),
+            Action::EnterSearchMode
+        );
+    }
+
+    #[test]
+    fn should_delegate_unclaimed_keys_to_normal_mode_in_file_tree_mode() {
+        for code in [
+            KeyCode::Char('j'),
+            KeyCode::Char('r'),
+            KeyCode::Char('c'),
+            KeyCode::Char(' '),
+            KeyCode::Enter,
+        ] {
+            assert_eq!(
+                map_file_tree_mode(key(code), DEFAULT_LEADER_KEY),
+                map_normal_mode(key(code), DEFAULT_LEADER_KEY),
+                "{code:?} should keep its normal-mode meaning in the tree"
+            );
+        }
+    }
+
+    #[test]
+    fn should_let_the_leader_key_win_over_a_filter_binding() {
+        // `leader = "e"` would otherwise be swallowed by the exclude filter.
+        assert_eq!(
+            map_file_tree_mode(key(KeyCode::Char('e')), 'e'),
+            Action::PendingLeaderCommand
+        );
+    }
+
+    #[test]
+    fn should_route_typed_chars_to_insert_in_file_tree_prompt_mode() {
+        assert_eq!(
+            map_file_tree_prompt_mode(key(KeyCode::Char('a'))),
+            Action::InsertChar('a')
+        );
+        // Keys that would otherwise act (q quits, / filters) are just text
+        // while the prompt is open.
+        assert_eq!(
+            map_file_tree_prompt_mode(key(KeyCode::Char('q'))),
+            Action::InsertChar('q')
+        );
+        assert_eq!(
+            map_file_tree_prompt_mode(key(KeyCode::Enter)),
+            Action::SubmitInput
+        );
+        assert_eq!(
+            map_file_tree_prompt_mode(key(KeyCode::Esc)),
+            Action::ExitMode
+        );
     }
 
     #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,4 +2,7 @@ pub mod handler;
 pub mod keybindings;
 pub mod mode;
 
-pub use keybindings::{Action, map_key_to_action, map_target_filter_mode};
+pub use keybindings::{
+    Action, map_file_tree_mode, map_file_tree_prompt_mode, map_key_to_action,
+    map_target_filter_mode,
+};

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,10 @@ use tuicr::handler::{
     handle_search_action, handle_submit_action_picker_action, handle_submit_confirm_action,
     handle_submit_resolver_action, handle_visual_action,
 };
-use tuicr::input::{Action, map_key_to_action, map_target_filter_mode};
+use tuicr::input::{
+    Action, map_file_tree_mode, map_file_tree_prompt_mode, map_key_to_action,
+    map_target_filter_mode,
+};
 use tuicr::terminal_state::{TerminalFeatures, TerminalSession};
 use tuicr::theme::resolve_theme_with_config;
 use tuicr::vcs::{DiffWhitespaceMode, GitBackendPreference};
@@ -588,12 +591,24 @@ fn main() -> anyhow::Result<()> {
                     // route through the filter-specific key map so typed
                     // characters update the filter buffer rather than driving
                     // commit-list navigation.
-                    let mut action =
-                        if app.input_mode == InputMode::CommitSelect && app.pr_filter_editing() {
-                            map_target_filter_mode(key)
-                        } else {
-                            map_key_to_action(key, app.input_mode, app.leader_key)
-                        };
+                    let mut action = if app.input_mode == InputMode::CommitSelect
+                        && app.pr_filter_editing()
+                    {
+                        map_target_filter_mode(key)
+                    } else if app.input_mode == InputMode::Normal && app.file_tree_prompt_editing()
+                    {
+                        // An open file-tree prompt (`i`/`e`/`/`) captures all
+                        // input until Enter/Esc, like the PR filter above.
+                        map_file_tree_prompt_mode(key)
+                    } else if app.input_mode == InputMode::Normal
+                        && app.focused_panel == FocusedPanel::FileList
+                    {
+                        // The tree claims i/e/I/E and `/` for filtering; the
+                        // diff keeps its own meanings for those keys.
+                        map_file_tree_mode(key, app.leader_key)
+                    } else {
+                        map_key_to_action(key, app.input_mode, app.leader_key)
+                    };
 
                     // Handle pending command setters (these work in any mode)
                     match action {

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -388,6 +388,10 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         if app.is_single_file_view && file_idx != app.diff_state.current_file_idx {
             continue;
         }
+        // See the matching filter guard in src/ui/diff_unified.rs.
+        if !app.file_passes_filter(file) {
+            continue;
+        }
         let path = file.display_path();
         let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -230,6 +230,12 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         if app.is_single_file_view && file_idx != app.diff_state.current_file_idx {
             continue;
         }
+        // File-tree include/exclude filters hide files from the diff too.
+        // Must stay in lockstep with `App::file_render_height`, which counts
+        // these files as zero lines.
+        if !app.file_passes_filter(file) {
+            continue;
+        }
         let path = file.display_path();
         let status = file.status.as_char();
         let is_reviewed = app.session.is_file_reviewed(path);

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -1,6 +1,7 @@
 use ratatui::{
     Frame,
-    layout::Rect,
+    layout::{Position, Rect},
+    style::Style,
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem},
 };
@@ -19,16 +20,31 @@ const UNREVIEWED_BOX: &str = "\u{25a2}"; // ▢
 pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::FileList;
 
-    let title = format!(
+    let mut title = format!(
         " Files \u{00b7} {}/{} ",
         app.reviewed_count(),
         app.file_count()
     );
-    let block = Block::default()
+    // A filter changes what the counts above mean, so say how much is hidden.
+    if app.file_filter_active() {
+        title.push_str(&format!(
+            "\u{00b7} {} of {} ",
+            app.file_count(),
+            app.unfiltered_file_count()
+        ));
+    }
+    let mut block = Block::default()
         .title(title)
         .borders(Borders::ALL)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
+
+    // Bottom border doubles as the filter status / prompt line. Using a
+    // block title instead of reserving an inner row keeps the list geometry
+    // (and therefore viewport_height and every scroll calculation) untouched.
+    if let Some(bottom) = filter_footer(app) {
+        block = block.title_bottom(bottom);
+    }
 
     let inner = block.inner(area);
     app.file_list_inner_area = Some(inner);
@@ -167,4 +183,235 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         .block(block);
 
     frame.render_stateful_widget(list, area, &mut app.file_list_state.list_state);
+
+    // Park the terminal cursor at the end of the prompt buffer so typing has
+    // a visible insertion point.
+    if let Some(draft) = app.file_tree_draft() {
+        let prefix = PROMPT_PAD + 2 + draft.buffer.width() as u16;
+        frame.set_cursor_position(Position {
+            x: (area.x + prefix).min(area.x + area.width.saturating_sub(1)),
+            y: area.y + area.height.saturating_sub(1),
+        });
+    }
+}
+
+/// Leading `│` border plus one space before the prompt sigil.
+const PROMPT_PAD: u16 = 2;
+
+/// Bottom-border content for the file tree: the active prompt while one is
+/// open, otherwise a summary of the applied filters and search.
+fn filter_footer(app: &App) -> Option<Line<'static>> {
+    let theme = &app.theme;
+
+    if let Some(draft) = app.file_tree_draft() {
+        return Some(Line::from(vec![
+            Span::styled(
+                format!(" {} ", draft.prompt.sigil()),
+                styles::mode_style(theme),
+            ),
+            Span::styled(
+                format!("{} ", draft.buffer),
+                Style::default().fg(theme.fg_primary),
+            ),
+        ]));
+    }
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    let mut push = |label: char, value: String| {
+        if !spans.is_empty() {
+            spans.push(Span::styled(
+                " \u{00b7} ",
+                Style::default().fg(theme.fg_dim),
+            ));
+        }
+        spans.push(Span::styled(
+            format!("{label}:"),
+            Style::default().fg(theme.fg_dim),
+        ));
+        spans.push(Span::styled(value, Style::default().fg(theme.fg_secondary)));
+    };
+
+    // Only the filters earn a slot here: they change what the panes contain
+    // and there is no other persistent cue for them. The `/` query is left
+    // out on purpose — the panel is narrow (a third pattern truncates to
+    // noise), and every `n`/`N` step reports the query and match position in
+    // the status bar anyway.
+    if let Some(include) = app.file_filter.include.as_ref() {
+        push('i', include.source.clone());
+    }
+    if let Some(exclude) = app.file_filter.exclude.as_ref() {
+        push('e', exclude.source.clone());
+    }
+
+    if spans.is_empty() {
+        return None;
+    }
+    spans.insert(0, Span::raw(" "));
+    spans.push(Span::raw(" "));
+    Some(Line::from(spans))
+}
+
+#[cfg(test)]
+mod tests {
+    //! Render checks for the filter status/prompt line in the file tree's
+    //! bottom border, driven through the real `ui::render`.
+    use crate::app::{App, DiffSource, FileTreePrompt, FocusedPanel, InputMode};
+    use crate::model::{DiffFile, DiffLine, FileStatus, ReviewSession, SessionDiffSource};
+    use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use std::path::PathBuf;
+
+    struct StubVcs(VcsInfo);
+    impl VcsBackend for StubVcs {
+        fn info(&self) -> &VcsInfo {
+            &self.0
+        }
+        fn get_working_tree_diff(
+            &self,
+            _hl: &crate::syntax::SyntaxHighlighter,
+        ) -> crate::error::Result<Vec<DiffFile>> {
+            Ok(Vec::new())
+        }
+        fn fetch_context_lines(
+            &self,
+            _path: &std::path::Path,
+            _status: FileStatus,
+            _ref_commit: Option<&str>,
+            _start: u32,
+            _end: u32,
+        ) -> crate::error::Result<Vec<DiffLine>> {
+            Ok(Vec::new())
+        }
+        fn file_line_count(
+            &self,
+            _path: &std::path::Path,
+            _status: FileStatus,
+            _ref_commit: Option<&str>,
+        ) -> crate::error::Result<u32> {
+            Ok(0)
+        }
+    }
+
+    fn file(path: &str) -> DiffFile {
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from(path)),
+            status: FileStatus::Modified,
+            hunks: vec![],
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash: 0,
+        }
+    }
+
+    fn app_with(paths: &[&str]) -> App {
+        let vcs_info = VcsInfo {
+            root_path: PathBuf::from("/tmp"),
+            head_commit: "head".into(),
+            branch_name: Some("main".into()),
+            vcs_type: VcsType::Git,
+        };
+        let session = ReviewSession::new(
+            vcs_info.root_path.clone(),
+            vcs_info.head_commit.clone(),
+            vcs_info.branch_name.clone(),
+            SessionDiffSource::WorkingTree,
+        );
+        let mut app = App::build(
+            Box::new(StubVcs(vcs_info.clone())),
+            vcs_info,
+            crate::theme::Theme::dark(),
+            None,
+            false,
+            paths.iter().map(|p| file(p)).collect(),
+            session,
+            DiffSource::WorkingTree,
+            InputMode::Normal,
+            Vec::new(),
+            None,
+            None,
+        )
+        .expect("build app");
+        app.show_file_list = true;
+        app.focused_panel = FocusedPanel::FileList;
+        app
+    }
+
+    fn draw(app: &mut App) -> Buffer {
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, app))
+            .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_text(buffer: &Buffer) -> String {
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn should_render_the_prompt_sigil_and_buffer_while_a_prompt_is_open() {
+        let mut app = app_with(&["src/main.rs", "README.md"]);
+        app.begin_file_tree_prompt(FileTreePrompt::Include);
+        for ch in r"\.rs$".chars() {
+            app.file_tree_prompt_insert_char(ch);
+        }
+
+        let text = buffer_text(&draw(&mut app));
+
+        assert!(
+            text.contains(r"i \.rs$"),
+            "expected the include prompt in the tree border, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn should_render_applied_filters_in_the_border_after_the_prompt_closes() {
+        let mut app = app_with(&["src/main.rs", "tests/smoke.rs", "README.md"]);
+        app.begin_file_tree_prompt(FileTreePrompt::Include);
+        for ch in r"\.rs$".chars() {
+            app.file_tree_prompt_insert_char(ch);
+        }
+        app.commit_file_tree_prompt();
+        app.begin_file_tree_prompt(FileTreePrompt::Exclude);
+        for ch in "^tests/".chars() {
+            app.file_tree_prompt_insert_char(ch);
+        }
+        app.commit_file_tree_prompt();
+
+        let text = buffer_text(&draw(&mut app));
+
+        assert!(
+            text.contains(r"i:\.rs$") && text.contains("e:^tests/"),
+            "expected both applied patterns in the tree border, got:\n{text}"
+        );
+        // Title reports the filtered count against the unfiltered total.
+        assert!(
+            text.contains("1 of 3"),
+            "expected a filtered/total count in the tree title, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn should_leave_the_border_clean_when_no_filter_is_set() {
+        let mut app = app_with(&["src/main.rs"]);
+
+        let text = buffer_text(&draw(&mut app));
+
+        assert!(
+            !text.contains("i:") && !text.contains("e:"),
+            "unfiltered tree should not advertise filters, got:\n{text}"
+        );
+    }
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -348,6 +348,37 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
             ),
             Span::raw("Collapse all directories"),
         ]),
+        Line::from(vec![
+            Span::styled(
+                "  i         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Filter to files matching a regex (hides others from tree + diff)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  e         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Filter out files matching a regex"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  I/E       ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Clear the include/exclude filter"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  /         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Search file paths; n/N step matches (selection only)"),
+        ]),
+        Line::from(Span::raw(
+            "  Patterns are case-insensitive and match the whole relative path.",
+        )),
         Line::from(""),
         Line::from(Span::styled(
             "Comment Navigator",

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -8,7 +8,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, Paragraph},
 };
 
-use crate::app::{App, DiffSource, InputMode, Message, MessageType};
+use crate::app::{App, DiffSource, FocusedPanel, InputMode, Message, MessageType};
 use crate::theme::Theme;
 use crate::ui::commit_row::CURSOR_GLYPH;
 use crate::ui::styles;
@@ -263,8 +263,16 @@ pub fn render_status_bar(frame: &mut Frame, app: &App, area: Rect) {
 
         let hints: Cow<'static, str> = if app.message.is_some() {
             Cow::Borrowed("")
+        } else if app.file_tree_prompt_editing() {
+            // File-tree prompts are a sub-state of Normal, so the mode chip
+            // still reads NORMAL; the hint is what tells the user Enter/Esc
+            // are the way out.
+            Cow::Borrowed("   \u{21b5} apply \u{00b7} esc cancel")
         } else {
             match app.input_mode {
+                InputMode::Normal if app.focused_panel == FocusedPanel::FileList => Cow::Borrowed(
+                    "   j/k move \u{00b7} \u{21b5} open \u{00b7} i/e filter \u{00b7} I/E clear \u{00b7} / search \u{00b7} r reviewed",
+                ),
                 InputMode::Normal => Cow::Borrowed(
                     "   j/k scroll \u{00b7} {/} file \u{00b7} m/M comment \u{00b7} r file \u{00b7} R hunk \u{00b7} c comment \u{00b7} ? help",
                 ),


### PR DESCRIPTION
This is meant to add similar functionality to the vscode `files to include` + `files to exclude` filters when searching the codebase, though in a more targeted way using basic regex to filter in/out files based on path.

Large diffs can be hard to navigate when only part of the change is relevant - this PR adds include/exclude filtering plus a path search to the file tree, active while the tree is focused:

  `i`   include prompt — keep only paths matching a regex
  `e`   exclude prompt — drop paths matching a regex
  `I`   clear the include filter
  `E`   clear the exclude filter
  `/`   search paths, n/N step matches (wraps)

Patterns are case-insensitive and match the full relative path. Include runs first, then exclude removes from what is left.

A filter narrows the diff pane as well as the tree, so `i \.rs$` means you actually only see the Rust files: hidden files also drop out of `}`/`{` file navigation, `[`/`]` hunk navigation, and the file and +/- counts in the header. Implemented as a view over `diff_files` rather than a mutation of it — `file_idx` stays an absolute index, so nothing downstream needs remapping. `App::file_passes_filter` is the single predicate, consulted by `build_visible_items`, `rebuild_annotations`, both diff renderers, `hunk_positions`, and `file_render_height`/`effective_file_height`, which report zero lines for hidden files so cumulative scroll offsets stay correct.

Keys are focus-scoped through `map_file_tree_mode`: the tree claims i/e/I/E and `/`, while the diff keeps `i` for editing the comment at the cursor and `/` for searching the diff. An open prompt is a text-input sub-state of Normal mode, mirroring the target selector's `pr_filter_draft`.

Enter applies, Esc cancels, ctrl-u/ctrl-w edit the line. Reopening a prompt pre-fills the applied pattern, so submitting an emptied buffer is the same as I/E. An invalid regex reports the reason and leaves the prompt open to be fixed. The tree title reports what is hidden (`Files · 2/12 · 12 of 58`) and the bottom border shows the active patterns.

Filters are a view, not an edit: comments on hidden files are not deleted and still export. They are session-local — never persisted — but survive `:e`.

<img width="636" height="1348" alt="Screenshot 2026-07-28 at 10 02 27 AM" src="https://github.com/user-attachments/assets/b2576558-4514-4d61-abfe-4a3817b3ef6a" />
