### PR TITLE
fix(jj): remove Git staging concepts from local selector

### DIFF
--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -269,6 +269,16 @@ impl App {
         highlighter: &SyntaxHighlighter,
         path_filter: Option<&str>,
     ) -> Result<VcsChangeStatus> {
+        // Jujutsu has no staging index: its working copy is represented by `@`.
+        // Probing the generic unstaged fallback would classify `jj diff` as
+        // "Unstaged changes" and duplicate the `@` row in the selector.
+        if vcs.info().vcs_type == VcsType::Jujutsu {
+            return Ok(VcsChangeStatus {
+                staged: false,
+                unstaged: false,
+            });
+        }
+
         if path_filter.is_none() {
             match vcs.get_change_status() {
                 Ok(status) => {

--- a/src/app/tests/change_status_tests.rs
+++ b/src/app/tests/change_status_tests.rs
@@ -93,6 +93,26 @@ fn mock_vcs(root_path: PathBuf) -> StatusProbeMock {
 }
 
 #[test]
+fn jj_status_never_creates_git_staging_rows() {
+    let dir = tempdir().expect("failed to create temp dir");
+    let mut vcs = mock_vcs(dir.path().to_path_buf());
+    vcs.info.vcs_type = VcsType::Jujutsu;
+
+    let status =
+        App::get_change_status_with_ignore(&vcs, dir.path(), &SyntaxHighlighter::default(), None)
+            .expect("failed to get change status");
+
+    assert_eq!(
+        status,
+        VcsChangeStatus {
+            staged: false,
+            unstaged: false,
+        },
+        "jj represents working-copy changes through @, not staged/unstaged rows"
+    );
+}
+
+#[test]
 fn status_probe_rechecks_positive_rows_when_ignore_rules_exist() {
     let dir = tempdir().expect("failed to create temp dir");
     fs::write(dir.path().join(".tuicrignore"), "ignored/\n").expect("failed to write .tuicrignore");

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -21,8 +21,12 @@ use crate::vcs::{
 
 /// Parse a jj description into (summary, optional body).
 fn parse_description(desc: &str) -> (String, Option<String>) {
+    if desc.trim().is_empty() {
+        return ("(no description set)".to_string(), None);
+    }
+
     let mut lines = desc.lines();
-    let summary = lines.next().unwrap_or("(no message)").to_string();
+    let summary = lines.next().unwrap_or("(no description set)").to_string();
     let body_text: String = lines
         .skip_while(|l| l.trim().is_empty())
         .collect::<Vec<_>>()
@@ -598,6 +602,18 @@ mod tests {
             .expect("Failed to modify file");
 
         Some(temp_dir)
+    }
+
+    #[test]
+    fn empty_description_uses_jj_wording() {
+        assert_eq!(
+            parse_description(""),
+            ("(no description set)".to_string(), None)
+        );
+        assert_eq!(
+            parse_description("  \n"),
+            ("(no description set)".to_string(), None)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Do not classify the Jujutsu working-copy diff as unstaged changes. The working copy is already represented by @, and jj has no staging index.

Use jj's standard "(no description set)" text for empty commit descriptions.

after/before
<img width="1876" height="530" alt="image" src="https://github.com/user-attachments/assets/d21acfe7-a7d2-4952-bd09-668db6820e98" />
