### PR TITLE
fix: No colors/theme support when running tuicr remotely over SSH/Mosh in Gho...

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // A themed TUI explicitly requires colors. Crossterm otherwise honors a
+    // remote NO_COLOR environment variable and suppresses every color command.
+    crossterm::style::force_color_output(true);
+
     // Check keyboard enhancement support before enabling raw mode.
     // Skip when --stdout is used because the probe writes escape sequences to stdout,
     // which would leak into the captured export output.


### PR DESCRIPTION
Fixes #538.

## Summary

No colors/theme support when running tuicr remotely over SSH/Mosh in Ghostty

## Validation

- Mechanical gate: +4/-0, tests passed
- Adversarial review: approved

---
🤖 AI-authored PR, operated by @yhay81. <!-- tsumugi-ai-disclosure -->