### PR TITLE
feat(forge): add Forgejo and Codeberg pull request discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,9 +49,8 @@ src/
 │   └── jj/              # Jujutsu backend (always compiled)
 │       └── mod.rs       # JjBackend: uses jj CLI, parses with diff_parser::GitStyle
 │
-├── forge/               # Remote forge integration (GitHub PR, GitLab MR, Bitbucket PR review)
-│   ├── mod.rs           # Detect and parse GitHub/GitLab/Bitbucket remotes
-│                        # (parse_any_remote_url: Bitbucket, then GitLab, then GitHub)
+├── forge/               # Remote forge integration (GitHub, Forgejo/Codeberg, GitLab, Bitbucket)
+│   ├── mod.rs           # Detect and parse forge remotes; Forgejo discovery uses Tea logins
 │   ├── traits.rs        # ForgeBackend trait, ForgeRepository, PullRequestTarget,
 │   │                    # PullRequestDetails, PullRequestInfo, PrSessionKey,
 │   │                    # CreateReviewRequest, GhCreateReviewResponse, ForgeFileLinesRequest
@@ -61,9 +60,9 @@ src/
 │   ├── remote_comments.rs # RemoteReviewThread shape + visibility filter
 │   ├── submit.rs        # Submit pipeline: preflight mapping, resolver actions,
 │   │                    # InlineComment payload, build_review_body, SubmitEvent
-│   ├── github/          # GitHub backend via `gh` CLI
+│   ├── github/          # GitHub and Forgejo-compatible backend via `gh` / `tea`
 │   │   ├── mod.rs       # GitHubGhBackend: ForgeBackend impl
-│   │   ├── gh.rs        # GhCommandRunner: spawn `gh`, parse output, error mapping
+│   │   ├── gh.rs        # GhCommandRunner: spawn `gh` or `tea`, parse output, error mapping
 │   │   ├── models.rs    # JSON parsing for `gh` REST + GraphQL responses
 │   │   ├── pr_info.rs   # Extended `gh pr view --json` parsing for PR description panel
 │   │   ├── review_threads.rs # GraphQL query for existing review threads
@@ -229,9 +228,9 @@ Repository-managed agent integrations:
 
 ## Forge integration
 
-Forge review (`tuicr pr <target>`, `tuicr mr <target>`, or their explicit `tuicr tui` forms) is the only feature in `src/forge/`. GitHub operations shell out to `gh`; GitLab operations shell out to `glab`; Bitbucket Cloud operations shell out to `bkt`.
+Forge review (`tuicr pr <target>`, `tuicr mr <target>`, or their explicit `tuicr tui` forms) is the only feature in `src/forge/`. GitHub operations shell out to `gh`; Forgejo and Codeberg operations shell out to `tea`; GitLab operations shell out to `glab`; Bitbucket Cloud operations shell out to `bkt`.
 
-Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbucket.org` only), then GitLab (host contains `gitlab`, or matches `glab config get host`), then GitHub. GitHub must stay last — its parser accepts any host, so it would otherwise claim every Bitbucket and self-hosted GitLab remote. Bitbucket Data Center is deliberately unsupported: it speaks REST 1.0, so those remotes are not claimed at all.
+Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbucket.org` only), then GitLab (host contains `gitlab`, or matches `glab config get host`), Codeberg, then GitHub. Local remote discovery additionally recognizes a non-GitHub host as Forgejo only when `tea logins list --output json` has a matching host. GitHub must stay last — its parser accepts any host, so it would otherwise claim every Bitbucket, Forgejo, and self-hosted GitLab remote. Bitbucket Data Center is deliberately unsupported: it speaks REST 1.0, so those remotes are not claimed at all.
 
 ### ForgeBackend trait
 
@@ -314,6 +313,8 @@ These are non-obvious things the implementation chain hit. Worth preserving for 
 15. **A diff file must be registered in the session before `r`, `R`, or a comment can land on it.** All three look the file up in `ReviewSession.files` by display path. The two review-mark toggles return silently when it is absent; `add_comment_to_session` returns `session does not contain file`. So any code path that assigns `self.diff_files` must also call `App::register_diff_files`. Narrowing the inline commit pane skipped this, so commit-only files could be neither marked nor commented on.
 
 16. **GNU Linux release binaries must stay dynamically linked.** Static glibc binaries can crash when hostname lookup loads a host NSS module (for example Fedora's `libnss_myhostname`). The musl artifacts are the supported static Linux builds. Direct updates must preserve the running binary's GNU/musl target environment when selecting an asset.
+
+17. **Forgejo and Codeberg require Tea discovery.** Match a configured Tea login by host instead of guessing from a hostname. Use Tea API endpoints for open PR pagination, metadata, file metadata, and the cumulative `.diff`. Review submission, commit selection, commit-range diffs, remote comments, and remote context expansion must fail closed with actionable errors until implemented.
 
 ### Keeping Docs Updated
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ src/
 │       └── mod.rs       # JjBackend: uses jj CLI, parses with diff_parser::GitStyle
 │
 ├── forge/               # Remote forge integration (GitHub, Forgejo/Codeberg, GitLab, Bitbucket)
-│   ├── mod.rs           # Detect and parse forge remotes; Forgejo discovery uses Tea logins
+│   ├── mod.rs           # Detect and parse forge remotes; Forgejo discovery uses fj auth
 │   ├── traits.rs        # ForgeBackend trait, ForgeRepository, PullRequestTarget,
 │   │                    # PullRequestDetails, PullRequestInfo, PrSessionKey,
 │   │                    # CreateReviewRequest, GhCreateReviewResponse, ForgeFileLinesRequest
@@ -60,9 +60,9 @@ src/
 │   ├── remote_comments.rs # RemoteReviewThread shape + visibility filter
 │   ├── submit.rs        # Submit pipeline: preflight mapping, resolver actions,
 │   │                    # InlineComment payload, build_review_body, SubmitEvent
-│   ├── github/          # GitHub and Forgejo-compatible backend via `gh` / `tea`
+│   ├── github/          # GitHub backend via `gh`, plus the Forgejo discovery/open/diff slice
 │   │   ├── mod.rs       # GitHubGhBackend: ForgeBackend impl
-│   │   ├── gh.rs        # GhCommandRunner: spawn `gh` or `tea`, parse output, error mapping
+│   │   ├── gh.rs        # GhCommandRunner: spawn `gh`, parse output, error mapping
 │   │   ├── models.rs    # JSON parsing for `gh` REST + GraphQL responses
 │   │   ├── pr_info.rs   # Extended `gh pr view --json` parsing for PR description panel
 │   │   ├── review_threads.rs # GraphQL query for existing review threads
@@ -228,9 +228,9 @@ Repository-managed agent integrations:
 
 ## Forge integration
 
-Forge review (`tuicr pr <target>`, `tuicr mr <target>`, or their explicit `tuicr tui` forms) is the only feature in `src/forge/`. GitHub operations shell out to `gh`; Forgejo and Codeberg operations shell out to `tea`; GitLab operations shell out to `glab`; Bitbucket Cloud operations shell out to `bkt`.
+Forge review (`tuicr pr <target>`, `tuicr mr <target>`, or their explicit `tuicr tui` forms) is the only feature in `src/forge/`. GitHub operations shell out to `gh`; Forgejo and Codeberg use Forgejo REST with credentials from `fj`; GitLab operations shell out to `glab`; Bitbucket Cloud operations shell out to `bkt`.
 
-Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbucket.org` only), then GitLab (host contains `gitlab`, or matches `glab config get host`), Codeberg, then GitHub. Local remote discovery additionally recognizes a non-GitHub host as Forgejo only when `tea logins list --output json` has a matching host. GitHub must stay last — its parser accepts any host, so it would otherwise claim every Bitbucket, Forgejo, and self-hosted GitLab remote. Bitbucket Data Center is deliberately unsupported: it speaks REST 1.0, so those remotes are not claimed at all.
+Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbucket.org` only), then GitLab (host contains `gitlab`, or matches `glab config get host`), Codeberg, then GitHub. Local remote discovery additionally recognizes a non-GitHub host as Forgejo only when the host is present in `fj`'s key store. GitHub must stay last — its parser accepts any host, so it would otherwise claim every Bitbucket, Forgejo, and self-hosted GitLab remote. Bitbucket Data Center is deliberately unsupported: it speaks REST 1.0, so those remotes are not claimed at all.
 
 ### ForgeBackend trait
 
@@ -314,7 +314,7 @@ These are non-obvious things the implementation chain hit. Worth preserving for 
 
 16. **GNU Linux release binaries must stay dynamically linked.** Static glibc binaries can crash when hostname lookup loads a host NSS module (for example Fedora's `libnss_myhostname`). The musl artifacts are the supported static Linux builds. Direct updates must preserve the running binary's GNU/musl target environment when selecting an asset.
 
-17. **Forgejo and Codeberg require Tea discovery.** Match a configured Tea login by host instead of guessing from a hostname. Use Tea API endpoints for open PR pagination, metadata, file metadata, and the cumulative `.diff`. Review submission, commit selection, commit-range diffs, remote comments, and remote context expansion must fail closed with actionable errors until implemented.
+17. **Forgejo and Codeberg require fj-backed identity.** Match a self-hosted Forgejo remote only when its host is present in `fj`'s key store instead of guessing from an arbitrary hostname. Use Forgejo REST for open PR pagination, metadata, and the cumulative `.diff`. Review submission, commit selection, commit-range diffs, remote comments, and remote context expansion must fail closed with actionable errors until implemented.
 
 ### Keeping Docs Updated
 

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ Requires `gh` authenticated to the repo.
 ### To Forgejo or Codeberg
 
 Open a pull request from a local clone or pass its URL to `tuicr pr`. Install and authenticate
-[`tea`](https://gitea.com/gitea/tea) for the Forgejo-compatible host, for example with
-`tea logins add`. tuicr loads open pull requests, metadata, and cumulative diffs through Tea.
+[`fj`](https://codeberg.org/forgejo-contrib/forgejo-cli) for the Forgejo host. tuicr loads open
+pull requests, metadata, and cumulative diffs through the Forgejo REST API.
 
 Forgejo and Codeberg review submission, commit selection, commit-range diffs, remote comments,
 and remote context expansion are not supported yet. Use `:clip` to export your review.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 - Review tracking at file or hunk granularity, persisted across sessions.
 - Three export targets: push a real review to GitHub, GitLab, or Bitbucket, copy structured
   markdown to your clipboard, or pipe to stdout.
-- Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR,
-  GitLab MR, or Bitbucket PR.
+- Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or GitHub,
+  Forgejo, Codeberg, GitLab, or Bitbucket pull requests.
 
 ## Install
 
@@ -79,9 +79,9 @@ tuicr                       # Pick from a commit selector
 tuicr tui                   # Same TUI, explicit subcommand
 tuicr -w                    # Uncommitted changes (skip selector)
 tuicr -r main..HEAD         # Commit range
-tuicr pr 125                # GitHub PR, or Bitbucket PR
+tuicr pr 125                # GitHub, Forgejo, Codeberg, or Bitbucket PR
 tuicr mr 125                # GitLab MR
-tuicr tui pr 125            # GitHub PR via explicit TUI subcommand
+tuicr tui pr 125            # PR via explicit TUI subcommand
 tuicr tui mr 125            # GitLab MR via explicit TUI subcommand
 tuicr --stdout              # Pipe the review to stdout
 tuicr review list           # List saved local review sessions
@@ -135,6 +135,15 @@ When you're done reviewing, send your comments wherever the work continues.
 `:submit` opens a picker for Comment, Approve, Request changes, or Draft. Inline comments land
 on the right lines as a real PR review. Review-level comments become the review summary.
 Requires `gh` authenticated to the repo.
+
+### To Forgejo or Codeberg
+
+Open a pull request from a local clone or pass its URL to `tuicr pr`. Install and authenticate
+[`tea`](https://gitea.com/gitea/tea) for the Forgejo-compatible host, for example with
+`tea logins add`. tuicr loads open pull requests, metadata, and cumulative diffs through Tea.
+
+Forgejo and Codeberg review submission, commit selection, commit-range diffs, remote comments,
+and remote context expansion are not supported yet. Use `:clip` to export your review.
 
 ### To GitLab
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -37,7 +37,7 @@ pub const UNSTAGED_SELECTION_ID: &str = "__tuicr_unstaged__";
 pub const GAP_EXPAND_BATCH: usize = 20;
 
 /// Create a forge backend for the given repository.
-/// Routes to GitHub (`gh`), Forgejo-compatible hosts (`tea`), GitLab (`glab`),
+/// Routes to GitHub (`gh`), Forgejo, GitLab (`glab`),
 /// Bitbucket Cloud (`bkt`), or Azure DevOps (`az`) based on `repo.kind`.
 fn create_forge_backend(
     repo: &ForgeRepository,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -37,9 +37,8 @@ pub const UNSTAGED_SELECTION_ID: &str = "__tuicr_unstaged__";
 pub const GAP_EXPAND_BATCH: usize = 20;
 
 /// Create a forge backend for the given repository.
-/// Routes to the GitHub backend (via `gh`), the GitLab backend (via `glab`),
-/// the Bitbucket Cloud backend (via `bkt`), or the Azure DevOps backend (via
-/// `az`) based on `repo.kind`.
+/// Routes to GitHub (`gh`), Forgejo-compatible hosts (`tea`), GitLab (`glab`),
+/// Bitbucket Cloud (`bkt`), or Azure DevOps (`az`) based on `repo.kind`.
 fn create_forge_backend(
     repo: &ForgeRepository,
     local_checkout: Option<PathBuf>,
@@ -48,7 +47,7 @@ fn create_forge_backend(
 ) -> Box<dyn ForgeBackend> {
     use crate::forge::traits::ForgeKind;
     match repo.kind {
-        ForgeKind::GitHub => {
+        ForgeKind::GitHub | ForgeKind::Forgejo => {
             use crate::forge::github::gh::GitHubGhBackend;
             Box::new(
                 GitHubGhBackend::new(Some(repo.clone()))

--- a/src/forge/canonical.rs
+++ b/src/forge/canonical.rs
@@ -99,7 +99,7 @@ mod tests {
     }
 
     impl GhCommandRunner for FakeRunner {
-        fn run(&self, args: &[String]) -> GhCommandResult<String> {
+        fn run_program(&self, _program: &str, args: &[String]) -> GhCommandResult<String> {
             self.calls.borrow_mut().push(args.to_vec());
             self.response
                 .borrow_mut()

--- a/src/forge/canonical.rs
+++ b/src/forge/canonical.rs
@@ -99,7 +99,7 @@ mod tests {
     }
 
     impl GhCommandRunner for FakeRunner {
-        fn run_program(&self, _program: &str, args: &[String]) -> GhCommandResult<String> {
+        fn run(&self, args: &[String]) -> GhCommandResult<String> {
             self.calls.borrow_mut().push(args.to_vec());
             self.response
                 .borrow_mut()

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -7,9 +7,9 @@ use crate::forge::remote_comments::{RemoteReviewSummary, RemoteReviewThread};
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestInfo,
-    PullRequestListQuery, PullRequestListScope, PullRequestTarget,
+    PullRequestListScope, PullRequestSummary, PullRequestTarget,
 };
-use crate::model::{DiffLine, FilePatch};
+use crate::model::{DiffLine, FilePatch, FileStatus};
 use crate::process::{
     CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
 };
@@ -54,6 +54,82 @@ const PR_INFO_JSON_FIELDS_WITHOUT_CHECKS_OR_COMMENTS: &str = concat!(
     "reviewDecision,mergeable,mergeStateStatus,reviewRequests,latestReviews"
 );
 
+#[derive(Debug, serde::Deserialize)]
+struct ForgejoUser {
+    login: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ForgejoBranch {
+    #[serde(default)]
+    r#ref: String,
+    #[serde(default)]
+    sha: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ForgejoPullRequest {
+    number: u64,
+    #[serde(default)]
+    title: String,
+    #[serde(default)]
+    state: String,
+    user: Option<ForgejoUser>,
+    #[serde(default, alias = "html_url")]
+    url: String,
+    head: ForgejoBranch,
+    base: ForgejoBranch,
+    #[serde(default)]
+    body: String,
+    #[serde(default, alias = "updated_at")]
+    updated: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    draft: bool,
+    #[serde(default)]
+    merged: bool,
+    #[serde(default)]
+    merged_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl ForgejoPullRequest {
+    /// Convert Forgejo's pull-request API response into Tuicr's neutral model.
+    fn into_summary(self, repository: &ForgeRepository) -> PullRequestSummary {
+        PullRequestSummary {
+            repository: repository.clone(),
+            number: self.number,
+            title: self.title,
+            author: self.user.map(|user| user.login),
+            head_ref_name: self.head.r#ref,
+            base_ref_name: self.base.r#ref,
+            updated_at: self.updated,
+            url: self.url,
+            state: self.state,
+            is_draft: self.draft,
+        }
+    }
+
+    fn into_details(self, repository: &ForgeRepository) -> PullRequestDetails {
+        PullRequestDetails {
+            repository: repository.clone(),
+            number: self.number,
+            title: self.title,
+            url: self.url,
+            state: self.state.clone(),
+            is_draft: self.draft,
+            author: self.user.map(|user| user.login),
+            head_ref_name: self.head.r#ref,
+            base_ref_name: self.base.r#ref,
+            head_sha: self.head.sha,
+            base_sha: self.base.sha,
+            body: self.body,
+            updated_at: self.updated,
+            closed: !self.state.eq_ignore_ascii_case("open") || self.merged,
+            merged_at: self.merged_at,
+            diff_start_sha: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GhCommandError {
     MissingGh,
@@ -63,7 +139,11 @@ pub enum GhCommandError {
 pub type GhCommandResult<T> = std::result::Result<T, GhCommandError>;
 
 pub trait GhCommandRunner {
-    fn run(&self, args: &[String]) -> GhCommandResult<String>;
+    fn run_program(&self, program: &str, args: &[String]) -> GhCommandResult<String>;
+
+    fn run(&self, args: &[String]) -> GhCommandResult<String> {
+        self.run_program("gh", args)
+    }
 
     /// Variant for `gh` invocations that take their payload on stdin (e.g.
     /// `gh api ... --input -`). The default panics; concrete runners that
@@ -77,9 +157,13 @@ pub trait GhCommandRunner {
 pub struct SystemGhRunner;
 
 impl GhCommandRunner for SystemGhRunner {
-    fn run(&self, args: &[String]) -> GhCommandResult<String> {
-        run_command_output("gh", None, args.iter().map(|arg| OsStr::new(arg.as_str())))
-            .map_err(GhCommandError::from)
+    fn run_program(&self, program: &str, args: &[String]) -> GhCommandResult<String> {
+        run_command_output(
+            program,
+            None,
+            args.iter().map(|arg| OsStr::new(arg.as_str())),
+        )
+        .map_err(GhCommandError::from)
     }
 
     fn run_with_stdin(&self, args: &[String], stdin: &str) -> GhCommandResult<String> {
@@ -146,6 +230,20 @@ fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<
     }
     let range = format!("{start_sha}..{end_sha}");
     run_git_diff(repo_root, &[range.as_str()]).ok()
+}
+
+/// Resolve a branch or ref in the local checkout. Forgejo's `tea` JSON exposes
+/// branch names but not always the PR head SHA, while tuicr sessions need a
+/// stable-ish head identifier for persistence.
+fn resolve_local_ref(repo_root: &Path, reference: &str) -> Option<String> {
+    run_command_output(
+        "git",
+        Some(repo_root),
+        ["rev-parse", reference].iter().map(|s| OsStr::new(*s)),
+    )
+    .ok()
+    .map(|output| output.trim().to_string())
+    .filter(|output| !output.is_empty())
 }
 
 #[derive(Debug, Clone)]
@@ -231,7 +329,6 @@ where
             .run(&args)
             .map_err(|err| map_gh_error(err, host))
     }
-
     fn pull_request_file_metadata(&self, pr: &PullRequestDetails) -> Result<Vec<FileMetadata>> {
         let mut metadata = Vec::new();
         for page in 1..=30 {
@@ -260,6 +357,12 @@ where
             "GitHub pull request exceeds the 3000-file REST API limit".into(),
         ))
     }
+
+    fn run_tea(&self, args: Vec<String>, host: &str) -> Result<String> {
+        self.runner
+            .run_program("tea", &args)
+            .map_err(|err| map_tea_error(err, host))
+    }
 }
 
 impl<R> ForgeBackend for GitHubGhBackend<R>
@@ -267,6 +370,10 @@ where
     R: GhCommandRunner,
 {
     fn list_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests> {
+        if query.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return self.list_forgejo_pull_requests(query);
+        }
+
         let page_size = query.page_size.max(1);
         let requested = query.already_loaded + page_size + 1;
         let mut args = vec![
@@ -309,6 +416,10 @@ where
 
     fn get_pull_request_info(&self, target: PullRequestTarget) -> Result<PullRequestInfo> {
         let repository = self.resolve_repository(&target)?;
+        if repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return self.get_forgejo_pull_request(&repository, target.number);
+        }
+
         let output = self.run_gh(
             vec![
                 "pr".to_string(),
@@ -331,6 +442,9 @@ where
     }
 
     fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
+        if pr.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return self.get_forgejo_pull_request_diff(pr);
+        }
         // We want the *cumulative* diff between base and head for the PR.
         // `gh pr diff --patch` returns mbox-style `git format-patch` output
         // — one patch per commit — so a 7-commit PR yields 7 separate
@@ -359,6 +473,12 @@ where
     }
 
     fn list_pull_request_commits(&self, pr: &PullRequestDetails) -> Result<Vec<PullRequestCommit>> {
+        if pr.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return Err(TuicrError::Forge(
+                "Forgejo commit selection is not supported yet; review the cumulative diff instead."
+                    .to_string(),
+            ));
+        }
         // GitHub paginates `pulls/<num>/commits` at 250 commits per page (max
         // per_page=100; PRs are capped at 250 commits via the API). Paginate
         // explicitly so multi-page PRs work; bound the loop defensively.
@@ -391,6 +511,12 @@ where
         start_sha: &str,
         end_sha: &str,
     ) -> Result<Vec<FilePatch>> {
+        if pr.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return Err(TuicrError::Forge(
+                "Forgejo commit-range diffs are not supported yet; review the cumulative diff instead."
+                    .to_string(),
+            ));
+        }
         // Fast path: when both SHAs live in the local checkout, `git diff`
         // gives us the cumulative diff in O(local-IO) without round-tripping
         // through GitHub. The PR diff text is the source of truth, but the
@@ -437,6 +563,10 @@ where
     }
 
     fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>> {
+        if pr.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return Ok(Vec::new());
+        }
+
         let mut all: Vec<RemoteReviewThread> = Vec::new();
         let mut cursor: Option<String> = None;
         // Bound the pagination loop so a buggy/cyclic server can't hang us.
@@ -461,6 +591,10 @@ where
     }
 
     fn list_review_summaries(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewSummary>> {
+        if pr.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return Ok(Vec::new());
+        }
+
         let mut all: Vec<RemoteReviewSummary> = Vec::new();
         let mut cursor: Option<String> = None;
         for _ in 0..100 {
@@ -511,6 +645,11 @@ where
     }
 
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
+        if request.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return Err(TuicrError::Forge(
+                "Forgejo remote context expansion is not supported yet.".to_string(),
+            ));
+        }
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
         }
@@ -554,6 +693,12 @@ where
         pr: &PullRequestDetails,
         request: CreateReviewRequest<'_>,
     ) -> Result<GhCreateReviewResponse> {
+        if pr.repository.kind == crate::forge::traits::ForgeKind::Forgejo {
+            return Err(TuicrError::Forge(
+                "Forgejo review submission is not supported yet; use :clip to export the review."
+                    .to_string(),
+            ));
+        }
         let payload = build_review_payload(
             request.commit_id,
             request.body,
@@ -592,6 +737,74 @@ impl<R> GitHubGhBackend<R>
 where
     R: GhCommandRunner,
 {
+    fn list_forgejo_pull_requests(&self, query: PullRequestListQuery) -> Result<PagedPullRequests> {
+        let page_size = query.page_size.max(1);
+        let limit = page_size + 1;
+        let page = (query.already_loaded / page_size) + 1;
+        let output = self.run_tea(
+            vec![
+                "api".to_string(),
+                "--repo".to_string(),
+                query.repository.slug(),
+                format!("/repos/{{owner}}/{{repo}}/pulls?state=open&page={page}&limit={limit}"),
+            ],
+            &query.repository.host,
+        )?;
+        let rows: Vec<ForgejoPullRequest> = serde_json::from_str(&output)?;
+        let has_more = rows.len() > page_size;
+        let pull_requests = rows
+            .into_iter()
+            .take(page_size)
+            .map(|row| row.into_summary(&query.repository))
+            .collect::<Vec<_>>();
+        let total_loaded = query.already_loaded + pull_requests.len();
+
+        Ok(PagedPullRequests {
+            pull_requests,
+            has_more,
+            total_loaded,
+        })
+    }
+
+    fn get_forgejo_pull_request(
+        &self,
+        repository: &ForgeRepository,
+        number: u64,
+    ) -> Result<PullRequestDetails> {
+        let output = self.run_tea(
+            vec![
+                "api".to_string(),
+                "--repo".to_string(),
+                repository.slug(),
+                format!("/repos/{{owner}}/{{repo}}/pulls/{number}"),
+            ],
+            &repository.host,
+        )?;
+        let pr: ForgejoPullRequest = serde_json::from_str(&output)?;
+        if pr.head.sha.is_empty() || pr.base.sha.is_empty() {
+            return Err(TuicrError::Forge(format!(
+                "Forgejo pull request #{number} did not include immutable head and base SHAs"
+            )));
+        }
+
+        Ok(pr.into_details(repository))
+    }
+
+    fn get_forgejo_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
+        let patch = self.run_tea(
+            vec![
+                "api".to_string(),
+                "--header".to_string(),
+                "Accept: application/vnd.github.diff".to_string(),
+                "--repo".to_string(),
+                pr.repository.slug(),
+                format!("/repos/{{owner}}/{{repo}}/pulls/{}.diff", pr.number),
+            ],
+            &pr.repository.host,
+        )?;
+        forgejo_patch_files(&patch)
+    }
+
     fn build_review_threads_args(
         &self,
         pr: &PullRequestDetails,
@@ -675,6 +888,48 @@ where
     }
 }
 
+fn forgejo_patch_files(patch: &str) -> Result<Vec<FilePatch>> {
+    let starts = patch
+        .match_indices("diff --git ")
+        .map(|(offset, _)| offset)
+        .collect::<Vec<_>>();
+
+    starts
+        .iter()
+        .enumerate()
+        .map(|(index, start)| {
+            let end = starts.get(index + 1).copied().unwrap_or(patch.len());
+            let block = &patch[*start..end];
+            let header = block.lines().next().unwrap_or_default();
+            let (old_path, new_path) = header
+                .strip_prefix("diff --git a/")
+                .and_then(|paths| paths.split_once(" b/"))
+                .ok_or_else(|| {
+                    TuicrError::Forge(format!("Forgejo returned an invalid diff header: `{header}`"))
+                })?;
+            let status = if block.contains("\nnew file mode ") {
+                FileStatus::Added
+            } else if block.contains("\ndeleted file mode ") {
+                FileStatus::Deleted
+            } else if block.contains("\nrename from ") {
+                FileStatus::Renamed
+            } else if block.contains("\ncopy from ") {
+                FileStatus::Copied
+            } else {
+                FileStatus::Modified
+            };
+            let (old_path, new_path) = match status {
+                FileStatus::Added => (None, Some(PathBuf::from(new_path))),
+                FileStatus::Deleted => (Some(PathBuf::from(old_path)), None),
+                _ => (Some(PathBuf::from(old_path)), Some(PathBuf::from(new_path))),
+            };
+            let mut file = FilePatch::new(old_path, new_path, status, block.to_string());
+            file.is_binary = block.contains("GIT binary patch") || block.contains("Binary files ");
+            Ok(file)
+        })
+        .collect()
+}
+
 pub fn parse_pull_request_target(input: &str) -> Result<PullRequestTarget> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
@@ -714,6 +969,17 @@ pub fn parse_github_remote_url(remote_url: &str) -> Option<ForgeRepository> {
     repository_from_path(strip_port(host), path)
 }
 
+/// Parse a Git remote into a Forgejo repository after `tea` has confirmed the
+/// remote belongs to its configured Forgejo/Gitea instance.
+pub fn parse_forgejo_remote_url(remote_url: &str) -> Option<ForgeRepository> {
+    let repository = parse_github_remote_url(remote_url)?;
+    Some(ForgeRepository::forgejo(
+        repository.host,
+        repository.owner,
+        repository.name,
+    ))
+}
+
 fn parse_numeric_target(target: &str) -> Option<PullRequestTarget> {
     if !target.chars().all(|ch| ch.is_ascii_digit()) {
         return None;
@@ -747,6 +1013,12 @@ fn parse_url_target(target: &str) -> Option<PullRequestTarget> {
         (
             parts.next()?.parse::<u64>().ok()?,
             ForgeRepository::gitlab(host, owner, strip_git_suffix(repo)),
+        )
+    } else if segment == "pulls" {
+        // Forgejo/Gitea: /<owner>/<repo>/pulls/<n>
+        (
+            parts.next()?.parse::<u64>().ok()?,
+            ForgeRepository::forgejo(host, owner, strip_git_suffix(repo)),
         )
     } else {
         return None;
@@ -951,6 +1223,22 @@ fn map_gh_error(error: GhCommandError, host: &str) -> TuicrError {
     }
 }
 
+fn map_tea_error(error: GhCommandError, host: &str) -> TuicrError {
+    match error {
+        GhCommandError::MissingGh => TuicrError::Forge(
+            "`tea` CLI not found. Install tea and authenticate it for Forgejo PR review."
+                .to_string(),
+        ),
+        GhCommandError::Failed { status, stderr } => TuicrError::Forge(format!(
+            "tea command failed{} for Forgejo host {host}: {}",
+            status
+                .map(|code| format!(" with exit status {code}"))
+                .unwrap_or_default(),
+            stderr.trim()
+        )),
+    }
+}
+
 fn looks_like_auth_failure(stderr: &str) -> bool {
     let lower = stderr.to_ascii_lowercase();
     lower.contains("gh auth login")
@@ -1133,8 +1421,30 @@ index 1111111..2222222 100644
     }
 
     impl GhCommandRunner for FakeGhRunner {
-        fn run(&self, args: &[String]) -> GhCommandResult<String> {
-            self.calls.borrow_mut().push(args.to_vec());
+        fn run_program(&self, program: &str, args: &[String]) -> GhCommandResult<String> {
+            if program == "tea" {
+                let mut recorded = vec![program.to_string()];
+                recorded.extend(args.iter().cloned());
+                self.calls.borrow_mut().push(recorded);
+            } else {
+                self.calls.borrow_mut().push(args.to_vec());
+            }
+            if program == "tea" {
+                if args.iter().any(|arg| arg.ends_with(".diff")) {
+                    return Ok(PR_PATCH.to_string());
+                }
+                if args.iter().any(|arg| arg.contains("/pulls?")) {
+                    return Ok(FORGEJO_PR_LIST_JSON.to_string());
+                }
+                if args.iter().any(|arg| arg.contains("/pulls/")) {
+                    return Ok(FORGEJO_PR_DETAILS_JSON.to_string());
+                }
+                return Err(GhCommandError::Failed {
+                    status: Some(1),
+                    stderr: "unexpected tea API request".to_string(),
+                });
+            }
+
             match args.first().map(String::as_str) {
                 // gh pr list/view/diff — second arg is the subcommand.
                 Some("pr") => match args.get(1).map(String::as_str) {
@@ -1255,6 +1565,38 @@ index 1111111..2222222 100644
 +    42
  }
 "##;
+
+    const FORGEJO_PR_LIST_JSON: &str = r##"[
+        {
+            "number": 42,
+            "title": "Improve Forgejo support",
+            "state": "open",
+            "user": { "login": "reviewer" },
+            "html_url": "https://code.example.test/team/service/pulls/42",
+            "head": { "ref": "feature/forgejo", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+            "base": { "ref": "main", "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+            "body": "Add Forgejo pull request support.",
+            "updated_at": "2026-06-22T21:51:00Z",
+            "draft": false,
+            "merged": false,
+            "merged_at": null
+        }
+    ]"##;
+
+    const FORGEJO_PR_DETAILS_JSON: &str = r##"{
+        "number": 42,
+        "title": "Improve Forgejo support",
+        "state": "open",
+        "user": { "login": "reviewer" },
+        "html_url": "https://code.example.test/team/service/pulls/42",
+        "head": { "ref": "feature/forgejo", "sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+        "base": { "ref": "main", "sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" },
+        "body": "Add Forgejo pull request support.",
+        "updated_at": "2026-06-22T21:51:00Z",
+        "draft": false,
+        "merged": false,
+        "merged_at": null
+    }"##;
 
     const REVIEW_THREADS_JSON: &str = r##"{
         "data": {
@@ -1846,6 +2188,66 @@ Match host github-work
             !diff_call.iter().any(|a| a == "--patch"),
             "`gh pr diff` must NOT pass --patch (mbox output duplicates files); got {diff_call:?}"
         );
+    }
+
+    #[test]
+    fn forgejo_pull_request_list_uses_tea_json() {
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(None, runner);
+        let repository = ForgeRepository::forgejo("code.example.test", "team", "service");
+        let result = backend
+            .list_pull_requests(PullRequestListQuery::first_page(repository, 1))
+            .unwrap();
+
+        assert_eq!(result.pull_requests.len(), 1);
+        assert_eq!(result.pull_requests[0].number, 42);
+        assert_eq!(result.pull_requests[0].author.as_deref(), Some("reviewer"));
+
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(calls[0][0], "tea");
+        assert_eq!(calls[0][1], "api");
+        assert!(
+            calls[0]
+                .iter()
+                .any(|arg| arg == "/repos/{owner}/{repo}/pulls?state=open&page=1&limit=2")
+        );
+    }
+
+    #[test]
+    fn forgejo_pull_request_details_and_diff_use_tea() {
+        let runner = FakeGhRunner::default();
+        let repository = ForgeRepository::forgejo("code.example.test", "team", "service");
+        let backend = GitHubGhBackend::with_runner(Some(repository.clone()), runner);
+        let details = backend
+            .get_pull_request(PullRequestTarget::number(42, "42"))
+            .unwrap();
+
+        assert_eq!(details.number, 42);
+        assert_eq!(details.body, "Add Forgejo pull request support.");
+        assert_eq!(details.head_sha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        let patch = backend.get_pull_request_diff(&details).unwrap();
+        assert_eq!(patch, PR_PATCH);
+
+        let calls = backend.runner.calls.borrow();
+        assert!(calls.iter().any(|args| {
+            args.first().map(String::as_str) == Some("tea")
+                && args.get(1).map(String::as_str) == Some("api")
+                && args.iter().any(|arg| arg.ends_with("/pulls/42.diff"))
+        }));
+    }
+
+    #[test]
+    fn forgejo_review_threads_are_empty_without_graphql() {
+        let runner = FakeGhRunner::default();
+        let repository = ForgeRepository::forgejo("code.example.test", "team", "service");
+        let backend = GitHubGhBackend::with_runner(Some(repository), runner);
+        let details = backend
+            .get_pull_request(PullRequestTarget::number(42, "42"))
+            .unwrap();
+
+        assert!(backend.list_review_threads(&details).unwrap().is_empty());
+        assert!(backend.list_review_summaries(&details).unwrap().is_empty());
     }
 
     #[test]

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -139,11 +139,7 @@ pub enum GhCommandError {
 pub type GhCommandResult<T> = std::result::Result<T, GhCommandError>;
 
 pub trait GhCommandRunner {
-    fn run_program(&self, program: &str, args: &[String]) -> GhCommandResult<String>;
-
-    fn run(&self, args: &[String]) -> GhCommandResult<String> {
-        self.run_program("gh", args)
-    }
+    fn run(&self, args: &[String]) -> GhCommandResult<String>;
 
     /// Variant for `gh` invocations that take their payload on stdin (e.g.
     /// `gh api ... --input -`). The default panics; concrete runners that
@@ -157,13 +153,9 @@ pub trait GhCommandRunner {
 pub struct SystemGhRunner;
 
 impl GhCommandRunner for SystemGhRunner {
-    fn run_program(&self, program: &str, args: &[String]) -> GhCommandResult<String> {
-        run_command_output(
-            program,
-            None,
-            args.iter().map(|arg| OsStr::new(arg.as_str())),
-        )
-        .map_err(GhCommandError::from)
+    fn run(&self, args: &[String]) -> GhCommandResult<String> {
+        run_command_output("gh", None, args.iter().map(|arg| OsStr::new(arg.as_str())))
+            .map_err(GhCommandError::from)
     }
 
     fn run_with_stdin(&self, args: &[String], stdin: &str) -> GhCommandResult<String> {
@@ -232,8 +224,8 @@ fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<
     run_git_diff(repo_root, &[range.as_str()]).ok()
 }
 
-/// Resolve a branch or ref in the local checkout. Forgejo's `tea` JSON exposes
-/// branch names but not always the PR head SHA, while tuicr sessions need a
+/// Resolve a branch or ref in the local checkout. Forgejo API responses can
+/// expose branch names without the PR head SHA, while tuicr sessions need a
 /// stable-ish head identifier for persistence.
 fn resolve_local_ref(repo_root: &Path, reference: &str) -> Option<String> {
     run_command_output(
@@ -358,10 +350,8 @@ where
         ))
     }
 
-    fn run_tea(&self, args: Vec<String>, host: &str) -> Result<String> {
-        self.runner
-            .run_program("tea", &args)
-            .map_err(|err| map_tea_error(err, host))
+    fn run_forgejo_api(&self, repository: &ForgeRepository, endpoint: &str) -> Result<String> {
+        forgejo_api_get(repository, endpoint)
     }
 }
 
@@ -743,14 +733,12 @@ where
         let page_size = query.page_size.max(1);
         let limit = page_size + 1;
         let page = (query.already_loaded / page_size) + 1;
-        let output = self.run_tea(
-            vec![
-                "api".to_string(),
-                "--repo".to_string(),
-                query.repository.slug(),
-                format!("/repos/{{owner}}/{{repo}}/pulls?state=open&page={page}&limit={limit}"),
-            ],
-            &query.repository.host,
+        let output = self.run_forgejo_api(
+            &query.repository,
+            &format!(
+                "/repos/{}/{}/pulls?state=open&page={page}&limit={limit}",
+                query.repository.owner, query.repository.name
+            ),
         )?;
         let rows: Vec<ForgejoPullRequest> = serde_json::from_str(&output)?;
         let has_more = rows.len() > page_size;
@@ -773,14 +761,12 @@ where
         repository: &ForgeRepository,
         number: u64,
     ) -> Result<PullRequestDetails> {
-        let output = self.run_tea(
-            vec![
-                "api".to_string(),
-                "--repo".to_string(),
-                repository.slug(),
-                format!("/repos/{{owner}}/{{repo}}/pulls/{number}"),
-            ],
-            &repository.host,
+        let output = self.run_forgejo_api(
+            repository,
+            &format!(
+                "/repos/{}/{}/pulls/{number}",
+                repository.owner, repository.name
+            ),
         )?;
         let pr: ForgejoPullRequest = serde_json::from_str(&output)?;
         if pr.head.sha.is_empty() || pr.base.sha.is_empty() {
@@ -793,16 +779,12 @@ where
     }
 
     fn get_forgejo_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
-        let patch = self.run_tea(
-            vec![
-                "api".to_string(),
-                "--header".to_string(),
-                "Accept: application/vnd.github.diff".to_string(),
-                "--repo".to_string(),
-                pr.repository.slug(),
-                format!("/repos/{{owner}}/{{repo}}/pulls/{}.diff", pr.number),
-            ],
-            &pr.repository.host,
+        let patch = self.run_forgejo_api(
+            &pr.repository,
+            &format!(
+                "/repos/{}/{}/pulls/{}.diff",
+                pr.repository.owner, pr.repository.name, pr.number
+            ),
         )?;
         forgejo_patch_files(&patch)
     }
@@ -973,8 +955,8 @@ pub fn parse_github_remote_url(remote_url: &str) -> Option<ForgeRepository> {
     repository_from_path(strip_port(host), path)
 }
 
-/// Parse a Git remote into a Forgejo repository after `tea` has confirmed the
-/// remote belongs to its configured Forgejo/Gitea instance.
+/// Parse a Git remote into a Forgejo repository after the caller has decided
+/// the host should be treated as Forgejo.
 pub fn parse_forgejo_remote_url(remote_url: &str) -> Option<ForgeRepository> {
     let repository = parse_github_remote_url(remote_url)?;
     Some(ForgeRepository::forgejo(
@@ -1019,7 +1001,7 @@ fn parse_url_target(target: &str) -> Option<PullRequestTarget> {
             ForgeRepository::gitlab(host, owner, strip_git_suffix(repo)),
         )
     } else if segment == "pulls" {
-        // Forgejo/Gitea: /<owner>/<repo>/pulls/<n>
+        // Forgejo: /<owner>/<repo>/pulls/<n>
         (
             parts.next()?.parse::<u64>().ok()?,
             ForgeRepository::forgejo(host, owner, strip_git_suffix(repo)),
@@ -1227,19 +1209,70 @@ fn map_gh_error(error: GhCommandError, host: &str) -> TuicrError {
     }
 }
 
-fn map_tea_error(error: GhCommandError, host: &str) -> TuicrError {
-    match error {
-        GhCommandError::MissingGh => TuicrError::Forge(
-            "`tea` CLI not found. Install tea and authenticate it for Forgejo PR review."
-                .to_string(),
-        ),
-        GhCommandError::Failed { status, stderr } => TuicrError::Forge(format!(
-            "tea command failed{} for Forgejo host {host}: {}",
-            status
-                .map(|code| format!(" with exit status {code}"))
-                .unwrap_or_default(),
-            stderr.trim()
-        )),
+fn forgejo_api_get(repository: &ForgeRepository, endpoint: &str) -> Result<String> {
+    let url = format!("https://{}/api/v1{}", repository.host, endpoint);
+    let agent: ureq::Agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(30)))
+        .http_status_as_error(false)
+        .build()
+        .into();
+
+    let mut request = agent.get(&url);
+    if endpoint.ends_with(".diff") {
+        request = request.header("Accept", "application/vnd.github.diff");
+    }
+    if let Some(token) = fj_token_for_host(&repository.host) {
+        request = request.header("Authorization", &format!("token {token}"));
+    }
+
+    let response = request.call().map_err(|err| {
+        TuicrError::Forge(format!(
+            "Forgejo request failed for host {}: {err}",
+            repository.host
+        ))
+    })?;
+    let status = response.status().as_u16();
+    let body = response.into_body().read_to_string().map_err(|err| {
+        TuicrError::Forge(format!(
+            "Forgejo response from host {} could not be read: {err}",
+            repository.host
+        ))
+    })?;
+
+    if (200..300).contains(&status) {
+        Ok(body)
+    } else if status == 401 || status == 403 {
+        Err(TuicrError::Forge(format!(
+            "Forgejo authentication failed for host {}. Run `fj auth login` or `fj auth add-token`, then try again.",
+            repository.host
+        )))
+    } else {
+        Err(TuicrError::Forge(format!(
+            "Forgejo request failed for host {} with HTTP {status}: {}",
+            repository.host,
+            body.trim()
+        )))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct FjKeys {
+    hosts: std::collections::BTreeMap<String, FjLoginInfo>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(tag = "type")]
+enum FjLoginInfo {
+    Application { token: String },
+    OAuth { token: String },
+}
+
+fn fj_token_for_host(host: &str) -> Option<String> {
+    let dirs = directories::ProjectDirs::from("", "forgejo-cli", "forgejo-cli")?;
+    let content = std::fs::read_to_string(dirs.data_dir().join("keys.json")).ok()?;
+    let keys: FjKeys = serde_json::from_str(&content).ok()?;
+    match keys.hosts.get(host)? {
+        FjLoginInfo::Application { token } | FjLoginInfo::OAuth { token } => Some(token.clone()),
     }
 }
 
@@ -1425,30 +1458,8 @@ index 1111111..2222222 100644
     }
 
     impl GhCommandRunner for FakeGhRunner {
-        fn run_program(&self, program: &str, args: &[String]) -> GhCommandResult<String> {
-            if program == "tea" {
-                let mut recorded = vec![program.to_string()];
-                recorded.extend(args.iter().cloned());
-                self.calls.borrow_mut().push(recorded);
-            } else {
-                self.calls.borrow_mut().push(args.to_vec());
-            }
-            if program == "tea" {
-                if args.iter().any(|arg| arg.ends_with(".diff")) {
-                    return Ok(PR_PATCH.to_string());
-                }
-                if args.iter().any(|arg| arg.contains("/pulls?")) {
-                    return Ok(FORGEJO_PR_LIST_JSON.to_string());
-                }
-                if args.iter().any(|arg| arg.contains("/pulls/")) {
-                    return Ok(FORGEJO_PR_DETAILS_JSON.to_string());
-                }
-                return Err(GhCommandError::Failed {
-                    status: Some(1),
-                    stderr: "unexpected tea API request".to_string(),
-                });
-            }
-
+        fn run(&self, args: &[String]) -> GhCommandResult<String> {
+            self.calls.borrow_mut().push(args.to_vec());
             match args.first().map(String::as_str) {
                 // gh pr list/view/diff — second arg is the subcommand.
                 Some("pr") => match args.get(1).map(String::as_str) {
@@ -2192,67 +2203,6 @@ Match host github-work
             !diff_call.iter().any(|a| a == "--patch"),
             "`gh pr diff` must NOT pass --patch (mbox output duplicates files); got {diff_call:?}"
         );
-    }
-
-    #[test]
-    fn forgejo_pull_request_list_uses_tea_json() {
-        let runner = FakeGhRunner::default();
-        let backend = GitHubGhBackend::with_runner(None, runner);
-        let repository = ForgeRepository::forgejo("code.example.test", "team", "service");
-        let result = backend
-            .list_pull_requests(PullRequestListQuery::first_page(repository, 1))
-            .unwrap();
-
-        assert_eq!(result.pull_requests.len(), 1);
-        assert_eq!(result.pull_requests[0].number, 42);
-        assert_eq!(result.pull_requests[0].author.as_deref(), Some("reviewer"));
-
-        let calls = backend.runner.calls.borrow();
-        assert_eq!(calls[0][0], "tea");
-        assert_eq!(calls[0][1], "api");
-        assert!(
-            calls[0]
-                .iter()
-                .any(|arg| arg == "/repos/{owner}/{repo}/pulls?state=open&page=1&limit=2")
-        );
-    }
-
-    #[test]
-    fn forgejo_pull_request_details_and_diff_use_tea() {
-        let runner = FakeGhRunner::default();
-        let repository = ForgeRepository::forgejo("code.example.test", "team", "service");
-        let backend = GitHubGhBackend::with_runner(Some(repository.clone()), runner);
-        let details = backend
-            .get_pull_request(PullRequestTarget::number(42, "42"))
-            .unwrap();
-
-        assert_eq!(details.number, 42);
-        assert_eq!(details.body, "Add Forgejo pull request support.");
-        assert_eq!(details.head_sha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
-        let patch = backend.get_pull_request_diff(&details).unwrap();
-        assert_eq!(patch.len(), 1);
-        assert_eq!(patch[0].patch, PR_PATCH.trim_start());
-
-        let calls = backend.runner.calls.borrow();
-        assert!(calls.iter().any(|args| {
-            args.first().map(String::as_str) == Some("tea")
-                && args.get(1).map(String::as_str) == Some("api")
-                && args.iter().any(|arg| arg.ends_with("/pulls/42.diff"))
-        }));
-    }
-
-    #[test]
-    fn forgejo_review_threads_are_empty_without_graphql() {
-        let runner = FakeGhRunner::default();
-        let repository = ForgeRepository::forgejo("code.example.test", "team", "service");
-        let backend = GitHubGhBackend::with_runner(Some(repository), runner);
-        let details = backend
-            .get_pull_request(PullRequestTarget::number(42, "42"))
-            .unwrap();
-
-        assert!(backend.list_review_threads(&details).unwrap().is_empty());
-        assert!(backend.list_review_summaries(&details).unwrap().is_empty());
     }
 
     #[test]

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -7,7 +7,7 @@ use crate::forge::remote_comments::{RemoteReviewSummary, RemoteReviewThread};
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestInfo,
-    PullRequestListScope, PullRequestSummary, PullRequestTarget,
+    PullRequestListQuery, PullRequestListScope, PullRequestSummary, PullRequestTarget,
 };
 use crate::model::{DiffLine, FilePatch, FileStatus};
 use crate::process::{
@@ -417,7 +417,9 @@ where
     fn get_pull_request_info(&self, target: PullRequestTarget) -> Result<PullRequestInfo> {
         let repository = self.resolve_repository(&target)?;
         if repository.kind == crate::forge::traits::ForgeKind::Forgejo {
-            return self.get_forgejo_pull_request(&repository, target.number);
+            return self
+                .get_forgejo_pull_request(&repository, target.number)
+                .map(PullRequestInfo::from_details);
         }
 
         let output = self.run_gh(
@@ -905,7 +907,9 @@ fn forgejo_patch_files(patch: &str) -> Result<Vec<FilePatch>> {
                 .strip_prefix("diff --git a/")
                 .and_then(|paths| paths.split_once(" b/"))
                 .ok_or_else(|| {
-                    TuicrError::Forge(format!("Forgejo returned an invalid diff header: `{header}`"))
+                    TuicrError::Forge(format!(
+                        "Forgejo returned an invalid diff header: `{header}`"
+                    ))
                 })?;
             let status = if block.contains("\nnew file mode ") {
                 FileStatus::Added
@@ -2227,7 +2231,8 @@ Match host github-work
         assert_eq!(details.head_sha, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
         let patch = backend.get_pull_request_diff(&details).unwrap();
-        assert_eq!(patch, PR_PATCH);
+        assert_eq!(patch.len(), 1);
+        assert_eq!(patch[0].patch, PR_PATCH.trim_start());
 
         let calls = backend.runner.calls.borrow();
         assert!(calls.iter().any(|args| {

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -178,7 +178,8 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
         }
     }
     for (name, url) in named_remote_urls(repo_root) {
-        if tea_recognizes_remote(repo_root, &name)
+        if parse_github_remote_url(&url).is_some_and(|repository| repository.host != "github.com")
+            && tea_recognizes_remote(repo_root, &name)
             && let Some(repository) = parse_forgejo_remote_url(&url)
         {
             return Some(repository);
@@ -192,7 +193,8 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
 pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Option<PathBuf> {
     if target_repo.kind == crate::forge::traits::ForgeKind::Forgejo
         && named_remote_urls(root).iter().any(|(name, url)| {
-            tea_recognizes_remote(root, name)
+            parse_github_remote_url(url).is_some_and(|repository| repository.host != "github.com")
+                && tea_recognizes_remote(root, name)
                 && parse_forgejo_remote_url(url).as_ref() == Some(target_repo)
         })
     {
@@ -202,6 +204,14 @@ pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Op
         .iter()
         .any(|url| parse_any_remote_url(url).as_ref() == Some(target_repo))
         .then(|| root.to_path_buf())
+}
+
+fn tea_recognizes_remote(repo_root: &Path, remote: &str) -> bool {
+    Command::new("tea")
+        .current_dir(repo_root)
+        .args(["api", "--remote", remote, "/version"])
+        .output()
+        .is_ok_and(|output| output.status.success())
 }
 
 #[cfg(test)]
@@ -284,12 +294,4 @@ mod tests {
             Some(dir.path().to_path_buf())
         );
     }
-}
-
-fn tea_recognizes_remote(repo_root: &Path, remote: &str) -> bool {
-    Command::new("tea")
-        .current_dir(repo_root)
-        .args(["api", "--remote", remote, "/version"])
-        .output()
-        .is_ok_and(|output| output.status.success())
 }

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -18,7 +18,6 @@ pub mod submit;
 pub mod traits;
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use git2::Repository;
 
@@ -177,10 +176,10 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
             return Some(repository);
         }
     }
-    for (name, url) in named_remote_urls(repo_root) {
+    for (_, url) in named_remote_urls(repo_root) {
         if parse_github_remote_url(&url).is_some_and(|repository| repository.host != "github.com")
-            && tea_recognizes_remote(repo_root, &name)
             && let Some(repository) = parse_forgejo_remote_url(&url)
+            && fj_has_login_for_host(&repository.host)
         {
             return Some(repository);
         }
@@ -192,10 +191,10 @@ pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
 /// necessarily `origin` — matches `target_repo`.
 pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Option<PathBuf> {
     if target_repo.kind == crate::forge::traits::ForgeKind::Forgejo
-        && named_remote_urls(root).iter().any(|(name, url)| {
+        && named_remote_urls(root).iter().any(|(_, url)| {
             parse_github_remote_url(url).is_some_and(|repository| repository.host != "github.com")
-                && tea_recognizes_remote(root, name)
                 && parse_forgejo_remote_url(url).as_ref() == Some(target_repo)
+                && fj_has_login_for_host(&target_repo.host)
         })
     {
         return Some(root.to_path_buf());
@@ -206,12 +205,19 @@ pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Op
         .then(|| root.to_path_buf())
 }
 
-fn tea_recognizes_remote(repo_root: &Path, remote: &str) -> bool {
-    Command::new("tea")
-        .current_dir(repo_root)
-        .args(["api", "--remote", remote, "/version"])
-        .output()
-        .is_ok_and(|output| output.status.success())
+fn fj_has_login_for_host(host: &str) -> bool {
+    fj_keys().is_some_and(|keys| keys.hosts.contains_key(host))
+}
+
+#[derive(serde::Deserialize)]
+struct FjKeys {
+    hosts: std::collections::BTreeMap<String, serde_json::Value>,
+}
+
+fn fj_keys() -> Option<FjKeys> {
+    let dirs = directories::ProjectDirs::from("", "forgejo-cli", "forgejo-cli")?;
+    let content = std::fs::read_to_string(dirs.data_dir().join("keys.json")).ok()?;
+    serde_json::from_str(&content).ok()
 }
 
 #[cfg(test)]

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -18,12 +18,13 @@ pub mod submit;
 pub mod traits;
 
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use git2::Repository;
 
 use crate::forge::azure::az::parse_azure_remote_url;
 use crate::forge::bitbucket::bkt::parse_bitbucket_remote_url;
-use crate::forge::github::gh::parse_github_remote_url;
+use crate::forge::github::gh::{parse_forgejo_remote_url, parse_github_remote_url};
 use crate::forge::gitlab::glab::parse_gitlab_remote_url;
 use crate::forge::traits::ForgeRepository;
 
@@ -99,6 +100,28 @@ fn remote_urls(repo_root: &Path) -> Vec<String> {
     all_urls
 }
 
+fn named_remote_urls(repo_root: &Path) -> Vec<(String, String)> {
+    let Ok(repo) = Repository::discover(repo_root) else {
+        return Vec::new();
+    };
+    let mut remotes = Vec::new();
+    if let Ok(remote) = repo.find_remote("origin")
+        && let Some(url) = remote.url()
+    {
+        remotes.push(("origin".to_string(), url.to_string()));
+    }
+    if let Ok(names) = repo.remotes() {
+        for name in names.iter().flatten() {
+            if let Ok(remote) = repo.find_remote(name)
+                && let Some(url) = remote.url()
+            {
+                remotes.push((name.to_string(), url.to_string()));
+            }
+        }
+    }
+    remotes
+}
+
 /// Try to detect an Azure DevOps forge repository for the local checkout at
 /// `repo_root`. Looks at `origin` first, then any remote whose URL parses as an
 /// Azure DevOps host. Returns `None` when no Azure remote is configured.
@@ -145,14 +168,36 @@ pub fn parse_any_remote_url_by_hostname(url: &str) -> Option<ForgeRepository> {
 /// Detect the forge repository for the local checkout at `repo_root`.
 /// Returns `None` when no remote can be parsed.
 pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
-    remote_urls(repo_root)
-        .iter()
-        .find_map(|url| parse_any_remote_url(url))
+    let urls = remote_urls(repo_root);
+    for url in &urls {
+        if let Some(repository) = parse_bitbucket_remote_url(url)
+            .or_else(|| parse_gitlab_remote_url(url))
+            .or_else(|| parse_azure_remote_url(url))
+        {
+            return Some(repository);
+        }
+    }
+    for (name, url) in named_remote_urls(repo_root) {
+        if tea_recognizes_remote(repo_root, &name)
+            && let Some(repository) = parse_forgejo_remote_url(&url)
+        {
+            return Some(repository);
+        }
+    }
+    urls.iter().find_map(|url| parse_github_remote_url(url))
 }
 
 /// `root`'s local checkout, but only when one of its remotes — not
 /// necessarily `origin` — matches `target_repo`.
 pub fn local_checkout_for_repo(root: &Path, target_repo: &ForgeRepository) -> Option<PathBuf> {
+    if target_repo.kind == crate::forge::traits::ForgeKind::Forgejo
+        && named_remote_urls(root).iter().any(|(name, url)| {
+            tea_recognizes_remote(root, name)
+                && parse_forgejo_remote_url(url).as_ref() == Some(target_repo)
+        })
+    {
+        return Some(root.to_path_buf());
+    }
     remote_urls(root)
         .iter()
         .any(|url| parse_any_remote_url(url).as_ref() == Some(target_repo))
@@ -239,4 +284,12 @@ mod tests {
             Some(dir.path().to_path_buf())
         );
     }
+}
+
+fn tea_recognizes_remote(repo_root: &Path, remote: &str) -> bool {
+    Command::new("tea")
+        .current_dir(repo_root)
+        .args(["api", "--remote", remote, "/version"])
+        .output()
+        .is_ok_and(|output| output.status.success())
 }

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -12,6 +12,7 @@ use crate::model::{DiffLine, FilePatch, FileStatus};
 pub enum ForgeKind {
     GitHub,
     GitLab,
+    Forgejo,
     /// Bitbucket Cloud only. Data Center speaks an unrelated REST 1.0 API and
     /// is rejected during remote-URL parsing.
     Bitbucket,
@@ -25,6 +26,7 @@ impl ForgeKind {
         match self {
             ForgeKind::GitHub => "GitHub",
             ForgeKind::GitLab => "GitLab",
+            ForgeKind::Forgejo => "Forgejo",
             ForgeKind::Bitbucket => "Bitbucket",
             ForgeKind::AzureDevOps => "Azure DevOps",
         }
@@ -60,6 +62,19 @@ impl ForgeRepository {
     ) -> Self {
         Self {
             kind: ForgeKind::GitLab,
+            host: host.into(),
+            owner: owner.into(),
+            name: name.into(),
+        }
+    }
+
+    pub fn forgejo(
+        host: impl Into<String>,
+        owner: impl Into<String>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind: ForgeKind::Forgejo,
             host: host.into(),
             owner: owner.into(),
             name: name.into(),

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -118,6 +118,7 @@ impl fmt::Display for PrSlug {
         let kind = match self.forge {
             ForgeKind::GitHub => "gh",
             ForgeKind::GitLab => "gl",
+            ForgeKind::Forgejo => "fj",
             ForgeKind::Bitbucket => "bb",
             ForgeKind::AzureDevOps => "az",
         };
@@ -189,6 +190,7 @@ impl FromStr for Slug {
             let forge = match kind {
                 "gh" => ForgeKind::GitHub,
                 "gl" => ForgeKind::GitLab,
+                "fj" => ForgeKind::Forgejo,
                 "bb" => ForgeKind::Bitbucket,
                 "az" => ForgeKind::AzureDevOps,
                 other => return Err(SlugParseError::UnknownForge(other.to_string())),

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -426,6 +426,7 @@ fn forge_badge_label(kind: Option<ForgeKind>) -> &'static str {
     match kind {
         Some(ForgeKind::GitHub) => "github",
         Some(ForgeKind::GitLab) => "gitlab",
+        Some(ForgeKind::Forgejo) => "forgejo",
         Some(ForgeKind::Bitbucket) => "bitbucket",
         Some(ForgeKind::AzureDevOps) => "azure",
         None => "forge",

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -177,9 +177,10 @@ fn parse_jj_diff_metadata(output: &str) -> Result<Vec<FileMetadata>> {
         )));
     }
 
+    let (records, remainder) = records.as_chunks::<3>();
+    debug_assert!(remainder.is_empty());
+
     records
-        .as_chunks::<3>()
-        .0
         .iter()
         .map(|record| {
             let source = (!record[1].is_empty()).then(|| PathBuf::from(record[1]));


### PR DESCRIPTION
## Summary

- add an explicit Forgejo forge type and stable `fj` session slug prefix for Forgejo and Codeberg PR sessions
- recognize Codeberg by hostname and self-hosted Forgejo only when the host exists in `fj`'s key store
- load PR metadata and cumulative diffs through Forgejo REST using `fj` credentials when available

## Safety

- Forgejo and Codeberg review submission, commit selection, commit-range diffs, remote comments, and remote context expansion still fail closed with actionable messages until those API paths are implemented
- GitHub remains the final catch-all parser so self-hosted Forgejo is not guessed from arbitrary hostnames
- use `:clip` to export Forgejo or Codeberg reviews in the interim

## Relationship to Gitea

This PR no longer uses `tea` or labels Gitea-compatible API access as Forgejo support. #652 is the fuller Gitea lane. This branch keeps Forgejo and Codeberg separate with their own `fj` identity.

Release-please impact: minor

## Tested

- `cargo fmt --all --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`