### PR TITLE
perf(comments): cull comment boxes outside the viewport

### DIFF
--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -584,6 +584,55 @@ mod tests {
         Theme::default()
     }
 
+    /// The renderer replaces off-screen comment boxes with exactly
+    /// `App::comment_display_lines` blank rows, and the annotation builder sizes
+    /// every comment the same way. If that count ever drifted from what
+    /// `format_comment_lines` actually emits, the document would desync — the
+    /// cursor would land on the wrong row and culled boxes would leave the wrong
+    /// number of gaps. Pin the two together.
+    #[test]
+    fn comment_display_lines_matches_rendered_box_height() {
+        let theme = test_theme();
+        let bodies = [
+            "",
+            "single line",
+            "first\nsecond\nthird",
+            "trailing newline\n",
+            "\n\nleading blanks",
+            &"x".repeat(300),
+            &"日本語のテキストです ".repeat(20),
+            "`code` **bold** and a very long tail that will need to wrap at least once or twice",
+        ];
+        // Viewport widths, including degenerate ones narrower than the box chrome.
+        for viewport_width in [9usize, 12, 40, 80, 120] {
+            for body in bodies {
+                let comment = crate::model::Comment::new(
+                    body.to_string(),
+                    crate::model::CommentType::from_id("note"),
+                    None,
+                );
+                let rendered = format_comment_lines(
+                    &theme,
+                    CommentTypePresentation {
+                        label: "NOTE".to_string(),
+                        color: Color::Blue,
+                    },
+                    &comment.content,
+                    None,
+                    // What every call site passes: the viewport minus the
+                    // cursor-indicator column.
+                    viewport_width.saturating_sub(1),
+                    None,
+                );
+                assert_eq!(
+                    App::comment_display_lines(&comment, viewport_width),
+                    rendered.len(),
+                    "width={viewport_width} body={body:?}"
+                );
+            }
+        }
+    }
+
     // -- wrap_segments tests --
 
     #[test]

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -17,7 +17,7 @@ use crate::ui::diff_view::{
     apply_horizontal_scroll, comment_type_presentation, cursor_indicator, cursor_indicator_spaced,
     diff_stat_title, hunk_header_text_and_style, paint_cursor_line_highlight,
     paint_visual_selection_overlay, populate_row_to_annotation, render_expander_line,
-    render_hidden_lines, scroll_comment_input_into_view,
+    render_hidden_lines, scroll_comment_input_into_view, skip_comment_box,
 };
 use crate::ui::styles;
 use crate::ui::text_utils::{
@@ -204,6 +204,11 @@ impl SideBySideContext<'_> {
         line_idx >= self.visible_start && line_idx < self.visible_end
     }
 
+    /// Same question for a multi-row comment box: does any of it land on screen?
+    fn box_visible(&self, top: usize, rows: usize) -> bool {
+        crate::ui::diff_view::comment_box_visible(top, rows, (self.visible_start, self.visible_end))
+    }
+
     fn search_for(&self, line_idx: usize) -> Option<(&str, Style)> {
         let needle = self.app.search_paint_at(line_idx)?;
         Some((needle, self.search_style))
@@ -369,6 +374,11 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 line_idx += 1;
             }
         } else {
+            let rows = App::comment_display_lines(comment, ctx.panel_width);
+            if !ctx.box_visible(line_idx, rows) {
+                skip_comment_box(&mut lines, &mut line_idx, rows);
+                continue;
+            }
             let comment_lines = comment_panel::format_comment_lines(
                 &app.theme,
                 comment_type_presentation(app, &comment.comment_type),
@@ -456,6 +466,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         &mut line_idx,
         ctx.current_line_idx,
         ctx.panel_width.saturating_sub(1),
+        (ctx.visible_start, ctx.visible_end),
     );
 
     for (file_idx, file) in app.diff_files.iter().enumerate() {
@@ -554,6 +565,11 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                         line_idx += 1;
                     }
                 } else {
+                    let rows = App::comment_display_lines(comment, ctx.panel_width);
+                    if !ctx.box_visible(line_idx, rows) {
+                        skip_comment_box(&mut lines, &mut line_idx, rows);
+                        continue;
+                    }
                     let comment_lines = comment_panel::format_comment_lines(
                         &app.theme,
                         comment_type_presentation(app, &comment.comment_type),
@@ -1928,26 +1944,33 @@ fn add_comments_to_line(
                     let line_range = comment
                         .line_range
                         .or_else(|| Some(LineRange::single(line_num)));
-                    let comment_lines = comment_panel::format_comment_lines(
-                        ctx.theme,
-                        comment_type_presentation(ctx.app, &comment.comment_type),
-                        &comment.content,
-                        line_range,
-                        ctx.panel_width.saturating_sub(1),
-                        (comment.author != ctx.app.username).then_some(comment.author.as_str()),
-                    );
                     let box_top_row = line_idx;
-                    for mut comment_line in comment_lines {
-                        let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
-                        comment_line.spans.insert(
-                            0,
-                            Span::styled(
-                                indicator,
-                                styles::current_line_indicator_style(ctx.theme),
-                            ),
+                    let rows = App::comment_display_lines(comment, ctx.panel_width);
+                    // The bar is recorded either way: it is painted above the
+                    // box, so it can be on screen while the box itself is not.
+                    if !ctx.box_visible(line_idx, rows) {
+                        skip_comment_box(lines, &mut line_idx, rows);
+                    } else {
+                        let comment_lines = comment_panel::format_comment_lines(
+                            ctx.theme,
+                            comment_type_presentation(ctx.app, &comment.comment_type),
+                            &comment.content,
+                            line_range,
+                            ctx.panel_width.saturating_sub(1),
+                            (comment.author != ctx.app.username).then_some(comment.author.as_str()),
                         );
-                        lines.push(comment_line);
-                        line_idx += 1;
+                        for mut comment_line in comment_lines {
+                            let indicator = cursor_indicator(line_idx, ctx.current_line_idx);
+                            comment_line.spans.insert(
+                                0,
+                                Span::styled(
+                                    indicator,
+                                    styles::current_line_indicator_style(ctx.theme),
+                                ),
+                            );
+                            lines.push(comment_line);
+                            line_idx += 1;
+                        }
                     }
                     crate::ui::diff_view::push_comment_bar(
                         &mut ctx.comment_bars.borrow_mut(),
@@ -2134,6 +2157,10 @@ mod remote_comments_side_by_side_snapshot_tests {
     }
 
     fn make_pr_app() -> App {
+        make_pr_app_with(vec![sample_diff_file()])
+    }
+
+    fn make_pr_app_with(diff_files: Vec<DiffFile>) -> App {
         let pr = PullRequestDiffSource {
             key: PrSessionKey::new(repo(), 125, "headsha".to_string()),
             base_sha: "basesha".to_string(),
@@ -2166,7 +2193,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             Theme::dark(),
             None,
             false,
-            vec![sample_diff_file()],
+            diff_files,
             session,
             DiffSource::PullRequest(Box::new(pr)),
             InputMode::Normal,
@@ -2197,6 +2224,77 @@ mod remote_comments_side_by_side_snapshot_tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    /// Side-by-side mirror of the unified culling test: the skip/emit wiring
+    /// here goes through `ctx.box_visible` and a by-value `line_idx`, so it
+    /// needs its own coverage.
+    #[test]
+    fn should_cull_comment_boxes_outside_the_viewport() {
+        use crate::app::AnnotatedLine;
+        use crate::model::{Comment, CommentType};
+
+        const NEEDLE: &str = "far-below-the-fold";
+
+        let lines: Vec<DiffLine> = (1..=120)
+            .map(|n| DiffLine {
+                origin: LineOrigin::Addition,
+                content: format!("line {n}"),
+                old_lineno: None,
+                new_lineno: Some(n),
+                highlighted_spans: None,
+            })
+            .collect();
+        let hunks = vec![DiffHunk {
+            header: "@@ -0,0 +1,120 @@".to_string(),
+            lines,
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: 120,
+        }];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        let path = PathBuf::from("src/lib.rs");
+        let file = DiffFile {
+            old_path: Some(path.clone()),
+            new_path: Some(path.clone()),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        };
+
+        let mut app = make_pr_app_with(vec![file]);
+        app.session
+            .get_file_mut(&path)
+            .expect("file registered in session")
+            .add_line_comment(
+                100,
+                Comment::new(NEEDLE.to_string(), CommentType::from_id("note"), None),
+            );
+        app.rebuild_annotations();
+
+        let body = body_text(&draw(&mut app));
+        assert!(
+            !body.contains(NEEDLE),
+            "off-screen comment should not be visible:\n{body}"
+        );
+
+        let comment_row = app
+            .line_annotations
+            .iter()
+            .position(|a| matches!(a, AnnotatedLine::LineComment { .. }))
+            .expect("comment annotated in the document");
+        app.diff_state.scroll_offset = comment_row;
+        app.diff_state.cursor_line = comment_row;
+
+        let body = body_text(&draw(&mut app));
+        assert!(
+            body.contains(NEEDLE),
+            "comment scrolled into view should render at its annotated row:\n{body}"
+        );
     }
 
     #[test]

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -15,11 +15,11 @@ use crate::model::{FileStatus, LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_view::{
-    apply_horizontal_scroll, comment_type_presentation, cursor_indicator, cursor_indicator_spaced,
-    diff_stat_title, hunk_header_text_and_style, paint_cursor_line_highlight,
-    paint_unified_diff_rows_with, paint_visual_selection_overlay, populate_row_to_annotation,
-    push_comment_bar, render_expander_line, render_hidden_lines, scroll_comment_input_into_view,
-    unified_line_bg_style,
+    apply_horizontal_scroll, comment_box_visible, comment_type_presentation, cursor_indicator,
+    cursor_indicator_spaced, diff_stat_title, hunk_header_text_and_style,
+    paint_cursor_line_highlight, paint_unified_diff_rows_with, paint_visual_selection_overlay,
+    populate_row_to_annotation, push_comment_bar, render_expander_line, render_hidden_lines,
+    scroll_comment_input_into_view, skip_comment_box, unified_line_bg_style,
 };
 use crate::ui::styles;
 use crate::vcs::git::calculate_gap;
@@ -158,6 +158,11 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 line_idx += 1;
             }
         } else {
+            let rows = App::comment_display_lines(comment, inner.width as usize);
+            if !comment_box_visible(line_idx, rows, (visible_start, visible_end)) {
+                skip_comment_box(&mut lines, &mut line_idx, rows);
+                continue;
+            }
             let comment_lines = comment_panel::format_comment_lines(
                 &app.theme,
                 comment_type_presentation(app, &comment.comment_type),
@@ -245,6 +250,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         &mut line_idx,
         current_line_idx,
         comment_width,
+        (visible_start, visible_end),
     );
 
     for (file_idx, file) in app.diff_files.iter().enumerate() {
@@ -352,6 +358,11 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         line_idx += 1;
                     }
                 } else {
+                    let rows = App::comment_display_lines(comment, inner.width as usize);
+                    if !comment_box_visible(line_idx, rows, (visible_start, visible_end)) {
+                        skip_comment_box(&mut lines, &mut line_idx, rows);
+                        continue;
+                    }
                     let comment_lines = comment_panel::format_comment_lines(
                         &app.theme,
                         comment_type_presentation(app, &comment.comment_type),
@@ -740,30 +751,49 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                         let line_range = comment
                                             .line_range
                                             .or_else(|| Some(LineRange::single(old_ln)));
-                                        let comment_lines = comment_panel::format_comment_lines(
-                                            &app.theme,
-                                            comment_type_presentation(app, &comment.comment_type),
-                                            &comment.content,
-                                            line_range,
-                                            comment_width,
-                                            (comment.author != app.username)
-                                                .then_some(comment.author.as_str()),
-                                        );
                                         let box_top_row = line_idx;
-                                        for mut comment_line in comment_lines {
-                                            let is_current = line_idx == current_line_idx;
-                                            let indicator = if is_current { "▶" } else { " " };
-                                            comment_line.spans.insert(
-                                                0,
-                                                Span::styled(
-                                                    indicator,
-                                                    styles::current_line_indicator_style(
-                                                        &app.theme,
-                                                    ),
+                                        let rows = App::comment_display_lines(
+                                            comment,
+                                            inner.width as usize,
+                                        );
+                                        // The bar is recorded either way: it is
+                                        // painted above the box, so it can be on
+                                        // screen while the box itself is not.
+                                        if !comment_box_visible(
+                                            line_idx,
+                                            rows,
+                                            (visible_start, visible_end),
+                                        ) {
+                                            skip_comment_box(&mut lines, &mut line_idx, rows);
+                                        } else {
+                                            let comment_lines = comment_panel::format_comment_lines(
+                                                &app.theme,
+                                                comment_type_presentation(
+                                                    app,
+                                                    &comment.comment_type,
                                                 ),
+                                                &comment.content,
+                                                line_range,
+                                                comment_width,
+                                                (comment.author != app.username)
+                                                    .then_some(comment.author.as_str()),
                                             );
-                                            lines.push(comment_line);
-                                            line_idx += 1;
+                                            for mut comment_line in comment_lines {
+                                                let is_current = line_idx == current_line_idx;
+                                                let indicator =
+                                                    if is_current { "▶" } else { " " };
+                                                comment_line.spans.insert(
+                                                    0,
+                                                    Span::styled(
+                                                        indicator,
+                                                        styles::current_line_indicator_style(
+                                                            &app.theme,
+                                                        ),
+                                                    ),
+                                                );
+                                                lines.push(comment_line);
+                                                line_idx += 1;
+                                            }
                                         }
                                         push_comment_bar(
                                             &mut comment_bars,
@@ -907,30 +937,48 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                         let line_range = comment
                                             .line_range
                                             .or_else(|| Some(LineRange::single(new_ln)));
-                                        let comment_lines = comment_panel::format_comment_lines(
-                                            &app.theme,
-                                            comment_type_presentation(app, &comment.comment_type),
-                                            &comment.content,
-                                            line_range,
-                                            comment_width,
-                                            (comment.author != app.username)
-                                                .then_some(comment.author.as_str()),
-                                        );
                                         let box_top_row = line_idx;
-                                        for mut comment_line in comment_lines {
-                                            let indicator =
-                                                cursor_indicator(line_idx, current_line_idx);
-                                            comment_line.spans.insert(
-                                                0,
-                                                Span::styled(
-                                                    indicator,
-                                                    styles::current_line_indicator_style(
-                                                        &app.theme,
-                                                    ),
+                                        let rows = App::comment_display_lines(
+                                            comment,
+                                            inner.width as usize,
+                                        );
+                                        // The bar is recorded either way: it is
+                                        // painted above the box, so it can be on
+                                        // screen while the box itself is not.
+                                        if !comment_box_visible(
+                                            line_idx,
+                                            rows,
+                                            (visible_start, visible_end),
+                                        ) {
+                                            skip_comment_box(&mut lines, &mut line_idx, rows);
+                                        } else {
+                                            let comment_lines = comment_panel::format_comment_lines(
+                                                &app.theme,
+                                                comment_type_presentation(
+                                                    app,
+                                                    &comment.comment_type,
                                                 ),
+                                                &comment.content,
+                                                line_range,
+                                                comment_width,
+                                                (comment.author != app.username)
+                                                    .then_some(comment.author.as_str()),
                                             );
-                                            lines.push(comment_line);
-                                            line_idx += 1;
+                                            for mut comment_line in comment_lines {
+                                                let indicator =
+                                                    cursor_indicator(line_idx, current_line_idx);
+                                                comment_line.spans.insert(
+                                                    0,
+                                                    Span::styled(
+                                                        indicator,
+                                                        styles::current_line_indicator_style(
+                                                            &app.theme,
+                                                        ),
+                                                    ),
+                                                );
+                                                lines.push(comment_line);
+                                                line_idx += 1;
+                                            }
                                         }
                                         push_comment_bar(
                                             &mut comment_bars,
@@ -1953,6 +2001,89 @@ mod remote_comments_snapshot_tests {
             app.diff_state.visible_line_count > 0 && app.diff_state.visible_line_count < 20,
             "expected logical visible_line_count 1..20, got {}",
             app.diff_state.visible_line_count
+        );
+    }
+
+    /// Comment boxes outside the viewport are replaced with blank placeholder
+    /// rows instead of being formatted. The rows still have to be there, and in
+    /// the right number, or every row below the comment would shift — so this
+    /// also scrolls to the row `line_annotations` assigned the comment and
+    /// expects the box to be there.
+    #[test]
+    fn should_cull_comment_boxes_outside_the_viewport() {
+        use crate::app::AnnotatedLine;
+        use crate::model::{Comment, CommentType};
+
+        const NEEDLE: &str = "far-below-the-fold";
+
+        let lines: Vec<DiffLine> = (1..=120)
+            .map(|n| DiffLine {
+                origin: LineOrigin::Addition,
+                content: format!("line {n}"),
+                old_lineno: None,
+                new_lineno: Some(n),
+                highlighted_spans: None,
+            })
+            .collect();
+        let hunks = vec![DiffHunk {
+            header: "@@ -0,0 +1,120 @@".to_string(),
+            lines,
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: 120,
+        }];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        let path = PathBuf::from("src/lib.rs");
+        let file = DiffFile {
+            old_path: Some(path.clone()),
+            new_path: Some(path.clone()),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        };
+
+        let mut app = make_revision_app(vec![file]);
+        app.session
+            .get_file_mut(&path)
+            .expect("file registered in session")
+            .add_line_comment(
+                100,
+                Comment::new(NEEDLE.to_string(), CommentType::from_id("note"), None),
+            );
+        app.rebuild_annotations();
+
+        // Top of the file: the comment is ~100 rows below a 12-row viewport.
+        let buffer = draw_unified_diff(&mut app);
+        let body = body_text(&buffer);
+        assert!(
+            !body.contains(NEEDLE),
+            "off-screen comment should not be visible:\n{body}"
+        );
+        assert!(
+            body.contains("line 1"),
+            "diff content should still render:\n{body}"
+        );
+
+        // Scroll to the row the annotation builder says the comment occupies.
+        // If the culled box had emitted the wrong number of placeholder rows,
+        // this index would point somewhere else and the body would not appear.
+        let comment_row = app
+            .line_annotations
+            .iter()
+            .position(|a| matches!(a, AnnotatedLine::LineComment { .. }))
+            .expect("comment annotated in the document");
+        app.diff_state.scroll_offset = comment_row;
+        app.diff_state.cursor_line = comment_row;
+
+        let buffer = draw_unified_diff(&mut app);
+        let body = body_text(&buffer);
+        assert!(
+            body.contains(NEEDLE),
+            "comment scrolled into view should render at its annotated row:\n{body}"
         );
     }
 

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -788,6 +788,24 @@ pub(super) struct CommentBarAnchor {
     pub height: usize,
 }
 
+/// Whether a comment box `rows` tall starting at logical row `top` overlaps the
+/// range being fully built this frame.
+pub(super) fn comment_box_visible(top: usize, rows: usize, visible: (usize, usize)) -> bool {
+    let (visible_start, visible_end) = visible;
+    top < visible_end && top.saturating_add(rows) > visible_start
+}
+
+/// Stand in for an off-screen comment box with `rows` blank rows, so
+/// `lines.len()` and `line_idx` stay exact without paying for its spans.
+///
+/// `rows` comes from `App::comment_display_lines`, the same mirror the
+/// annotation builder uses to keep `line_annotations` aligned with the rendered
+/// document — if it were ever wrong, navigation would already be broken.
+pub(super) fn skip_comment_box(lines: &mut Vec<Line<'_>>, line_idx: &mut usize, rows: usize) {
+    lines.extend(std::iter::repeat_with(Line::default).take(rows));
+    *line_idx += rows;
+}
+
 /// Per-call-site helper: record a bar anchor if the comment has a line
 /// range. No-op for file-level / review-level comments which don't anchor
 /// to a covered line span.

--- a/src/ui/pr_info_panel.rs
+++ b/src/ui/pr_info_panel.rs
@@ -89,12 +89,18 @@ pub fn append_pr_info_section(
     }
 }
 
+/// `visible` is the half-open logical-row range the caller is fully building
+/// this frame; boxes outside it are replaced with blank placeholder rows. These
+/// comments sit at the very top of the document, so for most of a review they
+/// are scrolled past — and formatting them costs the same markdown pass as any
+/// other comment box.
 pub fn append_issue_comments_section(
     app: &App,
     lines: &mut Vec<Line<'static>>,
     line_idx: &mut usize,
     current_line_idx: usize,
     content_width: usize,
+    visible: (usize, usize),
 ) {
     let Some(info) = app.pr_info.as_ref() else {
         return;
@@ -122,6 +128,14 @@ pub fn append_issue_comments_section(
         color: app.comment_type_color(&note_type),
     };
     for comment in &info.issue_comments {
+        // Derive the row count from the width the box is actually formatted at
+        // — `content_width` is the viewport minus the indicator column, which is
+        // exactly the offset `issue_comment_display_lines` expects.
+        let rows = issue_comment_display_lines(comment, content_width.saturating_add(1));
+        if !crate::ui::diff_view::comment_box_visible(*line_idx, rows, visible) {
+            crate::ui::diff_view::skip_comment_box(lines, line_idx, rows);
+            continue;
+        }
         for mut comment_line in
             format_issue_comment_lines(&app.theme, comment, content_width, &presentation)
         {


### PR DESCRIPTION
## Summary

Cull comment boxes outside the viewport in both diff renderers and in the PR issue-comments section, substituting the exact number of blank rows. Per-frame cost tracked total comment volume in the session rather than what was on screen; it is now roughly flat in comment count.

Fixes #552.

## Root cause

The renderer's visible-range guard only wrapped diff-line span building. The comment branch below it ran unconditionally, so a comment box 3,000 rows off screen was formatted, wrapped and span-built in full before being discarded.

## Measurements

`cargo test --release render_perf -- --ignored --nocapture`, same machine, `main` at 5ec9a83.

**Comment count** (20 files x 200 lines):

| comments | main | this PR |
| ---: | ---: | ---: |
| 0 | 0.65 ms | 0.49 ms |
| 20 | 1.80 ms | 0.62 ms |
| 60 | 4.01 ms | 0.82 ms |
| 200 | 12.74 ms | 1.04 ms |

The 12x at 200 comments is not the point — the shape is. Cost was linear in total comment volume; the residual growth on this branch is row bookkeeping and comment bars, not formatting.

**Diff size** is unchanged, as expected — nothing here touches diff-line rendering:

| diff lines | main | this PR |
| ---: | ---: | ---: |
| 200 | 0.35 ms | 0.37 ms |
| 40 000 | 2.48 ms | 2.57 ms |

## Design notes

- **Row counts for culled boxes come from `App::comment_display_lines`**, the mirror the annotation builder already uses, so this is a second consumer of an existing invariant rather than a new one. `comment_display_lines_matches_rendered_box_height` pins that mirror against `format_comment_lines` across bodies, multibyte text, and widths narrower than the box chrome.
- **Comment bars are still recorded for culled boxes**, since a bar is painted above its box and can be on screen while the box is not.
- **Not culled, deliberately:** comment-input mode (the scroll offset can move after the document is built, and #628's parser keeps typing cheap anyway) and remote review threads (plain spans, no markdown pass).

## Verify

`should_cull_comment_boxes_outside_the_viewport` in both renderers scrolls to the row `line_annotations` assigned the comment and expects the box there — if the placeholder count were off by even one, that index would point somewhere else.

No dependency or build changes: `Cargo.toml` and `Cargo.lock` are identical to `main`.
