### PR TITLE
fix: label remote comments by forge

### DIFF
--- a/src/app/submit.rs
+++ b/src/app/submit.rs
@@ -431,6 +431,14 @@ impl App {
         }
     }
 
+    /// Return the forge backing the active PR/MR diff, when reviewing one.
+    pub fn forge_kind(&self) -> Option<crate::forge::traits::ForgeKind> {
+        match &self.diff_source {
+            DiffSource::PullRequest(pr) => Some(pr.key.repository.kind),
+            _ => None,
+        }
+    }
+
     /// Apply the create-review result on the main thread. On success: flip
     /// each included `Comment` to `Submitted` (or `PushedDraft` for the
     /// draft event), stamp `remote_review_id`, save the session again, and

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -8,6 +8,7 @@ use ratatui::{
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::App;
+use crate::forge::traits::ForgeKind;
 use crate::model::LineRange;
 use crate::theme::Theme;
 use crate::ui::styles;
@@ -295,13 +296,14 @@ pub fn format_comment_input_lines(
 /// box; replies appear as `├─ ↳ @author ──` separator headers within the
 /// same box; the bottom rule appears once at the end.
 ///
-/// Visually distinct from local drafts: the `[github @author]` badge on
+/// Visually distinct from local drafts: the `[forge @author]` badge on
 /// the root header, and a muted palette throughout for resolved/outdated
 /// threads.
 pub fn format_remote_thread_lines(
     theme: &Theme,
     thread: &crate::forge::remote_comments::RemoteReviewThread,
     muted: bool,
+    forge_kind: Option<ForgeKind>,
 ) -> Vec<Line<'static>> {
     let (badge_fg, border_fg, body_fg) = if muted {
         (theme.fg_dim, theme.fg_dim, theme.fg_dim)
@@ -332,7 +334,7 @@ pub fn format_remote_thread_lines(
     while let Some(comment) = iter.next() {
         let author = comment.author.as_deref().unwrap_or("unknown");
         if is_first {
-            let mut badge_text = format!("[github @{author}");
+            let mut badge_text = format!("[{} @{author}", forge_badge_label(forge_kind));
             if thread.is_resolved {
                 badge_text.push_str(" resolved");
             } else if thread.is_outdated {
@@ -373,11 +375,12 @@ pub fn format_remote_thread_lines(
 }
 
 /// Format a remote review summary (the body of a `PullRequestReview`) as a
-/// box with a `[github @author <state>]` header. Renders at review scope —
+/// box with a `[forge @author <state>]` header. Renders at review scope —
 /// no line anchor — so the top corner is `╭`, not the line-anchored `├`.
 pub fn format_remote_review_summary_lines(
     theme: &Theme,
     summary: &crate::forge::remote_comments::RemoteReviewSummary,
+    forge_kind: Option<ForgeKind>,
 ) -> Vec<Line<'static>> {
     let badge_fg = theme.diff_hunk_header;
     let border_fg = theme.diff_hunk_header;
@@ -388,7 +391,7 @@ pub fn format_remote_review_summary_lines(
     let body_style = Style::default().fg(body_fg);
 
     let author = summary.author.as_deref().unwrap_or("unknown");
-    let mut badge_text = format!("[github @{author}");
+    let mut badge_text = format!("[{} @{author}", forge_badge_label(forge_kind));
     if let Some(state_label) = summary.state.badge_label() {
         badge_text.push(' ');
         badge_text.push_str(state_label);
@@ -417,11 +420,19 @@ pub fn format_remote_review_summary_lines(
     result
 }
 
+fn forge_badge_label(kind: Option<ForgeKind>) -> &'static str {
+    match kind {
+        Some(ForgeKind::GitHub) => "github",
+        Some(ForgeKind::GitLab) => "gitlab",
+        None => "forge",
+    }
+}
+
 /// Format a comment as multiple lines with a box border (themed version).
 ///
 /// `author` advertises the comment's author in the top-row badge and tints
 /// the box border. Callers pass `Some(name)` for non-self comments — the
-/// resulting badge reads `[TYPE @name]`, mirroring the `[github @author]`
+/// resulting badge reads `[TYPE @name]`, mirroring the remote forge badge
 /// format used for remote PR threads. `None` keeps the existing neutral
 /// `[TYPE]` badge and theme border.
 /// Render `content` as markdown-highlighted, border-prefixed, pre-wrapped lines
@@ -932,5 +943,58 @@ mod tests {
             content_spans > 1,
             "expected markdown highlighting to split the line, got {content_spans} span(s)"
         );
+    }
+
+    #[test]
+    fn remote_thread_badge_uses_gitlab_for_gitlab_comments() {
+        let thread = crate::forge::remote_comments::RemoteReviewThread {
+            id: "thread".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(1),
+            side: crate::forge::remote_comments::RemoteCommentSide::Right,
+            is_resolved: false,
+            is_outdated: false,
+            comments: vec![crate::forge::remote_comments::RemoteReviewComment {
+                id: "comment".to_string(),
+                author: Some("alice".to_string()),
+                body: "body".to_string(),
+                created_at: None,
+                in_reply_to: None,
+                url: String::new(),
+            }],
+        };
+
+        let lines =
+            format_remote_thread_lines(&test_theme(), &thread, false, Some(ForgeKind::GitLab));
+        let header = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(header.contains("[gitlab @alice]"));
+        assert!(!header.contains("[github @alice]"));
+    }
+
+    #[test]
+    fn remote_summary_badge_uses_github_for_github_comments() {
+        let summary = crate::forge::remote_comments::RemoteReviewSummary {
+            id: "summary".to_string(),
+            author: Some("alice".to_string()),
+            body: "body".to_string(),
+            state: crate::forge::remote_comments::RemoteReviewState::Commented,
+            created_at: None,
+            url: String::new(),
+        };
+
+        let lines =
+            format_remote_review_summary_lines(&test_theme(), &summary, Some(ForgeKind::GitHub));
+        let header = lines[0]
+            .spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+
+        assert!(header.contains("[github @alice]"));
     }
 }

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -266,7 +266,11 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     }
 
     for summary in &app.forge_review_summaries {
-        let summary_lines = comment_panel::format_remote_review_summary_lines(&app.theme, summary);
+        let summary_lines = comment_panel::format_remote_review_summary_lines(
+            &app.theme,
+            summary,
+            app.forge_kind(),
+        );
         for mut summary_line in summary_lines {
             let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
             summary_line.spans.insert(
@@ -345,8 +349,12 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 let Some(muted) = visibility.render_decision(thread) else {
                     continue;
                 };
-                let thread_lines =
-                    comment_panel::format_remote_thread_lines(&app.theme, thread, muted);
+                let thread_lines = comment_panel::format_remote_thread_lines(
+                    &app.theme,
+                    thread,
+                    muted,
+                    app.forge_kind(),
+                );
                 for mut comment_line in thread_lines {
                     let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
                     comment_line.spans.insert(
@@ -1729,7 +1737,12 @@ fn add_remote_threads_to_line(
         if !matches_side {
             continue;
         }
-        let thread_lines = comment_panel::format_remote_thread_lines(ctx.theme, thread, muted);
+        let thread_lines = comment_panel::format_remote_thread_lines(
+            ctx.theme,
+            thread,
+            muted,
+            ctx.app.forge_kind(),
+        );
         let box_top_row = line_idx;
         for mut comment_line in thread_lines {
             let indicator = cursor_indicator(line_idx, ctx.current_line_idx);

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -106,7 +106,11 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     }
 
     for summary in &app.forge_review_summaries {
-        let summary_lines = comment_panel::format_remote_review_summary_lines(&app.theme, summary);
+        let summary_lines = comment_panel::format_remote_review_summary_lines(
+            &app.theme,
+            summary,
+            app.forge_kind(),
+        );
         for mut summary_line in summary_lines {
             let indicator = cursor_indicator(line_idx, current_line_idx);
             summary_line.spans.insert(
@@ -186,8 +190,12 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 let Some(muted) = visibility.render_decision(thread) else {
                     continue;
                 };
-                let thread_lines =
-                    comment_panel::format_remote_thread_lines(&app.theme, thread, muted);
+                let thread_lines = comment_panel::format_remote_thread_lines(
+                    &app.theme,
+                    thread,
+                    muted,
+                    app.forge_kind(),
+                );
                 for mut comment_line in thread_lines {
                     let indicator = cursor_indicator(line_idx, current_line_idx);
                     comment_line.spans.insert(
@@ -1288,7 +1296,8 @@ fn render_remote_threads_for_anchor(
 
         // Render the entire thread as one fused box so it reads as a
         // single discussion unit.
-        let thread_lines = comment_panel::format_remote_thread_lines(&app.theme, thread, muted);
+        let thread_lines =
+            comment_panel::format_remote_thread_lines(&app.theme, thread, muted, app.forge_kind());
         let box_top_row = *line_idx;
         for mut comment_line in thread_lines {
             let indicator = cursor_indicator(*line_idx, current_line_idx);
@@ -1338,7 +1347,7 @@ fn render_expanded_context_line(
 mod remote_comments_snapshot_tests {
     //! Render-snapshot tests for inline remote review threads in the
     //! unified diff. We drive `ui::render` against `TestBackend` and check
-    //! for the `[github @author]` badge text on the expected row.
+    //! for the provider badge text on the expected row.
     use crate::app::{App, DiffSource, InputMode, PullRequestDiffSource};
     use crate::error::Result as TuicrResult;
     use crate::error::TuicrError;

--- a/src/ui/row_height.rs
+++ b/src/ui/row_height.rs
@@ -47,9 +47,13 @@ pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
             .get(*summary_idx)
             .and_then(|summary| {
                 let row = repeated_annotation_row(app, idx, annotation);
-                comment_panel::format_remote_review_summary_lines(&app.theme, summary)
-                    .into_iter()
-                    .nth(row)
+                comment_panel::format_remote_review_summary_lines(
+                    &app.theme,
+                    summary,
+                    app.forge_kind(),
+                )
+                .into_iter()
+                .nth(row)
             })
             .map_or(1, |line| formatted_line_height(line, viewport_width)),
 
@@ -63,9 +67,14 @@ pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
                     .render_decision(thread)
                     .unwrap_or(false);
                 let row = repeated_annotation_row(app, idx, annotation);
-                comment_panel::format_remote_thread_lines(&app.theme, thread, muted)
-                    .into_iter()
-                    .nth(row)
+                comment_panel::format_remote_thread_lines(
+                    &app.theme,
+                    thread,
+                    muted,
+                    app.forge_kind(),
+                )
+                .into_iter()
+                .nth(row)
             })
             .map_or(1, |line| formatted_line_height(line, viewport_width)),
 


### PR DESCRIPTION
## Summary
- Render GitHub remote comments with a `[github @user]` badge.
- Render GitLab MR comments with a `[gitlab @user]` badge.
- Derive the provider from the active PR/MR diff source instead of hardcoding GitHub.

## Testing
- `cargo fmt --all`
- `cargo test`
- 1,199 tests passed, 1 ignored.