### PR TITLE
fix: Option for relative line numbers in the diff gutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ appearance = "system"        # or "dark" / "light"
 mouse = true
 leader = ";"                  # configurable prefix for leader shortcuts
 comment_vim = false           # vim modal editing in the review comment box
+relative_line_numbers = false # show rendered-row distances in the diff gutter
 review_watch_interval_ms = 1000 # set to 0 to disable persisted-review polling
 
 [[comment_types]]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,6 +32,7 @@ leader = ","
 comment_vim = false
 comment_tab_width = 4
 wrap = false
+relative_line_numbers = false
 cursor_line = true
 transparent_background = true
 scroll_offset = 5
@@ -79,6 +80,7 @@ legend = true
 | `comment_vim`              | `false`      | Vim modal editing in the comment box; toggle at runtime with `:vim`. When off, default emacs/readline bindings.                                            |
 | `comment_tab_width`        | `4`          | Spaces inserted by Tab while typing in the vim comment box (Insert mode).                                                                                  |
 | `wrap`                     | `false`      | Line wrap in the diff view. Toggle with `:set wrap!`.                                                                                                      |
+| `relative_line_numbers`    | `false`      | Show gutter numbers as rendered-row distances from the cursor. Toggle with `:set relativenumber!`.                                                         |
 | `cursor_line`              | `true`       | Highlight the current cursor line and visual selection.                                                                                                    |
 | `transparent_background`   | `true`       | Let the terminal background show through panels. `false` paints the theme's `panel_bg`.                                                                    |
 | `scroll_offset`            | `0`          | Minimum lines visible above and below the cursor when scrolling (like Vim's `scrolloff`).                                                                  |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -139,6 +139,8 @@ In command mode,
 | `:submit draft` | Submit a Draft review (pending on GitHub) |
 | `:set wrap` | Enable line wrap in diff view |
 | `:set wrap!` | Toggle line wrap in diff view |
+| `:set relativenumber` / `:set norelativenumber` | Enable / disable relative rendered-row numbers |
+| `:set relativenumber!` | Toggle relative rendered-row numbers |
 | `:set commits` | Show inline commit selector |
 | `:set nocommits` | Hide inline commit selector |
 | `:set commits!` | Toggle inline commit selector |

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -452,6 +452,7 @@ impl App {
             input_mode,
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
+            relative_line_numbers: false,
             file_list_state: FileListState::default(),
             comment_navigator_state: CommentNavigatorState::default(),
             diff_state: DiffState::default(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1021,6 +1021,7 @@ pub struct App {
     pub input_mode: InputMode,
     pub focused_panel: FocusedPanel,
     pub diff_view_mode: DiffViewMode,
+    pub relative_line_numbers: bool,
 
     pub file_list_state: FileListState,
     pub comment_navigator_state: CommentNavigatorState,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -619,7 +619,12 @@ impl App {
             .copied()
             .max()
             .unwrap_or(0);
-        lineno_width(hunk_max.max(cache_max))
+        let relative_max = if self.relative_line_numbers {
+            self.line_annotations.len().saturating_sub(1) as u32
+        } else {
+            0
+        };
+        lineno_width(hunk_max.max(cache_max).max(relative_max))
     }
 
     pub fn pane_geometry(&self, inner: ratatui::layout::Rect, side: LineSide) -> PaneGeom {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -118,6 +118,7 @@ pub struct AppConfig {
     pub initial_commit_selection: Option<String>,
     pub ignore_whitespace: Option<bool>,
     pub wrap: Option<bool>,
+    pub relative_line_numbers: Option<bool>,
     pub export_legend: Option<bool>,
     pub cursor_line: Option<bool>,
     pub mouse: Option<bool>,
@@ -179,6 +180,7 @@ const KNOWN_KEYS: &[&str] = &[
     "initial_commit_selection",
     "ignore_whitespace",
     "wrap",
+    "relative_line_numbers",
     "export_legend",
     "cursor_line",
     "mouse",
@@ -399,6 +401,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             &["unified", "side-by-side"],
             &mut warnings,
         ),
+        relative_line_numbers: read_bool(table, "relative_line_numbers", &mut warnings),
         commit_order: read_enum(
             table,
             "commit_order",
@@ -914,6 +917,19 @@ mod tests {
             None
         );
         assert_eq!(outcome.warnings.len(), 1);
+    }
+
+    #[test]
+    fn should_parse_relative_line_numbers() {
+        let outcome = parse_config("relative_line_numbers = true\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.relative_line_numbers),
+            Some(true)
+        );
+        assert!(outcome.warnings.is_empty());
     }
 
     // diff_view

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -39,6 +39,18 @@ const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec::new(&["set wrap"], CommandKind::SetWrap),
     CommandSpec::new(&["set wrap!"], CommandKind::ToggleWrap),
     CommandSpec::new(&["wrap"], CommandKind::ToggleWrap),
+    CommandSpec::new(
+        &["set relativenumber"],
+        CommandKind::SetRelativeLineNumbers(true),
+    ),
+    CommandSpec::new(
+        &["set norelativenumber"],
+        CommandKind::SetRelativeLineNumbers(false),
+    ),
+    CommandSpec::new(
+        &["set relativenumber!"],
+        CommandKind::ToggleRelativeLineNumbers,
+    ),
     CommandSpec::new(&["vim", "set vim!"], CommandKind::ToggleVim),
     CommandSpec::new(&["set vim"], CommandKind::SetVim(true)),
     CommandSpec::new(&["novim", "set novim"], CommandKind::SetVim(false)),
@@ -113,6 +125,8 @@ enum CommandKind {
     Update,
     SetWrap,
     ToggleWrap,
+    SetRelativeLineNumbers(bool),
+    ToggleRelativeLineNumbers,
     ToggleVim,
     SetVim(bool),
     SetCommitsVisible(bool),
@@ -559,6 +573,27 @@ fn command_spec_for(cmd: &str) -> Option<&'static CommandSpec> {
     COMMAND_SPECS.iter().find(|spec| spec.names.contains(&cmd))
 }
 
+#[cfg(test)]
+mod relative_line_number_command_tests {
+    use super::{CommandKind, command_spec_for};
+
+    #[test]
+    fn parses_relative_line_number_commands() {
+        assert_eq!(
+            command_spec_for("set relativenumber").map(|spec| spec.kind),
+            Some(CommandKind::SetRelativeLineNumbers(true))
+        );
+        assert_eq!(
+            command_spec_for("set norelativenumber").map(|spec| spec.kind),
+            Some(CommandKind::SetRelativeLineNumbers(false))
+        );
+        assert_eq!(
+            command_spec_for("set relativenumber!").map(|spec| spec.kind),
+            Some(CommandKind::ToggleRelativeLineNumbers)
+        );
+    }
+}
+
 /// CommandCompleter computes command-buffer replacements without mutating App.
 struct CommandCompleter<'a> {
     /// Registry whose command names are exposed as completion candidates.
@@ -792,6 +827,14 @@ fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
         }
         CommandKind::ToggleWrap => {
             app.toggle_diff_wrap();
+            CommandAfterDispatch::ExitCommandMode
+        }
+        CommandKind::SetRelativeLineNumbers(enabled) => {
+            app.relative_line_numbers = enabled;
+            CommandAfterDispatch::ExitCommandMode
+        }
+        CommandKind::ToggleRelativeLineNumbers => {
+            app.relative_line_numbers = !app.relative_line_numbers;
             CommandAfterDispatch::ExitCommandMode
         }
         CommandKind::ToggleVim => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -296,6 +296,7 @@ fn main() -> anyhow::Result<()> {
         if let Some(wrap) = cfg.wrap {
             app.diff_state.wrap_lines = wrap;
         }
+        app.relative_line_numbers = cfg.relative_line_numbers.unwrap_or(false);
         // Open in single-file view when the user opts in. Pristine
         // `--all-files` already turned it on inside `App::new`, so we
         // only toggle if it's still off.

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -166,6 +166,16 @@ impl SideBySideContext<'_> {
     fn is_visible(&self, line_idx: usize) -> bool {
         line_idx >= self.visible_start && line_idx < self.visible_end
     }
+
+    fn display_lineno(&self, source_line: Option<u32>, line_idx: usize) -> Option<u32> {
+        source_line.map(|line| {
+            if self.app.relative_line_numbers {
+                line_idx.abs_diff(self.current_line_idx) as u32
+            } else {
+                line
+            }
+        })
+    }
 }
 
 pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -988,12 +998,12 @@ fn render_sbs_expanded_context_line(
     let lw = ctx.lineno_width;
     let content_width = ctx.content_width;
     let indicator = cursor_indicator(*line_idx, ctx.current_line_idx);
-    let old_line_num = expanded_line
-        .old_lineno
+    let old_line_num = ctx
+        .display_lineno(expanded_line.old_lineno, *line_idx)
         .map(|n| format!("{n:>lw$} "))
         .unwrap_or_else(|| " ".repeat(lw + 1));
-    let new_line_num = expanded_line
-        .new_lineno
+    let new_line_num = ctx
+        .display_lineno(expanded_line.new_lineno, *line_idx)
         .map(|n| format!("{n:>lw$} "))
         .unwrap_or_else(|| " ".repeat(lw + 1));
     let ec_style = styles::expanded_context_style(theme);
@@ -1147,12 +1157,12 @@ fn render_context_line_side_by_side(
 ) -> (usize, Option<SideBySideCursorInfo>) {
     if ctx.is_visible(line_idx) {
         let w = ctx.lineno_width;
-        let old_line_num = diff_line
-            .old_lineno
+        let old_line_num = ctx
+            .display_lineno(diff_line.old_lineno, line_idx)
             .map(|n| format!("{n:>w$}"))
             .unwrap_or_else(|| " ".repeat(w));
-        let new_line_num = diff_line
-            .new_lineno
+        let new_line_num = ctx
+            .display_lineno(diff_line.new_lineno, line_idx)
             .map(|n| format!("{n:>w$}"))
             .unwrap_or_else(|| " ".repeat(w));
 
@@ -1209,12 +1219,12 @@ fn render_context_line_side_by_side(
             ctx.theme,
             indicator,
             SideSpec {
-                lineno: diff_line.old_lineno,
+                lineno: ctx.display_lineno(diff_line.old_lineno, line_idx),
                 marker: " ",
                 marker_style: ctx_style,
             },
             SideSpec {
-                lineno: diff_line.new_lineno,
+                lineno: ctx.display_lineno(diff_line.new_lineno, line_idx),
                 marker: " ",
                 marker_style: ctx_style,
             },
@@ -1314,6 +1324,7 @@ fn render_deletion_addition_pair_side_by_side(
                     del_line,
                     ctx.content_width,
                     ctx.lineno_width,
+                    ctx.display_lineno(del_line.old_lineno, line_idx),
                 );
             } else {
                 add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
@@ -1329,6 +1340,7 @@ fn render_deletion_addition_pair_side_by_side(
                     add_line,
                     ctx.content_width,
                     ctx.lineno_width,
+                    ctx.display_lineno(add_line.new_lineno, line_idx),
                 );
             } else {
                 add_empty_column_spans(&mut spans, ctx.content_width, ctx.lineno_width);
@@ -1343,7 +1355,7 @@ fn render_deletion_addition_pair_side_by_side(
                         content_spans_for_diff_line(ctx.theme, dl, LineOrigin::Deletion),
                         column_pad_style(ctx.theme, dl, LineOrigin::Deletion),
                         "▌",
-                        dl.old_lineno,
+                        ctx.display_lineno(dl.old_lineno, line_idx),
                         styles::diff_del_style(ctx.theme),
                     ),
                     None => (Vec::new(), Style::default(), " ", None, Style::default()),
@@ -1354,7 +1366,7 @@ fn render_deletion_addition_pair_side_by_side(
                         content_spans_for_diff_line(ctx.theme, al, LineOrigin::Addition),
                         column_pad_style(ctx.theme, al, LineOrigin::Addition),
                         "▌",
-                        al.new_lineno,
+                        ctx.display_lineno(al.new_lineno, line_idx),
                         styles::diff_add_style(ctx.theme),
                     ),
                     None => (Vec::new(), Style::default(), " ", None, Style::default()),
@@ -1477,6 +1489,7 @@ fn render_standalone_addition_side_by_side(
             diff_line,
             ctx.content_width,
             ctx.lineno_width,
+            ctx.display_lineno(diff_line.new_lineno, line_idx),
         );
 
         lines.push(Line::from(spans));
@@ -1493,7 +1506,7 @@ fn render_standalone_addition_side_by_side(
                 marker_style: Style::default(),
             },
             SideSpec {
-                lineno: diff_line.new_lineno,
+                lineno: ctx.display_lineno(diff_line.new_lineno, line_idx),
                 marker: "▌",
                 marker_style: styles::diff_add_style(ctx.theme),
             },
@@ -1611,9 +1624,9 @@ fn add_deletion_spans(
     diff_line: &crate::model::DiffLine,
     content_width: usize,
     lw: usize,
+    display_lineno: Option<u32>,
 ) {
-    let line_num = diff_line
-        .old_lineno
+    let line_num = display_lineno
         .map(|n| format!("{n:>lw$}"))
         .unwrap_or_else(|| " ".repeat(lw));
 
@@ -1642,9 +1655,9 @@ fn add_addition_spans(
     diff_line: &crate::model::DiffLine,
     content_width: usize,
     lw: usize,
+    display_lineno: Option<u32>,
 ) {
-    let line_num = diff_line
-        .new_lineno
+    let line_num = display_lineno
         .map(|n| format!("{n:>lw$}"))
         .unwrap_or_else(|| " ".repeat(lw));
 

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -435,6 +435,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                 expanded_line,
                                 &app.theme,
                                 lw,
+                                app.relative_line_numbers,
                             );
                         }
                     }
@@ -510,6 +511,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                 expanded_line,
                                 &app.theme,
                                 lw,
+                                app.relative_line_numbers,
                             );
                         }
                     }
@@ -549,6 +551,13 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         // line numbers, matching the side-by-side view.
                         let line_num_str = if file.is_commit_message {
                             " ".repeat(lw + 1)
+                        } else if app.relative_line_numbers {
+                            crate::ui::diff_view::relative_line_number_field(
+                                diff_line.new_lineno.or(diff_line.old_lineno),
+                                line_idx,
+                                current_line_idx,
+                                lw,
+                            )
                         } else {
                             crate::ui::diff_view::unified_line_number_field(diff_line, lw)
                         };
@@ -980,6 +989,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                             expanded_line,
                             &app.theme,
                             lw,
+                            app.relative_line_numbers,
                         );
                     }
                 }
@@ -1015,6 +1025,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                             expanded_line,
                             &app.theme,
                             lw,
+                            app.relative_line_numbers,
                         );
                     }
                 }
@@ -1303,9 +1314,19 @@ fn render_expanded_context_line(
     expanded_line: &crate::model::DiffLine,
     theme: &Theme,
     lw: usize,
+    relative_line_numbers: bool,
 ) {
     let indicator = cursor_indicator(*line_idx, current_line_idx);
-    let line_num = crate::ui::diff_view::expanded_context_lineno_field(expanded_line, lw);
+    let line_num = if relative_line_numbers {
+        crate::ui::diff_view::relative_line_number_field(
+            expanded_line.new_lineno,
+            *line_idx,
+            current_line_idx,
+            lw,
+        )
+    } else {
+        crate::ui::diff_view::expanded_context_lineno_field(expanded_line, lw)
+    };
     let line_spans = vec![
         Span::styled(indicator, styles::current_line_indicator_style(theme)),
         Span::styled(line_num, styles::expanded_context_style(theme)),

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -75,6 +75,29 @@ pub(super) fn unified_line_number_field(dl: &DiffLine, lw: usize) -> String {
     }
 }
 
+pub(super) fn relative_line_number_field(
+    source_line: Option<u32>,
+    line_idx: usize,
+    current_line_idx: usize,
+    lw: usize,
+) -> String {
+    source_line
+        .map(|_| format!("{:>lw$} ", line_idx.abs_diff(current_line_idx)))
+        .unwrap_or_else(|| " ".repeat(lw + 1))
+}
+
+#[cfg(test)]
+mod relative_line_number_tests {
+    use super::relative_line_number_field;
+
+    #[test]
+    fn uses_rendered_row_distance_and_preserves_missing_sides() {
+        assert_eq!(relative_line_number_field(Some(100), 14, 10, 3), "  4 ");
+        assert_eq!(relative_line_number_field(Some(100), 10, 10, 3), "  0 ");
+        assert_eq!(relative_line_number_field(None, 14, 10, 3), "    ");
+    }
+}
+
 /// Single-cell origin marker for a unified diff line (`▌` for add/del,
 /// space for context). Callers append a trailing space of their own.
 pub(super) fn unified_line_origin_marker(dl: &DiffLine) -> &'static str {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -720,6 +720,20 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  :set relativenumber[!]",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Enable/toggle relative rendered-row numbers"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :set norelativenumber",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("  Disable relative rendered-row numbers"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  :set commits",
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
Fixes #509.

## Summary

Option for relative line numbers in the diff gutter

## Validation

- Mechanical gate: +162/-19, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->