### PR TITLE
feat(skill): add Herdr launcher support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ src/
 
 Repository-managed agent integrations:
 
-- `skills/tuicr/` - Shared agent skill bundle for coding agents, for example Claude Code, Codex, and similar tools; launches tuicr in a tmux split pane
+- `skills/tuicr/` - Shared agent skill bundle for coding agents, for example Claude Code, Codex, and similar tools; launches tuicr in a tmux, Zellij, or Herdr split pane
 
 ### Key Types
 

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ I reviewed your code and have the following comments. Please address them.
 
 Paste it back to any coding agent (Claude, Codex, Cursor, etc).
 
-For an agent-driven workflow where your agent opens tuicr in a tmux split pane, see
-[skills/tuicr/SKILL.md](skills/tuicr/SKILL.md).
+For an agent-driven workflow where your agent opens tuicr in a tmux, Zellij, or Herdr
+split pane, see [skills/tuicr/SKILL.md](skills/tuicr/SKILL.md).
 
 ### To stdout
 

--- a/skills/tuicr/SKILL.md
+++ b/skills/tuicr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tuicr
-description: Use tuicr's review CLI to read and add comments in active TUI review sessions, and launch tuicr in tmux/zellij when a user needs an interactive review pane.
+description: Use tuicr's review CLI to read and add comments in active TUI review sessions, and launch tuicr in tmux, Zellij, or Herdr when a user needs an interactive review pane.
 ---
 
 # tuicr Review Workflow
@@ -63,8 +63,8 @@ If the user's intent is ambiguous, ask which workflow they want.
      `"active": true` as a convenience signal. If slug resolution fails, ask the
      user for the slug or repo path used by the session.
 
-The CLI works even if the agent is not running inside tmux or zellij, so do not
-require a multiplexer just to connect to an existing active session.
+The CLI works even if the agent is not running inside tmux, Zellij, or Herdr,
+so do not require a multiplexer just to connect to an existing active session.
 
 ## Start A Session
 
@@ -74,17 +74,22 @@ When the user needs an interactive tuicr pane and no active session exists:
 |-------------|--------|
 | `$TMUX` is set | Run `tuicr-wrapper.sh /path/to/repo` |
 | `$ZELLIJ` is set | Run `tuicr-wrapper-zellij.sh /path/to/repo` |
-| Neither is set | Tell the user you are waiting for them to start `tuicr` in the repo, then attach with `tuicr review list` after they say it is ready |
+| `$HERDR_ENV` is `1` | Run `tuicr-wrapper-herdr.sh /path/to/repo` |
+| None is set | Tell the user you are waiting for them to start `tuicr` in the repo, then attach with `tuicr review list` after they say it is ready |
 
-If both `$TMUX` and `$ZELLIJ` are set, prefer the innermost multiplexer if that
-is clear; otherwise ask.
+If more than one multiplexer marker is set, prefer the innermost multiplexer if
+that is clear; otherwise ask.
 
 Wrapper paths are relative to this skill directory:
 
 ```bash
 <skill-directory>/tuicr-wrapper.sh /path/to/repo
 <skill-directory>/tuicr-wrapper-zellij.sh /path/to/repo
+<skill-directory>/tuicr-wrapper-herdr.sh /path/to/repo
 ```
+
+The Herdr wrapper requires `jq` to read pane IDs and completion results from
+Herdr's JSON responses.
 
 If your tool supports command timeouts, use a long timeout, such as 10 minutes,
 because the wrappers wait for the TUI to exit. Once the TUI creates its active
@@ -207,12 +212,17 @@ zellij:
 - Toggle fullscreen: `Alt-f`
 - Cycle stacked panes: `Alt` + `[` / `]`
 
+Herdr:
+
+- Select a pane: click it in the Herdr UI
+- Close tuicr: press `q`; the wrapper then closes the review pane
+
 ## Error Handling
 
 | Situation | Action |
 |-----------|--------|
 | Multiple plausible active sessions | Ask which session slug to use |
-| No active session, tmux/zellij available | Start a new tuicr pane with the matching wrapper |
+| No active session, tmux/Zellij/Herdr available | Start a new tuicr pane with the matching wrapper |
 | No active session, no multiplexer | Tell the user you are waiting for them to start `tuicr` |
 | `tuicr` not installed | Tell the user to install tuicr |
 | Not a repository | Ask for the correct repo directory |

--- a/skills/tuicr/tuicr-wrapper-herdr.sh
+++ b/skills/tuicr/tuicr-wrapper-herdr.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -e -u -o pipefail
+
+TUICR_PANE_DIRECTION="${TUICR_PANE_DIRECTION:-right}"
+HERDR_BIN="${HERDR_BIN:-herdr}"
+JQ_BIN="${JQ_BIN:-jq}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info() {
+  printf "%b[tuicr]%b %s\n" "$GREEN" "$NC" "$*"
+}
+
+log_warn() {
+  printf "%b[tuicr]%b %s\n" "$YELLOW" "$NC" "$*"
+}
+
+log_error() {
+  printf "%b[tuicr]%b %s\n" "$RED" "$NC" "$*" >&2
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [directory]
+
+Launch tuicr in a Herdr split pane.
+
+Arguments:
+  directory    Repository directory to review (default: current directory)
+
+Environment variables:
+  TUICR_PANE_DIRECTION  Split direction: right or down (default: right)
+  HERDR_BIN             Path to the Herdr executable (default: herdr)
+  JQ_BIN                Path to the jq executable (default: jq)
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") ~/project
+  TUICR_PANE_DIRECTION=down $(basename "$0")
+EOF
+}
+
+require_command() {
+  local command_name="$1"
+  local display_name="$2"
+
+  if ! command -v "$command_name" &>/dev/null; then
+    log_error "$display_name not found on PATH"
+    return 1
+  fi
+}
+
+new_pane_id=""
+
+cleanup() {
+  local status=$?
+
+  if [[ -n "$new_pane_id" ]]; then
+    "$HERDR_BIN" pane close "$new_pane_id" >/dev/null 2>&1 || true
+  fi
+
+  return "$status"
+}
+
+launch_tuicr_pane() {
+  local target_dir="$1"
+
+  case "$TUICR_PANE_DIRECTION" in
+    right|down) ;;
+    *)
+      log_warn "Unknown TUICR_PANE_DIRECTION '$TUICR_PANE_DIRECTION'; using 'right'"
+      TUICR_PANE_DIRECTION="right"
+      ;;
+  esac
+
+  log_info "Launching tuicr in a Herdr pane split $TUICR_PANE_DIRECTION"
+  log_info "Directory: $target_dir"
+
+  local split_response
+  split_response=$("$HERDR_BIN" pane split --current \
+    --direction "$TUICR_PANE_DIRECTION" \
+    --cwd "$target_dir" \
+    --focus)
+
+  new_pane_id=$(printf '%s\n' "$split_response" | \
+    "$JQ_BIN" -er '.result.pane.pane_id')
+
+  local tuicr_bin
+  tuicr_bin=$(command -v tuicr)
+
+  local quoted_tuicr
+  printf -v quoted_tuicr '%q' "$tuicr_bin"
+
+  local completion_suffix="_DONE_$$_${RANDOM}__"
+  local completion_token="__TUICR${completion_suffix}"
+  local pane_command
+  pane_command="$quoted_tuicr; tuicr_status=\$?; printf '\\n__TUICR%s:%s\\n' '$completion_suffix' \"\$tuicr_status\""
+
+  "$HERDR_BIN" pane run "$new_pane_id" "$pane_command" >/dev/null
+
+  log_info "tuicr is running in pane $new_pane_id"
+  log_info "Waiting for tuicr to exit..."
+
+  local wait_response
+  wait_response=$("$HERDR_BIN" pane wait-output "$new_pane_id" \
+    --match "$completion_token" \
+    --source recent-unwrapped)
+
+  local matched_line
+  matched_line=$(printf '%s\n' "$wait_response" | \
+    "$JQ_BIN" -er '.result.matched_line')
+
+  local tuicr_status="${matched_line##*:}"
+  if [[ ! "$tuicr_status" =~ ^[0-9]+$ ]]; then
+    log_error "Could not read tuicr exit status from Herdr output"
+    return 1
+  fi
+
+  "$HERDR_BIN" pane close "$new_pane_id" >/dev/null
+  new_pane_id=""
+
+  if [[ "$tuicr_status" -eq 0 ]]; then
+    log_info "tuicr finished"
+  else
+    log_error "tuicr exited with status $tuicr_status"
+  fi
+
+  return "$tuicr_status"
+}
+
+main() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  if [[ "${HERDR_ENV:-}" != "1" ]]; then
+    log_error "Not running inside a Herdr-managed pane"
+    echo "Run your coding agent inside Herdr, then invoke the tuicr skill again."
+    exit 1
+  fi
+
+  require_command "$HERDR_BIN" "Herdr"
+  require_command "$JQ_BIN" "jq"
+  require_command "tuicr" "tuicr"
+
+  local target_dir="${1:-.}"
+  if [[ ! -d "$target_dir" ]]; then
+    log_error "Directory not found: $target_dir"
+    exit 1
+  fi
+  target_dir=$(cd "$target_dir" && pwd)
+
+  trap cleanup EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
+
+  launch_tuicr_pane "$target_dir"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- add a Herdr launcher for the repository-managed `tuicr` agent skill
- split and focus a sibling pane, run `tuicr` in the selected repository, wait for its exit, and clean up the created pane
- route `HERDR_ENV=1` sessions through the new wrapper and document Herdr alongside tmux and Zellij
- keep session discovery and comment exchange on the existing `tuicr review` CLI

Closes #500

## Validation

- `bash -n skills/tuicr/tuicr-wrapper-herdr.sh`
- `cargo fmt --check`
- `cargo test`
- verified the wrapper rejects use outside `HERDR_ENV=1`
- live Herdr smoke test confirmed the new pane is focused, runs `tuicr` in the requested cwd, returns the TUI exit status, and is removed after `q`
- reviewed the complete change through `tuicr` launched by the new Herdr wrapper