### PR TITLE
fix(forge): use the comment type label in the submit prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,6 +315,8 @@ These are non-obvious things the implementation chain hit. Worth preserving for 
 
 16. **GNU Linux release binaries must stay dynamically linked.** Static glibc binaries can crash when hostname lookup loads a host NSS module (for example Fedora's `libnss_myhostname`). The musl artifacts are the supported static Linux builds. Direct updates must preserve the running binary's GNU/musl target environment when selecting an asset.
 
+17. **The `[TYPE]` prefix uses the config-resolved `label`, not the `CommentType` id.** `CommentType` carries no label — it lives on `CommentTypeDefinition` (`App::comment_types`), so `as_str()` only ever yields the uppercased id. Four resolvers render this tag and must agree: `App::comment_type_label` (TUI), `export_comment_type_label` (`src/output/markdown.rs`), `SubmitContext::type_label` (`src/forge/submit.rs`), and `describe_row` (`src/ui/submit_modals.rs`). The last is easy to miss and previews the tag the user is deciding about, so disagreement means choosing Move-to-summary vs Omit against a tag that never gets posted. This is why the submit path takes a `SubmitContext` rather than a bare `&ForgeConfig`.
+
 ### Keeping Docs Updated
 
 When adding user-facing features, update the relevant documentation:

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -180,7 +180,7 @@ and fall back through normal precedence.
 Comment categories control:
 
 - The classification badge shown in the TUI (color + label)
-- The `[TYPE]` tag in the exported markdown
+- The `[TYPE]` tag in the exported markdown and in comments submitted to a forge
 - The Tab cycle order in comment mode
 
 ### Fields
@@ -188,7 +188,7 @@ Comment categories control:
 | Field        | Required | Description                                                                             |
 | ------------ | -------- | --------------------------------------------------------------------------------------- |
 | `id`         | yes      | Stable internal value. Saved in sessions and used for matching.                         |
-| `label`      | no       | Visible tag in UI and export (`[QUESTION]`, `[NITPICK]`). Defaults to `id` uppercased.  |
+| `label`      | no       | Visible tag in the UI, export, and submitted comments (`[QUESTION]`, `[NITPICK]`). Defaults to `id` uppercased. |
 | `definition` | no       | Guidance text for LLMs, included in the exported `Comment types:` legend.               |
 | `color`      | no       | Comment badge / border color. Terminal name (`yellow`, `light_red`) or hex (`#RRGGBB`). |
 
@@ -231,7 +231,7 @@ comment_type_prefix = false
 
 | Key                   | Default | Description                                                                                                                                                                 |
 | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `comment_type_prefix` | `true`  | Prepend `[TYPE] ` to comment bodies on submit (e.g. `[ISSUE] Magic number should be a constant`). Set to `false` to send the raw comment body without a classification tag. |
+| `comment_type_prefix` | `true`  | Prepend `[TYPE] ` to comment bodies on submit (e.g. `[ISSUE] Magic number should be a constant`). The tag uses the type's `label`, uppercased — the same text the TUI badge and export show. Set to `false` to send the raw comment body without a classification tag. |
 
 When enabled (the default), submitted comments look like:
 

--- a/src/app/submit.rs
+++ b/src/app/submit.rs
@@ -23,7 +23,8 @@ impl App {
         skip_confirm: bool,
     ) {
         use crate::forge::submit::{
-            CommentAnchor, InlineComment, ResolverAction, UnmappableItem, map_comment,
+            CommentAnchor, InlineComment, ResolverAction, SubmitContext, UnmappableItem,
+            map_comment,
         };
 
         let DiffSource::PullRequest(pr) = &self.diff_source else {
@@ -61,6 +62,8 @@ impl App {
             None => self.diff_files.iter().collect(),
         };
 
+        let submit_ctx = SubmitContext::new(&self.forge_config, &self.comment_types);
+
         let mut mappable: Vec<InlineComment> = Vec::new();
         let mut unmappable: Vec<UnmappableItem> = Vec::new();
         let mut total_local_drafts = 0_usize;
@@ -78,7 +81,7 @@ impl App {
                 }
                 total_local_drafts += 1;
                 bucket_mapping(
-                    map_comment(comment, CommentAnchor::FileLevel, file, &self.forge_config),
+                    map_comment(comment, CommentAnchor::FileLevel, file, submit_ctx),
                     &mut mappable,
                     &mut unmappable,
                 );
@@ -100,7 +103,7 @@ impl App {
                         }
                     };
                     bucket_mapping(
-                        map_comment(comment, anchor, file, &self.forge_config),
+                        map_comment(comment, anchor, file, submit_ctx),
                         &mut mappable,
                         &mut unmappable,
                     );
@@ -270,7 +273,9 @@ impl App {
     /// network round-trip on a background thread. The result is applied
     /// later in `poll_pr_submit_events`.
     pub fn spawn_pr_submit(&mut self) -> Result<()> {
-        use crate::forge::submit::{MovedToSummaryItem, ResolverAction, build_review_body};
+        use crate::forge::submit::{
+            MovedToSummaryItem, ResolverAction, SubmitContext, build_review_body,
+        };
         use crate::forge::traits::{CreateReviewRequest, PullRequestTarget};
 
         // Snapshot identity from the PR diff source first so the borrow on
@@ -314,7 +319,7 @@ impl App {
         let body = build_review_body(
             &self.session.review_comments,
             &summary_items,
-            &self.forge_config,
+            SubmitContext::new(&self.forge_config, &self.comment_types),
         );
 
         // Save the session BEFORE the network call — keeps the user's

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -10,9 +10,47 @@
 
 use std::path::PathBuf;
 
+use crate::app::CommentTypeDefinition;
 use crate::config::ForgeConfig;
-use crate::model::comment::Comment;
+use crate::model::comment::{Comment, CommentType};
 use crate::model::{DiffFile, FileStatus, LineOrigin, LineRange, LineSide};
+
+/// The `[forge]` settings plus the config-resolved comment types. The types
+/// are needed because `CommentType` carries only an id — the user-facing
+/// `label` lives on [`CommentTypeDefinition`].
+#[derive(Debug, Clone, Copy)]
+pub struct SubmitContext<'a> {
+    pub forge: &'a ForgeConfig,
+    pub comment_types: &'a [CommentTypeDefinition],
+}
+
+impl<'a> SubmitContext<'a> {
+    pub fn new(forge: &'a ForgeConfig, comment_types: &'a [CommentTypeDefinition]) -> Self {
+        Self {
+            forge,
+            comment_types,
+        }
+    }
+
+    /// Resolved `[TYPE]` text, or an empty string for `None` so callers omit
+    /// the tag. Mirrors `App::comment_type_label` and
+    /// `export_comment_type_label` — those three must agree.
+    fn type_label(&self, comment_type: &CommentType) -> String {
+        if comment_type.is_none() {
+            return String::new();
+        }
+
+        if let Some(definition) = self
+            .comment_types
+            .iter()
+            .find(|definition| definition.id == comment_type.id())
+        {
+            return definition.label.to_ascii_uppercase();
+        }
+
+        comment_type.as_str()
+    }
+}
 
 /// Which forge review event a `:submit*` command corresponds to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -175,16 +213,17 @@ pub enum MappedComment {
 
 /// Compute the inline body for `comment` honoring the `[TYPE]` prefix toggle.
 /// File-level bodies are prefixed `[TYPE] File-level:`.
-fn build_inline_body(comment: &Comment, file_level: bool, config: &ForgeConfig) -> String {
-    if !config.comment_type_prefix {
+fn build_inline_body(comment: &Comment, file_level: bool, ctx: SubmitContext<'_>) -> String {
+    if !ctx.forge.comment_type_prefix {
         return comment.content.clone();
     }
     // `None` comments carry no `[TYPE]` tag, but file-level ones keep the
     // `File-level:` marker so the reader still knows where the comment applies.
-    let type_tag = if comment.comment_type.is_none() {
+    let label = ctx.type_label(&comment.comment_type);
+    let type_tag = if label.is_empty() {
         String::new()
     } else {
-        format!("[{ty}] ", ty = comment.comment_type.as_str())
+        format!("[{label}] ")
     };
     let prefix = if file_level {
         format!("{type_tag}File-level: ")
@@ -217,7 +256,7 @@ pub fn map_comment(
     comment: &Comment,
     anchor: CommentAnchor,
     file: &DiffFile,
-    config: &ForgeConfig,
+    ctx: SubmitContext<'_>,
 ) -> MappedComment {
     let path = file.display_path().clone();
 
@@ -253,7 +292,7 @@ pub fn map_comment(
                     start_side: None,
                     range_anchors: None,
                     old_path,
-                    body: build_inline_body(comment, true, config),
+                    body: build_inline_body(comment, true, ctx),
                     comment_id: comment.id.clone(),
                 })
             }
@@ -264,7 +303,7 @@ pub fn map_comment(
             },
         },
         CommentAnchor::Range => match comment.line_range {
-            Some(range) => map_range(comment, file, config, range),
+            Some(range) => map_range(comment, file, ctx, range),
             None => MappedComment::Unmappable {
                 comment: comment.clone(),
                 file: path,
@@ -286,7 +325,7 @@ pub fn map_comment(
                 start_side: None,
                 range_anchors: None,
                 old_path,
-                body: build_inline_body(comment, false, config),
+                body: build_inline_body(comment, false, ctx),
                 comment_id: comment.id.clone(),
             }),
         },
@@ -382,7 +421,7 @@ fn find_diff_anchor(file: &DiffFile, line: u32, side: LineSide) -> Option<DiffAn
 fn map_range(
     comment: &Comment,
     file: &DiffFile,
-    config: &ForgeConfig,
+    ctx: SubmitContext<'_>,
     range: LineRange,
 ) -> MappedComment {
     let path = file.display_path().clone();
@@ -426,7 +465,7 @@ fn map_range(
             start_side: None,
             range_anchors: None,
             old_path,
-            body: build_inline_body(comment, false, config),
+            body: build_inline_body(comment, false, ctx),
             comment_id: comment.id.clone(),
         });
     }
@@ -444,7 +483,7 @@ fn map_range(
         start_side: Some(side.into()),
         range_anchors,
         old_path,
-        body: build_inline_body(comment, false, config),
+        body: build_inline_body(comment, false, ctx),
         comment_id: comment.id.clone(),
     })
 }
@@ -529,7 +568,7 @@ pub struct MovedToSummaryItem {
 pub fn build_review_body(
     review_level: &[Comment],
     moved_to_summary: &[MovedToSummaryItem],
-    config: &ForgeConfig,
+    ctx: SubmitContext<'_>,
 ) -> String {
     let mut sections: Vec<String> = Vec::new();
 
@@ -539,8 +578,9 @@ pub fn build_review_body(
             if i > 0 {
                 block.push_str("\n\n");
             }
-            if config.comment_type_prefix && !c.comment_type.is_none() {
-                block.push_str(&format!("[{}] ", c.comment_type.as_str()));
+            let label = ctx.type_label(&c.comment_type);
+            if ctx.forge.comment_type_prefix && !label.is_empty() {
+                block.push_str(&format!("[{label}] "));
             }
             block.push_str(&c.content);
         }
@@ -550,8 +590,9 @@ pub fn build_review_body(
     if !moved_to_summary.is_empty() {
         let mut block = String::from("## Unplaced comments\n");
         for item in moved_to_summary {
-            let prefix = if config.comment_type_prefix && !item.comment.comment_type.is_none() {
-                format!("[{}] ", item.comment.comment_type.as_str())
+            let label = ctx.type_label(&item.comment.comment_type);
+            let prefix = if ctx.forge.comment_type_prefix && !label.is_empty() {
+                format!("[{label}] ")
             } else {
                 String::new()
             };
@@ -623,6 +664,35 @@ mod tests {
 
     fn default_config() -> ForgeConfig {
         ForgeConfig::default()
+    }
+
+    /// `issue`/`note` label == id (most tests assert the uppercased id);
+    /// `emoji` carries a distinct label to pin label passthrough.
+    fn test_comment_types() -> Vec<CommentTypeDefinition> {
+        vec![
+            CommentTypeDefinition {
+                id: "issue".to_string(),
+                label: "issue".to_string(),
+                definition: None,
+                color: None,
+            },
+            CommentTypeDefinition {
+                id: "note".to_string(),
+                label: "note".to_string(),
+                definition: None,
+                color: None,
+            },
+            CommentTypeDefinition {
+                id: "emoji".to_string(),
+                label: "\u{1F4AC} note".to_string(),
+                definition: None,
+                color: None,
+            },
+        ]
+    }
+
+    fn ctx_of<'a>(forge: &'a ForgeConfig, types: &'a [CommentTypeDefinition]) -> SubmitContext<'a> {
+        SubmitContext::new(forge, types)
     }
 
     fn comment_with_line(side: LineSide, new: Option<u32>, old: Option<u32>) -> Comment {
@@ -720,7 +790,7 @@ mod tests {
             &comment,
             anchor_from(&comment),
             &typical_file(),
-            &default_config(),
+            ctx_of(&default_config(), &test_comment_types()),
         );
         match mapped {
             MappedComment::Inline(inline) => {
@@ -741,7 +811,7 @@ mod tests {
             &comment,
             anchor_from(&comment),
             &typical_file(),
-            &default_config(),
+            ctx_of(&default_config(), &test_comment_types()),
         );
         assert!(matches!(
             mapped,
@@ -762,7 +832,7 @@ mod tests {
             &comment,
             anchor_from(&comment),
             &typical_file(),
-            &default_config(),
+            ctx_of(&default_config(), &test_comment_types()),
         );
         match mapped {
             MappedComment::Inline(inline) => {
@@ -784,7 +854,7 @@ mod tests {
             &comment,
             anchor_from(&comment),
             &typical_file(),
-            &default_config(),
+            ctx_of(&default_config(), &test_comment_types()),
         );
         match mapped {
             MappedComment::Inline(inline) => {
@@ -803,7 +873,7 @@ mod tests {
             &comment,
             anchor_from(&comment),
             &typical_file(),
-            &default_config(),
+            ctx_of(&default_config(), &test_comment_types()),
         );
         match mapped {
             MappedComment::Inline(inline) => {
@@ -824,7 +894,12 @@ mod tests {
             line(LineOrigin::Addition, Some(12), None),
         ])]);
         let comment = comment_range(LineSide::New, LineRange::new(10, 12));
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 12);
@@ -844,7 +919,12 @@ mod tests {
             line(LineOrigin::Deletion, None, Some(22)),
         ])]);
         let comment = comment_range(LineSide::Old, LineRange::new(20, 22));
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 22);
@@ -860,7 +940,12 @@ mod tests {
     fn should_flatten_single_line_range_to_inline_without_start_fields() {
         let file = file_with_hunks(vec![hunk(vec![line(LineOrigin::Addition, Some(15), None)])]);
         let comment = comment_range(LineSide::New, LineRange::single(15));
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.line, 15);
@@ -881,7 +966,12 @@ mod tests {
             line(LineOrigin::Addition, Some(11), None),
         ])]);
         let comment = comment_range(LineSide::New, LineRange::new(10, 11));
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 let anchors = inline.range_anchors.expect("range anchors");
@@ -916,7 +1006,12 @@ mod tests {
             line(LineOrigin::Context, Some(12), Some(7)),
         ])]);
         let comment = comment_range(LineSide::New, LineRange::new(10, 12));
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert_eq!(inline.counterpart_line, Some(7));
@@ -943,7 +1038,12 @@ mod tests {
             line(LineOrigin::Deletion, None, Some(22)),
         ])]);
         let comment = comment_range(LineSide::New, LineRange::new(20, 22));
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Unmappable { reason, .. } => {
                 assert_eq!(reason, UnmappableReason::MixedSideRange);
@@ -961,7 +1061,7 @@ mod tests {
             &comment,
             anchor_from(&comment),
             &typical_file(),
-            &default_config(),
+            ctx_of(&default_config(), &test_comment_types()),
         );
         match mapped {
             MappedComment::Inline(inline) => {
@@ -978,7 +1078,12 @@ mod tests {
         // Pure deletion file: nothing on the New side.
         let file = file_with_hunks(vec![hunk(vec![line(LineOrigin::Deletion, None, Some(5))])]);
         let comment = comment_file_level();
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         match mapped {
             MappedComment::Unmappable { reason, .. } => {
                 assert_eq!(reason, UnmappableReason::FileLevelNoAnchor);
@@ -992,7 +1097,12 @@ mod tests {
         let mut file = typical_file();
         file.is_binary = true;
         let comment = comment_with_line(LineSide::New, Some(11), None);
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         assert!(matches!(
             mapped,
             MappedComment::Unmappable {
@@ -1007,7 +1117,12 @@ mod tests {
         let mut file = typical_file();
         file.is_too_large = true;
         let comment = comment_file_level();
-        let mapped = map_comment(&comment, anchor_from(&comment), &file, &default_config());
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &file,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         assert!(matches!(
             mapped,
             MappedComment::Unmappable {
@@ -1025,7 +1140,12 @@ mod tests {
         let cfg = ForgeConfig {
             comment_type_prefix: false,
         };
-        let mapped = map_comment(&comment, anchor_from(&comment), &typical_file(), &cfg);
+        let mapped = map_comment(
+            &comment,
+            anchor_from(&comment),
+            &typical_file(),
+            ctx_of(&cfg, &test_comment_types()),
+        );
         match mapped {
             MappedComment::Inline(inline) => {
                 assert!(!inline.body.contains("[ISSUE]"));
@@ -1043,14 +1163,18 @@ mod tests {
 
     #[test]
     fn should_return_empty_body_when_no_inputs() {
-        let body = build_review_body(&[], &[], &default_config());
+        let body = build_review_body(&[], &[], ctx_of(&default_config(), &test_comment_types()));
         assert_eq!(body, "");
     }
 
     #[test]
     fn should_render_review_level_comments_with_type_prefix() {
         let comments = vec![note("first"), note("second")];
-        let body = build_review_body(&comments, &[], &default_config());
+        let body = build_review_body(
+            &comments,
+            &[],
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         assert_eq!(body, "[NOTE] first\n\n[NOTE] second");
     }
 
@@ -1060,7 +1184,11 @@ mod tests {
             comment: Comment::new("kaboom".to_string(), CommentType::from_id("issue"), None),
             file: PathBuf::from("src/lib.rs"),
         };
-        let body = build_review_body(&[], &[item], &default_config());
+        let body = build_review_body(
+            &[],
+            &[item],
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         assert!(body.contains("## Unplaced comments"));
         assert!(body.contains("- [ISSUE] src/lib.rs: kaboom"));
     }
@@ -1072,7 +1200,11 @@ mod tests {
             comment: Comment::new("middle".to_string(), CommentType::from_id("note"), None),
             file: PathBuf::from("a.rs"),
         }];
-        let body = build_review_body(&review, &summary, &default_config());
+        let body = build_review_body(
+            &review,
+            &summary,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         let top = body.find("[NOTE] top").expect("review comment");
         let middle = body.find("## Unplaced comments").expect("unplaced section");
         assert!(top < middle, "section ordering: {body}");
@@ -1084,7 +1216,7 @@ mod tests {
             comment_type_prefix: false,
         };
         let comments = vec![note("just text")];
-        let body = build_review_body(&comments, &[], &cfg);
+        let body = build_review_body(&comments, &[], ctx_of(&cfg, &test_comment_types()));
         assert_eq!(body, "just text");
     }
 
@@ -1095,7 +1227,11 @@ mod tests {
             comment: Comment::new("also untyped".to_string(), CommentType::None, None),
             file: PathBuf::from("a.rs"),
         }];
-        let body = build_review_body(&comments, &summary, &default_config());
+        let body = build_review_body(
+            &comments,
+            &summary,
+            ctx_of(&default_config(), &test_comment_types()),
+        );
         assert!(!body.contains('['), "no type tag expected on None: {body}");
         assert!(body.contains("untyped"));
         assert!(body.contains("- a.rs: also untyped"));
@@ -1106,13 +1242,84 @@ mod tests {
         let comment = Comment::new("untyped".to_string(), CommentType::None, None);
         // Line-level: raw content, no `[TYPE]`.
         assert_eq!(
-            build_inline_body(&comment, false, &default_config()),
+            build_inline_body(
+                &comment,
+                false,
+                ctx_of(&default_config(), &test_comment_types())
+            ),
             "untyped"
         );
         // File-level: keep the `File-level:` marker, drop the `[TYPE]`.
         assert_eq!(
-            build_inline_body(&comment, true, &default_config()),
+            build_inline_body(
+                &comment,
+                true,
+                ctx_of(&default_config(), &test_comment_types())
+            ),
             "File-level: untyped"
+        );
+    }
+
+    #[test]
+    fn should_use_configured_label_for_type_prefix_on_submit() {
+        let comment = Comment::new("looks odd".to_string(), CommentType::from_id("emoji"), None);
+        assert_eq!(
+            build_inline_body(
+                &comment,
+                false,
+                ctx_of(&default_config(), &test_comment_types())
+            ),
+            "[💬 NOTE] looks odd"
+        );
+        assert_eq!(
+            build_inline_body(
+                &comment,
+                true,
+                ctx_of(&default_config(), &test_comment_types())
+            ),
+            "[💬 NOTE] File-level: looks odd"
+        );
+    }
+
+    #[test]
+    fn should_fall_back_to_uppercased_id_for_unconfigured_type() {
+        let comment = Comment::new("fix".to_string(), CommentType::from_id("ghost"), None);
+        assert_eq!(
+            build_inline_body(
+                &comment,
+                false,
+                ctx_of(&default_config(), &test_comment_types())
+            ),
+            "[GHOST] fix"
+        );
+    }
+
+    #[test]
+    fn should_use_configured_label_in_review_body_and_unplaced_summary() {
+        let comments = vec![Comment::new(
+            "a thought".to_string(),
+            CommentType::from_id("emoji"),
+            None,
+        )];
+        let body = build_review_body(
+            &comments,
+            &[],
+            ctx_of(&default_config(), &test_comment_types()),
+        );
+        assert!(body.contains("[💬 NOTE] a thought"), "body was: {body}");
+
+        let item = MovedToSummaryItem {
+            comment: Comment::new("unplaced".to_string(), CommentType::from_id("emoji"), None),
+            file: PathBuf::from("a.rs"),
+        };
+        let body = build_review_body(
+            &[],
+            &[item],
+            ctx_of(&default_config(), &test_comment_types()),
+        );
+        assert!(
+            body.contains("[💬 NOTE] a.rs: unplaced"),
+            "body was: {body}"
         );
     }
 

--- a/src/ui/submit_modals.rs
+++ b/src/ui/submit_modals.rs
@@ -102,7 +102,10 @@ pub fn render_submit_resolver(frame: &mut Frame, app: &App) {
             Style::default()
         };
         lines.push(Line::from(Span::styled(
-            format!("{cursor} {action_label}  {row}", row = describe_row(item)),
+            format!(
+                "{cursor} {action_label}  {row}",
+                row = describe_row(app, item)
+            ),
             style,
         )));
     }
@@ -214,8 +217,15 @@ pub fn render_submit_confirm(frame: &mut Frame, app: &App) {
     frame.render_widget(paragraph, inner);
 }
 
-fn describe_row(item: &UnmappableItem) -> String {
-    let kind = item.comment.comment_type.as_str();
+/// The `[TYPE]` tag here must match what submit actually sends, so it resolves
+/// the configured `label` rather than the raw id.
+fn describe_row(app: &App, item: &UnmappableItem) -> String {
+    let label = app.comment_type_label(&item.comment.comment_type);
+    let type_tag = if label.is_empty() {
+        String::new()
+    } else {
+        format!("[{label}] ")
+    };
     let path = item.file.display();
     let preview: String = item.comment.content.chars().take(40).collect();
     let ellipsis = if item.comment.content.chars().count() > 40 {
@@ -224,7 +234,7 @@ fn describe_row(item: &UnmappableItem) -> String {
         ""
     };
     let reason = item.reason.human_label();
-    format!("{path} [{kind}] {preview}{ellipsis}  ({reason})")
+    format!("{path} {type_tag}{preview}{ellipsis}  ({reason})")
 }
 
 fn body_summary_label(app: &App, moved_count: usize) -> String {
@@ -517,6 +527,48 @@ mod tests {
         assert!(text.contains("Enter: toggle action"));
         // Cursor marker on row 0
         assert!(text.contains("> [x] Move to summary"));
+    }
+
+    #[test]
+    fn resolver_row_uses_configured_label_and_omits_tag_for_untyped() {
+        use crate::app::CommentTypeDefinition;
+        use crate::forge::submit::UnmappableReason;
+        let mut app = make_pr_app();
+        app.comment_types = vec![CommentTypeDefinition {
+            id: "note".to_string(),
+            label: "\u{1F4AC} note".to_string(),
+            definition: None,
+            color: None,
+        }];
+        app.submit_state = Some(SubmitState {
+            event: SubmitEvent::Comment,
+            mappable: Vec::new(),
+            unmappable: vec![
+                unmappable_item(
+                    "img.png",
+                    CommentType::from_id("note"),
+                    "binary art",
+                    UnmappableReason::BinaryFile,
+                ),
+                unmappable_item(
+                    "src/lib.rs",
+                    CommentType::None,
+                    "untyped remark",
+                    UnmappableReason::FileLevelNoAnchor,
+                ),
+            ],
+            resolver_choices: vec![ResolverAction::MoveToSummary, ResolverAction::MoveToSummary],
+            resolver_cursor: 0,
+            commit_id: "abcdef0123".to_string(),
+            skip_confirm: false,
+        });
+        let text = buffer_text(&draw_resolver(&app));
+        // The emoji spans two cells, so the buffer reads back with padding.
+        assert!(text.contains("\u{1F4AC}"), "emoji in tag: {text}");
+        assert!(text.contains("NOTE]"), "label tag: {text}");
+        // Untyped comments render no tag at all — never a literal `[NONE]`.
+        assert!(!text.contains("[NONE]"), "untyped tag leaked: {text}");
+        assert!(text.contains("untyped remark"), "untyped row: {text}");
     }
 
     #[test]


### PR DESCRIPTION
A comment type with a configured `label` shows that label in the TUI badge and the markdown export, but submits the raw id. With `{ id = "note", label = "💬 note" }`, the TUI and export both show `[💬 NOTE]` while the posted comment says `[NOTE]`.

`CommentType` carries only an id — the `label` lives on the config-resolved `CommentTypeDefinition`, so `CommentType::as_str()` can only ever yield the uppercased id. The UI and export paths already resolve through the definitions (`App::comment_type_label`, `export_comment_type_label`); the submit path took a bare `&ForgeConfig`, which holds just `comment_type_prefix`, so it had no way to reach them.

## Change

`build_inline_body` / `map_comment` / `map_range` / `build_review_body` now take a `SubmitContext` (forge config + resolved types) and resolve the label the same way the other two paths do.

`describe_row` in the unmappable-comment resolver modal was a fourth site building the tag from the same enum. It previewed `[NOTE]` while the submitted body said `[💬 NOTE]`, so you pick Move-to-summary vs Omit against a tag that isn't what gets posted. It also printed a literal `[NONE]` for untyped comments, where the other resolvers render no tag at all. Both now match.

`docs/CONFIG.md` said `label` applies to the UI and export; it now says submit too. `AGENTS.md` gets an entry listing the four resolvers that have to agree, since `describe_row` is the easy one to miss.

## Notes

This changes submitted output for anyone already configuring an emoji `label` — the tag becomes what they see in the TUI. The Defaults section of `docs/CONFIG.md` describes the tag as one thing prepended "on submit **or** export", and `export_comment_type_label` already existed, so this reads as the intended behaviour rather than a policy change. Nothing in the repo records an id-only rule.

319 added lines, ~230 of them tests; the production change is under 90.

Four tests added, covering the emoji label on submit, the review body, and the two resolver-modal fixes. CI is green. Two `vcs::git` tests fail on my machine on `main` as well — local git rejects the `relativeworktrees` extension — so they're unrelated to this change.

Closes #659.
