### PR TITLE
fix(tree): keep a directory's files together when a sibling shares its prefix

### DIFF
--- a/src/app/tests/tree_tests.rs
+++ b/src/app/tests/tree_tests.rs
@@ -1,5 +1,6 @@
 use crate::app::*;
-use crate::model::{DiffFile, FileStatus};
+use crate::model::{DiffFile, DiffLine, FileStatus};
+use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
 
 fn make_file(path: &str) -> DiffFile {
     DiffFile {
@@ -185,4 +186,111 @@ fn test_sibling_dirs_independent() {
     h.toggle("src"); // collapse src
 
     assert_eq!(h.visible_file_count(), 1); // only tests/test.rs
+}
+
+struct StubVcs(VcsInfo);
+impl VcsBackend for StubVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.0
+    }
+    fn get_working_tree_diff(
+        &self,
+        _hl: &crate::syntax::SyntaxHighlighter,
+    ) -> crate::error::Result<Vec<DiffFile>> {
+        Ok(Vec::new())
+    }
+    fn fetch_context_lines(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start: u32,
+        _end: u32,
+    ) -> crate::error::Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+    fn file_line_count(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> crate::error::Result<u32> {
+        Ok(0)
+    }
+}
+
+fn app_with(paths: &[&str]) -> App {
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: "head".into(),
+        branch_name: Some("main".into()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+    App::build(
+        Box::new(StubVcs(vcs_info.clone())),
+        vcs_info,
+        crate::theme::Theme::dark(),
+        None,
+        false,
+        paths.iter().map(|p| make_file(p)).collect(),
+        session,
+        DiffSource::WorkingTree,
+        InputMode::Normal,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("build app")
+}
+
+/// Renders the visible tree as (label, depth) pairs, with directories
+/// suffixed by '/' so a mis-parented file is obvious in the assertion.
+fn rendered_tree(app: &App) -> Vec<(String, usize)> {
+    app.build_visible_items()
+        .iter()
+        .map(|item| match item {
+            FileTreeItem::Directory { path, depth, .. } => (format!("{path}/"), *depth),
+            FileTreeItem::File { file_idx, depth } => (
+                app.diff_files[*file_idx]
+                    .display_path()
+                    .to_string_lossy()
+                    .to_string(),
+                *depth,
+            ),
+        })
+        .collect()
+}
+
+#[test]
+fn test_interleaved_paths_stay_under_own_directory() {
+    // A sibling directory sharing a prefix used to sort between a directory
+    // and its own subdirectory, because '.' sorts before '/'. That split the
+    // ChronoStream subtree in two, and since build_visible_items emits a
+    // directory header only once, ChronoStream/Subdir rendered indented under
+    // ChronoStream.BuildTests.
+    let mut app = app_with(&[
+        "ChronoStream/Subdir/file.cs",
+        "ChronoStream.BuildTests/test.cs",
+        "ChronoStream/root.cs",
+    ]);
+    app.sort_files_by_directory(true);
+    app.expand_all_dirs();
+
+    assert_eq!(
+        rendered_tree(&app),
+        vec![
+            ("ChronoStream/".to_string(), 0),
+            ("ChronoStream/root.cs".to_string(), 1),
+            ("ChronoStream/Subdir/".to_string(), 1),
+            ("ChronoStream/Subdir/file.cs".to_string(), 2),
+            ("ChronoStream.BuildTests/".to_string(), 0),
+            ("ChronoStream.BuildTests/test.cs".to_string(), 1),
+        ]
+    );
 }

--- a/src/app/tree.rs
+++ b/src/app/tree.rs
@@ -130,7 +130,6 @@ impl App {
 
     pub(in crate::app) fn sort_files_by_directory(&mut self, reset_position: bool) {
         use std::collections::BTreeMap;
-        use std::path::Path;
 
         self.file_line_count_cache.clear();
 
@@ -140,7 +139,7 @@ impl App {
             None
         };
 
-        let mut dir_map: BTreeMap<String, Vec<DiffFile>> = BTreeMap::new();
+        let mut dir_map: BTreeMap<Vec<String>, Vec<DiffFile>> = BTreeMap::new();
         let mut commit_msg_files: Vec<DiffFile> = Vec::new();
 
         for file in self.diff_files.drain(..) {
@@ -148,16 +147,24 @@ impl App {
                 commit_msg_files.push(file);
                 continue;
             }
-            let path = file.display_path();
-            let dir = if let Some(parent) = path.parent() {
-                if parent == Path::new("") {
-                    ".".to_string()
-                } else {
-                    parent.to_string_lossy().to_string()
-                }
-            } else {
-                ".".to_string()
-            };
+            // Key on the parent's components, not on the joined parent
+            // string. `build_visible_items` emits a directory header only the
+            // first time it sees a directory, so every subtree has to come out
+            // of here contiguous. A flat string sort breaks that whenever a
+            // sibling shares a prefix, because '.' and '-' sort before '/':
+            // "ChronoStream.BuildTests" lands between "ChronoStream" and
+            // "ChronoStream/Subdir", and the orphaned half then renders
+            // indented under the sibling.
+            let dir: Vec<String> = file
+                .display_path()
+                .parent()
+                .map(|parent| {
+                    parent
+                        .components()
+                        .map(|c| c.as_os_str().to_string_lossy().to_string())
+                        .collect()
+                })
+                .unwrap_or_default();
 
             dir_map.entry(dir).or_default().push(file);
         }


### PR DESCRIPTION
## Problem

Reported in #438: files render under a directory they don't belong to. @Dynge's screenshot shows files from `ChronoStream/` appearing nested under `ChronoStream.BuildTests/`.

`sort_files_by_directory` groups files into a `BTreeMap` keyed by the joined parent path string. `.` is ASCII 46 and `/` is 47, so `ChronoStream.BuildTests` sorts between `ChronoStream` and `ChronoStream/Subdir`. That splits the `ChronoStream` subtree into two runs that are no longer adjacent.

`build_visible_items` emits a directory header only the first time it sees a directory, and it derives each file's indent from its ancestor count. Once the subtree is split, that function suppresses the second run's header, and those files render indented under whichever directory landed between the halves.

Any sibling whose name continues with a character below `/` hits this. `.` and `-` are the common ones, so `foo.Tests` next to `foo/`, or `my-lib` next to `my/`.

## Fix

Key the map on the parent's path components rather than the joined string. Comparing component by component keeps a parent adjacent to its own children.

## Verification

Added `test_interleaved_paths_stay_under_own_directory` using @Dynge's repro paths. It drives a real `App` through `sort_files_by_directory` and `build_visible_items`. I deliberately did not use the local `TreeTestHarness`: it keeps its own copy of the tree logic, so a test written against it passes no matter what the production path does. I checked that first, and a harness-based version of this test did pass against the unfixed code.

With the fix reverted and the test left alone, it fails with the reported symptom:

```
left:  [("ChronoStream/", 0), ("ChronoStream/root.cs", 1), ("ChronoStream.BuildTests/", 0), ("ChronoStream.BuildTests/test.cs", 1), ("ChronoStream/Subdir/", 1), ("ChronoStream/Subdir/file.cs", 2)]
right: [("ChronoStream/", 0), ("ChronoStream/root.cs", 1), ("ChronoStream/Subdir/", 1), ("ChronoStream/Subdir/file.cs", 2), ("ChronoStream.BuildTests/", 0), ("ChronoStream.BuildTests/test.cs", 1)]
```

`cargo fmt --all --check` and `cargo clippy --all-targets -- -D warnings` are both clean. `cargo test` gives 1196 passed, 2 failed. The two failures are `vcs::git::libgit2::tests::should_discover_worktree_with_relativeworktrees_extension` and `vcs::git::tests::default_preference_routes_reftable_repo_to_cli`, which fail identically on an unmodified checkout here. My git is 2.43.0, which predates both extensions.
