### PR TITLE
refactor(app): unify the file-collapse predicate

### DIFF
--- a/src/app/annotations.rs
+++ b/src/app/annotations.rs
@@ -163,10 +163,10 @@ impl App {
                     .push(AnnotatedLine::FileHeader { file_idx });
             }
 
-            // If reviewed, skip all content for this file. Single-file
-            // view ignores the reviewed-collapse since the user
-            // explicitly focused this file.
-            if self.session.is_file_reviewed(path) && !self.is_single_file_view {
+            // If collapsed, skip all content for this file. Single-file
+            // view ignores the collapse since the user explicitly focused
+            // this file.
+            if self.is_file_collapsed(file) && !self.is_single_file_view {
                 continue;
             }
 

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -841,16 +841,15 @@ impl App {
                 continue;
             }
             let path = file.display_path();
-            let is_reviewed = self.session.is_file_reviewed(path);
 
+            // Mutually exclusive, so only one file-state lookup per file.
             if !single {
                 cumulative += 1; // File header
-            }
-            if !single && is_reviewed {
-                // multi-file collapsed: no body, no trailing spacing
-                continue;
-            }
-            if single && is_reviewed {
+                if self.is_file_collapsed(file) {
+                    // multi-file collapsed: no body, no trailing spacing
+                    continue;
+                }
+            } else if self.session.is_file_reviewed(path) {
                 cumulative += 1; // banner
             }
             if let Some(review) = self.session.files.get(path) {
@@ -994,7 +993,7 @@ impl App {
     }
 
     pub(in crate::app) fn file_render_height(&self, file_idx: usize, file: &DiffFile) -> usize {
-        if self.session.is_file_reviewed(file.display_path()) {
+        if self.is_file_collapsed(file) {
             return 1; // collapsed: header only
         }
         1 + self.file_render_body_height(file_idx, file) // header + body

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -273,6 +273,28 @@ impl App {
         }
     }
 
+    /// Whether a file's diff body is hidden, leaving only its header row.
+    ///
+    /// Reviewed files collapse so a long review stream shrinks as it is
+    /// worked through. The annotation builder, both diff renderers, and the
+    /// scroll-height math all have to agree on this or the cursor lands on
+    /// rows that aren't drawn, so they share this one predicate.
+    ///
+    /// Deliberately says nothing about single-file view: the call sites
+    /// disagree about it (`file_render_height` ignores it, the renderers
+    /// honor it), so each keeps its own gate rather than having one folded
+    /// in here.
+    ///
+    /// Both renderers and `hunk_positions` call this once per file per
+    /// frame, so it has to stay cheap — currently a single map lookup.
+    /// Callers reach it through a `!is_single_file_view` branch that is
+    /// exclusive with the reviewed-banner branch, so no site pays for two
+    /// lookups to decide one thing.
+    #[inline]
+    pub fn is_file_collapsed(&self, file: &DiffFile) -> bool {
+        self.session.is_file_reviewed(file.display_path())
+    }
+
     pub fn file_count(&self) -> usize {
         self.diff_files.len()
     }

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -517,6 +517,42 @@ fn release_then_press_walks_when_keyboard_enhancement_supported() {
 }
 
 #[test]
+fn is_file_collapsed_tracks_reviewed_state() {
+    let files = vec![
+        file("a.rs", vec![hunk(1, 3)]),
+        file("b.rs", vec![hunk(1, 3)]),
+    ];
+    let mut app = app_with(files);
+
+    let a = app.diff_files[0].clone();
+    let b = app.diff_files[1].clone();
+    assert!(!app.is_file_collapsed(&a));
+    assert!(!app.is_file_collapsed(&b));
+
+    app.toggle_reviewed_for_file_idx(0, false);
+    assert!(app.is_file_collapsed(&a));
+    assert!(!app.is_file_collapsed(&b));
+}
+
+#[test]
+fn is_file_collapsed_ignores_single_file_view() {
+    // The predicate deliberately says nothing about single-file view: its
+    // consumers disagree about it (`file_render_height` ignores it, the
+    // renderers honor it), so each keeps its own gate. Locking that here
+    // stops a future change from folding the check in and silently
+    // altering `file_render_height`.
+    let files = vec![file("a.rs", vec![hunk(1, 3)])];
+    let mut app = app_with(files);
+    app.toggle_reviewed_for_file_idx(0, false);
+    let a = app.diff_files[0].clone();
+
+    app.is_single_file_view = false;
+    assert!(app.is_file_collapsed(&a));
+    app.is_single_file_view = true;
+    assert!(app.is_file_collapsed(&a));
+}
+
+#[test]
 fn effective_file_height_is_zero_for_non_current_in_single_file_view() {
     let files = vec![
         file("a.rs", vec![hunk(1, 3)]),

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -404,8 +404,9 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             continue;
         }
         let path = file.display_path();
-        let is_reviewed = app.session.is_file_reviewed(path);
 
+        // Mutually exclusive branches, as in the unified renderer: each
+        // side pays for only the file-state lookup it actually needs.
         if !app.is_single_file_view {
             let indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
             let header_text = crate::ui::diff_view::file_header_prefix_text(app, file);
@@ -418,15 +419,14 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 ),
             ]));
             line_idx += 1;
-        }
 
-        // If file is reviewed (and we're in multi-file view), skip the
-        // body. Single-file view keeps the focused file visible under a
-        // dimmed banner.
-        if is_reviewed && !app.is_single_file_view {
-            continue;
-        }
-        if is_reviewed && app.is_single_file_view {
+            // Collapsed files render as the header alone.
+            if app.is_file_collapsed(file) {
+                continue;
+            }
+        } else if app.session.is_file_reviewed(path) {
+            // Single-file view keeps the focused file visible under a
+            // dimmed banner.
             let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -246,12 +246,14 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             continue;
         }
         let path = file.display_path();
-        let is_reviewed = app.session.is_file_reviewed(path);
 
-        // The `═══ filename ═══` separator is redundant in single-file
-        // view: the status bar and file list already name the file, and
-        // the wide bar of `═` characters confuses horizontal scrolling.
+        // Multi-file and single-file view are mutually exclusive here, so
+        // this is one branch rather than two guarded conditions: each side
+        // then pays for only the file-state lookup it actually needs.
         if !app.is_single_file_view {
+            // The `═══ filename ═══` separator is redundant in single-file
+            // view: the status bar and file list already name the file, and
+            // the wide bar of `═` characters confuses horizontal scrolling.
             let indicator = cursor_indicator_spaced(line_idx, current_line_idx);
             let header_text = crate::ui::diff_view::file_header_prefix_text(app, file);
             lines.push(Line::from(vec![
@@ -263,15 +265,14 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 ),
             ]));
             line_idx += 1;
-        }
 
-        // If file is reviewed (and we're in multi-file view), skip
-        // rendering the body. In single-file view the user explicitly
-        // focused this file, so show its content under a dimmed banner.
-        if is_reviewed && !app.is_single_file_view {
-            continue;
-        }
-        if is_reviewed && app.is_single_file_view {
+            // Collapsed files render as the header alone.
+            if app.is_file_collapsed(file) {
+                continue;
+            }
+        } else if app.session.is_file_reviewed(path) {
+            // Single-file view shows a reviewed file's content anyway --
+            // the user explicitly focused it -- under a dimmed banner.
             let indicator = cursor_indicator(line_idx, current_line_idx);
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),


### PR DESCRIPTION
Whether a file's diff body is hidden was decided independently in five places: the annotation builder, both diff renderers, and two scroll-height helpers. They have to agree or the cursor lands on rows that were never drawn, which is the failure mode behind several past scroll fixes.

This extracts `App::is_file_collapsed` and routes all five through it. **No behavior change** — it's a consolidation, and the tests that existed before still pass unchanged.

### Why the predicate says nothing about single-file view

The call sites genuinely disagree: `file_render_height` ignores `is_single_file_view` while the renderers honor it. Folding the check into the predicate would have silently changed `file_render_height` for its two callers, so each site keeps its own gate and the asymmetry is preserved rather than accidentally "fixed". There's a test locking that in (`is_file_collapsed_ignores_single_file_view`) so a future change can't quietly fold it in.

### No added per-frame cost

This is called once per file per frame, so I checked the lookup count rather than assuming.

Three sites had cached a reviewed bool and used it to decide two different things — whether to collapse, and whether to draw the "Marked reviewed" banner — which a naive predicate call would have turned into a second map lookup per file per frame. Those two decisions are mutually exclusive on `is_single_file_view`, so they're now one `if/else` instead of two guarded conditions. Each branch performs exactly one file-state lookup, matching the previous count:

| | before | after |
|---|---|---|
| multi-file | `file_header_prefix_text` + collapse gate (2) | unchanged (2) |
| single-file | `is_file_reviewed` (1) | unchanged (1) |
| `hunk_positions` | one lookup per file (1) | unchanged (1) |

Uses of `is_file_reviewed` that drive reviewed-*specific* decoration — the tree checkbox, the `✓` header mark, the banner — are left alone. Only the collapse gates moved.

### Testing

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (1199 passing) are clean on top of 5675284. Dogfooded per CONTRIBUTING by reviewing this diff in tuicr itself.

### Note

This is the first of two: #525 builds on it to collapse files marked generated in `.gitattributes`, which is what motivated the refactor. This one stands on its own merits either way — five copies of one predicate is a latent bug regardless of whether the follow-up is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
