### PR TITLE
fix: reindex recovered PR sessions

### DIFF
--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -53,6 +53,9 @@ impl App {
         };
 
         if path.exists() {
+            if self.session.pr_session_key.is_some() {
+                crate::persistence::storage::reindex_session(&self.session)?;
+            }
             if self.ephemeral_session_paths.contains(&path) {
                 let saved_path = self.save_current_session_merging_external()?;
                 return Ok(Some(saved_path));

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -1189,7 +1189,7 @@ fn should_keep_saved_pr_session_through_quit_reopen_and_same_head_reload() {
 }
 
 #[test]
-fn should_use_persisted_new_head_session_instead_of_carrying_old_head_state() {
+fn should_use_and_reindex_persisted_new_head_session() {
     // given an old-head PR session with reviewed state
     let _reviews = TestReviewsDir::new();
     let mut app = build_app();
@@ -1229,7 +1229,10 @@ fn should_use_persisted_new_head_session_instead_of_carrying_old_head_state() {
             CommentType::from_id("note"),
             None,
         ));
+    let persisted_path = crate::persistence::storage::session_path(&persisted_b).unwrap();
+    let slug = crate::slug::Slug::from(persisted_b.pr_session_key.as_ref().unwrap()).to_string();
     write_session_file_without_manifest(&persisted_b);
+    let persisted_contents = std::fs::read(&persisted_path).unwrap();
 
     // when the PR reload advances to that head
     let backend_b = Box::new(FakeForgeBackend::open_pr_details(
@@ -1248,6 +1251,12 @@ fn should_use_persisted_new_head_session_instead_of_carrying_old_head_state() {
     let changed_review = app.session.files.get(&changed_path).unwrap();
     assert_eq!(changed_review.file_comments.len(), 1);
     assert_eq!(changed_review.file_comments[0].content, "new-head draft");
+    let resolved = crate::review_store::ReviewStore::new()
+        .resolve_pr_session(&slug)
+        .unwrap()
+        .unwrap();
+    assert_eq!(resolved.path(), persisted_path);
+    assert_eq!(std::fs::read(&persisted_path).unwrap(), persisted_contents);
 }
 
 #[test]

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -1189,7 +1189,7 @@ fn should_keep_saved_pr_session_through_quit_reopen_and_same_head_reload() {
 }
 
 #[test]
-fn should_use_and_reindex_persisted_new_head_session() {
+fn should_reindex_recovered_pr_session() {
     // given an old-head PR session with reviewed state
     let _reviews = TestReviewsDir::new();
     let mut app = build_app();
@@ -1230,7 +1230,8 @@ fn should_use_and_reindex_persisted_new_head_session() {
             None,
         ));
     let persisted_path = crate::persistence::storage::session_path(&persisted_b).unwrap();
-    let slug = crate::slug::Slug::from(persisted_b.pr_session_key.as_ref().unwrap()).to_string();
+    let pr_session_key = persisted_b.pr_session_key.as_ref().unwrap();
+    let slug = crate::slug::Slug::from(pr_session_key).to_string();
     write_session_file_without_manifest(&persisted_b);
     let persisted_contents = std::fs::read(&persisted_path).unwrap();
 

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -66,6 +66,23 @@ pub(crate) fn save_session_in_dir(session: &ReviewSession, reviews_dir: &Path) -
     })
 }
 
+pub(crate) fn reindex_session(session: &ReviewSession) -> Result<()> {
+    let reviews_dir = get_reviews_dir()?;
+    maybe_migrate(&reviews_dir)?;
+    with_reviews_dir_lock(&reviews_dir, || {
+        let slug = slug_for_session(session)?;
+        let relative = relative_path_for_slug(&slug, session)?;
+        let full_path = reviews_dir.join(&relative);
+        if !full_path.is_file() {
+            return Err(TuicrError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("session file not found: {}", full_path.display()),
+            )));
+        }
+        upsert_session_manifest(session, &reviews_dir, &slug, relative)
+    })
+}
+
 pub(crate) fn update_session_in_dir<T>(
     session_ref: &Path,
     reviews_dir: &Path,
@@ -342,13 +359,22 @@ fn save_session_in_dir_unlocked(session: &ReviewSession, reviews_dir: &Path) -> 
     let json = serde_json::to_string_pretty(session)?;
     write_atomic(&full_path, json.as_bytes())?;
 
-    let mut manifest = manifest::load_manifest(reviews_dir).unwrap_or_default();
-    let anchor = manifest_anchor_for(&slug);
-    let entry = manifest::entry_from_session(session, relative, anchor);
-    manifest.upsert(slug.to_string(), entry);
-    manifest::save_manifest(reviews_dir, &manifest)?;
+    upsert_session_manifest(session, reviews_dir, &slug, relative)?;
 
     Ok(full_path)
+}
+
+fn upsert_session_manifest(
+    session: &ReviewSession,
+    reviews_dir: &Path,
+    slug: &Slug,
+    relative: PathBuf,
+) -> Result<()> {
+    let mut manifest = manifest::load_manifest(reviews_dir).unwrap_or_default();
+    let anchor = manifest_anchor_for(slug);
+    let entry = manifest::entry_from_session(session, relative, anchor);
+    manifest.upsert(slug.to_string(), entry);
+    manifest::save_manifest(reviews_dir, &manifest)
 }
 
 fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {


### PR DESCRIPTION
Re-index PR sessions recovered from their deterministic path so the review list and review add see them immediately. The repair only updates the manifest and leaves the session JSON unchanged.

Adds regression coverage for missing and stale manifest entries.

Tests:
- cargo test should_reindex_recovered_pr_session
- cargo fmt --all -- --check

Closes #449