### PR TITLE
perf(git): speed up CLI backend startup

### DIFF
--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -272,7 +272,7 @@ impl App {
         if path_filter.is_none() {
             match vcs.get_change_status() {
                 Ok(status) => {
-                    if !crate::tuicrignore::has_ignore_rules(repo_root) {
+                    if !crate::tuicrignore::has_tuicrignore(repo_root) {
                         return Ok(status);
                     }
                     return Self::verify_status_against_ignore(

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -39,6 +39,10 @@ pub fn has_ignore_rules(repo_root: &Path) -> bool {
     repo_root.join(".gitignore").is_file() || repo_root.join(".tuicrignore").is_file()
 }
 
+pub fn has_tuicrignore(repo_root: &Path) -> bool {
+    repo_root.join(".tuicrignore").is_file()
+}
+
 fn load_matcher(repo_root: &Path) -> Option<ignore::gitignore::Gitignore> {
     let gitignore_file = repo_root.join(".gitignore");
     let tuicrignore_file = repo_root.join(".tuicrignore");

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -236,8 +236,8 @@ impl VcsBackend for GitCliBackend {
             return get_cli_change_status(&self.root_path);
         }
 
-        // Limit untracked discovery to sparse-checkout cones. Plain `git status`
-        // reports untracked files outside the cone.
+        // Keep sparse probes pathspec-scoped. Plain `git status` reports
+        // out-of-cone untracked files and would show an empty Unstaged row.
         let staged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--cached", "--"])?;
         let tracked_unstaged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--"])?;
         let untracked_pathspecs = if tracked_unstaged {
@@ -476,6 +476,9 @@ fn get_cli_change_status(workdir: &Path) -> Result<VcsChangeStatus> {
     Ok(parse_porcelain_status(&output.stdout))
 }
 
+/// Parse NUL-delimited porcelain v1 records into staged and unstaged flags.
+/// The first two bytes are the index and worktree states. Rename and copy
+/// records include a second pathname record, which the parser skips.
 fn parse_porcelain_status(output: &[u8]) -> VcsChangeStatus {
     let mut status = VcsChangeStatus::default();
     let mut entries = output.split(|byte| *byte == 0);

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -461,7 +461,7 @@ fn parse_git_runtime_flags(output: &str) -> (bool, bool) {
 fn get_cli_change_status(workdir: &Path) -> Result<VcsChangeStatus> {
     let output = Command::new("git")
         .current_dir(workdir)
-        .args(["status", "--porcelain=v1", "-z"])
+        .args(["status", "--porcelain=v1", "-z", "--untracked-files=normal"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -1516,6 +1516,29 @@ mod tests {
     fn detects_change_status_without_loading_diff() {
         let (temp_dir, backend, _ids) = setup_sparse_index_repo();
         write_file(temp_dir.path(), "keep/file.txt", "keep modified\n");
+
+        let status = backend
+            .get_change_status()
+            .expect("failed to get change status");
+
+        assert_eq!(
+            status,
+            VcsChangeStatus {
+                staged: false,
+                unstaged: true,
+            }
+        );
+    }
+
+    #[test]
+    fn detects_untracked_files_when_git_status_hides_them() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+        git(workdir, &["init"]);
+        git(workdir, &["config", "status.showUntrackedFiles", "no"]);
+        write_file(workdir, "untracked.txt", "untracked\n");
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+            .expect("failed to discover cli backend");
 
         let status = backend
             .get_change_status()

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -232,9 +232,12 @@ impl VcsBackend for GitCliBackend {
     }
 
     fn get_change_status(&self) -> Result<VcsChangeStatus> {
-        // Tracked changes have cheap exact probes. Untracked files require a
-        // working-tree scan, so only pay that cost when tracked unstaged changes
-        // have not already proven the "unstaged" row should be shown.
+        if self.repo_mode == GitRepoMode::Standard {
+            return get_cli_change_status(&self.root_path);
+        }
+
+        // Limit untracked discovery to sparse-checkout cones. Plain `git status`
+        // reports untracked files outside the cone.
         let staged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--cached", "--"])?;
         let tracked_unstaged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--"])?;
         let untracked_pathspecs = if tracked_unstaged {
@@ -453,6 +456,40 @@ fn parse_git_runtime_flags(output: &str) -> (bool, bool) {
     // `feature.manyFiles` makes core.untrackedCache default to true, but
     // `git config --get core.untrackedCache` does not print that implied value.
     (untracked_cache.unwrap_or(many_files), fsmonitor)
+}
+
+fn get_cli_change_status(workdir: &Path) -> Result<VcsChangeStatus> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(["status", "--porcelain=v1", "-z"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(parse_porcelain_status(&output.stdout))
+}
+
+fn parse_porcelain_status(output: &[u8]) -> VcsChangeStatus {
+    let mut status = VcsChangeStatus::default();
+    let mut entries = output.split(|byte| *byte == 0);
+    while let Some(entry) = entries.next() {
+        if entry.len() < 2 {
+            continue;
+        }
+        status.staged |= !matches!(entry[0], b' ' | b'?');
+        status.unstaged |= entry[1] != b' ';
+        if matches!(entry[0], b'R' | b'C') || matches!(entry[1], b'R' | b'C') {
+            entries.next();
+        }
+    }
+    status
 }
 
 fn has_diff_changes(workdir: &Path, args: &[&str]) -> Result<bool> {
@@ -1183,6 +1220,18 @@ mod tests {
             args.join(" "),
             String::from_utf8_lossy(&output.stderr)
         );
+    }
+
+    #[test]
+    fn parses_porcelain_status_sides() {
+        assert_eq!(
+            parse_porcelain_status(b"M  staged\0 M unstaged\0?? untracked\0"),
+            VcsChangeStatus {
+                staged: true,
+                unstaged: true,
+            }
+        );
+        assert_eq!(parse_porcelain_status(b""), VcsChangeStatus::default());
     }
 
     fn write_file(workdir: &Path, path: &str, content: &str) {


### PR DESCRIPTION
Closes #560.

## Context

`backend = "cli"` already exists. It selects native Git for all Git operations. This PR improves startup when that setting is enabled. The default libgit2 backend is unchanged.

## Problem

The CLI backend runs separate probes for staged, tracked unstaged, and untracked files. Untracked discovery is slow in large repositories.

Measured in a large monorepo:

- Default libgit2 startup: 22.8s
- Existing CLI backend startup: 9.42s

## Change

Standard Git repositories now use one machine-readable probe:

```bash
git status --porcelain=v1 -z --untracked-files=normal
```

The parser folds Git's two status columns into staged and unstaged booleans. It also handles the extra pathname emitted for renames and copies.

`--untracked-files=normal` is explicit. Without it, `status.showUntrackedFiles=no` can hide an untracked-only worktree. tuicr would then hide the Unstaged changes row. An integration test covers this repository configuration.

Sparse checkout and sparse index repositories keep the existing scoped probes. Plain `git status` can report untracked files outside the sparse cone.

Git already applies `.gitignore` during status. tuicr only enumerates paths when `.tuicrignore` adds application-specific rules. This condition lives in generic app code. Today, only `GitCliBackend` returns a successful cheap status result, so only that backend takes the new path. The libgit2, Jujutsu, and Mercurial behavior remains unchanged.

## Result

With `backend = "cli"`:

- Before: 9.42s
- After: 1.19s

## Recording

The recording uses a synthetic repository with 1,000,001 tracked files. It contains no private source or repository metadata. Both runs use a warm filesystem cache and `backend = "cli"`.

![startup benchmark](https://raw.githubusercontent.com/idriss-mortadi/tuicr/pr-assets/pr-assets/568/startup-speed.gif)

The recorded synthetic benchmark measured 5.96s before and 339ms after.

<details>
<summary>reproduce the synthetic benchmark</summary>

this script checks required tools, commit availability, free disk space, and platform support. it builds both revisions and creates a temporary synthetic repository. it removes all temporary files when it exits.

```bash
#!/usr/bin/env bash
set -euo pipefail

base=8323f135018ab0c1d07e228a423bd504c3503593
head=589eaad6755805a7f363e5a65e48002173f7a4e6

for command in git cargo python3 script; do
  command -v "$command" >/dev/null || {
    echo "missing required command: $command" >&2
    exit 1
  }
done

[[ $(uname -s) == Darwin ]] || {
  echo "this recording script currently expects macOS script(1)" >&2
  exit 1
}

root=$(git rev-parse --show-toplevel 2>/dev/null) || {
  echo "run this from a tuicr checkout" >&2
  exit 1
}

grep -q '^name = "tuicr"$' "$root/Cargo.toml" || {
  echo "run this from a tuicr checkout" >&2
  exit 1
}

available_kb=$(df -Pk /tmp | awk 'NR == 2 {print $4}')
(( available_kb >= 8 * 1024 * 1024 )) || {
  echo "at least 8 GiB free under /tmp is required" >&2
  exit 1
}

if ! git -C "$root" cat-file -e "$base^{commit}" 2>/dev/null ||
   ! git -C "$root" cat-file -e "$head^{commit}" 2>/dev/null; then
  git -C "$root" fetch https://github.com/agavra/tuicr.git \
    main refs/pull/568/head
fi

for commit in "$base" "$head"; do
  git -C "$root" cat-file -e "$commit^{commit}" 2>/dev/null || {
    echo "could not fetch required commit: $commit" >&2
    exit 1
  }
done

work=$(mktemp -d /tmp/tuicr-pr-568-benchmark.XXXXXX)
cleanup() {
  git -C "$root" worktree remove --force "$work/original" >/dev/null 2>&1 || true
  git -C "$root" worktree remove --force "$work/improved" >/dev/null 2>&1 || true
  rm -rf "$work"
}
trap cleanup EXIT

git -C "$root" worktree add --detach "$work/original" "$base"
git -C "$root" worktree add --detach "$work/improved" "$head"
CARGO_TARGET_DIR="$work/original-target" cargo build --release --manifest-path "$work/original/Cargo.toml"
CARGO_TARGET_DIR="$work/improved-target" cargo build --release --manifest-path "$work/improved/Cargo.toml"

repo="$work/repo"
config="$work/config"
data="$work/data"
mkdir -p "$repo" "$config/tuicr" "$data"
printf 'backend = "cli"\nno_update_check = true\n' > "$config/tuicr/config.toml"

git -C "$repo" init -q
git -C "$repo" config user.name 'tuicr benchmark'
git -C "$repo" config user.email benchmark@example.com
git -C "$repo" config core.untrackedCache true

python3 - "$repo" <<'PY'
from pathlib import Path
import sys

root = Path(sys.argv[1])
for directory in range(5_000):
    folder = root / "src" / f"package-{directory:04d}"
    folder.mkdir(parents=True)
    for filename in range(200):
        (folder / f"file-{filename:03d}.txt").write_text("benchmark\n")
(root / ".gitignore").write_text("build/\n")
(root / "untracked.txt").write_text("visible untracked file\n")
PY

git -C "$repo" add .gitignore src
git -C "$repo" commit -qm 'synthetic million-file repository'
git -C "$repo" status --porcelain=v1 >/dev/null

original="$work/original-target/release/tuicr"
improved="$work/improved-target/release/tuicr"

prewarm() {
  local binary=$1
  (
    cd "$repo"
    printf q | script -q /dev/null env \
      XDG_CONFIG_HOME="$config" \
      XDG_DATA_HOME="$data" \
      "$binary" >/dev/null 2>&1
  )
}

run_case() {
  local label=$1
  local binary=$2
  local log=$3

  clear
  printf '\n  tuicr cli startup benchmark\n\n'
  printf '  synthetic repository: 1,000,001 tracked files\n'
  printf '  warm filesystem cache\n'
  printf '  version: %s\n\n' "$label"
  printf '  opening tuicr...\n'
  sleep 1

  (
    cd "$repo"
    XDG_CONFIG_HOME="$config" \
    XDG_DATA_HOME="$data" \
    TUICR_PROFILE="$log" \
    "$binary"
  )

  clear
  elapsed=$(grep 'operation="startup.app_init"}: close' "$log" | tail -1 | sed -E 's/.*time.busy=([^ ]+).*/\1/')
  printf '\n  %s startup: %s\n\n' "$label" "$elapsed"
}

prewarm "$original"
prewarm "$improved"
run_case 'before this pr' "$original" "$work/before.log"
printf '  press enter to run the improved version'
read -r
run_case 'after this pr' "$improved" "$work/after.log"
printf '  press enter to finish'
read -r
```

</details>

## Validation

- `cargo test`: 1300 passed, 2 ignored
- `cargo check --all-targets`: passed
- Sparse checkout status tests: passed
- `status.showUntrackedFiles=no` integration test: passed

`cargo clippy --all-targets -- -D warnings` remains blocked by the existing `items_after_test_module` finding in `src/handler.rs:577`.

