### PR TITLE
Strip SSH port before building forge --repo URLs

### DIFF
--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -619,7 +619,7 @@ pub fn parse_github_remote_url(remote_url: &str) -> Option<ForgeRepository> {
         .map(|(_, rest)| rest)
         .unwrap_or(without_scheme);
     let (host, path) = without_user.split_once('/')?;
-    repository_from_path(host, path)
+    repository_from_path(strip_port(host), path)
 }
 
 fn parse_numeric_target(target: &str) -> Option<PullRequestTarget> {
@@ -809,6 +809,18 @@ fn trim_url_suffix(value: &str) -> &str {
         .next()
         .unwrap_or(value)
         .trim_end_matches('/')
+}
+
+/// Strip a trailing `:<port>` from a host, e.g. `example.com:2222` ->
+/// `example.com`. `ssh://` remotes commonly carry a non-default SSH port
+/// (GitHub Enterprise instances behind a custom port); that port is
+/// meaningless for the HTTPS API host used to build `--repo` arguments, and
+/// left in place it turns into a broken URL.
+fn strip_port(host: &str) -> &str {
+    match host.rsplit_once(':') {
+        Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+        _ => host,
+    }
 }
 
 fn strip_git_suffix(value: &str) -> &str {
@@ -1297,6 +1309,18 @@ index 1111111..2222222 100644
     fn parses_ssh_remote_url() {
         let repository =
             parse_github_remote_url("ssh://git@github.example.com/agavra/tuicr.git").unwrap();
+        assert_eq!(repository.host, "github.example.com");
+        assert_eq!(repository.slug(), "agavra/tuicr");
+    }
+
+    #[test]
+    fn parses_ssh_remote_url_with_custom_port() {
+        // GitHub Enterprise instances behind a non-default SSH port must not
+        // leak that port into the ForgeRepository host; it breaks `--repo`
+        // URL construction against the HTTPS API.
+        let repository =
+            parse_github_remote_url("ssh://git@github.example.com:2222/agavra/tuicr.git")
+                .unwrap();
         assert_eq!(repository.host, "github.example.com");
         assert_eq!(repository.slug(), "agavra/tuicr");
     }

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -1319,8 +1319,7 @@ index 1111111..2222222 100644
         // leak that port into the ForgeRepository host; it breaks `--repo`
         // URL construction against the HTTPS API.
         let repository =
-            parse_github_remote_url("ssh://git@github.example.com:2222/agavra/tuicr.git")
-                .unwrap();
+            parse_github_remote_url("ssh://git@github.example.com:2222/agavra/tuicr.git").unwrap();
         assert_eq!(repository.host, "github.example.com");
         assert_eq!(repository.slug(), "agavra/tuicr");
     }

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -858,6 +858,7 @@ pub fn parse_gitlab_remote_url(remote_url: &str) -> Option<ForgeRepository> {
         .map(|(_, rest)| rest)
         .unwrap_or(without_scheme);
     let (host, path) = without_user.split_once('/')?;
+    let host = strip_port(host);
     if !is_gitlab_host(host) {
         return None;
     }
@@ -992,6 +993,18 @@ fn trim_url_suffix(value: &str) -> &str {
         .next()
         .unwrap_or(value)
         .trim_end_matches('/')
+}
+
+/// Strip a trailing `:<port>` from a host, e.g. `example.com:2222` ->
+/// `example.com`. `ssh://` remotes commonly carry a non-default SSH port
+/// (self-hosted instances, GitLab's SSH-over-443 setup); that port is
+/// meaningless for the HTTPS API host used to build `--repo` arguments, and
+/// left in place it turns into a broken URL (wrong port, TLS failure).
+fn strip_port(host: &str) -> &str {
+    match host.rsplit_once(':') {
+        Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+        _ => host,
+    }
 }
 
 fn strip_git_suffix(value: &str) -> &str {
@@ -2050,6 +2063,25 @@ mod tests {
     fn should_ignore_github_remote_url() {
         assert!(parse_gitlab_remote_url("https://github.com/owner/repo.git").is_none());
         assert!(parse_gitlab_remote_url("git@github.com:owner/repo.git").is_none());
+    }
+
+    #[test]
+    fn should_strip_ssh_port_from_self_hosted_ssh_scheme_remote() {
+        // `ssh://` remotes carrying a non-default SSH port (self-hosted
+        // instances behind a custom port) must not leak that port into the
+        // ForgeRepository host; it's meaningless for the HTTPS API and
+        // breaks `--repo` URL construction (wrong port, TLS failure).
+        let repo = parse_gitlab_remote_url(
+            "ssh://git@gitlab.example.com:2222/engineering/platform/widget-service.git",
+        )
+        .unwrap();
+        assert_eq!(repo.host, "gitlab.example.com");
+        assert_eq!(repo.owner, "engineering/platform");
+        assert_eq!(repo.name, "widget-service");
+        assert_eq!(
+            GitLabGlabBackend::<SystemGlabRunner>::repo_arg(&repo),
+            "https://gitlab.example.com/engineering/platform/widget-service"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Discovered while switching to the Pull Requests tab on the initial `tuicr` selector screen: the tab failed to load PRs against a self-hosted GitLab remote.

Root cause: `ssh://user@host:port/owner/repo` remotes (common for self-hosted GitLab/GHE on a non-default SSH port) leaked `host:port` into `ForgeRepository.host`. That host built the `--repo https://host:port/...` argument passed to `glab`/`gh`, which fails at the TLS layer since the SSH port isn't the HTTPS port.

Repro, confirmed against a real self-hosted GitLab remote on port 2222:
```
$ glab mr list --repo "https://gitlab.example.com:2222/owner/repo" ...
Get "https://gitlab.example.com:2222/api/v4/...": tls: first record does not look like a TLS handshake.
```

**Fix:** `strip_port()` added to both `parse_gitlab_remote_url` and `parse_github_remote_url`; drops the trailing `:<port>` before constructing `ForgeRepository`.

**Testing:** regression tests added for both parsers (`should_strip_ssh_port_from_self_hosted_ssh_scheme_remote`, `parses_ssh_remote_url_with_custom_port`). Full `cargo test --lib` passes.