### PR TITLE
diff view: hide the Review Comments section while it is empty

### DIFF
--- a/src/app/annotations.rs
+++ b/src/app/annotations.rs
@@ -85,10 +85,11 @@ impl App {
             }
         }
 
-        // The review-comments header is omitted in single-file view (see
-        // the matching guard in `src/ui/diff_unified.rs`), so the
-        // annotation list mirrors the render.
-        if !self.is_single_file_view {
+        // The review-comments header is omitted in single-file view and
+        // until the section has content (see the matching guard in
+        // `src/ui/diff_unified.rs`), so the annotation list mirrors the
+        // render.
+        if self.show_review_comments_header() {
             self.line_annotations
                 .push(AnnotatedLine::ReviewCommentsHeader);
         }

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -1,6 +1,34 @@
 use super::*;
 
 impl App {
+    /// Whether the `═══ Review Comments ═══` section has anything to show:
+    /// a remote review summary, a local review-level comment, or a visible
+    /// review-level (line: None) remote thread. Mirrors exactly what the
+    /// section renders, so the header gate stays in sync between the renderer
+    /// and the annotation model.
+    pub fn has_review_section_content(&self) -> bool {
+        if !self.forge_review_summaries.is_empty() || !self.session.review_comments.is_empty() {
+            return true;
+        }
+        let visibility = self.session.remote_comments_visibility;
+        if matches!(
+            visibility,
+            crate::forge::remote_comments::PrCommentsVisibility::Hide
+        ) {
+            return false;
+        }
+        self.forge_review_threads
+            .iter()
+            .filter(|thread| thread.line.is_none())
+            .any(|thread| visibility.render_decision(thread).is_some())
+    }
+
+    /// Whether the `═══ Review Comments ═══` section header should render.
+    /// Omitted in single-file view and while the section has no content yet.
+    pub fn show_review_comments_header(&self) -> bool {
+        !self.is_single_file_view && self.has_review_section_content()
+    }
+
     pub fn comment_navigator_idx_at_screen_row(&self, screen_row: u16) -> Option<usize> {
         let inner = self.comment_navigator_inner_area?;
         if screen_row < inner.y || screen_row >= inner.y + inner.height {

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -961,9 +961,14 @@ impl App {
     }
 
     pub(in crate::app) fn review_comments_section_height(&self) -> usize {
-        // Header line is only rendered in multi-file view. See the guards
-        // in `src/ui/diff_unified.rs` and `src/ui/diff_side_by_side.rs`.
-        let mut height = if self.is_single_file_view { 0 } else { 1 };
+        // The header line must follow the render gate exactly (multi-file
+        // view + non-empty section). See the guards in
+        // `src/ui/diff_unified.rs` and `src/ui/diff_side_by_side.rs`.
+        let mut height = if self.show_review_comments_header() {
+            1
+        } else {
+            0
+        };
         for summary in &self.forge_review_summaries {
             height += crate::forge::remote_comments::summary_display_lines(summary);
         }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -957,9 +957,14 @@ impl App {
     }
 
     pub(in crate::app) fn review_comments_section_height(&self) -> usize {
-        // Header line is only rendered in multi-file view. See the guards
-        // in `src/ui/diff_unified.rs` and `src/ui/diff_side_by_side.rs`.
-        let mut height = if self.is_single_file_view { 0 } else { 1 };
+        // The header line must follow the render gate exactly (multi-file
+        // view + non-empty section). See the guards in
+        // `src/ui/diff_unified.rs` and `src/ui/diff_side_by_side.rs`.
+        let mut height = if self.show_review_comments_header() {
+            1
+        } else {
+            0
+        };
         for summary in &self.forge_review_summaries {
             height += crate::forge::remote_comments::summary_display_lines(summary);
         }

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -447,3 +447,26 @@ fn should_comment_on_a_commit_only_file_after_narrowing_the_commit_pane() {
         "the comment must be stored against the file"
     );
 }
+
+#[test]
+fn review_comments_header_hidden_while_empty() {
+    let mut app = build_app(vec![normal_commit("a")]);
+    app.is_single_file_view = false;
+
+    // Empty section -> no header.
+    assert!(!app.has_review_section_content());
+    assert!(!app.show_review_comments_header());
+
+    // A local review comment gives the section content -> header shows.
+    app.session.review_comments.push(crate::model::Comment::new(
+        "review-level".to_string(),
+        crate::model::CommentType::from_id("note"),
+        None,
+    ));
+    assert!(app.has_review_section_content());
+    assert!(app.show_review_comments_header());
+
+    // Single-file view always hides the header.
+    app.is_single_file_view = true;
+    assert!(!app.show_review_comments_header());
+}

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -269,3 +269,26 @@ fn commit_selection_summary_shows_position_for_single_and_count_for_range() {
         Some("2 of 3 commits")
     );
 }
+
+#[test]
+fn review_comments_header_hidden_while_empty() {
+    let mut app = build_app(vec![normal_commit("a")]);
+    app.is_single_file_view = false;
+
+    // Empty section -> no header.
+    assert!(!app.has_review_section_content());
+    assert!(!app.show_review_comments_header());
+
+    // A local review comment gives the section content -> header shows.
+    app.session.review_comments.push(crate::model::Comment::new(
+        "review-level".to_string(),
+        crate::model::CommentType::from_id("note"),
+        None,
+    ));
+    assert!(app.has_review_section_content());
+    assert!(app.show_review_comments_header());
+
+    // Single-file view always hides the header.
+    app.is_single_file_view = true;
+    assert!(!app.show_review_comments_header());
+}

--- a/src/app/tests/pr_info_tests.rs
+++ b/src/app/tests/pr_info_tests.rs
@@ -128,7 +128,14 @@ fn should_not_add_pr_info_to_file_tree() {
 
 #[test]
 fn should_order_overview_sections_before_file_diffs() {
-    let app = build_pr_app();
+    let mut app = build_pr_app();
+    // The review-comments header only renders once the section has content.
+    app.session.review_comments.push(crate::model::Comment::new(
+        "review-level".to_string(),
+        crate::model::CommentType::from_id("note"),
+        None,
+    ));
+    app.rebuild_annotations();
     assert!(matches!(
         app.line_annotations.first(),
         Some(crate::app::AnnotatedLine::PrInfoLine { line_idx: 0 })

--- a/src/app/tests/scroll_behavior_tests.rs
+++ b/src/app/tests/scroll_behavior_tests.rs
@@ -111,17 +111,17 @@ fn build_scroll_app(n: usize, viewport: usize, scroll_offset_config: usize) -> A
 
 #[test]
 fn zz_on_last_line_centers_cursor() {
-    // 40 diff lines + 4 overhead = 44 total. max_cursor = 42. Viewport = 20.
+    // 40 diff lines + 3 overhead = 43 total. max_cursor = 41. Viewport = 20.
     let mut app = build_scroll_app(40, 20, 5);
-    assert_eq!(app.total_lines(), 44);
-    let last = app.max_cursor_line(); // 42
+    assert_eq!(app.total_lines(), 43);
+    let last = app.max_cursor_line(); // 41
 
     app.diff_state.cursor_line = last;
     app.center_cursor();
 
-    // scroll = cursor - viewport/2 = 42 - 10 = 32
-    assert_eq!(app.diff_state.scroll_offset, 32);
-    assert_eq!(app.diff_state.cursor_line, 42);
+    // scroll = cursor - viewport/2 = 41 - 10 = 31
+    assert_eq!(app.diff_state.scroll_offset, 31);
+    assert_eq!(app.diff_state.cursor_line, 41);
 }
 
 #[test]

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -299,7 +299,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
 
     // The `═══ Review Comments ═══` label is redundant in single-file
     // view -- see the matching guard in `src/ui/diff_unified.rs`.
-    if !app.is_single_file_view {
+    if app.show_review_comments_header() {
         let general_indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
         lines.push(Line::from(vec![
             Span::styled(

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -256,7 +256,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
 
     // The `═══ Review Comments ═══` label is redundant in single-file
     // view -- see the matching guard in `src/ui/diff_unified.rs`.
-    if !app.is_single_file_view {
+    if app.show_review_comments_header() {
         let general_indicator = cursor_indicator_spaced(line_idx, ctx.current_line_idx);
         lines.push(Line::from(vec![
             Span::styled(

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -85,8 +85,9 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
     // The `═══ Review Comments ═══` label is redundant in single-file
     // view (review-level comments are still rendered below; they just
-    // don't need a banner that confuses horizontal scroll).
-    if !app.is_single_file_view {
+    // don't need a banner that confuses horizontal scroll). It's also hidden
+    // while the section has no content.
+    if app.show_review_comments_header() {
         let general_indicator = cursor_indicator_spaced(line_idx, current_line_idx);
         lines.push(Line::from(vec![
             Span::styled(

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -86,8 +86,9 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
     // The `═══ Review Comments ═══` label is redundant in single-file
     // view (review-level comments are still rendered below; they just
-    // don't need a banner that confuses horizontal scroll).
-    if !app.is_single_file_view {
+    // don't need a banner that confuses horizontal scroll). It's also hidden
+    // while the section has no content.
+    if app.show_review_comments_header() {
         let general_indicator = cursor_indicator_spaced(line_idx, current_line_idx);
         lines.push(Line::from(vec![
             Span::styled(


### PR DESCRIPTION
The `═══ Review Comments ═══` section always rendered, even before any
review comment existed. Hide the header until the section has content — a
remote review summary, a local review comment, or a visible review-level
remote thread. Per review feedback this is now simply the behavior — no
config option.

The gate goes through a shared `App::show_review_comments_header()` used
by the unified and side-by-side renderers, the annotation builder, and the
scroll height model (`review_comments_section_height`), so the display,
the cursor/click model, and scrolling stay in sync.

Covered by a unit test (`review_comments_header_hidden_while_empty`);
`cargo fmt`, `check`, `clippy -D warnings`, and `cargo test` all pass
locally.