### PR TITLE
fix: deduplicate remote review threads

### DIFF
--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -1169,8 +1169,7 @@ impl App {
             .list_review_summaries(&opened.details)
             .unwrap_or_default();
         self.enter_pr_diff_mode(backend, opened)?;
-        self.forge_review_threads =
-            crate::forge::remote_comments::dedupe_threads(threads);
+        self.forge_review_threads = crate::forge::remote_comments::dedupe_threads(threads);
         self.forge_review_summaries = summaries;
         self.prune_locked_comments();
         self.rebuild_annotations();

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -1035,7 +1035,8 @@ impl App {
                 let mut threads_loaded = false;
                 match threads {
                     Ok(t) => {
-                        self.forge_review_threads = t;
+                        self.forge_review_threads =
+                            crate::forge::remote_comments::dedupe_threads(t);
                         threads_loaded = true;
                     }
                     Err(e) => {
@@ -1168,7 +1169,8 @@ impl App {
             .list_review_summaries(&opened.details)
             .unwrap_or_default();
         self.enter_pr_diff_mode(backend, opened)?;
-        self.forge_review_threads = threads;
+        self.forge_review_threads =
+            crate::forge::remote_comments::dedupe_threads(threads);
         self.forge_review_summaries = summaries;
         self.prune_locked_comments();
         self.rebuild_annotations();

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -2598,7 +2598,12 @@ fn should_apply_remote_threads_event_when_relevant() {
         repository: pr_key.repository.clone(),
         pr_number: pr_key.number,
         head_sha: pr_key.head_sha.clone(),
-        threads: Ok(vec![sample_thread(2, "delayed", false, false)]),
+        // The same forge thread can appear more than once in a malformed or
+        // overlapping paginated response; the UI must keep one copy.
+        threads: Ok(vec![
+            sample_thread(2, "delayed", false, false),
+            sample_thread(2, "duplicate", false, false),
+        ]),
         summaries: Ok(Vec::new()),
     })
     .unwrap();

--- a/src/forge/remote_comments.rs
+++ b/src/forge/remote_comments.rs
@@ -243,6 +243,19 @@ pub fn group_threads_by_path(
     groups
 }
 
+/// Remove duplicate forge threads while preserving the first occurrence.
+///
+/// A thread's forge-assigned ID is stable across pagination and refreshes, so
+/// duplicate IDs are never separate discussions. Keeping this invariant at
+/// the cache boundary prevents one API anomaly from rendering a comment twice.
+pub fn dedupe_threads(threads: Vec<RemoteReviewThread>) -> Vec<RemoteReviewThread> {
+    let mut seen = std::collections::HashSet::new();
+    threads
+        .into_iter()
+        .filter(|thread| thread.id.is_empty() || seen.insert(thread.id.clone()))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -329,6 +342,21 @@ mod tests {
         assert_eq!(unresolved.len(), 2);
         assert_eq!(unresolved[0].id, "a");
         assert_eq!(unresolved[1].id, "c");
+    }
+
+    #[test]
+    fn should_dedupe_threads_by_forge_id_preserving_order() {
+        // given
+        let first = make_thread("same", "src/lib.rs", Some(10), false, false);
+        let duplicate = make_thread("same", "src/lib.rs", Some(20), false, false);
+        let other = make_thread("other", "src/main.rs", Some(30), false, false);
+        // when
+        let deduped = dedupe_threads(vec![first, duplicate, other]);
+        // then
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(deduped[0].id, "same");
+        assert_eq!(deduped[0].line, Some(10));
+        assert_eq!(deduped[1].id, "other");
     }
 
     #[test]


### PR DESCRIPTION
Some PR comments were displayed more than once when the review service returned duplicate thread records.

This change deduplicates comments using each thread’s unique ID while preserving their original order. It also adds regression coverage to ensure duplicate comments are rendered only once.

### Testing

- Added a test covering duplicate review threads.
- Verified that unique comments remain unchanged.