### PR TITLE
feat(skills): add a cmux wrapper for launching tuicr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ src/
 
 Repository-managed agent integrations:
 
-- `skills/tuicr/` - Shared agent skill bundle for coding agents, for example Claude Code, Codex, and similar tools; launches tuicr in a tmux, Zellij, or Herdr split pane
+- `skills/tuicr/` - Shared agent skill bundle for coding agents, for example Claude Code, Codex, and similar tools; launches tuicr in a cmux, tmux, Zellij, or Herdr split pane
 
 ### Key Types
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ I reviewed your code and have the following comments. Please address them.
 
 Paste it back to any coding agent (Claude, Codex, Cursor, etc).
 
-For an agent-driven workflow where your agent opens tuicr in a tmux, Zellij, or Herdr
-split pane, see [skills/tuicr/SKILL.md](skills/tuicr/SKILL.md).
+For an agent-driven workflow where your agent opens tuicr in a cmux, tmux, Zellij, or
+Herdr split pane, see [skills/tuicr/SKILL.md](skills/tuicr/SKILL.md).
 
 ### To stdout
 

--- a/skills/tuicr/SKILL.md
+++ b/skills/tuicr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tuicr
-description: Use tuicr's review CLI to read and add comments in active TUI review sessions, and launch tuicr in tmux, Zellij, or Herdr when a user needs an interactive review pane.
+description: Use tuicr's review CLI to read and add comments in active TUI review sessions, and launch tuicr in cmux, tmux, Zellij, or Herdr when a user needs an interactive review pane.
 ---
 
 # tuicr Review Workflow
@@ -72,13 +72,15 @@ When the user needs an interactive tuicr pane and no active session exists:
 
 | Environment | Action |
 |-------------|--------|
+| `$CMUX_WORKSPACE_ID` is set | Run `tuicr-wrapper-cmux.sh /path/to/repo` |
 | `$TMUX` is set | Run `tuicr-wrapper.sh /path/to/repo` |
 | `$ZELLIJ` is set | Run `tuicr-wrapper-zellij.sh /path/to/repo` |
 | `$HERDR_ENV` is `1` | Run `tuicr-wrapper-herdr.sh /path/to/repo` |
 | None is set | Tell the user you are waiting for them to start `tuicr` in the repo, then attach with `tuicr review list` after they say it is ready |
 
 If more than one multiplexer marker is set, prefer the innermost multiplexer if
-that is clear; otherwise ask.
+that is clear; otherwise ask. cmux hosts a Ghostty terminal, so `$TERM_PROGRAM`
+reads `ghostty` inside cmux — check `$CMUX_WORKSPACE_ID`, not the terminal name.
 
 tuicr supports both git and Jujutsu (jj) repositories, and jj workspaces may
 have no `.git` directory at all. Do not pre-check the directory with
@@ -88,6 +90,7 @@ run the wrapper and let it validate the repository.
 Wrapper paths are relative to this skill directory:
 
 ```bash
+<skill-directory>/tuicr-wrapper-cmux.sh /path/to/repo
 <skill-directory>/tuicr-wrapper.sh /path/to/repo
 <skill-directory>/tuicr-wrapper-zellij.sh /path/to/repo
 <skill-directory>/tuicr-wrapper-herdr.sh /path/to/repo
@@ -96,11 +99,19 @@ Wrapper paths are relative to this skill directory:
 The Herdr wrapper requires `jq` to read pane IDs and completion results from
 Herdr's JSON responses.
 
+The cmux wrapper accepts pass-through tuicr arguments after `--`, which is how
+you scope the review — for example `-- -w` for uncommitted working-tree changes
+or `-- -r <revset>` for a commit range.
+
 If your tool supports command timeouts, use a long timeout, such as 10 minutes,
-because the wrappers wait for the TUI to exit. Once the TUI creates its active
-session, use `tuicr review list --repo /path/to/repo` to capture the slug. If
-your environment cannot run another command while the wrapper is waiting, read
-the comments after the user exits tuicr.
+because the tmux, Zellij, and Herdr wrappers wait for the TUI to exit. The cmux
+wrapper is the exception: it returns as soon as the pane is running and prints
+the new surface ref between `=== TUICR SURFACE ===` markers. Capture that ref —
+it is how you close the pane later with `cmux close-surface --surface <ref>`.
+Once the TUI creates its active session, use
+`tuicr review list --repo /path/to/repo` to capture the slug. If your
+environment cannot run another command while a blocking wrapper is waiting,
+read the comments after the user exits tuicr.
 
 ## Read User Comments
 
@@ -202,6 +213,13 @@ comments are unavailable.
 
 ## Multiplexer Tips
 
+cmux:
+
+- Switch panes: click the pane, or `cmux focus-pane --pane <ref>`
+- Close tuicr: press `q`; the pane closes itself. Force it with `cmux close-surface --surface <ref>`
+- List panes: `cmux list-panes`
+- Read a pane without focusing it: `cmux read-screen --surface <ref>`
+
 tmux:
 
 - Switch panes: `Ctrl-b` then arrow keys
@@ -227,8 +245,9 @@ Herdr:
 | Situation | Action |
 |-----------|--------|
 | Multiple plausible active sessions | Ask which session slug to use |
-| No active session, tmux/Zellij/Herdr available | Start a new tuicr pane with the matching wrapper |
+| No active session, cmux/tmux/Zellij/Herdr available | Start a new tuicr pane with the matching wrapper |
 | No active session, no multiplexer | Tell the user you are waiting for them to start `tuicr` |
+| cmux wrapper printed no surface ref | Run `cmux list-panes` to find the pane, or ask the user to start `tuicr` themselves |
 | `tuicr` not installed | Tell the user to install tuicr |
 | Not a repository | Ask for the correct repo directory |
 | Comments are empty | Confirm the selected session or ask the user to save/add comments |

--- a/skills/tuicr/tuicr-wrapper-cmux.sh
+++ b/skills/tuicr/tuicr-wrapper-cmux.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+set -e -u -o pipefail
+
+# Configuration - override via environment variables
+TUICR_PANE_DIRECTION="${TUICR_PANE_DIRECTION:-right}"  # left, right, up or down
+CMUX_BIN="${CMUX_BIN:-cmux}"
+
+# Backward-compat: map old tmux-style position to a cmux direction
+case "${TUICR_PANE_POSITION:-}" in
+  top) TUICR_PANE_DIRECTION="up" ;;
+  bottom) TUICR_PANE_DIRECTION="down" ;;
+  left|right) TUICR_PANE_DIRECTION="$TUICR_PANE_POSITION" ;;
+esac
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+  echo -e "${GREEN}[tuicr]${NC} $*"
+}
+
+log_warn() {
+  echo -e "${YELLOW}[tuicr]${NC} $*"
+}
+
+log_error() {
+  echo -e "${RED}[tuicr]${NC} $*"
+}
+
+usage() {
+  cat << EOF
+Usage: $(basename "$0") [directory] [-- tuicr-args...]
+
+Launch tuicr in a cmux split pane to review changes.
+
+Arguments:
+  directory    Git or jj repository directory to review (default: current directory)
+  tuicr-args   Extra arguments passed through to tuicr (e.g. -w, -r <revset>)
+
+Environment variables:
+  TUICR_PANE_DIRECTION  Split direction: left, right, up or down (default: right)
+  CMUX_BIN              Path to the cmux executable (default: cmux)
+
+Examples:
+  $(basename "$0")                       # Review changes in current directory
+  $(basename "$0") ~/project             # Review changes in ~/project
+  $(basename "$0") . -- -w               # Review uncommitted working-tree changes
+  TUICR_PANE_DIRECTION=down $(basename "$0")
+EOF
+}
+
+check_cmux() {
+  if ! command -v "$CMUX_BIN" &> /dev/null; then
+    log_error "cmux command not found on PATH"
+    return 1
+  fi
+  if [[ -z "${CMUX_WORKSPACE_ID:-}" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+check_tuicr() {
+  if ! command -v tuicr &> /dev/null; then
+    log_error "tuicr not found. Install it first."
+    return 1
+  fi
+  return 0
+}
+
+check_repo() {
+  local dir="$1"
+  if git -C "$dir" rev-parse --git-dir &> /dev/null; then
+    return 0
+  fi
+  if command -v jj &> /dev/null \
+    && jj --repository "$dir" --ignore-working-copy root &> /dev/null; then
+    return 0
+  fi
+  log_error "Not a git or jj repository: $dir"
+  return 1
+}
+
+# ponytail: no already-running guard. cmux workspaces are independent contexts and
+# a global `pgrep -x tuicr` blocks a legitimate review whenever another workspace
+# has one open. A stray pane costs nothing; `cmux list-panes` finds it.
+
+launch_tuicr_pane() {
+  local target_dir="$1"
+  shift
+  local tuicr_args=("$@")
+
+  case "$TUICR_PANE_DIRECTION" in
+    left|right|up|down) ;;
+    *)
+      log_warn "Unknown TUICR_PANE_DIRECTION '$TUICR_PANE_DIRECTION', defaulting to 'right'"
+      TUICR_PANE_DIRECTION="right"
+      ;;
+  esac
+
+  log_info "Launching tuicr in a $TUICR_PANE_DIRECTION-split cmux pane"
+  log_info "Directory: $target_dir"
+
+  # `cmux new-pane` prints: OK surface:<n> pane:<n> workspace:<n>
+  local create_output
+  create_output=$("$CMUX_BIN" new-pane \
+    --type terminal \
+    --direction "$TUICR_PANE_DIRECTION" \
+    --focus true)
+
+  local surface_ref
+  surface_ref=$(printf '%s\n' "$create_output" | grep -o 'surface:[0-9]*' | head -1)
+
+  if [[ -z "$surface_ref" ]]; then
+    log_error "Could not read the new surface id from cmux: $create_output"
+    return 1
+  fi
+
+  # A new pane starts a login shell in the workspace cwd; cd explicitly so the
+  # wrapper works regardless of which directory that turns out to be.
+  local command_line
+  # exec: no shell survives tuicr, so cmux closes the pane when the TUI exits
+  printf -v command_line 'cd %q && exec tuicr' "$target_dir"
+  local arg
+  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
+    printf -v command_line '%s %q' "$command_line" "$arg"
+  done
+
+  "$CMUX_BIN" send --surface "$surface_ref" "$command_line"$'\n' > /dev/null
+
+  log_info "tuicr is running in $surface_ref"
+  log_info "The pane closes itself when tuicr exits; force it with: $CMUX_BIN close-surface --surface $surface_ref"
+  echo ""
+  echo "=== TUICR SURFACE ==="
+  echo "$surface_ref"
+  echo "=== END TUICR SURFACE ==="
+  echo ""
+  # ponytail: returns immediately — cmux has no tmux-style `wait-for`, and the
+  # documented agent loop is polling `tuicr review comments` anyway. Add a FIFO
+  # handshake (as the zellij wrapper does) only if a blocking launch is needed.
+  log_info "Not waiting for exit. Read feedback with: tuicr review comments --repo $target_dir --session <slug>"
+}
+
+main() {
+  # Handle help
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+  fi
+
+  # Check for tuicr
+  if ! check_tuicr; then
+    exit 1
+  fi
+
+  # Determine target directory, then split off any pass-through tuicr args
+  local target_dir="."
+  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+    target_dir="$1"
+    shift
+  fi
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
+  target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
+
+  # Verify it's a git or jj repo
+  if ! check_repo "$target_dir"; then
+    exit 1
+  fi
+
+  # Check we're inside cmux
+  if ! check_cmux; then
+    log_error "Not running inside cmux!"
+    echo ""
+    echo "To use tuicr with your coding agent, run that agent inside cmux."
+    echo ""
+    echo "1. Open the repository in cmux."
+    echo ""
+    echo "2. Start the agent from a cmux terminal."
+    echo ""
+    echo "3. Then run /tuicr again."
+    exit 1
+  fi
+
+  launch_tuicr_pane "$target_dir" "$@"
+}
+
+main "$@"


### PR DESCRIPTION
Adds `skills/tuicr/tuicr-wrapper-cmux.sh`, so the skill can open a tuicr review pane in [cmux](https://cmux.com) the same way it already does in tmux, Zellij, and Herdr.

## Behavior

Three intentional differences from the tmux wrapper:

- **No already-running guard.** `cmux list-panes` reports no per-pane command, so the only available check is a global `pgrep -x tuicr`, which would block a legitimate review whenever another cmux workspace has one open.
- **Pass-through tuicr args after `--`** (e.g. `-- -w`, `-- -r <revset>`), which is how an agent scopes the review. Easy to drop if you would rather keep the wrappers identical.
- **Non-blocking.** tuicr is launched with `exec`, so no shell survives it and cmux closes the pane on exit. The wrapper returns as soon as the pane is running and prints the surface ref, which lets an agent poll `tuicr review comments` while the review is still open.

## Skill changes

- new `$CMUX_WORKSPACE_ID` row in the environment table. That variable detects cmux.
- cmux entries in the multiplexer tips and the wrapper path list.
- README and AGENTS.md now say "cmux, tmux, Zellij, or Herdr".

No Rust code touched.