### PR TITLE
fix(release): dynamically link GNU Linux artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,25 +193,23 @@ jobs:
           echo "CARGO_TARGET_${cargo_target}_LINKER=musl-gcc" >> "$GITHUB_ENV"
           echo "CC_${cc_target}=musl-gcc" >> "$GITHUB_ENV"
 
-      - name: Configure static GNU runtime
-        if: runner.os == 'Linux' && endsWith(matrix.build_target, '-gnu')
-        shell: bash
-        run: echo 'RUSTFLAGS=-C target-feature=+crt-static' >> "$GITHUB_ENV"
-
       - name: Build
         run: cargo build --release --target ${{ matrix.build_target }}
 
-      - name: Verify static Linux binary
+      - name: Verify Linux binary
         if: runner.os == 'Linux'
         shell: bash
         run: |
           binary=target/${{ matrix.build_target }}/release/tuicr
           test "$("$binary" --version)" = "tuicr ${{ steps.version.outputs.version }}"
-          if readelf -lW "$binary" | grep -Eq '(^|[[:space:]])INTERP([[:space:]]|$)'; then
-            echo "Linux release binary contains a dynamic interpreter" >&2
-            readelf -lW "$binary" >&2
-            exit 1
-          fi
+          case '${{ matrix.build_target }}' in
+            *-musl)
+              ! readelf -lW "$binary" | grep -Eq '(^|[[:space:]])INTERP([[:space:]]|$)'
+              ;;
+            *-gnu)
+              readelf -lW "$binary" | grep -Eq '(^|[[:space:]])INTERP([[:space:]]|$)'
+              ;;
+          esac
 
       - name: Package binary (unix)
         if: runner.os != 'Windows'

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,8 +38,9 @@ If you need to rebuild binaries for an existing release:
 4. **Click "Run workflow"**
 
 Linux binaries are built for both GNU and musl targets, and their archive names
-use the matching target triples. GNU archives are dynamically linked; use the
-musl archives when a fully static binary is required.
+use the matching target triples. GNU archives retain the names expected by existing
+`tuicr update` installations but are dynamically linked. Musl archives remain fully
+static, and direct updates preserve the installed binary's libc target.
 
 ## What Gets Updated
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,9 +16,9 @@ This project uses an automated release workflow via GitHub Actions.
    - Publishes to crates.io
    - Creates GitHub Release with release notes
    - Builds and uploads binaries for:
-     - `x86_64-unknown-linux-gnu` (Linux x64, static glibc)
+     - `x86_64-unknown-linux-gnu` (Linux x64, dynamic glibc)
      - `x86_64-unknown-linux-musl` (Linux x64, static musl)
-     - `aarch64-unknown-linux-gnu` (Linux ARM64, static glibc)
+     - `aarch64-unknown-linux-gnu` (Linux ARM64, dynamic glibc)
      - `aarch64-unknown-linux-musl` (Linux ARM64, static musl)
      - `x86_64-apple-darwin` (macOS x64)
      - `aarch64-apple-darwin` (macOS Apple Silicon)
@@ -38,8 +38,8 @@ If you need to rebuild binaries for an existing release:
 4. **Click "Run workflow"**
 
 Linux binaries are built for both GNU and musl targets, and their archive names
-use the matching target triples. The static GNU archives preserve compatibility
-with existing `tuicr update` installations.
+use the matching target triples. GNU archives are dynamically linked; use the
+musl archives when a fully static binary is required.
 
 ## What Gets Updated
 

--- a/src/update/install/source.rs
+++ b/src/update/install/source.rs
@@ -24,9 +24,14 @@ pub(super) fn release_asset_name(
     os: &str,
     arch: &str,
 ) -> Result<String, UpdateError> {
+    let (x86_64_linux, aarch64_linux) = if cfg!(target_env = "musl") {
+        ("x86_64-unknown-linux-musl", "aarch64-unknown-linux-musl")
+    } else {
+        ("x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu")
+    };
     let target = match (os, arch) {
-        ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
-        ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
+        ("linux", "x86_64") => x86_64_linux,
+        ("linux", "aarch64") => aarch64_linux,
         ("macos", "x86_64") => "x86_64-apple-darwin",
         ("macos", "aarch64") => "aarch64-apple-darwin",
         ("windows", "x86_64") => "x86_64-pc-windows-msvc",

--- a/src/update/install/tests.rs
+++ b/src/update/install/tests.rs
@@ -527,9 +527,20 @@ fn rejects_bad_release_metadata_assets_and_digests() {
 #[test]
 fn maps_every_published_target_and_rejects_unsupported_targets() {
     assert_eq!(package_repository_url(), env!("CARGO_PKG_REPOSITORY"));
+    let (x86_64_linux, aarch64_linux) = if cfg!(target_env = "musl") {
+        (
+            "x86_64-unknown-linux-musl.tar.gz",
+            "aarch64-unknown-linux-musl.tar.gz",
+        )
+    } else {
+        (
+            "x86_64-unknown-linux-gnu.tar.gz",
+            "aarch64-unknown-linux-gnu.tar.gz",
+        )
+    };
     let cases = [
-        ("linux", "x86_64", "x86_64-unknown-linux-gnu.tar.gz"),
-        ("linux", "aarch64", "aarch64-unknown-linux-gnu.tar.gz"),
+        ("linux", "x86_64", x86_64_linux),
+        ("linux", "aarch64", aarch64_linux),
         ("macos", "x86_64", "x86_64-apple-darwin.tar.gz"),
         ("macos", "aarch64", "aarch64-apple-darwin.tar.gz"),
         ("windows", "x86_64", "x86_64-pc-windows-msvc.zip"),


### PR DESCRIPTION
Closes #609.

## Problem

v0.22.0 forced static glibc into the GNU Linux release artifacts. The startup update check calls `getaddrinfo`. On Fedora 44 that makes glibc load the host `libnss_myhostname.so.2` into the statically linked process, which crashes in `__libc_early_init` with SIGFPE.

## What changed

- Build GNU Linux artifacts with dynamic glibc.
- Keep musl artifacts fully static.
- Verify the expected linkage for both target families in the release workflow.
- Preserve the installed GNU or musl target when a direct binary runs `tuicr update`.
- Document the two Linux artifact variants and update compatibility.

## Verification

- Reproduced exit 136/SIGFPE with the official v0.22.0 GNU artifact on Fedora 44.
- Confirmed the same artifact stays running with `--no-update-check`, and the official musl artifact stays running with update checks enabled.
- Rebuilt `x86_64-unknown-linux-gnu`, confirmed it has an ELF interpreter, and launched it successfully with update checks enabled.