### PR TITLE
fix(diff): keep hunk lines whose content starts with `---` or `+++`

### DIFF
--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -292,19 +292,19 @@ where
             continue;
         }
 
+        // No `---`/`+++` header check here: a hunk body line is never a file
+        // header. The outer loop only starts a file on a `diff --git `/`diff `
+        // line, `parse_file_header` consumes the `---`/`+++` pair before the
+        // first `@@`, and this loop breaks on the next `diff `/`@@` above. A
+        // check here would instead match *content*: deleting a line beginning
+        // with `--` (a SQL/Lua/Haskell comment, a YAML `---` separator, a
+        // Markdown front-matter fence) emits `---…`, and skipping it would drop
+        // the line and desynchronize every following line number in the hunk.
         let (origin, content, old_ln, new_ln) = if let Some(stripped) = line.strip_prefix('+') {
-            if line.starts_with("+++") {
-                // Skip +++ header lines
-                continue;
-            }
             let ln = new_lineno;
             new_lineno += 1;
             (LineOrigin::Addition, stripped, None, Some(ln))
         } else if let Some(stripped) = line.strip_prefix('-') {
-            if line.starts_with("---") {
-                // Skip --- header lines
-                continue;
-            }
             let ln = old_lineno;
             old_lineno += 1;
             (LineOrigin::Deletion, stripped, Some(ln), None)
@@ -807,6 +807,86 @@ copy to dest.rs
         assert_eq!(lines[4].origin, LineOrigin::Context);
         assert_eq!(lines[4].old_lineno, Some(7));
         assert_eq!(lines[4].new_lineno, Some(8));
+    }
+
+    #[test]
+    fn should_keep_deleted_lines_whose_content_starts_with_dashes() {
+        // Deleting a YAML front-matter fence emits `----` (the `-` origin plus
+        // the `---` content); it must not be mistaken for a `---` file header.
+        let diff = r#"diff --git a/post.md b/post.md
+--- a/post.md
++++ b/post.md
+@@ -1,5 +1,2 @@
+----
+-title: hello
+----
+ intro
+-old body
++new body
+"#;
+        let files =
+            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let lines = &files[0].hunks[0].lines;
+        assert_eq!(lines.len(), 6);
+
+        assert_eq!(lines[0].origin, LineOrigin::Deletion);
+        assert_eq!(lines[0].content, "---");
+        assert_eq!(lines[0].old_lineno, Some(1));
+
+        assert_eq!(lines[2].origin, LineOrigin::Deletion);
+        assert_eq!(lines[2].content, "---");
+        assert_eq!(lines[2].old_lineno, Some(3));
+
+        // Line numbers after the skipped lines must not shift.
+        assert_eq!(lines[3].origin, LineOrigin::Context);
+        assert_eq!(lines[3].old_lineno, Some(4));
+        assert_eq!(lines[3].new_lineno, Some(1));
+
+        assert_eq!(lines[4].origin, LineOrigin::Deletion);
+        assert_eq!(lines[4].old_lineno, Some(5));
+    }
+
+    #[test]
+    fn should_keep_deleted_sql_comment_lines() {
+        // `--` is the line-comment token in SQL, Lua, Haskell, Ada and Elm.
+        let diff = r#"diff --git a/q.sql b/q.sql
+--- a/q.sql
++++ b/q.sql
+@@ -1,2 +1,1 @@
+--- count the rows
+ SELECT 1;
+"#;
+        let files =
+            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let lines = &files[0].hunks[0].lines;
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].origin, LineOrigin::Deletion);
+        assert_eq!(lines[0].content, "-- count the rows");
+        assert_eq!(lines[0].old_lineno, Some(1));
+        assert_eq!(lines[1].old_lineno, Some(2));
+    }
+
+    #[test]
+    fn should_keep_added_lines_whose_content_starts_with_plus_signs() {
+        let diff = r#"diff --git a/loop.c b/loop.c
+--- a/loop.c
++++ b/loop.c
+@@ -1,1 +1,3 @@
+ int i = 0;
++++i;
++return i;
+"#;
+        let files =
+            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+        let lines = &files[0].hunks[0].lines;
+        assert_eq!(lines.len(), 3);
+
+        assert_eq!(lines[1].origin, LineOrigin::Addition);
+        assert_eq!(lines[1].content, "++i;");
+        assert_eq!(lines[1].new_lineno, Some(2));
+
+        // The following addition must not reuse the skipped line's number.
+        assert_eq!(lines[2].new_lineno, Some(3));
     }
 
     // ============ Jujutsu (jj) format tests - uses DiffFormat::GitStyle ============


### PR DESCRIPTION
## The bug

`parse_hunk` skips any hunk body line starting with `---` / `+++`, intending to ignore stray file-header lines:

https://github.com/agavra/tuicr/blob/246f839e83ac4149489c43357e5ee2230bd16676/src/vcs/diff_parser.rs#L295-L310

The check runs against the **prefixed patch line**, not the line's content. A deleted line is emitted as `-` + content, so:

- deleting `---` (YAML document separator / Markdown front-matter fence) emits `----` → matches → dropped
- deleting `-- count the rows` (SQL/Lua/Haskell/Ada/Elm comment) emits `--- count the rows` → matches → dropped
- adding `++i;` emits `+++i;` → matches → dropped

Worse, `continue` runs **before** `old_lineno` / `new_lineno` is incremented, so the dropped line's number is reused by the next line — every following line number on that side of the hunk shifts by one, compounding per dropped line.

## Repro

```
diff --git a/post.md b/post.md
--- a/post.md
+++ b/post.md
@@ -1,5 +1,2 @@
----
-title: hello
----
 intro
-old body
+new body
```

Parsed today — 4 lines instead of 6, both `---` deletions invisible, old-side numbers wrong:

```
Deletion old=Some(1) "title: hello"   <- actually old line 2
Context  old=Some(2) "intro"          <- actually old line 4
Deletion old=Some(3) "old body"       <- actually old line 5
Addition new=Some(2) "new body"
```

## Impact

The reviewer never sees that the line was deleted. And because `find_line_with_counterpart` in `src/forge/submit.rs` uses `DiffLine::old_lineno` / `new_lineno` verbatim as the forge comment position, a comment placed later in that hunk is **posted on the wrong upstream line**.

Reachable on the GitHub/GitLab PR path (`forge/pr_open.rs`, `app/pr.rs` both call `parse_unified_diff`), and on the jj, hg and sparse-Git CLI backends. The default libgit2 backend is unaffected.

## The fix

Delete both guards. They are dead for their stated purpose: `parse_unified_diff_lines` only starts a file on a `diff --git ` / `diff ` header, `parse_file_header` consumes the `---`/`+++` pair before the first `@@`, and the hunk loop already breaks on the next `diff ` / `@@` — so a genuine file header can never reach that code. A comment in their place records why no check belongs there.

## Verification

Three regression tests added (deleted YAML fence, deleted SQL comment, added `++i;`), each asserting both the retained line and the unshifted numbers that follow. Confirmed they fail on `main` before the fix:

```
should_keep_deleted_lines_whose_content_starts_with_dashes  left: 4  right: 6
should_keep_deleted_sql_comment_lines                       left: 1  right: 2
should_keep_added_lines_whose_content_starts_with_plus_signs left: 2 right: 3
```

`cargo test` → **1203 passed, 0 failed**. `cargo fmt --all --check` and `cargo clippy -- -D warnings` clean.