### PR TITLE
fix: keep the comment input on screen at EOF when lines wrap

### DIFF
--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -36,6 +36,37 @@ struct SbsRowMeta {
     right_pad_style: Style,
 }
 
+type WrappedRows = Vec<Vec<Span<'static>>>;
+
+fn sbs_wrapped_sides(meta: &SbsRowMeta, content_width: usize) -> (WrappedRows, WrappedRows) {
+    (
+        wrap_spans(&meta.left_content, content_width),
+        wrap_spans(&meta.right_content, content_width),
+    )
+}
+
+fn sbs_row_height(
+    lines: &[Line],
+    sbs_meta: &std::collections::HashMap<usize, SbsRowMeta>,
+    idx: usize,
+    wrap: bool,
+    content_width: usize,
+    viewport_width: usize,
+) -> usize {
+    if !wrap || content_width == 0 {
+        return 1;
+    }
+    match sbs_meta.get(&idx) {
+        Some(meta) => {
+            let (left_rows, right_rows) = sbs_wrapped_sides(meta, content_width);
+            left_rows.len().max(right_rows.len())
+        }
+        None => lines
+            .get(idx)
+            .map_or(1, |line| wrap_spans(&line.spans, viewport_width).len()),
+    }
+}
+
 fn content_spans_for_diff_line(
     theme: &Theme,
     dl: &DiffLine,
@@ -871,12 +902,15 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     app.comment_input_annotation_offset = annotation_offset;
 
     // Auto-scroll so the comment input box stays visible while the user types.
+    let wrap = app.diff_state.wrap_lines;
+    let viewport_width = inner.width as usize;
     scroll_comment_input_into_view(
         &mut app.diff_state.scroll_offset,
         comment_input_box_range,
         comment_cursor_logical_line,
         inner.height as usize,
         lines.len(),
+        |idx| sbs_row_height(&lines, &sbs_meta, idx, wrap, content_width, viewport_width),
     );
 
     let visible_lines_unscrolled: Vec<Line> = lines
@@ -902,8 +936,6 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     app.diff_state.max_content_width = max_content_width;
 
     let scroll_offset = app.diff_state.scroll_offset;
-    let wrap = app.diff_state.wrap_lines;
-    let viewport_width = inner.width as usize;
     let visible_lines_unscrolled_for_overlay = visible_lines_unscrolled.clone();
     // Single pass: wrap each logical line once, producing both the visual
     // rows to render and the per-line height used by every row-mapping
@@ -917,17 +949,8 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             let logical_idx = scroll_offset + i;
             match sbs_meta.get(&logical_idx) {
                 Some(m) => {
-                    let left_rows = if m.left_content.is_empty() {
-                        vec![Vec::new()]
-                    } else {
-                        wrap_spans(&m.left_content, content_width)
-                    };
-                    let right_rows = if m.right_content.is_empty() {
-                        vec![Vec::new()]
-                    } else {
-                        wrap_spans(&m.right_content, content_width)
-                    };
-                    let n = left_rows.len().max(right_rows.len()).max(1);
+                    let (left_rows, right_rows) = sbs_wrapped_sides(m, content_width);
+                    let n = left_rows.len().max(right_rows.len());
                     heights.push(n);
                     let empty_row: Vec<Span> = Vec::new();
                     for k in 0..n {
@@ -2020,7 +2043,8 @@ mod remote_comments_side_by_side_snapshot_tests {
     };
     use crate::forge::traits::{ForgeRepository, PrSessionKey};
     use crate::model::{
-        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, ReviewSession, SessionDiffSource,
+        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide, ReviewSession,
+        SessionDiffSource,
     };
     use crate::syntax::SyntaxHighlighter;
     use crate::theme::Theme;
@@ -2206,7 +2230,6 @@ mod remote_comments_side_by_side_snapshot_tests {
         let mut app = make_pr_app();
         app.forge_review_threads = vec![thread()];
         app.rebuild_annotations();
-        // when
         let buffer = draw(&mut app);
         // then
         let body = body_text(&buffer);
@@ -2222,7 +2245,6 @@ mod remote_comments_side_by_side_snapshot_tests {
         let mut app = make_pr_app();
         app.forge_review_threads = vec![thread()];
         app.set_remote_comments_visibility(PrCommentsVisibility::Hide);
-        // when
         let buffer = draw(&mut app);
         // then
         let body = body_text(&buffer);
@@ -2497,6 +2519,54 @@ mod remote_comments_side_by_side_snapshot_tests {
         assert_eq!(
             checked, 1,
             "expected the commit message body to render exactly once, got {checked}"
+        );
+    }
+
+    fn wrapping_diff_file(count: u32) -> DiffFile {
+        let lines: Vec<DiffLine> = (1..=count)
+            .map(|i| DiffLine {
+                origin: LineOrigin::Addition,
+                content: format!("line {i} {}", "x".repeat(200)),
+                old_lineno: None,
+                new_lineno: Some(i),
+                highlighted_spans: None,
+            })
+            .collect();
+        let hunks = vec![DiffHunk {
+            header: format!("@@ -0,0 +1,{count} @@"),
+            lines,
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: count,
+        }];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Added,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    #[test]
+    fn should_show_comment_input_at_eof_when_lines_wrap() {
+        let mut app = make_pr_app();
+        app.diff_files = vec![wrapping_diff_file(40)];
+        app.set_diff_wrap(true);
+        app.rebuild_annotations();
+        let _ = draw_sbs(&mut app, 160, 20);
+        app.jump_to_bottom();
+        app.enter_comment_mode(false, Some((40, LineSide::New)));
+        let buf = draw_sbs(&mut app, 160, 20);
+        let body = body_text(&buf);
+        assert!(
+            body.contains("Type your comment..."),
+            "expected the comment input box to be visible in:\n{body}"
         );
     }
 }

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -24,6 +24,15 @@ use crate::ui::diff_view::{
 use crate::ui::styles;
 use crate::vcs::git::calculate_gap;
 
+fn unified_row_height(lines: &[Line], idx: usize, wrap: bool, viewport_width: usize) -> usize {
+    if !wrap || viewport_width == 0 {
+        return 1;
+    }
+    lines.get(idx).map_or(1, |line| {
+        crate::ui::text_utils::wrap_spans(&line.spans, viewport_width).len()
+    })
+}
+
 pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
@@ -1125,12 +1134,15 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     // Auto-scroll so the comment input box stays visible while the user types.
     // Without this, adding a comment near the bottom/top of the viewport would
     // place the input box off-screen and the user couldn't see what they type.
+    let wrap = app.diff_state.wrap_lines;
+    let viewport_width = inner.width as usize;
     scroll_comment_input_into_view(
         &mut app.diff_state.scroll_offset,
         comment_input_box_range,
         comment_cursor_logical_line,
         inner.height as usize,
         lines.len(),
+        |idx| unified_row_height(&lines, idx, wrap, viewport_width),
     );
 
     let visible_lines_unscrolled: Vec<Line> = lines
@@ -1156,8 +1168,6 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     app.diff_state.max_content_width = max_content_width;
 
     let scroll_offset = app.diff_state.scroll_offset;
-    let wrap = app.diff_state.wrap_lines;
-    let viewport_width = inner.width as usize;
     let visible_lines_unscrolled_for_bg = visible_lines_unscrolled.clone();
     // Single pass: wrap each logical line once, producing both the visual
     // rows to render and the per-line height used by every row-mapping
@@ -1423,7 +1433,8 @@ mod remote_comments_snapshot_tests {
     };
     use crate::forge::traits::{ForgeRepository, PrSessionKey};
     use crate::model::{
-        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, ReviewSession, SessionDiffSource,
+        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide, ReviewSession,
+        SessionDiffSource,
     };
     use crate::syntax::SyntaxHighlighter;
     use crate::theme::Theme;
@@ -1700,6 +1711,52 @@ mod remote_comments_snapshot_tests {
         }
     }
 
+    fn wrapping_diff_file(count: u32) -> DiffFile {
+        let lines: Vec<DiffLine> = (1..=count)
+            .map(|i| DiffLine {
+                origin: LineOrigin::Addition,
+                content: format!("line {i} {}", "x".repeat(120)),
+                old_lineno: None,
+                new_lineno: Some(i),
+                highlighted_spans: None,
+            })
+            .collect();
+        let hunks = vec![DiffHunk {
+            header: format!("@@ -0,0 +1,{count} @@"),
+            lines,
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: count,
+        }];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: None,
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Added,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    #[test]
+    fn should_show_comment_input_at_eof_when_lines_wrap() {
+        let mut app = make_revision_app(vec![wrapping_diff_file(40)]);
+        app.diff_state.wrap_lines = true;
+        let _ = draw_unified_diff(&mut app);
+        app.jump_to_bottom();
+        app.enter_comment_mode(false, Some((40, LineSide::New)));
+        let buffer = draw_unified_diff(&mut app);
+        let body = body_text(&buffer);
+        assert!(
+            body.contains("Type your comment..."),
+            "expected the comment input box to be visible in:\n{body}"
+        );
+    }
+
     #[test]
     fn should_render_commit_message_without_line_numbers_in_unified() {
         let mut app = make_revision_app(vec![commit_message_file(
@@ -1741,7 +1798,6 @@ mod remote_comments_snapshot_tests {
         let mut app = make_pr_app();
         app.forge_review_threads = vec![thread("t1", "alice", "looks good?", 2, false, false)];
         app.rebuild_annotations();
-        // when
         let buffer = draw(&mut app);
         // then — the badge appears somewhere in the rendered frame
         let body = body_text(&buffer);
@@ -1807,7 +1863,6 @@ mod remote_comments_snapshot_tests {
         let before = body_text(&draw(&mut app));
         assert!(before.contains("[github @alice]"));
 
-        // when
         assert!(app.set_remote_comments_visibility(PrCommentsVisibility::Hide));
         // then
         let after = body_text(&draw(&mut app));
@@ -1861,7 +1916,6 @@ mod remote_comments_snapshot_tests {
             }],
         }];
         app.rebuild_annotations();
-        // when
         let buffer = draw(&mut app);
         let body = body_text(&buffer);
         // then — the badge and body appear in the rendered frame

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -351,6 +351,7 @@ pub(super) fn scroll_comment_input_into_view(
     cursor_line: Option<usize>,
     viewport_height: usize,
     total_lines: usize,
+    row_height: impl Fn(usize) -> usize,
 ) {
     let Some((box_start, box_end)) = box_range else {
         return;
@@ -359,21 +360,31 @@ pub(super) fn scroll_comment_input_into_view(
         return;
     }
 
-    let box_height = box_end.saturating_sub(box_start) + 1;
+    let topmost_offset_showing = |last: usize| {
+        let mut offset = last;
+        let mut rows = row_height(last).max(1);
+        while offset > 0 {
+            let rows_of_line_above = row_height(offset - 1).max(1);
+            if rows + rows_of_line_above > viewport_height {
+                break;
+            }
+            rows += rows_of_line_above;
+            offset -= 1;
+        }
+        offset
+    };
 
-    if box_height <= viewport_height {
-        if box_start < *scroll_offset {
-            *scroll_offset = box_start;
-        } else if box_end >= *scroll_offset + viewport_height {
-            *scroll_offset = box_end + 1 - viewport_height;
-        }
-    } else if let Some(cursor) = cursor_line {
-        // Box too tall for viewport: keep the text cursor line visible.
-        if cursor < *scroll_offset {
-            *scroll_offset = cursor;
-        } else if cursor >= *scroll_offset + viewport_height {
-            *scroll_offset = cursor + 1 - viewport_height;
-        }
+    let offset_showing_box_end = topmost_offset_showing(box_end);
+    let box_fits_in_viewport = offset_showing_box_end <= box_start;
+
+    let offsets_keeping_the_input_visible = if box_fits_in_viewport {
+        Some((offset_showing_box_end, box_start))
+    } else {
+        cursor_line.map(|cursor| (topmost_offset_showing(cursor), cursor))
+    };
+
+    if let Some((topmost, bottommost)) = offsets_keeping_the_input_visible {
+        *scroll_offset = (*scroll_offset).clamp(topmost, bottommost);
     }
 
     // Clamp so we never scroll past the last line. This must match
@@ -1117,12 +1128,20 @@ pub(super) fn apply_horizontal_scroll(line: Line, scroll_x: usize) -> Line {
 mod tests {
     use super::*;
 
+    fn unwrapped(_line: usize) -> usize {
+        1
+    }
+
+    fn two_rows_per_line(_line: usize) -> usize {
+        2
+    }
+
     #[test]
     fn should_not_scroll_when_comment_box_already_visible() {
         // given: box at lines 5-7, viewport shows lines 0-9
         let mut scroll = 0;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((5, 7)), Some(6), 10, 100);
+        scroll_comment_input_into_view(&mut scroll, Some((5, 7)), Some(6), 10, 100, unwrapped);
         // then
         assert_eq!(scroll, 0);
     }
@@ -1132,7 +1151,7 @@ mod tests {
         // given: box at lines 20-22, viewport shows lines 0-9
         let mut scroll = 0;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((20, 22)), Some(21), 10, 100);
+        scroll_comment_input_into_view(&mut scroll, Some((20, 22)), Some(21), 10, 100, unwrapped);
         // then: scroll so box_end (22) is the last visible line => scroll = 22 - 10 + 1 = 13
         assert_eq!(scroll, 13);
     }
@@ -1142,7 +1161,7 @@ mod tests {
         // given: box at lines 5-7, viewport shows lines 20-29
         let mut scroll = 20;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((5, 7)), Some(6), 10, 100);
+        scroll_comment_input_into_view(&mut scroll, Some((5, 7)), Some(6), 10, 100, unwrapped);
         // then: scroll so box_start (5) is the first visible line
         assert_eq!(scroll, 5);
     }
@@ -1152,7 +1171,7 @@ mod tests {
         // given: box spans 20 lines, viewport only 10 lines
         let mut scroll = 0;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((30, 49)), Some(45), 10, 100);
+        scroll_comment_input_into_view(&mut scroll, Some((30, 49)), Some(45), 10, 100, unwrapped);
         // then: scroll so cursor (45) is the last visible line => scroll = 45 - 10 + 1 = 36
         assert_eq!(scroll, 36);
     }
@@ -1162,7 +1181,7 @@ mod tests {
         // given: scroll already past max (e.g., content shrank)
         let mut scroll = 200;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((95, 97)), Some(96), 10, 100);
+        scroll_comment_input_into_view(&mut scroll, Some((95, 97)), Some(96), 10, 100, unwrapped);
         // then: pulled back so the box is the first visible line
         assert_eq!(scroll, 95);
     }
@@ -1172,7 +1191,14 @@ mod tests {
         // given: a box range beyond the rendered content
         let mut scroll = 0;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((150, 152)), Some(151), 10, 100);
+        scroll_comment_input_into_view(
+            &mut scroll,
+            Some((150, 152)),
+            Some(151),
+            10,
+            100,
+            unwrapped,
+        );
         // then: clamped to max_scroll = 100 - 1 = 99, matching App::max_scroll_offset
         assert_eq!(scroll, 99);
     }
@@ -1183,9 +1209,41 @@ mod tests {
         // leaving blank rows below the content, then a 4-line input box opened
         let mut scroll = 78;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((99, 102)), Some(100), 40, 104);
+        scroll_comment_input_into_view(&mut scroll, Some((99, 102)), Some(100), 40, 104, unwrapped);
         // then: the box is already visible, so the centering must survive
         assert_eq!(scroll, 78);
+    }
+
+    #[test]
+    fn should_count_wrapped_rows_when_pulling_the_box_into_view() {
+        let mut scroll = 0;
+
+        scroll_comment_input_into_view(
+            &mut scroll,
+            Some((20, 22)),
+            Some(21),
+            10,
+            100,
+            two_rows_per_line,
+        );
+
+        assert_eq!(scroll, 18);
+    }
+
+    #[test]
+    fn should_keep_the_text_cursor_visible_when_wrapping_makes_the_box_too_tall() {
+        let mut scroll = 0;
+
+        scroll_comment_input_into_view(
+            &mut scroll,
+            Some((20, 23)),
+            Some(22),
+            6,
+            100,
+            two_rows_per_line,
+        );
+
+        assert_eq!(scroll, 20);
     }
 
     #[test]
@@ -1193,7 +1251,7 @@ mod tests {
         // given
         let mut scroll = 42;
         // when
-        scroll_comment_input_into_view(&mut scroll, None, None, 10, 100);
+        scroll_comment_input_into_view(&mut scroll, None, None, 10, 100, unwrapped);
         // then
         assert_eq!(scroll, 42);
     }
@@ -1203,7 +1261,7 @@ mod tests {
         // given: viewport shows 0-9, box starts at 8 and ends at 10 (footer off-screen)
         let mut scroll = 0;
         // when
-        scroll_comment_input_into_view(&mut scroll, Some((8, 10)), Some(9), 10, 100);
+        scroll_comment_input_into_view(&mut scroll, Some((8, 10)), Some(9), 10, 100, unwrapped);
         // then: scroll so box_end (10) is visible => scroll = 10 - 10 + 1 = 1
         assert_eq!(scroll, 1);
     }


### PR DESCRIPTION
With wrapping on — the default — opening a comment on the last line of a file puts the input box below the viewport. You can see its left border bleed onto the last row but not the box itself, so you type blind.

### Repro

1. Open a diff with lines long enough to wrap
2. `G` to the last line, then `c`

```
│▶  60╭▌ line 60: the quick brown fox jumps over the lazy dog the quick brown ...
│the l│zy dog the quick brown fox jumps over the lazy dog the quick brown fox ...
│lazy │og the quick brown fox jumps over the lazy dog the quick brown fox jump...
│dog  │
│     ├── Add [SUGGESTION] [INSERT] L60 (i:insert  Alt-Enter:save  Esc:normal ...
│disc──────────────────────────────────────────────────────────────────────────╮
└───────────────────────────────────────────────────────────────────────────────
```

Same in unified and side-by-side. At EOF there is nothing left to scroll into, so it never comes back.

### Cause

`scroll_comment_input_into_view` measured the box in logical lines and compared it against `viewport_height`, a row count:

```rust
} else if box_end >= *scroll_offset + viewport_height {
    *scroll_offset = box_end + 1 - viewport_height;
}
```

With wrapping off the two units coincide. With it on a line can cover several rows, so `viewport_height` rows hold fewer than `viewport_height` lines and the computed offset is too small.

### Fix

Take a `row_height` accessor and walk up from the bottom of the box accumulating rows until the viewport is full, instead of subtracting line counts. The walk is bounded by `viewport_height`, and each renderer builds the accessor on the `wrap_spans` it already uses, so only the lines the walk touches get measured. With wrapping off every line is one row and the result is identical to the old arithmetic; the `total_lines - 1` clamp from #595 is untouched.

The side-by-side accessor and the renderer's own wrap pass now share `sbs_wrapped_sides`, so the height rule stays stated once — that pass already carries a "so the two can't disagree" comment.

### Tests

Two unit tests on the scroll math, plus a render test in each view. All four fail on the old arithmetic.

`cargo test`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt` clean. Dogfooded with a release build: box visible at EOF, top and middle of a file unaffected, `zz` centering at EOF still survives.

### Possible follow-ups

Two things I noticed but left out of this PR:

- The same greedy row-budget walk now exists in six places (`App::scroll_offset_for_rows_above`, `last_fully_visible_annotation`, `page_lines_down`, `page_view_lines_down`, `populate_row_to_annotation`, and the new one). `topmost_offset_showing(x)` is exactly `scroll_offset_for_rows_above(x, viewport_height - row_height(x))`. They can't be merged as-is — the app-side walk measures annotations while this one has to measure the rendered lines, which include the input box — but the walk itself could move to `row_height.rs`, generic over its height source. Happy to do that separately.
- `ensure_cursor_visible`, `scroll_up` and `scroll_view_up` (`src/app/navigation.rs`) subtract `visible_lines` — a count valid at the *previous* scroll offset — from `cursor_line`. The units are consistent so it isn't this bug, but with non-uniform wrap heights it can still under- or over-scroll, and that's the default path for `j`/`k`/`Ctrl-D`. Separate repro, separate fix.
