### PR TITLE
fix: cover Bitbucket variant in forge_badge_label

### DIFF
--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -424,6 +424,7 @@ fn forge_badge_label(kind: Option<ForgeKind>) -> &'static str {
     match kind {
         Some(ForgeKind::GitHub) => "github",
         Some(ForgeKind::GitLab) => "gitlab",
+        Some(ForgeKind::Bitbucket) => "bitbucket",
         None => "forge",
     }
 }


### PR DESCRIPTION
main did not compile because forge_badge_label's match on ForgeKind was missing an arm for the Bitbucket variant.