### PR TITLE
fix(pr): skip linguist-generated files before highlighting

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -287,6 +287,11 @@ The top-level `export_legend` key predates this section and still works. When bo
 
 tuicr reads `.tuicrignore` from the repository root and excludes matching files from all review diffs. Rules follow gitignore-style pattern matching, including `!` negation.
 
+When reviewing a forge pull request from its matching local checkout, tuicr also
+omits files marked `linguist-generated=true` in `.gitattributes`. These files are
+filtered before syntax highlighting, so large generated artifacts do not stall
+PR loading.
+
 `.gitignore` is also honored automatically.
 
 Example:

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -410,22 +410,19 @@ impl App {
         request: &PrRangeReloadRequest,
         patch: &str,
     ) -> Result<()> {
-        use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
-
         let highlighter = self.theme.syntax_highlighter();
-        let parsed = match parse_unified_diff(patch, DiffFormat::GitStyle, highlighter) {
-            Ok(files) => files,
-            Err(TuicrError::NoChanges) => Vec::new(),
-            Err(e) => return Err(e),
-        };
-
         let local_checkout = self
             .forge_backend
             .as_deref()
             .and_then(|b| b.local_checkout_path());
-        let files = match local_checkout.as_deref() {
-            Some(root) => crate::tuicrignore::filter_diff_files(root, parsed),
-            None => parsed,
+        let files = match crate::forge::pr_open::parse_pr_diff(
+            patch,
+            local_checkout.as_deref(),
+            highlighter,
+        ) {
+            Ok(files) => files,
+            Err(TuicrError::NoChanges) => Vec::new(),
+            Err(e) => return Err(e),
         };
 
         self.diff_files = files;

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -7,8 +7,9 @@
 //! Key invariants enforced here:
 //! - The current local checkout is never treated as the source of truth.
 //!   Diffs are parsed from `gh pr diff`; SHAs are captured from PR metadata.
-//! - `.tuicrignore` is applied only when the caller supplies a local
-//!   checkout path. Outside a checkout, the unfiltered diff is shown.
+//! - `.tuicrignore` and `linguist-generated` attributes are applied only when
+//!   the caller supplies a local checkout path. Outside a checkout, the
+//!   unfiltered diff is shown.
 //! - No checkout mutation. We never spawn `git checkout/fetch/reset/stash`
 //!   or branch-creation commands here.
 
@@ -19,10 +20,11 @@ use crate::forge::traits::{
     ForgeBackend, PrSessionKey, PullRequestCommit, PullRequestDetails, PullRequestInfo,
     PullRequestReviewMetadata, PullRequestTarget,
 };
+use crate::gitattributes::LinguistGeneratedMatcher;
 use crate::model::{DiffFile, ReviewSession, SessionDiffSource};
 use crate::syntax::SyntaxHighlighter;
 use crate::tuicrignore;
-use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
+use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff_filtered};
 
 /// Everything the App needs to enter PR review mode.
 #[derive(Debug)]
@@ -44,9 +46,10 @@ pub struct OpenedPullRequest {
 
 /// Open a PR target through a forge backend and prepare review state.
 ///
-/// `local_checkout` is optional: when provided, `.tuicrignore` rules at the
-/// root are applied. When absent (PR opened via URL outside a checkout, or
-/// for a different repo), no filtering happens.
+/// `local_checkout` is optional: when provided, `.tuicrignore` rules and
+/// `linguist-generated` attributes at the root are applied. When absent (PR
+/// opened via URL outside a checkout, or for a different repo), no filtering
+/// happens.
 pub fn open_pull_request(
     backend: &dyn ForgeBackend,
     target: PullRequestTarget,
@@ -94,8 +97,8 @@ pub fn fetch_pr_data(
     Ok((details, patch, commits, review_metadata, pr_info))
 }
 
-/// CPU-only half of the PR open path: parse the patch, apply
-/// `.tuicrignore`, and build the session. Runs on the main thread because
+/// CPU-only half of the PR open path: parse the patch, apply repository file
+/// filters, and build the session. Runs on the main thread because
 /// `SyntaxHighlighter` is not trivially `Send`-cloneable.
 pub fn prepare_open_pr(
     details: PullRequestDetails,
@@ -106,7 +109,7 @@ pub fn prepare_open_pr(
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
-    let parsed = match parse_unified_diff(patch, DiffFormat::GitStyle, highlighter) {
+    let parsed = match parse_pr_diff(patch, local_checkout, highlighter) {
         Ok(files) => files,
         Err(TuicrError::NoChanges) => {
             return Err(TuicrError::Forge(format!(
@@ -117,10 +120,7 @@ pub fn prepare_open_pr(
         Err(e) => return Err(e),
     };
 
-    let diff_files = match local_checkout {
-        Some(root) => tuicrignore::filter_diff_files(root, parsed),
-        None => parsed,
-    };
+    let diff_files = parsed;
 
     let key = PrSessionKey::from_details(&details);
     let session = build_session(&details, &key, &diff_files);
@@ -137,6 +137,24 @@ pub fn prepare_open_pr(
         commits,
         review_metadata,
         pr_info,
+    })
+}
+
+pub(crate) fn parse_pr_diff(
+    patch: &str,
+    local_checkout: Option<&Path>,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffFile>> {
+    let generated = local_checkout.and_then(LinguistGeneratedMatcher::open);
+    let parsed = parse_unified_diff_filtered(patch, DiffFormat::GitStyle, highlighter, |path| {
+        !generated
+            .as_ref()
+            .is_some_and(|matcher| matcher.is_generated(path))
+    })?;
+
+    Ok(match local_checkout {
+        Some(root) => tuicrignore::filter_diff_files(root, parsed),
+        None => parsed,
     })
 }
 
@@ -271,6 +289,22 @@ index 1111111..2222222 100644
  }
 "##;
 
+    const GENERATED_AND_SOURCE_PATCH: &str = r##"diff --git a/generated.js b/generated.js
+index 1111111..2222222 100644
+--- a/generated.js
++++ b/generated.js
+@@ -1 +1 @@
+-const answer = 41;
++const answer = 42;
+diff --git a/src/lib.rs b/src/lib.rs
+index 3333333..4444444 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -1 +1 @@
+-pub fn answer() -> u32 { 41 }
++pub fn answer() -> u32 { 42 }
+"##;
+
     #[test]
     fn should_parse_pr_diff_and_build_session_keyed_by_head_sha() {
         // given
@@ -300,6 +334,40 @@ index 1111111..2222222 100644
         assert_eq!(
             backend.calls.borrow().as_slice(),
             &["get_pull_request", "get_pull_request_diff"],
+        );
+    }
+
+    #[test]
+    fn should_filter_linguist_generated_files_before_highlighting_pr_diff() {
+        // given a local checkout whose Git attributes mark one PR file as generated
+        let checkout = tempfile::tempdir().expect("failed to create temp dir");
+        git2::Repository::init(checkout.path()).expect("failed to initialize repository");
+        std::fs::write(
+            checkout.path().join(".gitattributes"),
+            "generated.js linguist-generated=true\n",
+        )
+        .expect("failed to write .gitattributes");
+        let highlighter = SyntaxHighlighter::default();
+
+        // when
+        let opened = prepare_open_pr(
+            details(),
+            GENERATED_AND_SOURCE_PATCH,
+            Vec::new(),
+            PullRequestReviewMetadata::default(),
+            PullRequestInfo::from_details(details()),
+            Some(checkout.path()),
+            &highlighter,
+        )
+        .unwrap();
+
+        // then the generated file is absent, while the retained source file is highlighted
+        assert_eq!(opened.diff_files.len(), 1);
+        assert_eq!(opened.diff_files[0].display_path(), Path::new("src/lib.rs"));
+        assert!(
+            opened.diff_files[0].hunks[0].lines[0]
+                .highlighted_spans
+                .is_some()
         );
     }
 

--- a/src/gitattributes.rs
+++ b/src/gitattributes.rs
@@ -1,0 +1,68 @@
+use std::path::Path;
+
+use git2::{AttrCheckFlags, AttrValue, Repository};
+
+const LINGUIST_GENERATED: &str = "linguist-generated";
+
+/// Resolves `linguist-generated` with Git's own attribute matcher.
+///
+/// Attribute lookup is best-effort: a PR opened outside a usable local Git
+/// checkout keeps its full diff rather than failing to open.
+pub(crate) struct LinguistGeneratedMatcher {
+    repo: Repository,
+}
+
+impl LinguistGeneratedMatcher {
+    pub(crate) fn open(repo_root: &Path) -> Option<Self> {
+        Repository::open(repo_root).ok().map(|repo| Self { repo })
+    }
+
+    pub(crate) fn is_generated(&self, path: &Path) -> bool {
+        let Ok(value) = self
+            .repo
+            .get_attr(path, LINGUIST_GENERATED, AttrCheckFlags::default())
+        else {
+            return false;
+        };
+
+        matches!(
+            AttrValue::from_string(value),
+            AttrValue::True | AttrValue::String("true")
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn honors_true_bare_false_and_unspecified_attribute_values() {
+        let checkout = tempfile::tempdir().expect("failed to create temp dir");
+        Repository::init(checkout.path()).expect("failed to initialize repository");
+        fs::write(
+            checkout.path().join(".gitattributes"),
+            concat!(
+                "generated.js linguist-generated=true\n",
+                "bare.js linguist-generated\n",
+                "source.js -linguist-generated\n",
+            ),
+        )
+        .expect("failed to write .gitattributes");
+        let matcher = LinguistGeneratedMatcher::open(checkout.path()).unwrap();
+
+        assert!(matcher.is_generated(Path::new("generated.js")));
+        assert!(matcher.is_generated(Path::new("bare.js")));
+        assert!(!matcher.is_generated(Path::new("source.js")));
+        assert!(!matcher.is_generated(Path::new("other.js")));
+    }
+
+    #[test]
+    fn returns_no_matcher_outside_a_git_checkout() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+
+        assert!(LinguistGeneratedMatcher::open(dir.path()).is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod editor;
 pub mod error;
 pub mod forge;
+mod gitattributes;
 pub mod handler;
 pub mod hash;
 pub mod input;

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -5,7 +5,7 @@
 //! through this parser to avoid sparse-index limitations in libgit2.
 
 use std::borrow::Cow;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
@@ -26,10 +26,25 @@ pub fn parse_unified_diff(
     format: DiffFormat,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    parse_unified_diff_lines(
+    parse_unified_diff_filtered(diff_text, format, highlighter, |_| true)
+}
+
+/// Parse unified diff output while excluding files before their hunks are
+/// materialized or syntax highlighted.
+pub(crate) fn parse_unified_diff_filtered<F>(
+    diff_text: &str,
+    format: DiffFormat,
+    highlighter: &SyntaxHighlighter,
+    include_file: F,
+) -> Result<Vec<DiffFile>>
+where
+    F: FnMut(&Path) -> bool,
+{
+    parse_unified_diff_lines_filtered(
         diff_text.lines().map(|line| Ok(Cow::Borrowed(line))),
         format,
         highlighter,
+        include_file,
     )
 }
 
@@ -45,8 +60,22 @@ pub fn parse_unified_diff_lines<'a, I>(
 where
     I: Iterator<Item = Result<Cow<'a, str>>>,
 {
+    parse_unified_diff_lines_filtered(diff_lines, format, highlighter, |_| true)
+}
+
+fn parse_unified_diff_lines_filtered<'a, I, F>(
+    diff_lines: I,
+    format: DiffFormat,
+    highlighter: &SyntaxHighlighter,
+    mut include_file: F,
+) -> Result<Vec<DiffFile>>
+where
+    I: Iterator<Item = Result<Cow<'a, str>>>,
+    F: FnMut(&Path) -> bool,
+{
     let mut files: Vec<DiffFile> = Vec::new();
     let mut lines = diff_lines.peekable();
+    let mut saw_file = false;
 
     let header_prefix = match format {
         DiffFormat::Hg => "diff ",
@@ -57,6 +86,7 @@ where
     // `next_line` instead of `lines.next()` to propagate I/O errors.
     while let Some(line) = next_line(&mut lines)? {
         if line.starts_with(header_prefix) {
+            saw_file = true;
             let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format)?;
 
             // For git-style diffs (jj, git patches), if parse_file_header didn't find
@@ -76,25 +106,29 @@ where
                 }
             }
 
+            let file_path = new_path.as_deref().or(old_path.as_deref());
+            let included = file_path.is_none_or(&mut include_file);
+
             // Check if binary. `git diff --binary` can emit lowercase
             // "GIT binary patch", so keep this check explicit instead of a
             // case-sensitive substring search.
             if peek_line(&mut lines)?.is_some_and(is_binary_patch_line) {
                 next_line(&mut lines)?; // consume binary message
-                files.push(DiffFile {
-                    old_path,
-                    new_path,
-                    status,
-                    hunks: Vec::new(),
-                    is_binary: true,
-                    is_too_large: false,
-                    is_commit_message: false,
-                    content_hash: 0,
-                });
+                if included {
+                    files.push(DiffFile {
+                        old_path,
+                        new_path,
+                        status,
+                        hunks: Vec::new(),
+                        is_binary: true,
+                        is_too_large: false,
+                        is_commit_message: false,
+                        content_hash: 0,
+                    });
+                }
                 continue;
             }
 
-            let file_path = new_path.as_ref().or(old_path.as_ref());
             let mut hunks = Vec::new();
 
             // Parse hunks until next file or end
@@ -102,33 +136,53 @@ where
                 if line.starts_with("diff ") {
                     break;
                 } else if line.starts_with("@@") {
-                    if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter)? {
-                        hunks.push(hunk);
+                    if included {
+                        if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter)? {
+                            hunks.push(hunk);
+                        }
+                    } else {
+                        skip_hunk(&mut lines)?;
                     }
                 } else {
                     next_line(&mut lines)?; // skip non-hunk, non-diff lines
                 }
             }
 
-            let content_hash = DiffFile::compute_content_hash(&hunks);
-            files.push(DiffFile {
-                old_path,
-                new_path,
-                status,
-                hunks,
-                is_binary: false,
-                is_too_large: false,
-                is_commit_message: false,
-                content_hash,
-            });
+            if included {
+                let content_hash = DiffFile::compute_content_hash(&hunks);
+                files.push(DiffFile {
+                    old_path,
+                    new_path,
+                    status,
+                    hunks,
+                    is_binary: false,
+                    is_too_large: false,
+                    is_commit_message: false,
+                    content_hash,
+                });
+            }
         }
     }
 
-    if files.is_empty() {
+    if !saw_file {
         return Err(TuicrError::NoChanges);
     }
 
     Ok(files)
+}
+
+fn skip_hunk<'a, I>(lines: &mut std::iter::Peekable<I>) -> Result<()>
+where
+    I: Iterator<Item = Result<Cow<'a, str>>>,
+{
+    next_line(lines)?; // hunk header
+    while let Some(line) = peek_line(lines)? {
+        if line.starts_with("@@") || line.starts_with("diff ") {
+            break;
+        }
+        next_line(lines)?;
+    }
+    Ok(())
 }
 
 fn next_line<'a, I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<Cow<'a, str>>>
@@ -257,7 +311,7 @@ where
 
 fn parse_hunk<'a, I>(
     lines: &mut std::iter::Peekable<I>,
-    file_path: Option<&PathBuf>,
+    file_path: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Option<DiffHunk>>
 where


### PR DESCRIPTION
Fixes #588.

## What changed

- Resolve `linguist-generated` through Git's attribute matcher when a PR has a matching local checkout.
- Exclude generated files in the unified-diff parser before their hunks are materialized or syntax highlighted.
- Use the same filtered path for initial PR loading and commit-range reloads.
- Document the local-checkout behavior and cover `true`, bare, false, and unspecified attribute values.

This is intentionally narrower than #525: that PR adds optional post-load collapsing and review-progress behavior. The change here addresses the #588 stall specifically by preventing generated files from reaching syntax highlighting at all.

## Verification

- Regression test failed before the fix (`2` files loaded instead of `1`) and passes after it; the retained Rust file still has highlighted spans.
- `cargo check`
- `cargo fmt --all --check`
- `cargo clippy -- -D warnings`
- `cargo test` (`1473 passed`, `0 failed`, `2 ignored`)
- Dogfooded with `cargo run -- --no-update-check` against this branch's own six-file diff.

## AI assistance

Implemented and reviewed with OpenAI Codex. I verified the behavior, tests, full diff, and final commit locally.
