### PR TITLE
Add configurable file line stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Path: `~/.config/tuicr/config.toml` on Linux/macOS, `%APPDATA%\tuicr\config.toml
 ```toml
 theme = "catppuccin-mocha"
 diff_view = "side-by-side"   # or "unified"
+show_file_line_stats = true  # show per-file +added -removed counts
 ignore_whitespace = false    # ignore all whitespace in local VCS diffs
 appearance = "system"        # or "dark" / "light"
 mouse = true

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,6 +27,7 @@ theme_light = "gruvbox-light"
 diff_view = "side-by-side"
 ignore_whitespace = false
 show_file_list = true
+show_file_line_stats = true
 show_pr_checks = false
 show_pr_comments = true
 mouse = true
@@ -80,6 +81,7 @@ legend = true
 | `initial_commit_selection` | `all`        | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`.  |
 | `ignore_whitespace`        | `false`      | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged.                                                                              |
 | `show_file_list`           | `true`       | Whether the file list panel is visible on startup. Toggle with `<leader>e`.                                                                                |
+| `show_file_line_stats`     | `true`       | Show per-file `+added -removed` line counts in the file list.                                                                                              |
 | `show_pr_checks`           | `false`      | Whether PR CI checks are fetched and shown. Set to `true` to include GitHub check rollups.                                                           |
 | `show_pr_comments`         | `true`       | Whether PR conversation comments are fetched and shown. Set to `false` to skip PR comments.                                                         |
 | `show_commits`             | `true`       | Whether the inline commit selector pane is visible on startup for multi-commit reviews. Toggle with `<leader>s` or `:set commits!`.                        |

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -480,6 +480,7 @@ impl App {
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
             relative_line_numbers: false,
+            show_file_line_stats: true,
             file_list_state: FileListState::default(),
             comment_navigator_state: CommentNavigatorState::default(),
             diff_state: DiffState::default(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1129,6 +1129,8 @@ pub struct App {
     pub focused_panel: FocusedPanel,
     pub diff_view_mode: DiffViewMode,
     pub relative_line_numbers: bool,
+    /// Whether file-list rows show per-file added and removed line counts.
+    pub show_file_line_stats: bool,
 
     pub file_list_state: FileListState,
     pub comment_navigator_state: CommentNavigatorState,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,9 @@ pub struct AppConfig {
     pub backend: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
+    /// Whether file-list rows show per-file added and removed line counts.
+    /// Defaults to true.
+    pub show_file_line_stats: Option<bool>,
     /// Whether pull-request CI checks are fetched and shown.
     /// Defaults to false.
     pub show_pr_checks: Option<bool>,
@@ -184,6 +187,7 @@ const KNOWN_KEYS: &[&str] = &[
     "backend",
     "comment_types",
     "show_file_list",
+    "show_file_line_stats",
     "show_pr_checks",
     "show_pr_comments",
     "show_commits",
@@ -408,6 +412,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             .get("comment_types")
             .and_then(|v| parse_comment_types(v, &mut warnings)),
         show_file_list: read_bool(table, "show_file_list", &mut warnings),
+        show_file_line_stats: read_bool(table, "show_file_line_stats", &mut warnings),
         show_pr_checks: read_bool(table, "show_pr_checks", &mut warnings),
         show_pr_comments: read_bool(table, "show_pr_comments", &mut warnings),
         show_commits: read_bool(table, "show_commits", &mut warnings),
@@ -910,6 +915,34 @@ mod tests {
         let outcome = parse_config("show_file_list = \"no\"\n");
         assert_eq!(
             outcome.config.as_ref().and_then(|cfg| cfg.show_file_list),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+    }
+
+    // show_file_line_stats
+
+    #[test]
+    fn should_parse_show_file_line_stats_false() {
+        let outcome = parse_config("show_file_line_stats = false\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.show_file_line_stats),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_show_file_line_stats_with_invalid_type() {
+        let outcome = parse_config("show_file_line_stats = \"no\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.show_file_line_stats),
             None
         );
         assert_eq!(outcome.warnings.len(), 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -295,6 +295,7 @@ fn main() -> anyhow::Result<()> {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
         }
+        app.show_file_line_stats = cfg.show_file_line_stats.unwrap_or(true);
         // Start with the commit selector pane hidden. `(` / `)` still cycle the
         // selected commit while hidden; `<leader>s` / `:set commits!` reveal it.
         if cfg.show_commits == Some(false) {

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -67,7 +67,7 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("?");
-                depth * 2 + 4 + filename.width()
+                depth * 2 + 4 + filename.width() + file_stat_width(file, app.show_file_line_stats)
             }
         })
         .max()
@@ -165,6 +165,7 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                             ));
                         }
                         spans.push(Span::raw(filename.to_string()));
+                        spans.extend(file_stat_spans(file, &app.theme, app.show_file_line_stats));
                         Line::from(spans)
                     }
                 }
@@ -193,6 +194,35 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
             y: area.y + area.height.saturating_sub(1),
         });
     }
+}
+
+/// Width of the GitHub-style ` +N -N` suffix for a normal file row.
+fn file_stat_width(file: &crate::model::DiffFile, show_file_line_stats: bool) -> usize {
+    if !show_file_line_stats || file.is_commit_message {
+        return 0;
+    }
+
+    let (additions, deletions) = file.stat();
+    format!(" +{additions} -{deletions}").width()
+}
+
+/// Coloured GitHub-style line counts shown after a file name.
+fn file_stat_spans(
+    file: &crate::model::DiffFile,
+    theme: &crate::theme::Theme,
+    show_file_line_stats: bool,
+) -> Vec<Span<'static>> {
+    if !show_file_line_stats || file.is_commit_message {
+        return Vec::new();
+    }
+
+    let (additions, deletions) = file.stat();
+    vec![
+        Span::raw(" "),
+        Span::styled(format!("+{additions}"), Style::default().fg(theme.diff_add)),
+        Span::raw(" "),
+        Span::styled(format!("-{deletions}"), Style::default().fg(theme.diff_del)),
+    ]
 }
 
 /// Leading `│` border plus one space before the prompt sigil.
@@ -256,7 +286,9 @@ mod tests {
     //! Render checks for the filter status/prompt line in the file tree's
     //! bottom border, driven through the real `ui::render`.
     use crate::app::{App, DiffSource, FileTreePrompt, FocusedPanel, InputMode};
-    use crate::model::{DiffFile, DiffLine, FileStatus, ReviewSession, SessionDiffSource};
+    use crate::model::{
+        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, ReviewSession, SessionDiffSource,
+    };
     use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -358,6 +390,60 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn should_render_colored_added_and_removed_line_counts_for_each_file() {
+        let mut app = app_with(&["src/main.rs"]);
+        app.diff_files[0].hunks = vec![DiffHunk {
+            header: "@@ -1,1 +1,2 @@".into(),
+            lines: vec![
+                DiffLine {
+                    origin: LineOrigin::Deletion,
+                    content: "old".into(),
+                    old_lineno: Some(1),
+                    new_lineno: None,
+                    highlighted_spans: None,
+                },
+                DiffLine {
+                    origin: LineOrigin::Addition,
+                    content: "new".into(),
+                    old_lineno: None,
+                    new_lineno: Some(1),
+                    highlighted_spans: None,
+                },
+                DiffLine {
+                    origin: LineOrigin::Addition,
+                    content: "another new line".into(),
+                    old_lineno: None,
+                    new_lineno: Some(2),
+                    highlighted_spans: None,
+                },
+            ],
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 2,
+        }];
+
+        let spans = super::file_stat_spans(&app.diff_files[0], &app.theme, true);
+        assert_eq!(spans[1].content, "+2");
+        assert_eq!(spans[1].style.fg, Some(app.theme.diff_add));
+        assert_eq!(spans[3].content, "-1");
+        assert_eq!(spans[3].style.fg, Some(app.theme.diff_del));
+
+        let text = buffer_text(&draw(&mut app));
+        assert!(
+            text.contains("main.rs +2 -1"),
+            "expected file line counts in the file list, got:\n{text}"
+        );
+
+        app.show_file_line_stats = false;
+        let text = buffer_text(&draw(&mut app));
+        assert!(
+            !text.contains("main.rs +2 -1"),
+            "expected file line counts to be hidden, got:\n{text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Show GitHub-style `+added -removed` counts in the file list. Add `show_file_line_stats` to disable them when needed.