### PR TITLE
fix(ui): give the reviewed banner an annotation slot in single-file view

### DIFF
--- a/src/app/annotations.rs
+++ b/src/app/annotations.rs
@@ -165,9 +165,16 @@ impl App {
 
             // If reviewed, skip all content for this file. Single-file
             // view ignores the reviewed-collapse since the user
-            // explicitly focused this file.
-            if self.session.is_file_reviewed(path) && !self.is_single_file_view {
-                continue;
+            // explicitly focused this file, and renders the body under a
+            // "Marked reviewed" banner instead — that banner is a rendered
+            // row, so it needs its own annotation slot to keep this stream
+            // index-parallel with the renderers.
+            if self.session.is_file_reviewed(path) {
+                if !self.is_single_file_view {
+                    continue;
+                }
+                self.line_annotations
+                    .push(AnnotatedLine::ReviewedBanner { file_idx });
             }
 
             // File comments

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -267,6 +267,10 @@ pub enum AnnotatedLine {
     RemoteReviewSummaryLine { summary_idx: usize },
     /// File header line
     FileHeader { file_idx: usize },
+    /// "Marked reviewed" banner shown in single-file view when the focused
+    /// file is reviewed. Both renderers emit this row, so it needs an
+    /// annotation slot to keep `line_annotations` index-parallel with them.
+    ReviewedBanner { file_idx: usize },
     /// A file-level comment line (part of a multi-line comment box)
     FileComment { file_idx: usize, comment_idx: usize },
     /// Expander line showing hidden context with direction arrow
@@ -436,6 +440,7 @@ fn commits_since_last_review_selection(
 pub fn annotation_file_idx(annotation: &AnnotatedLine) -> Option<usize> {
     match annotation {
         AnnotatedLine::FileHeader { file_idx }
+        | AnnotatedLine::ReviewedBanner { file_idx }
         | AnnotatedLine::FileComment { file_idx, .. }
         | AnnotatedLine::HunkHeader { file_idx, .. }
         | AnnotatedLine::DiffLine { file_idx, .. }
@@ -519,7 +524,9 @@ pub fn find_source_line(
 fn is_decoration(annotation: &AnnotatedLine) -> bool {
     matches!(
         annotation,
-        AnnotatedLine::Spacing | AnnotatedLine::FileHeader { .. }
+        AnnotatedLine::Spacing
+            | AnnotatedLine::FileHeader { .. }
+            | AnnotatedLine::ReviewedBanner { .. }
     )
 }
 

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -306,7 +306,7 @@ impl App {
                 bodies.insert(0, format!("github {}", thread.path));
                 Some(bodies.join(" "))
             }
-            AnnotatedLine::Spacing => None,
+            AnnotatedLine::Spacing | AnnotatedLine::ReviewedBanner { .. } => None,
         }
     }
 }

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -530,3 +530,36 @@ fn effective_file_height_is_zero_for_non_current_in_single_file_view() {
     let current = &app.diff_files[0].clone();
     assert!(app.effective_file_height(0, current) > 0);
 }
+
+#[test]
+fn reviewed_banner_keeps_annotations_aligned_with_rendered_rows() {
+    let mut app = app_with(vec![file("a.rs", vec![hunk(1, 3)])]);
+    app.toggle_single_file_view();
+
+    let before = app.line_annotations.len();
+    app.toggle_reviewed();
+
+    // Single-file view renders the focused file under a "Marked reviewed"
+    // banner, so both the annotation stream and the height model grow by
+    // exactly that one row.
+    assert!(app.session.is_file_reviewed(&PathBuf::from("a.rs")));
+    assert_eq!(app.line_annotations.len(), before + 1);
+    assert_eq!(app.line_annotations.len(), app.total_lines());
+    assert!(matches!(
+        app.line_annotations.first(),
+        Some(AnnotatedLine::ReviewedBanner { file_idx: 0 })
+    ));
+    assert!(matches!(
+        app.line_annotations.get(1),
+        Some(AnnotatedLine::HunkHeader { .. })
+    ));
+
+    // With the banner occupying row 0, moving down from it lands on the
+    // hunk header the renderer draws directly beneath it.
+    app.diff_state.cursor_line = 0;
+    app.cursor_down(1);
+    assert!(matches!(
+        app.line_annotations.get(app.diff_state.cursor_line),
+        Some(AnnotatedLine::HunkHeader { .. })
+    ));
+}

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -441,7 +441,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(
-                    "  Marked reviewed -- r to re-open",
+                    crate::ui::diff_view::REVIEWED_BANNER_TEXT,
                     Style::default()
                         .fg(app.theme.fg_secondary)
                         .add_modifier(Modifier::DIM),

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -276,7 +276,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             lines.push(Line::from(vec![
                 Span::styled(indicator, styles::current_line_indicator_style(&app.theme)),
                 Span::styled(
-                    "  Marked reviewed -- r to re-open",
+                    crate::ui::diff_view::REVIEWED_BANNER_TEXT,
                     Style::default()
                         .fg(app.theme.fg_secondary)
                         .add_modifier(Modifier::DIM),

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -22,6 +22,11 @@ pub(super) const HEADER_RULE: &str = "══════════════
 /// Shared text before `HEADER_RULE` for the synthetic review-comments banner.
 pub(super) const REVIEW_COMMENTS_HEADER_PREFIX: &str = "═══ Review Comments ";
 
+/// Banner shown in single-file view when the focused file is marked reviewed.
+/// Shared by both renderers and by `row_height` so the rendered row and its
+/// measured height cannot drift apart.
+pub(super) const REVIEWED_BANNER_TEXT: &str = "  Marked reviewed -- r to re-open";
+
 /// Text portion of a per-file section header, without the trailing
 /// `HEADER_RULE`. Callers concatenate `HEADER_RULE` themselves so the rule
 /// can be styled as a separate span (both renderers) or absorbed into a

--- a/src/ui/row_height.rs
+++ b/src/ui/row_height.rs
@@ -331,6 +331,10 @@ fn full_row_text(app: &App, annotation: &AnnotatedLine) -> String {
             format!("{indicator}{l} {r}")
         }
 
+        AnnotatedLine::ReviewedBanner { .. } => {
+            format!("{indicator}{}", diff_view::REVIEWED_BANNER_TEXT)
+        }
+
         AnnotatedLine::BinaryOrEmpty { file_idx } => {
             let text = app
                 .diff_files
@@ -722,6 +726,7 @@ mod tests {
             AnnotatedLine::RemoteThreadLine { .. } => Some("RemoteThreadLine"),
             AnnotatedLine::Spacing => Some("Spacing"),
             AnnotatedLine::BinaryOrEmpty { .. } => Some("BinaryOrEmpty"),
+            AnnotatedLine::ReviewedBanner { .. } => Some("ReviewedBanner"),
             _ => None,
         }
     }


### PR DESCRIPTION
## The bug

In single-file view, a file marked reviewed keeps its body visible under a `Marked reviewed -- r to re-open` banner. Three places model that row, and only two of them agree:

| | banner counted? |
|---|---|
| `src/ui/diff_unified.rs:274-285` (renderer) | ✅ `lines.push(...)`, `line_idx += 1` |
| `src/ui/diff_side_by_side.rs:439-451` (renderer) | ✅ `lines.push(...)`, `line_idx += 1` |
| `src/app/navigation.rs:1352-1357` (`effective_file_height`) | ✅ `let banner = if …is_file_reviewed(…) { 1 } else { 0 }` |
| `src/app/annotations.rs:169-171` (`rebuild_annotations`) | ❌ nothing pushed |

The reviewed-collapse `continue` is gated on `&& !self.is_single_file_view`, so in single-file view the loop falls straight through to file comments without pushing a slot for the banner the renderers just emitted.

## Impact

`cursor_line` indexes `line_annotations`, while the renderer draws the cursor indicator at the matching **rendered** row. From the banner onwards the two are off by one:

- the `▶` sits on one row while `c` (comment), `R` (hunk reviewed), `e` (open in editor), visual selection and mouse clicks all resolve the row **below** it — so a comment is filed against a different line than the one the user is looking at, and that line number is what gets posted upstream;
- the file's last content line is unreachable, because `max_cursor_line()` derives from `total_lines()` (which counts the banner) rather than from the annotation list.

Concretely, for one file with one hunk of 3 lines: rendered = `[banner, HunkHeader, diff, diff, diff, spacing]` = 6 rows, `total_lines()` = 6, `line_annotations.len()` = **5**.

Multi-file view is unaffected — there the renderer skips the body *and* its trailing spacing, and the annotations `continue` too, so all three models agree.

## The fix

Add an `AnnotatedLine::ReviewedBanner { file_idx }` variant and push it exactly where the renderers emit the row. It is registered as a decoration, so cursor motions step over it the way they do `Spacing` / `FileHeader`.

Both renderers and `row_height::full_row_text` now read the banner text from one shared `diff_view::REVIEWED_BANNER_TEXT` constant, so the rendered row and its measured height can't drift apart again.

I did not reuse `AnnotatedLine::Spacing` for the slot: `row_height`'s `Spacing` arm resolves the unified single-file "next file" hint text, which wraps to a different height than the banner, so it would have traded an index desync for a height desync.

Because `annotation_file_idx`, `is_decoration`, `full_row_text` and the search-text match are all exhaustive, the compiler enforced every site that needed the new variant.

## Verification

Regression test asserts `line_annotations.len() == total_lines()` for a reviewed file in single-file view, that row 0 is the banner and row 1 the hunk header, and that moving down from the banner lands on the hunk header. Confirmed it fails on `main` before the fix:

```
reviewed_banner_keeps_annotations_aligned_with_rendered_rows  left: 5  right: 6
```

`cargo test` → **1201 passed, 0 failed**. `cargo fmt --all --check` and `cargo clippy -- -D warnings` clean.

(`cargo clippy --all-targets` reports a pre-existing `items after a test module` error at `src/handler.rs:577`, untouched by this branch; CI runs plain `cargo clippy`, which is green.)