### PR TITLE
Feat/open editor with e

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `v` / `V` | Visual mode (range comment) |
 | `r` | Toggle file reviewed |
 | `R` | Toggle hunk reviewed |
+| `e` | Open focused file in `$EDITOR` |
 | `y` | Copy review to clipboard |
 | `:edit` | Open focused file in `$EDITOR` |
 | `:submit` | Push review to GitHub or GitLab |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -83,6 +83,7 @@ Shown below the file tree when local comments or visible remote PR threads exist
 | `dd` | Delete comment at cursor |
 | `i` | Edit comment at cursor (vim: text cursor at start) |
 | `A` | Edit comment at cursor with text cursor at end (vim mode only) |
+| `e` | Open focused file in `$EDITOR` |
 | `y` | Copy review to clipboard |
 
 ## Visual mode

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -94,7 +94,7 @@ fn editor_family(program: &str) -> EditorFamily {
         .and_then(|name| name.to_str())
         .unwrap_or(program);
     match name {
-        "vi" | "vim" | "nvim" | "nano" => EditorFamily::PlusLine,
+        "vi" | "vim" | "nvim" | "nano" | "emacs" | "emacsclient" => EditorFamily::PlusLine,
         "code" | "code-insiders" | "codium" | "cursor" => EditorFamily::GotoLine,
         _ => EditorFamily::Plain,
     }
@@ -156,6 +156,22 @@ mod tests {
             assert_eq!(command.program, editor);
             assert_eq!(args(&command), vec!["+42", "/repo/src/main.rs"]);
         }
+    }
+
+    #[test]
+    fn emacs_receives_plus_line_before_path() {
+        for editor in ["emacs", "emacsclient"] {
+            let command = EditorCommand::from_editor(editor, &target(Some(42)));
+            assert_eq!(command.program, editor);
+            assert_eq!(args(&command), vec!["+42", "/repo/src/main.rs"]);
+        }
+    }
+
+    #[test]
+    fn emacs_args_are_preserved() {
+        let command = EditorCommand::from_editor("emacs -nw", &target(Some(42)));
+        assert_eq!(command.program, "emacs");
+        assert_eq!(args(&command), vec!["-nw", "+42", "/repo/src/main.rs"]);
     }
 
     #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1556,6 +1556,7 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 app.set_error(format!("Failed to load diff: {e}"));
             }
         }
+        Action::EditFile => app.queue_editor_for_focused_item(),
         _ => {}
     }
 }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -44,6 +44,7 @@ pub enum Action {
     /// Edit the comment at cursor with the text cursor at end (vim `A`).
     EditCommentAtEnd,
     PendingDCommand,
+    EditFile,
     SearchNext,
     SearchPrev,
 
@@ -206,6 +207,7 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
         (KeyCode::Char('d'), KeyModifiers::NONE) => Action::PendingDCommand,
         (KeyCode::Char('v') | KeyCode::Char('V'), _) => Action::EnterVisualMode,
         (KeyCode::Char('y'), KeyModifiers::NONE) => Action::ExportToClipboard,
+        (KeyCode::Char('e'), KeyModifiers::NONE) => Action::EditFile,
         (KeyCode::Char('n'), KeyModifiers::NONE) => Action::SearchNext,
         (KeyCode::Char('N'), _) => Action::SearchPrev,
 
@@ -501,9 +503,9 @@ mod tests {
     }
 
     #[test]
-    fn should_leave_lowercase_e_unbound_in_normal_mode() {
+    fn should_map_lowercase_e_to_edit_file_in_normal_mode() {
         let action = map_normal_mode(key(KeyCode::Char('e')), DEFAULT_LEADER_KEY);
-        assert_eq!(action, Action::None);
+        assert_eq!(action, Action::EditFile);
     }
 
     #[test]

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -439,6 +439,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  e         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Open focused file in $EDITOR"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  v/V       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
Resolves #482.

## Summary

Adds a single-key `e` binding to open the focused file in `$EDITOR` (same action as `:edit`), and extends editor line-navigation support to Emacs.

## Changes

### `e` key opens focused file in `$EDITOR`

- **`src/input/keybindings.rs`**: Adds `Action::EditFile` variant (under Review actions section) and maps unmodified `e` → `Action::EditFile` in normal mode.
- **`src/handler.rs`**: Dispatches `Action::EditFile` to `app.queue_editor_for_focused_item()` in `handle_shared_normal_action`, covering the diff view, file list, comment navigator, and inline commit selector.
- **`src/ui/help_popup.rs`**: Adds `e` help entry.
- **`docs/KEYBINDINGS.md`**, **`README.md`**: Document `e` binding.

Works from the diff view (also passes the cursor line as `+N` to supported editors) and from the file list, matching the lazygit `e` convention.

### Emacs `+NN` line navigation support

- **`src/editor.rs`**: Adds `emacs` and `emacsclient` to the `PlusLine` editor family so they receive `+42 /path/to/file` syntax instead of silently dropping the line number. `emacs -nw` and similar argument patterns are preserved correctly.

## Tests

- All existing lib tests pass.
- keybinding tests pass, including the updated `should_map_lowercase_e_to_edit_file_in_normal_mode`.
- editor tests pass, including new `emacs_receives_plus_line_before_path` and `emacs_args_are_preserved`.
