### PR TITLE
docs: document remaining config keys

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -37,6 +37,8 @@ transparent_background = true
 scroll_offset = 5
 no_update_check = false
 review_watch_interval_ms = 1000
+single_file_view = false
+username = "user"
 
 backend = "libgit2"
 
@@ -84,6 +86,8 @@ legend = true
 | `scroll_offset`            | `0`          | Minimum lines visible above and below the cursor when scrolling (like Vim's `scrolloff`).                                                                  |
 | `no_update_check`          | `false`      | Skip startup update check when `true`.                                                                                                                     |
 | `review_watch_interval_ms` | `1000`       | Poll interval for persisted review-session changes. Set to `0` to disable automatic local-session reloads.                                                 |
+| `single_file_view`         | `false`      | Start in single-file view for supported review targets. Pristine `--all-files` mode always starts in single-file view.                                     |
+| `username`                 | `"user"`     | Display name stamped on local comments and used as the viewer identity for local comment coloring.                                                         |
 | `backend`                  | `libgit2`    | Git backend: `libgit2` or `cli`. Sparse-checkout repos auto-route to `cli`.                                                                                |
 | `comment_types`            | (none)       | Comment categories. Untyped by default. See [Comment types](#comment-types).                                                                               |
 | `export_legend`            | `true`       | Include the `Comment types:` legend in the exported review. Superseded by `legend` under [Export](#export).                                                |


### PR DESCRIPTION
## Summary
- add `single_file_view` and `username` to the full config example
- document their defaults and behavior in the config options table

## Verification
- `git diff --check`
- direct inspection against `src/config/mod.rs` accepted keys

Note: `cargo test config::tests::should_parse_single_file_view_true config::tests::should_parse_username --lib` could not run locally because this cron environment has no installed Rust stable toolchain (`cargo` missing; `rustup run stable` reports stable-aarch64-apple-darwin is not installed).
