### PR TITLE
feat(gitlab): resolve, reply to, edit and delete MR discussion threads

### DIFF
--- a/docs/GITLAB.md
+++ b/docs/GITLAB.md
@@ -58,6 +58,26 @@ not add you as a reviewer on your behalf.
 `:submit draft` remains GitHub-only. Run it against a GitLab MR and tuicr returns
 an unsupported-operation error rather than submitting.
 
+## Discussion threads
+
+Existing MR discussions are writable from the diff view. Put the cursor on a
+thread, then:
+
+| Command | Result |
+|---------|--------|
+| `:resolve` / `:unresolve` | Toggles the thread's resolved state. |
+| `:reply`, or `c` on a thread | Opens the editor; Ctrl-S posts the text as a reply. |
+| `i` | Edits the note under the cursor. |
+| `dd` | Deletes the note under the cursor. |
+
+Editing and deleting are limited to your own notes. Ownership is checked against
+the login GitLab reports for your token, so someone else's note is refused in
+tuicr rather than failing at the API. When the forge reports no identity at all,
+both are refused.
+
+Each write is a single request and the thread list is refetched afterwards, so
+the view shows what GitLab now holds rather than a locally patched guess.
+
 ## Self-hosted GitLab
 
 Authenticate against your instance once:

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -739,10 +739,14 @@ impl App {
         self.comment_vim_pending = CommentVimPending::None;
         self.comment_is_review_level = false;
         self.editing_comment_id = None;
+        self.remote_thread_edit = None;
         self.comment_line_range = None;
     }
 
     pub fn save_comment(&mut self) {
+        if self.save_remote_thread_edit() {
+            return;
+        }
         if self.comment_buffer.trim().is_empty() {
             self.set_message("Comment cannot be empty");
             return;

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -511,6 +511,8 @@ impl App {
             forge_review_summaries: Vec::new(),
             forge_review_threads_loading: false,
             pr_threads_rx: None,
+            pr_viewer_login: None,
+            remote_thread_edit: None,
             forge_config: crate::config::ForgeConfig::default(),
             username: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             submit_state: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -585,6 +585,16 @@ pub enum InputMode {
     SubmitActionPicker,
 }
 
+/// A pending write against a remote discussion thread, held while the comment
+/// editor is open so `save_comment` knows to call the forge instead of the
+/// session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteThreadEdit {
+    pub thread_id: String,
+    /// Note being rewritten. `None` means the text becomes a new reply.
+    pub comment_id: Option<String>,
+}
+
 /// CommandCompletionState keeps one Tab-completion run anchored to the text
 /// the user typed before cycling began.
 ///
@@ -1175,6 +1185,15 @@ pub struct App {
     /// Background-thread channel that delivers remote-thread fetch results.
     /// `Receiver` is only present while a fetch is in flight.
     pub pr_threads_rx: Option<std::sync::mpsc::Receiver<PrThreadsEvent>>,
+    /// Forge login of the authenticated user for the open PR, from the forge
+    /// itself rather than the local `username` config. Editing and deleting
+    /// remote notes is gated on it, since forges only allow authors to do
+    /// either. `None` when the forge did not report an identity.
+    pub pr_viewer_login: Option<String>,
+    /// Remote thread comment the editor is currently composing against, set
+    /// while replying to or editing a forge thread. `None` for local drafts,
+    /// which `save_comment` writes to the session instead.
+    pub remote_thread_edit: Option<RemoteThreadEdit>,
 
     /// `[forge]` section settings resolved at startup. Drives the body/footer
     /// formatting on submit. Defaults to `ForgeConfig::default()` when the
@@ -1600,6 +1619,7 @@ mod init;
 mod modes;
 mod navigation;
 mod pr;
+mod remote_threads;
 mod reviewed;
 mod search;
 mod session;

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -45,6 +45,8 @@ impl App {
         self.forge_review_summaries = Vec::new();
         self.forge_review_threads_loading = false;
         self.pr_threads_rx = None;
+        self.pr_viewer_login = review_metadata.viewer_login.clone();
+        self.remote_thread_edit = None;
         // Latest known remote head — equal to the session head at open time;
         // refreshed by future `gh pr view` calls in PR 6.
         self.current_pr_head = Some(details.head_sha.clone());

--- a/src/app/remote_threads.rs
+++ b/src/app/remote_threads.rs
@@ -1,0 +1,303 @@
+//! Mutating remote discussion threads from the diff view.
+//!
+//! Every entry point resolves its target from the cursor, so the caller only
+//! has to name the operation. Forge calls run synchronously - each is a single
+//! request, and the thread list is refetched afterwards so the view reflects
+//! what the forge now holds rather than a locally patched guess.
+
+use crate::app::{AnnotatedLine, App, DiffSource, InputMode, RemoteThreadEdit};
+use crate::forge::remote_comments::RemoteReviewThread;
+use crate::forge::traits::{ForgeBackend, PullRequestDetails};
+
+impl App {
+    /// Resolve or unresolve the thread under the cursor.
+    pub fn set_thread_resolved_at_cursor(&mut self, resolved: bool) {
+        let Some((thread_idx, _)) = self.remote_thread_at_cursor() else {
+            self.set_warning("Place the cursor on a remote thread first");
+            return;
+        };
+        let thread_id = self.forge_review_threads[thread_idx].id.clone();
+        let verb = if resolved { "Resolved" } else { "Unresolved" };
+        self.run_thread_mutation(verb, |backend, pr| {
+            backend.set_thread_resolved(pr, &thread_id, resolved)
+        });
+    }
+
+    /// Open the comment editor to append a reply to the thread under the cursor.
+    pub fn reply_to_thread_at_cursor(&mut self) {
+        let Some((thread_idx, _)) = self.remote_thread_at_cursor() else {
+            self.set_warning("Place the cursor on a remote thread first");
+            return;
+        };
+        let thread_id = self.forge_review_threads[thread_idx].id.clone();
+        self.remote_thread_edit = Some(RemoteThreadEdit {
+            thread_id,
+            comment_id: None,
+        });
+        self.open_editor_for_remote_thread(String::new());
+        self.set_message("Reply to thread — Ctrl-S to post, Esc to cancel");
+    }
+
+    /// Open the comment editor on your own note under the cursor.
+    pub fn edit_remote_note_at_cursor(&mut self) -> bool {
+        let Some((thread_idx, note_idx)) = self.own_remote_note_at_cursor() else {
+            return false;
+        };
+        let thread = &self.forge_review_threads[thread_idx];
+        let body = thread.comments[note_idx].body.clone();
+        self.remote_thread_edit = Some(RemoteThreadEdit {
+            thread_id: thread.id.clone(),
+            comment_id: Some(thread.comments[note_idx].id.clone()),
+        });
+        self.open_editor_for_remote_thread(body);
+        self.set_message("Editing remote comment — Ctrl-S to save, Esc to cancel");
+        true
+    }
+
+    /// Delete your own note under the cursor.
+    pub fn delete_remote_note_at_cursor(&mut self) -> bool {
+        let Some((thread_idx, note_idx)) = self.own_remote_note_at_cursor() else {
+            return false;
+        };
+        let thread = &self.forge_review_threads[thread_idx];
+        let thread_id = thread.id.clone();
+        let comment_id = thread.comments[note_idx].id.clone();
+        self.run_thread_mutation("Deleted remote comment", |backend, pr| {
+            backend.delete_thread_comment(pr, &thread_id, &comment_id)
+        });
+        true
+    }
+
+    /// Apply the editor buffer to the pending reply or edit. Returns false when
+    /// no remote write is pending, leaving the local-draft path to the caller.
+    pub fn save_remote_thread_edit(&mut self) -> bool {
+        let Some(pending) = self.remote_thread_edit.clone() else {
+            return false;
+        };
+        let body = self.comment_buffer.trim().to_string();
+        if body.is_empty() {
+            self.set_message("Comment cannot be empty");
+            return true;
+        }
+
+        let label = match &pending.comment_id {
+            Some(_) => "Updated remote comment",
+            None => "Replied to thread",
+        };
+        self.run_thread_mutation(label, |backend, pr| match &pending.comment_id {
+            Some(comment_id) => {
+                backend.edit_thread_comment(pr, &pending.thread_id, comment_id, &body)
+            }
+            None => backend.reply_to_thread(pr, &pending.thread_id, &body),
+        });
+        self.exit_comment_mode();
+        true
+    }
+
+    /// Whether the active backend can write to remote threads at all.
+    pub fn supports_remote_thread_mutations(&self) -> bool {
+        self.forge_backend
+            .as_deref()
+            .is_some_and(|backend| backend.supports_thread_mutations())
+    }
+
+    /// Thread and note under the cursor, when both resolve and the note is
+    /// yours. Warns about the reason it did not, so callers can fall through to
+    /// their local-comment behavior only when the cursor is elsewhere.
+    fn own_remote_note_at_cursor(&mut self) -> Option<(usize, usize)> {
+        if !self.supports_remote_thread_mutations() {
+            self.set_message(format!(
+                "{} comment — read only in tuicr",
+                self.forge_display_name()
+            ));
+            return None;
+        }
+        let (thread_idx, row) = self.remote_thread_at_cursor()?;
+        let thread = &self.forge_review_threads[thread_idx];
+        let Some(note_idx) = note_index_for_row(thread, row) else {
+            self.set_warning("Place the cursor on a comment inside the thread");
+            return None;
+        };
+        let author = thread.comments[note_idx].author.as_deref();
+        if !self.is_own_remote_note(author) {
+            let author = author.unwrap_or("someone else");
+            self.set_warning(format!("Cannot modify @{author}'s comment"));
+            return None;
+        }
+        Some((thread_idx, note_idx))
+    }
+
+    /// Index of the thread under the cursor plus the cursor's row offset within
+    /// the thread's rendered block.
+    fn remote_thread_at_cursor(&self) -> Option<(usize, usize)> {
+        let cursor = self.diff_state.cursor_line;
+        let &AnnotatedLine::RemoteThreadLine { thread_idx } = self.line_annotations.get(cursor)?
+        else {
+            return None;
+        };
+        self.forge_review_threads.get(thread_idx)?;
+        let row = self.line_annotations[..cursor]
+            .iter()
+            .rev()
+            .take_while(|candidate| {
+                matches!(
+                    candidate,
+                    AnnotatedLine::RemoteThreadLine { thread_idx: prev } if *prev == thread_idx
+                )
+            })
+            .count();
+        Some((thread_idx, row))
+    }
+
+    fn is_own_remote_note(&self, author: Option<&str>) -> bool {
+        let Some(author) = author else {
+            return false;
+        };
+        let Some(viewer) = self.pr_viewer_login.as_deref() else {
+            return false;
+        };
+        author.eq_ignore_ascii_case(viewer)
+    }
+
+    fn open_editor_for_remote_thread(&mut self, body: String) {
+        self.input_mode = InputMode::Comment;
+        self.diff_state.scroll_x = 0;
+        self.comment_cursor = body.len();
+        self.comment_buffer = body;
+        self.comment_type = self.default_comment_type();
+        self.comment_is_review_level = false;
+        self.comment_is_file_level = false;
+        self.comment_line = None;
+        self.comment_line_range = None;
+        self.editing_comment_id = None;
+    }
+
+    /// Run `call` against the active forge backend, then re-read the thread list
+    /// from that same backend so the view shows what the forge now holds. Both
+    /// calls are synchronous: each is one request, and the reread has to observe
+    /// the write, which an out-of-band background fetch could race.
+    fn run_thread_mutation(
+        &mut self,
+        success: &str,
+        call: impl FnOnce(&dyn ForgeBackend, &PullRequestDetails) -> crate::error::Result<()>,
+    ) {
+        let Some(pr) = self.pr_details_for_mutation() else {
+            self.set_warning("Remote threads can only be changed in PR mode");
+            return;
+        };
+        let Some(backend) = self.forge_backend.as_deref() else {
+            self.set_warning("No forge backend for this review");
+            return;
+        };
+        if let Err(err) = call(backend, &pr) {
+            self.set_error(format!("{err}"));
+            return;
+        }
+        // The write landed, so a failed reread is a stale view rather than a
+        // failed operation - say so instead of reporting the write as failed.
+        match backend.list_review_threads(&pr) {
+            Ok(threads) => {
+                self.forge_review_threads = threads;
+                self.rebuild_annotations();
+                self.set_message(success.to_string());
+            }
+            Err(err) => self.set_warning(format!("{success}, but reloading threads failed: {err}")),
+        }
+    }
+
+    /// Rebuild the `PullRequestDetails` the backend needs from the open PR.
+    /// Only the fields the discussion endpoints read are meaningful here.
+    fn pr_details_for_mutation(&self) -> Option<PullRequestDetails> {
+        let DiffSource::PullRequest(pr) = &self.diff_source else {
+            return None;
+        };
+        Some(PullRequestDetails {
+            repository: pr.key.repository.clone(),
+            number: pr.key.number,
+            title: pr.title.clone(),
+            url: pr.url.clone(),
+            state: pr.state.clone(),
+            is_draft: false,
+            author: None,
+            head_ref_name: pr.head_ref_name.clone(),
+            base_ref_name: pr.base_ref_name.clone(),
+            head_sha: pr.key.head_sha.clone(),
+            base_sha: pr.base_sha.clone(),
+            body: String::new(),
+            updated_at: None,
+            closed: pr.closed,
+            merged_at: None,
+            diff_start_sha: None,
+        })
+    }
+}
+
+/// Which comment in `thread` occupies `row` of its rendered block. Mirrors the
+/// layout in `comment_panel::format_remote_thread_lines`: one header row per
+/// comment, then its body rows, and a single footer row closing the thread.
+/// The footer belongs to no comment.
+fn note_index_for_row(thread: &RemoteReviewThread, row: usize) -> Option<usize> {
+    let mut offset = 0;
+    for (idx, comment) in thread.comments.iter().enumerate() {
+        let block = 1 + comment.body.split('\n').count();
+        if row < offset + block {
+            return Some(idx);
+        }
+        offset += block;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::note_index_for_row;
+    use crate::forge::remote_comments::{
+        RemoteCommentSide, RemoteReviewComment, RemoteReviewThread,
+    };
+
+    fn comment(id: &str, body: &str) -> RemoteReviewComment {
+        RemoteReviewComment {
+            id: id.to_string(),
+            author: Some("alice".to_string()),
+            body: body.to_string(),
+            created_at: None,
+            in_reply_to: None,
+            url: String::new(),
+        }
+    }
+
+    fn thread(comments: Vec<RemoteReviewComment>) -> RemoteReviewThread {
+        RemoteReviewThread {
+            id: "t1".to_string(),
+            path: "src/lib.rs".to_string(),
+            line: Some(10),
+            side: RemoteCommentSide::Right,
+            is_resolved: false,
+            is_outdated: false,
+            comments,
+        }
+    }
+
+    #[test]
+    fn should_map_rows_to_the_comment_they_render() {
+        // given a root with a two-line body and one single-line reply:
+        // rows 0-2 are the root (header + 2 body), rows 3-4 the reply.
+        let thread = thread(vec![
+            comment("root", "first\nsecond"),
+            comment("reply", "ok"),
+        ]);
+        // when/then
+        assert_eq!(note_index_for_row(&thread, 0), Some(0));
+        assert_eq!(note_index_for_row(&thread, 2), Some(0));
+        assert_eq!(note_index_for_row(&thread, 3), Some(1));
+        assert_eq!(note_index_for_row(&thread, 4), Some(1));
+    }
+
+    #[test]
+    fn should_map_footer_row_to_no_comment() {
+        // given a thread whose only comment occupies rows 0-1
+        let thread = thread(vec![comment("root", "body")]);
+        // when/then — row 2 is the closing rule
+        assert_eq!(note_index_for_row(&thread, 2), None);
+    }
+}

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -2570,7 +2570,7 @@ fn should_warn_when_comments_command_used_outside_pr_mode() {
     // then — visibility unchanged, a warning surfaced on the message bar
     assert_eq!(
         app.session.remote_comments_visibility,
-        PrCommentsVisibility::Unresolved
+        PrCommentsVisibility::default()
     );
     let msg = app
         .message
@@ -2652,4 +2652,296 @@ fn should_discard_stale_remote_threads_event_after_switching_pr() {
     app.poll_pr_threads_events();
     // then — stale result was dropped
     assert!(app.forge_review_threads.is_empty());
+}
+
+/// Records every thread mutation and serves an updated thread list afterwards,
+/// so tests can assert both the call the App made and the state it adopted.
+struct MutationLog {
+    threads: std::cell::RefCell<Vec<RemoteReviewThread>>,
+    mutations: std::cell::RefCell<Vec<String>>,
+}
+
+struct MutatingForgeBackend {
+    details: crate::forge::traits::PullRequestDetails,
+    patch: String,
+    log: std::rc::Rc<MutationLog>,
+    viewer: Option<String>,
+    supported: bool,
+}
+
+impl MutatingForgeBackend {
+    fn new(log: std::rc::Rc<MutationLog>, viewer: Option<&str>, supported: bool) -> Self {
+        Self {
+            details: test_pr_details(42, "answer"),
+            patch: crate::forge::github::gh::tests_fixture::SIMPLE_PATCH.to_string(),
+            log,
+            viewer: viewer.map(str::to_string),
+            supported,
+        }
+    }
+
+    fn record(&self, call: String) {
+        self.log.mutations.borrow_mut().push(call);
+    }
+}
+
+impl crate::forge::traits::ForgeBackend for MutatingForgeBackend {
+    fn list_pull_requests(
+        &self,
+        _q: crate::forge::traits::PullRequestListQuery,
+    ) -> Result<crate::forge::traits::PagedPullRequests> {
+        unimplemented!()
+    }
+    fn get_pull_request(
+        &self,
+        _t: crate::forge::traits::PullRequestTarget,
+    ) -> Result<crate::forge::traits::PullRequestDetails> {
+        Ok(self.details.clone())
+    }
+    fn get_pull_request_diff(
+        &self,
+        _p: &crate::forge::traits::PullRequestDetails,
+    ) -> Result<String> {
+        Ok(self.patch.clone())
+    }
+    fn fetch_file_lines(
+        &self,
+        _r: crate::forge::traits::ForgeFileLinesRequest,
+    ) -> Result<Vec<crate::model::DiffLine>> {
+        Ok(Vec::new())
+    }
+    fn list_review_threads(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+    ) -> Result<Vec<RemoteReviewThread>> {
+        Ok(self.log.threads.borrow().clone())
+    }
+    fn list_pull_request_commits(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+    ) -> Result<Vec<crate::forge::traits::PullRequestCommit>> {
+        Ok(Vec::new())
+    }
+    fn list_pull_request_review_metadata(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+    ) -> Result<PullRequestReviewMetadata> {
+        Ok(PullRequestReviewMetadata {
+            viewer_login: self.viewer.clone(),
+            reviews: Vec::new(),
+        })
+    }
+    fn get_pull_request_commit_range_diff(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        _start_sha: &str,
+        _end_sha: &str,
+    ) -> Result<String> {
+        unreachable!()
+    }
+    fn create_review(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        _request: crate::forge::traits::CreateReviewRequest<'_>,
+    ) -> Result<crate::forge::traits::GhCreateReviewResponse> {
+        unimplemented!()
+    }
+    fn supports_thread_mutations(&self) -> bool {
+        self.supported
+    }
+    fn set_thread_resolved(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        thread_id: &str,
+        resolved: bool,
+    ) -> Result<()> {
+        self.record(format!("resolve {thread_id} {resolved}"));
+        for thread in self.log.threads.borrow_mut().iter_mut() {
+            if thread.id == thread_id {
+                thread.is_resolved = resolved;
+            }
+        }
+        Ok(())
+    }
+    fn reply_to_thread(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        thread_id: &str,
+        body: &str,
+    ) -> Result<()> {
+        self.record(format!("reply {thread_id} {body}"));
+        for thread in self.log.threads.borrow_mut().iter_mut() {
+            if thread.id == thread_id {
+                thread.comments.push(RemoteReviewComment {
+                    id: "new".to_string(),
+                    author: self.viewer.clone(),
+                    body: body.to_string(),
+                    created_at: None,
+                    in_reply_to: None,
+                    url: String::new(),
+                });
+            }
+        }
+        Ok(())
+    }
+    fn edit_thread_comment(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        thread_id: &str,
+        comment_id: &str,
+        body: &str,
+    ) -> Result<()> {
+        self.record(format!("edit {thread_id} {comment_id} {body}"));
+        Ok(())
+    }
+    fn delete_thread_comment(
+        &self,
+        _pr: &crate::forge::traits::PullRequestDetails,
+        thread_id: &str,
+        comment_id: &str,
+    ) -> Result<()> {
+        self.record(format!("delete {thread_id} {comment_id}"));
+        self.log.threads.borrow_mut().clear();
+        Ok(())
+    }
+}
+
+/// Open a PR whose diff carries one remote thread and leave the cursor on the
+/// thread's first rendered row. Returns the app plus a handle to the backend so
+/// callers can read back the mutations it recorded.
+fn app_on_remote_thread(
+    author: &str,
+    viewer: Option<&str>,
+    supported: bool,
+) -> (App, std::rc::Rc<MutationLog>) {
+    let mut thread = sample_thread(2, "remote body", false, false);
+    thread.comments[0].author = Some(author.to_string());
+    thread.comments[0].id = "C1".to_string();
+
+    let log = std::rc::Rc::new(MutationLog {
+        threads: std::cell::RefCell::new(vec![thread]),
+        mutations: std::cell::RefCell::new(Vec::new()),
+    });
+    let backend = MutatingForgeBackend::new(std::rc::Rc::clone(&log), viewer, supported);
+    let mut app = build_app();
+    let summary = sample_pr(42, "answer");
+    app.open_pr_with_backend(&summary, Box::new(backend), None)
+        .unwrap();
+
+    let cursor = app
+        .line_annotations
+        .iter()
+        .position(|a| matches!(a, AnnotatedLine::RemoteThreadLine { .. }))
+        .expect("thread annotation should be rendered");
+    app.diff_state.cursor_line = cursor;
+    (app, log)
+}
+
+#[test]
+fn should_resolve_the_thread_under_the_cursor() {
+    // given
+    let (mut app, log) = app_on_remote_thread("alice", Some("bob"), true);
+    // when
+    app.set_thread_resolved_at_cursor(true);
+    // then — the call went out and the reread state was adopted
+    assert_eq!(log.mutations.borrow().as_slice(), ["resolve T true"]);
+    assert!(app.forge_review_threads[0].is_resolved);
+}
+
+#[test]
+fn should_warn_instead_of_resolving_when_cursor_is_off_thread() {
+    // given the cursor on a plain diff line
+    let (mut app, log) = app_on_remote_thread("alice", Some("bob"), true);
+    app.diff_state.cursor_line = 0;
+    // when
+    app.set_thread_resolved_at_cursor(true);
+    // then
+    assert!(log.mutations.borrow().is_empty());
+    let msg = app.message.as_ref().expect("expected a warning");
+    assert!(matches!(msg.message_type, MessageType::Warning));
+}
+
+#[test]
+fn should_post_reply_typed_into_the_comment_editor() {
+    // given
+    let (mut app, log) = app_on_remote_thread("alice", Some("bob"), true);
+    app.reply_to_thread_at_cursor();
+    assert_eq!(app.input_mode, InputMode::Comment);
+    app.comment_buffer = "thanks, fixed".to_string();
+    // when
+    app.save_comment();
+    // then — posted as a reply, not stored as a local draft
+    assert_eq!(log.mutations.borrow().as_slice(), ["reply T thanks, fixed"]);
+    assert!(app.session.review_comments.is_empty());
+    assert_eq!(app.input_mode, InputMode::Normal);
+    assert!(app.remote_thread_edit.is_none());
+    assert_eq!(app.forge_review_threads[0].comments.len(), 2);
+}
+
+#[test]
+fn should_edit_own_remote_note_through_the_comment_editor() {
+    // given the viewer authored the note under the cursor
+    let (mut app, log) = app_on_remote_thread("bob", Some("bob"), true);
+    // when
+    assert!(app.edit_remote_note_at_cursor());
+    // then — the editor opens prefilled with the existing body
+    assert_eq!(app.comment_buffer, "remote body");
+    app.comment_buffer = "reworded".to_string();
+    app.save_comment();
+    assert_eq!(log.mutations.borrow().as_slice(), ["edit T C1 reworded"]);
+}
+
+#[test]
+fn should_refuse_to_edit_someone_elses_remote_note() {
+    // given a note authored by someone other than the viewer
+    let (mut app, log) = app_on_remote_thread("alice", Some("bob"), true);
+    // when
+    assert!(!app.edit_remote_note_at_cursor());
+    // then
+    assert!(log.mutations.borrow().is_empty());
+    assert_eq!(app.input_mode, InputMode::Normal);
+    let msg = app.message.as_ref().expect("expected a warning");
+    assert!(
+        msg.content.contains("@alice"),
+        "got message: {}",
+        msg.content
+    );
+}
+
+#[test]
+fn should_refuse_to_edit_remote_note_when_forge_cannot_mutate_threads() {
+    // given a backend without thread mutation support (GitHub today)
+    let (mut app, log) = app_on_remote_thread("bob", Some("bob"), false);
+    // when
+    assert!(!app.edit_remote_note_at_cursor());
+    // then
+    assert!(log.mutations.borrow().is_empty());
+    let msg = app.message.as_ref().expect("expected a message");
+    assert!(
+        msg.content.contains("read only"),
+        "got message: {}",
+        msg.content
+    );
+}
+
+#[test]
+fn should_delete_own_remote_note() {
+    // given
+    let (mut app, log) = app_on_remote_thread("bob", Some("bob"), true);
+    // when
+    assert!(app.delete_remote_note_at_cursor());
+    // then
+    assert_eq!(log.mutations.borrow().as_slice(), ["delete T C1"]);
+    assert!(app.forge_review_threads.is_empty());
+}
+
+#[test]
+fn should_refuse_to_delete_when_the_forge_reports_no_viewer_identity() {
+    // given no viewer login, so ownership cannot be established
+    let (mut app, log) = app_on_remote_thread("bob", None, true);
+    // when
+    assert!(!app.delete_remote_note_at_cursor());
+    // then
+    assert!(log.mutations.borrow().is_empty());
+    assert_eq!(app.forge_review_threads.len(), 1);
 }

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -786,12 +786,102 @@ where
             state: state.to_string(),
         })
     }
+
+    fn supports_thread_mutations(&self) -> bool {
+        true
+    }
+
+    fn set_thread_resolved(
+        &self,
+        pr: &PullRequestDetails,
+        thread_id: &str,
+        resolved: bool,
+    ) -> Result<()> {
+        self.run_discussion_mutation(
+            pr,
+            "PUT",
+            &format!("discussions/{thread_id}"),
+            &[("resolved", if resolved { "true" } else { "false" })],
+        )
+        .map(drop)
+    }
+
+    fn reply_to_thread(&self, pr: &PullRequestDetails, thread_id: &str, body: &str) -> Result<()> {
+        self.run_discussion_mutation(
+            pr,
+            "POST",
+            &format!("discussions/{thread_id}/notes"),
+            &[("body", body)],
+        )
+        .map(drop)
+    }
+
+    fn edit_thread_comment(
+        &self,
+        pr: &PullRequestDetails,
+        thread_id: &str,
+        comment_id: &str,
+        body: &str,
+    ) -> Result<()> {
+        self.run_discussion_mutation(
+            pr,
+            "PUT",
+            &format!("discussions/{thread_id}/notes/{comment_id}"),
+            &[("body", body)],
+        )
+        .map(drop)
+    }
+
+    fn delete_thread_comment(
+        &self,
+        pr: &PullRequestDetails,
+        thread_id: &str,
+        comment_id: &str,
+    ) -> Result<()> {
+        self.run_discussion_mutation(
+            pr,
+            "DELETE",
+            &format!("discussions/{thread_id}/notes/{comment_id}"),
+            &[],
+        )
+        .map(drop)
+    }
 }
 
 impl<R> GitLabGlabBackend<R>
 where
     R: GlabCommandRunner,
 {
+    /// Run one write against a merge request's discussion endpoints.
+    ///
+    /// `suffix` is appended to `projects/{p}/merge_requests/{n}/`. Fields are
+    /// sent with `--raw-field` so bodies containing `=` or looking like a
+    /// filename are not reinterpreted by glab.
+    fn run_discussion_mutation(
+        &self,
+        pr: &PullRequestDetails,
+        method: &str,
+        suffix: &str,
+        fields: &[(&str, &str)],
+    ) -> Result<String> {
+        let project = gl_project_path(&pr.repository.owner, &pr.repository.name);
+        let mut args = vec![
+            "api".to_string(),
+            format!(
+                "projects/{}/merge_requests/{}/{}",
+                project, pr.number, suffix
+            ),
+            "--method".to_string(),
+            method.to_string(),
+        ];
+        for (name, value) in fields {
+            args.push("--raw-field".to_string());
+            args.push(format!("{name}={value}"));
+        }
+        args.extend(Self::api_hostname_args(&pr.repository));
+        self.run_glab(args, &pr.repository.host)
+    }
+
     fn fetch_file_via_api(&self, request: &ForgeFileLinesRequest) -> Result<String> {
         let project = gl_project_path(&request.repository.owner, &request.repository.name);
         let path_str = request.path.to_string_lossy().replace('\\', "/");
@@ -1993,6 +2083,92 @@ mod tests {
                 "draft path must not publish"
             );
         }
+    }
+
+    #[test]
+    fn should_put_resolved_flag_on_discussion() {
+        let repo = ForgeRepository::gitlab("code.pan.run", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let runner = RecordingRunner::new_with_responses(vec![String::new()]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        backend.set_thread_resolved(&pr, "disc-1", true).unwrap();
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(
+            calls[0].0,
+            vec![
+                "api",
+                "projects/owner%2Frepo/merge_requests/42/discussions/disc-1",
+                "--method",
+                "PUT",
+                "--raw-field",
+                "resolved=true",
+                "--hostname",
+                "code.pan.run",
+            ]
+        );
+    }
+
+    #[test]
+    fn should_post_reply_to_discussion_notes() {
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let runner = RecordingRunner::new_with_responses(vec![String::new()]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        // A body containing `=` must survive intact, hence --raw-field.
+        backend
+            .reply_to_thread(&pr, "disc-1", "a = b, still one field")
+            .unwrap();
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(
+            calls[0].0,
+            vec![
+                "api",
+                "projects/owner%2Frepo/merge_requests/42/discussions/disc-1/notes",
+                "--method",
+                "POST",
+                "--raw-field",
+                "body=a = b, still one field",
+            ]
+        );
+    }
+
+    #[test]
+    fn should_put_and_delete_individual_thread_notes() {
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let runner = RecordingRunner::new_with_responses(vec![String::new(), String::new()]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        backend
+            .edit_thread_comment(&pr, "disc-1", "77", "new body")
+            .unwrap();
+        backend.delete_thread_comment(&pr, "disc-1", "77").unwrap();
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(
+            calls[0].0,
+            vec![
+                "api",
+                "projects/owner%2Frepo/merge_requests/42/discussions/disc-1/notes/77",
+                "--method",
+                "PUT",
+                "--raw-field",
+                "body=new body",
+            ]
+        );
+        assert_eq!(
+            calls[1].0,
+            vec![
+                "api",
+                "projects/owner%2Frepo/merge_requests/42/discussions/disc-1/notes/77",
+                "--method",
+                "DELETE",
+            ]
+        );
     }
 
     #[test]

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::error::Result;
+use crate::error::{Result, TuicrError};
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::submit::SubmitEvent;
 use crate::model::{DiffLine, FileStatus};
@@ -552,6 +552,60 @@ pub trait ForgeBackend {
         pr: &PullRequestDetails,
         request: CreateReviewRequest<'_>,
     ) -> Result<GhCreateReviewResponse>;
+
+    /// Whether the four thread-mutation methods below are implemented. Callers
+    /// check this before offering the operations in the UI, rather than letting
+    /// the user compose a reply only to have it rejected on submit.
+    fn supports_thread_mutations(&self) -> bool {
+        false
+    }
+
+    /// Mark an existing discussion thread resolved or unresolved. `thread_id`
+    /// is the `RemoteReviewThread::id` the backend itself produced.
+    fn set_thread_resolved(
+        &self,
+        _pr: &PullRequestDetails,
+        _thread_id: &str,
+        _resolved: bool,
+    ) -> Result<()> {
+        Err(unsupported_thread_mutation("resolving threads"))
+    }
+
+    /// Append a reply to an existing discussion thread.
+    fn reply_to_thread(
+        &self,
+        _pr: &PullRequestDetails,
+        _thread_id: &str,
+        _body: &str,
+    ) -> Result<()> {
+        Err(unsupported_thread_mutation("replying to threads"))
+    }
+
+    /// Rewrite the body of one comment in a thread. `comment_id` is the
+    /// `RemoteReviewComment::id` from the same backend.
+    fn edit_thread_comment(
+        &self,
+        _pr: &PullRequestDetails,
+        _thread_id: &str,
+        _comment_id: &str,
+        _body: &str,
+    ) -> Result<()> {
+        Err(unsupported_thread_mutation("editing thread comments"))
+    }
+
+    /// Delete one comment from a thread.
+    fn delete_thread_comment(
+        &self,
+        _pr: &PullRequestDetails,
+        _thread_id: &str,
+        _comment_id: &str,
+    ) -> Result<()> {
+        Err(unsupported_thread_mutation("deleting thread comments"))
+    }
+}
+
+fn unsupported_thread_mutation(action: &str) -> TuicrError {
+    TuicrError::UnsupportedOperation(format!("This forge backend does not support {action}"))
 }
 
 #[cfg(test)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -92,6 +92,9 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         &["comments hide"],
         CommandKind::Comments(PrCommentsVisibility::Hide),
     ),
+    CommandSpec::new(&["resolve"], CommandKind::ResolveThread(true)),
+    CommandSpec::new(&["unresolve"], CommandKind::ResolveThread(false)),
+    CommandSpec::new(&["reply"], CommandKind::ReplyToThread),
 ];
 
 /// CommandSpec is the single registry entry used by both completion and
@@ -140,6 +143,8 @@ enum CommandKind {
     SubmitPicker,
     Submit(SubmitEvent),
     Comments(PrCommentsVisibility),
+    ResolveThread(bool),
+    ReplyToThread,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -912,6 +917,16 @@ fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
             set_remote_comments_visibility(app, visibility);
             CommandAfterDispatch::ExitCommandMode
         }
+        CommandKind::ResolveThread(resolved) => {
+            app.exit_command_mode();
+            app.set_thread_resolved_at_cursor(resolved);
+            CommandAfterDispatch::KeepMode
+        }
+        CommandKind::ReplyToThread => {
+            app.exit_command_mode();
+            app.reply_to_thread_at_cursor();
+            CommandAfterDispatch::KeepMode
+        }
     }
 }
 
@@ -1455,9 +1470,10 @@ fn edit_comment_at_cursor(app: &mut App, cursor_at_end: bool) {
             "Comment already pushed to {forge} — read only in tuicr"
         ));
     } else if !app.enter_edit_mode(cursor_at_end) {
+        // On a remote thread, `edit_remote_note_at_cursor` explains itself
+        // whenever it declines (someone else's note, a read-only forge).
         if app.cursor_on_remote_thread() {
-            let forge = app.forge_display_name();
-            app.set_message(format!("{forge} comment — read only in tuicr"));
+            app.edit_remote_note_at_cursor();
         } else {
             app.set_message("No comment at cursor");
         }
@@ -1610,6 +1626,8 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
             let line = app.get_line_at_cursor();
             if line.is_some() {
                 app.enter_comment_mode(false, line);
+            } else if app.cursor_on_remote_thread() && app.supports_remote_thread_mutations() {
+                app.reply_to_thread_at_cursor();
             } else {
                 app.set_message("Move cursor to a diff line to add a line comment");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,11 +517,10 @@ fn main() -> anyhow::Result<()> {
                                     "Comment already pushed to {forge} — read only in tuicr"
                                 ));
                             } else if !app.delete_comment_at_cursor() {
+                                // On a remote thread, the delete path explains
+                                // itself whenever it declines.
                                 if app.cursor_on_remote_thread() {
-                                    let forge = app.forge_display_name();
-                                    app.set_message(format!(
-                                        "{forge} comment — read only in tuicr"
-                                    ));
+                                    app.delete_remote_note_at_cursor();
                                 } else {
                                     app.set_message("No comment at cursor");
                                 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -438,7 +438,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  c         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Add line comment"),
+            Span::raw("Add line comment, or reply to the remote thread at cursor"),
         ]),
         Line::from(vec![
             Span::styled(
@@ -459,14 +459,14 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  i         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Edit comment at cursor"),
+            Span::raw("Edit comment at cursor (your own remote comments too)"),
         ]),
         Line::from(vec![
             Span::styled(
                 "  dd        ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Delete comment at cursor"),
+            Span::raw("Delete comment at cursor (your own remote comments too)"),
         ]),
         Line::from(vec![
             Span::styled(
@@ -739,6 +739,27 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("  Hide remote comments in PR mode"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :resolve  ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Resolve the remote thread under the cursor (GitLab)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :unresolve",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Reopen the remote thread under the cursor (GitLab)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  :reply    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Reply to the remote thread under the cursor (same as c)"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
Addresses #410 and #483 for GitLab. Opening it as a concrete proposal rather than a finished answer for every forge — the trait is the general part, the GitLab backend is the one implementation, and the UX is deliberately small. Happy to reshape any of it.

## Problem

Remote threads are read-only. `i` and `dd` on one answer `read only in tuicr`, and `c` refuses because the cursor is not on a diff line. Responding to review feedback means leaving for the web UI — which, for the agent-driven back-and-forth #483 describes, is the whole loop.

## What this adds

`ForgeBackend` gains four thread mutations behind a `supports_thread_mutations()` capability check, each defaulting to an unsupported-operation error. GitHub, Bitbucket and Azure are untouched and keep today's behaviour; the UI asks the capability before offering an operation, rather than letting you compose a reply and rejecting it on submit.

GitLab implements them over the discussions REST endpoints. Bodies go out as `--raw-field` so text containing `=`, or text that looks like a filename, survives `glab` intact.

In the diff view, with the cursor on a thread:

| Input | Result |
|-------|--------|
| `:resolve` / `:unresolve` | Toggle the thread's resolved state |
| `:reply`, or `c` on a thread | Open the editor; Ctrl-S posts the text as a reply |
| `i` | Edit the note under the cursor |
| `dd` | Delete the note under the cursor |

`c`/`i`/`dd` keep their existing meanings everywhere else — the thread path is only reached where those keys previously printed a refusal.

## On the two design questions in the issues

**Ownership.** Editing and deleting are gated on the login the forge reports for the viewer, not the local `username` config, so someone else's note is refused inside tuicr rather than failing at the API. No reported identity means both are refused.

**Resolution semantics.** @mathstuf's point in #483 — that a reviewer's resolution and a contributor's are different things — is real, but modelling it beyond what the forge stores would need state tuicr does not have. This maps `:resolve` straight onto the forge's own resolved flag and nothing more, which leaves room for a richer model later.

Each write is a single request followed by a refetch, so the view shows what the forge holds rather than a locally patched guess.

## Tests

Ten new tests: four in the GitLab backend pinning the exact `glab` argv for each endpoint, and six driving the app through the cursor — resolve on and off a thread, a reply typed into the editor, editing your own note, refusing someone else's, refusing when the backend cannot mutate threads, deleting your own, and refusing when the forge reports no viewer identity.

`cargo test` (1374 passed), `cargo fmt --check` and `cargo clippy --all-targets` are clean. `docs/GITLAB.md` gains a "Discussion threads" section.

Verified against a self-hosted GitLab instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)