### PR TITLE
docs: mark Hunk as a standalone binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Auto-detects git, jj, or mercurial.
 | git | ✅ | ✅ | ✅ | ❌ | ✅ |
 | jj | ✅ | ✅ | ✅ | ❌ | ❌ |
 | Mercurial (hg) | ✅ | ❌ | ❌ | ❌ | ❌ |
-| Single static binary | ✅ | (needs Node) | ✅ | ✅ | ✅ |
+| Single static binary | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ¹ Lumen has `j`/`k` navigation but no broader vim model (visual mode, `{N}G`, `Ctrl-d`/`Ctrl-u`,
 etc.).


### PR DESCRIPTION
Hunk is available as a standalone compiled binary through Homebrew, mise, Nix, and release artifacts, so it should receive a checkmark in the “Single static binary” row.

Its npm installation does require Node.js, but that is an installation-path detail rather than a runtime requirement for Hunk’s binary distributions.

Please and thanks!