### PR TITLE
fix: keep the TUI on screen when opening a windowed editor

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -122,6 +122,12 @@ Shown below the file tree when local comments or visible remote PR threads exist
 | `e` | Open focused file in `$EDITOR` |
 | `y` | Copy review to clipboard |
 
+`e` opens the file at the cursor's line. Terminal editors (`vim`, `nvim`, `nano`, …)
+take over the screen and tuicr reloads the diff once they exit. Windowed editors
+(`code`, `cursor`, `zed`, `subl`, …) open in their own window while tuicr stays on
+screen; reload with `:e` after editing. Adding `--wait` to `$EDITOR` opts a windowed
+editor back into the blocking behaviour.
+
 ## Visual mode
 
 | Key | Action |

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -449,6 +449,7 @@ impl App {
             diff_files,
             diff_source,
             pending_editor_target: None,
+            editor_launches: Vec::new(),
             input_mode,
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -7,7 +7,7 @@ use ratatui::style::Color;
 
 use crate::comment_vim::CommentVimEditor;
 use crate::config::{CommentTypeConfig, ExportConfig};
-use crate::editor::EditorTarget;
+use crate::editor::{EditorLaunch, EditorTarget};
 use crate::error::{Result, TuicrError};
 use crate::forge::context::{ContextProvider, ForgeContextProvider, VcsContextProvider};
 use crate::forge::selector::PullRequestsTab;
@@ -1042,6 +1042,9 @@ pub struct App {
     pub diff_files: Vec<DiffFile>,
     pub diff_source: DiffSource,
     pub pending_editor_target: Option<EditorTarget>,
+    /// Windowed editors that have not exited yet; polled by
+    /// `poll_editor_launches`.
+    pub(crate) editor_launches: Vec<EditorLaunch>,
 
     pub input_mode: InputMode,
     pub focused_panel: FocusedPanel,

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -1,3 +1,5 @@
+use crate::editor::{EditorError, LaunchState};
+
 use super::*;
 
 impl App {
@@ -60,6 +62,34 @@ impl App {
     /// because `App` does not own terminal state.
     pub fn take_pending_editor_target(&mut self) -> Option<EditorTarget> {
         self.pending_editor_target.take()
+    }
+
+    /// Tracks a launched windowed editor so it gets cleaned up once it exits
+    /// and a failed launch gets reported.
+    pub fn track_editor_launch(&mut self, launch: EditorLaunch) {
+        self.editor_launches.push(launch);
+    }
+
+    /// Cleans up exited windowed editors and reports the ones that never
+    /// started.
+    ///
+    /// Returns whether a message was set.
+    pub fn poll_editor_launches(&mut self) -> bool {
+        let mut failures = Vec::new();
+        self.editor_launches
+            .retain_mut(|launch| match launch.poll() {
+                LaunchState::Running => true,
+                LaunchState::Exited => false,
+                LaunchState::FailedToLaunch(status) => {
+                    failures.push(status);
+                    false
+                }
+            });
+        let reported = !failures.is_empty();
+        for status in failures {
+            self.set_error(EditorError::Exit(status).to_string());
+        }
+        reported
     }
 
     /// Resolves the currently focused UI item into an editor target.

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,6 +1,15 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::process::{Command, ExitStatus};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+/// How long after launch a windowed editor's exit still counts as a launch
+/// failure worth reporting.
+///
+/// A launcher that cannot reach its application dies within a moment. An
+/// editor that exits later was in the user's hands, and its exit code is not
+/// something tuicr should interrupt the review with.
+const LAUNCH_FAILURE_WINDOW: Duration = Duration::from_secs(5);
 
 /// Source location tuicr can hand off to an external editor.
 ///
@@ -75,6 +84,116 @@ impl EditorCommand {
     pub fn run(&self) -> std::io::Result<std::process::ExitStatus> {
         Command::new(&self.program).args(&self.args).status()
     }
+
+    /// Spawns the prepared editor command without waiting for it to exit.
+    ///
+    /// Standard streams are detached so a chatty editor cannot write over the
+    /// TUI, which stays on screen for the whole handoff. The caller polls the
+    /// returned handle so the finished process gets cleaned up.
+    pub fn spawn_detached(&self) -> std::io::Result<EditorLaunch> {
+        let child = Command::new(&self.program)
+            .args(&self.args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+        Ok(EditorLaunch {
+            child,
+            started: Instant::now(),
+        })
+    }
+
+    /// Whether this invocation needs the terminal tuicr is drawn on.
+    pub fn surface(&self) -> EditorSurface {
+        // An explicit wait flag means the user wants tuicr to block until the
+        // file is closed, so the terminal has to be handed over either way.
+        let waits = self
+            .args
+            .iter()
+            .any(|arg| arg == "-w" || arg == "--wait" || arg == "--block");
+        if !waits && is_windowed_editor(&self.program) {
+            EditorSurface::Gui
+        } else {
+            EditorSurface::Terminal
+        }
+    }
+}
+
+/// A windowed editor that was launched and may still be open.
+#[derive(Debug)]
+pub struct EditorLaunch {
+    child: Child,
+    started: Instant,
+}
+
+impl EditorLaunch {
+    /// Cleans up the editor process if it has exited.
+    ///
+    /// Blocking editors report a bad exit status through `EditorError::Exit`;
+    /// this is the equivalent for editors tuicr does not wait on.
+    pub fn poll(&mut self) -> LaunchState {
+        match self.child.try_wait() {
+            Ok(None) => LaunchState::Running,
+            Ok(Some(status))
+                if !status.success() && self.started.elapsed() < LAUNCH_FAILURE_WINDOW =>
+            {
+                LaunchState::FailedToLaunch(status)
+            }
+            Ok(Some(_)) | Err(_) => LaunchState::Exited,
+        }
+    }
+}
+
+/// Where a launched editor has got to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LaunchState {
+    /// Still open.
+    Running,
+    /// Gone, with nothing worth reporting.
+    Exited,
+    /// Died soon enough after launch that it never reached the user.
+    FailedToLaunch(ExitStatus),
+}
+
+/// Where an editor draws itself once launched.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditorSurface {
+    /// Takes over the terminal; tuicr must suspend for the duration.
+    Terminal,
+    /// Opens its own window; tuicr keeps drawing.
+    Gui,
+}
+
+/// Whether a program is a known editor that opens its own window.
+///
+/// Unrecognized editors are assumed to be terminal editors: suspending for a
+/// GUI editor costs a flicker, while not suspending for a terminal editor
+/// leaves two programs fighting over the same screen.
+fn is_windowed_editor(program: &str) -> bool {
+    let name = Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program);
+    matches!(
+        name,
+        "code"
+            | "code-insiders"
+            | "codium"
+            | "cursor"
+            | "windsurf"
+            | "zed"
+            | "subl"
+            | "sublime_text"
+            | "mate"
+            | "idea"
+            | "webstorm"
+            | "goland"
+            | "pycharm"
+            | "clion"
+            | "rustrover"
+            | "phpstorm"
+            | "rubymine"
+    )
 }
 
 /// Line-navigation syntax family for a recognized editor executable.
@@ -118,16 +237,20 @@ fn status_label(status: &ExitStatus) -> String {
         .unwrap_or_else(|| "signal".to_string())
 }
 
-/// Opens `target` in the user's editor.
+/// Runs `command` to completion in the terminal.
 ///
 /// The caller owns terminal restoration before displaying any returned error.
-pub fn run_editor(target: &EditorTarget) -> Result<(), EditorError> {
-    let command = EditorCommand::from_env(target);
+pub fn run_editor(command: &EditorCommand) -> Result<(), EditorError> {
     match command.run() {
         Ok(status) if status.success() => Ok(()),
         Ok(status) => Err(EditorError::Exit(status)),
         Err(err) => Err(EditorError::Launch(err)),
     }
+}
+
+/// Hands `command` to a windowed editor without waiting for it to exit.
+pub fn launch_editor(command: &EditorCommand) -> Result<EditorLaunch, EditorError> {
+    command.spawn_detached().map_err(EditorError::Launch)
 }
 
 #[cfg(test)]
@@ -195,6 +318,92 @@ mod tests {
         let command = EditorCommand::from_editor("vim -f", &target(Some(42)));
         assert_eq!(command.program, "vim");
         assert_eq!(args(&command), vec!["-f", "+42", "/repo/src/main.rs"]);
+    }
+
+    #[test]
+    fn windowed_editors_do_not_claim_the_terminal() {
+        for editor in [
+            "code",
+            "cursor",
+            "zed",
+            "subl",
+            "/usr/local/bin/code-insiders",
+        ] {
+            let command = EditorCommand::from_editor(editor, &target(Some(42)));
+            assert_eq!(command.surface(), EditorSurface::Gui, "{editor}");
+        }
+    }
+
+    #[test]
+    fn terminal_and_unknown_editors_claim_the_terminal() {
+        for editor in ["vim", "nvim", "nano", "emacs", "helix", "kak"] {
+            let command = EditorCommand::from_editor(editor, &target(Some(42)));
+            assert_eq!(command.surface(), EditorSurface::Terminal, "{editor}");
+        }
+    }
+
+    #[test]
+    fn wait_flag_keeps_windowed_editors_blocking() {
+        for editor in ["code --wait", "code -w", "zed --wait"] {
+            let command = EditorCommand::from_editor(editor, &target(Some(42)));
+            assert_eq!(command.surface(), EditorSurface::Terminal, "{editor}");
+        }
+    }
+
+    #[test]
+    fn launching_a_missing_program_fails_immediately() {
+        let command = EditorCommand {
+            program: "tuicr-no-such-editor".to_string(),
+            args: vec![OsString::from("/repo/src/main.rs")],
+        };
+        assert!(matches!(
+            launch_editor(&command),
+            Err(EditorError::Launch(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    fn shell_command(script: &str) -> EditorCommand {
+        EditorCommand {
+            program: "/bin/sh".to_string(),
+            args: vec![OsString::from("-c"), OsString::from(script)],
+        }
+    }
+
+    /// Polls until the editor is no longer running, so the assertions do not
+    /// race the child's exit.
+    #[cfg(unix)]
+    fn poll_until_settled(launch: &mut EditorLaunch) -> LaunchState {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match launch.poll() {
+                LaunchState::Running if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                state => return state,
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn an_editor_that_dies_on_launch_reports_its_status() {
+        let mut launch = launch_editor(&shell_command("exit 3")).expect("spawn");
+        let LaunchState::FailedToLaunch(status) = poll_until_settled(&mut launch) else {
+            panic!("expected a launch failure");
+        };
+        assert_eq!(status.code(), Some(3));
+        assert_eq!(
+            EditorError::Exit(status).to_string(),
+            "Editor exited with status 3"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn a_successful_editor_is_cleaned_up_without_a_message() {
+        let mut launch = launch_editor(&shell_command("exit 0")).expect("spawn");
+        assert_eq!(poll_until_settled(&mut launch), LaunchState::Exited);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use crossterm::{
 
 use tuicr::app::{self, App, AppStartupOptions, FocusedPanel, InputMode};
 use tuicr::cli::parse_cli_args;
-use tuicr::editor::{EditorError, EditorTarget};
+use tuicr::editor::{EditorCommand, EditorError, EditorLaunch, EditorSurface, EditorTarget};
 use tuicr::handler::{
     handle_command_action, handle_comment_action, handle_comment_navigator_action,
     handle_commit_select_action, handle_commit_selector_action, handle_confirm_action,
@@ -378,6 +378,7 @@ fn main() -> anyhow::Result<()> {
         app.poll_pr_range_reload_events();
         app.poll_pr_threads_events();
         app.poll_pr_submit_events();
+        needs_redraw |= app.poll_editor_launches();
         needs_redraw |= app.poll_persisted_session_changes();
         needs_redraw |= pr_pending;
 
@@ -693,7 +694,18 @@ fn main() -> anyhow::Result<()> {
                     dispatch_action(&mut app, action);
                     if let Some(target) = app.take_pending_editor_target() {
                         match run_editor_from_tui(&mut terminal, &target) {
-                            Ok(Ok(())) => {
+                            // The editor is still open, so there is nothing to
+                            // pick up yet; the user reloads once they are done.
+                            Ok(Ok(EditorOutcome::Detached(launch))) => {
+                                app.track_editor_launch(launch);
+                                let hint = if app.diff_source.includes_worktree_changes() {
+                                    " (:e to reload)"
+                                } else {
+                                    ""
+                                };
+                                app.set_message(format!("Opened {}{hint}", target.path.display()));
+                            }
+                            Ok(Ok(EditorOutcome::Finished)) => {
                                 if app.diff_source.includes_worktree_changes() {
                                     match app.reload_diff_files() {
                                         Ok((count, invalidated)) => {
@@ -867,12 +879,27 @@ fn handle_comment_vim_key(app: &mut App, key: crossterm::event::KeyEvent) -> boo
     true
 }
 
+/// How the editor handoff ended, so the caller knows whether the file could
+/// already have been edited.
+enum EditorOutcome {
+    /// A terminal editor ran to completion.
+    Finished,
+    /// A windowed editor was launched and is still open.
+    Detached(EditorLaunch),
+}
+
 fn run_editor_from_tui<W: Write>(
     terminal: &mut TerminalSession<W>,
     target: &EditorTarget,
-) -> anyhow::Result<Result<(), EditorError>> {
+) -> anyhow::Result<Result<EditorOutcome, EditorError>> {
+    let command = EditorCommand::from_env(target);
+    // Windowed editors never draw on our terminal, so suspending would only
+    // blank the TUI for as long as the editor takes to come up.
+    if command.surface() == EditorSurface::Gui {
+        return Ok(tuicr::editor::launch_editor(&command).map(EditorOutcome::Detached));
+    }
     let suspension = terminal.suspend()?;
-    let editor_result = tuicr::editor::run_editor(target);
+    let editor_result = tuicr::editor::run_editor(&command);
     suspension.resume()?;
-    Ok(editor_result)
+    Ok(editor_result.map(|()| EditorOutcome::Finished))
 }


### PR DESCRIPTION
fixes https://github.com/agavra/tuicr/issues/580

`e` suspended the terminal around every editor launch, which flickers for editors that open their own window. Windowed editors are now spawned detached and cleaned up as they exit, with an early exit still reported. Terminal editors keep the blocking behaviour, as does any `$EDITOR` carrying `--wait`.