### PR TITLE
fix(vcs): quote file paths passed to jj and hg

### DIFF
--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -135,11 +135,11 @@ impl VcsBackend for HgBackend {
             return Ok(Vec::new());
         }
 
-        let path_str = file_path.to_string_lossy();
+        let pattern = hg_path_pattern(file_path);
         let content = if let Some(commit) = ref_commit {
-            run_hg_command(&self.info.root_path, ["cat", "-r", commit, &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", commit, &pattern])?
         } else if file_status == FileStatus::Deleted {
-            run_hg_command(&self.info.root_path, ["cat", "-r", ".", &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", ".", &pattern])?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
@@ -153,11 +153,11 @@ impl VcsBackend for HgBackend {
         file_status: FileStatus,
         ref_commit: Option<&str>,
     ) -> Result<u32> {
-        let path_str = file_path.to_string_lossy();
+        let pattern = hg_path_pattern(file_path);
         let content = if let Some(commit) = ref_commit {
-            run_hg_command(&self.info.root_path, ["cat", "-r", commit, &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", commit, &pattern])?
         } else if file_status == FileStatus::Deleted {
-            run_hg_command(&self.info.root_path, ["cat", "-r", ".", &path_str])?
+            run_hg_command(&self.info.root_path, ["cat", "-r", ".", &pattern])?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
@@ -435,6 +435,20 @@ impl VcsBackend for HgBackend {
     }
 }
 
+/// Render `path` as an hg file pattern that matches it and nothing else.
+///
+/// hg treats positional file arguments as patterns. The default notation is
+/// verbatim, so most names survive unquoted, but a name that happens to start
+/// with a pattern prefix (`re:`, `glob:`, `set:`, `listfile:`, ...) is silently
+/// reinterpreted -- `hg cat -r . 're:weird.txt'` matches nothing, and a name
+/// like `re:.*` would match every file in the repo. The `path:` prefix pins the
+/// rest of the argument to a verbatim repository-root-relative path, so nothing
+/// after it needs escaping. This is the hg analogue of `jj_fileset_arg`; see
+/// <https://github.com/agavra/tuicr/issues/602>.
+fn hg_path_pattern(path: &Path) -> String {
+    format!("path:{}", path.to_string_lossy())
+}
+
 /// Fetch the full content of `paths` at `rev` in a single `hg cat` subprocess.
 ///
 /// hg cat is dominated by Python startup (~280 ms) regardless of file count,
@@ -445,12 +459,9 @@ fn hg_cat_batch(root: &Path, rev: &str, paths: &[PathBuf]) -> Result<HashMap<Pat
         return Ok(HashMap::new());
     }
     let template = format!("\n{BATCH_BOUNDARY}\n{{path}}\n{{data}}");
-    let path_strs: Vec<String> = paths
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
+    let patterns: Vec<String> = paths.iter().map(|p| hg_path_pattern(p)).collect();
     let mut args: Vec<&str> = vec!["cat", "-r", rev, "--template", &template];
-    args.extend(path_strs.iter().map(String::as_str));
+    args.extend(patterns.iter().map(String::as_str));
     let output = run_hg_command(root, &args)?;
     Ok(parse_batched_files(&output))
 }
@@ -1071,6 +1082,90 @@ mod tests {
         fs::write(root.join("App.vue"), edited).expect("Failed to modify Vue file");
 
         Some(temp_dir)
+    }
+
+    #[test]
+    fn test_hg_path_pattern_pins_names_to_verbatim_paths() {
+        assert_eq!(
+            hg_path_pattern(Path::new("routes/(app)/+page.svelte")),
+            "path:routes/(app)/+page.svelte"
+        );
+        assert_eq!(
+            hg_path_pattern(Path::new("re:weird.txt")),
+            "path:re:weird.txt"
+        );
+    }
+
+    /// Set up an hg repo whose only file is named like an hg pattern prefix, so
+    /// an unprefixed argument would be reinterpreted as a regex instead of a
+    /// file name. `:` is reserved on Windows, hence the unix gate.
+    #[cfg(unix)]
+    fn setup_test_repo_with_pattern_like_name() -> Option<(tempfile::TempDir, PathBuf)> {
+        if !hg_available() {
+            return None;
+        }
+
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let root = temp_dir.path();
+
+        Command::new("hg")
+            .args(["init"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to init hg repo");
+
+        // Vue so the diff goes through the container full-file highlight path,
+        // which batches paths into a single `hg cat`.
+        let rel = PathBuf::from("re:App.vue");
+        let initial = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hi')\nconst other = 1\n</script>\n";
+        fs::write(root.join(&rel), initial).expect("Failed to write Vue file");
+
+        Command::new("hg")
+            .args(["add", "--", "path:re:App.vue"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to add file");
+        Command::new("hg")
+            .args(["commit", "-m", "Add Vue file"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to commit");
+
+        let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
+        fs::write(root.join(&rel), edited).expect("Failed to modify Vue file");
+
+        Some((temp_dir, rel))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_hg_handles_paths_that_look_like_pattern_prefixes() {
+        let Some((temp, rel)) = setup_test_repo_with_pattern_like_name() else {
+            eprintln!("Skipping test: hg command not available");
+            return;
+        };
+
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
+
+        // The batched `hg cat` behind container highlighting must resolve the
+        // name verbatim rather than treating `re:` as a regex pattern.
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("diff should succeed for a pattern-like file name");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].new_path.as_deref(), Some(rel.as_path()));
+
+        let lines = backend
+            .fetch_context_lines(&rel, FileStatus::Modified, Some("."), 1, 2)
+            .expect("context lines should be fetchable for a pattern-like name");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].content, "<template>");
+
+        let count = backend
+            .file_line_count(&rel, FileStatus::Modified, Some("."))
+            .expect("line count should be readable for a pattern-like name");
+        assert_eq!(count, 9);
     }
 
     #[test]

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -173,17 +173,14 @@ impl VcsBackend for JjBackend {
             return Ok(Vec::new());
         }
 
-        let path_str = file_path.to_string_lossy();
+        let fileset = jj_fileset_arg(file_path);
         let content = if let Some(commit) = ref_commit {
             run_jj_command(
                 &self.info.root_path,
-                ["file", "show", "-r", commit, &path_str],
+                ["file", "show", "-r", commit, &fileset],
             )?
         } else if file_status == FileStatus::Deleted {
-            run_jj_command(
-                &self.info.root_path,
-                ["file", "show", "-r", "@-", &path_str],
-            )?
+            run_jj_command(&self.info.root_path, ["file", "show", "-r", "@-", &fileset])?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
@@ -197,17 +194,14 @@ impl VcsBackend for JjBackend {
         file_status: FileStatus,
         ref_commit: Option<&str>,
     ) -> Result<u32> {
-        let path_str = file_path.to_string_lossy();
+        let fileset = jj_fileset_arg(file_path);
         let content = if let Some(commit) = ref_commit {
             run_jj_command(
                 &self.info.root_path,
-                ["file", "show", "-r", commit, &path_str],
+                ["file", "show", "-r", commit, &fileset],
             )?
         } else if file_status == FileStatus::Deleted {
-            run_jj_command(
-                &self.info.root_path,
-                ["file", "show", "-r", "@-", &path_str],
-            )?
+            run_jj_command(&self.info.root_path, ["file", "show", "-r", "@-", &fileset])?
         } else {
             std::fs::read_to_string(self.info.root_path.join(file_path))?
         };
@@ -432,6 +426,23 @@ impl VcsBackend for JjBackend {
     }
 }
 
+/// Render `path` as a jj fileset argument that matches it and nothing else.
+///
+/// jj parses positional path arguments as fileset expressions, so a file name
+/// containing meta characters (`(`, `)`, `|`, `&`, `~`, whitespace, ...) is a
+/// syntax error when passed bare -- see
+/// <https://github.com/agavra/tuicr/issues/602>. Wrapping the name in a quoted
+/// string literal keeps it out of the expression grammar, and the `root-file:`
+/// prefix pins it to an exact workspace-relative path (the paths we pass come
+/// from diff output, which is always workspace-relative).
+fn jj_fileset_arg(path: &Path) -> String {
+    let escaped = path
+        .to_string_lossy()
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"");
+    format!("root-file:\"{escaped}\"")
+}
+
 /// Fetch the full content of `paths` at `rev` in a single `jj file show`
 /// subprocess. jj is much cheaper per-call than hg, but batching still avoids
 /// repeated process startup when there are many container files in a diff.
@@ -440,12 +451,9 @@ fn jj_show_batch(root: &Path, rev: &str, paths: &[PathBuf]) -> Result<HashMap<Pa
         return Ok(HashMap::new());
     }
     let template = format!("\"\\n{BATCH_BOUNDARY}\\n\" ++ path ++ \"\\n\"");
-    let path_strs: Vec<String> = paths
-        .iter()
-        .map(|p| p.to_string_lossy().into_owned())
-        .collect();
+    let filesets: Vec<String> = paths.iter().map(|p| jj_fileset_arg(p)).collect();
     let mut args: Vec<&str> = vec!["file", "show", "-r", rev, "-T", &template];
-    args.extend(path_strs.iter().map(String::as_str));
+    args.extend(filesets.iter().map(String::as_str));
     let output = run_jj_command(root, &args)?;
     Ok(parse_batched_files(&output))
 }
@@ -1137,6 +1145,86 @@ mod tests {
                 "vue hunk line {line:?} should have varied fg colors, got {unique_fgs:?}"
             );
         }
+    }
+
+    /// Create a repo whose only file lives under a directory with fileset meta
+    /// characters in its name, so every `jj file show` call has to quote it.
+    fn setup_test_repo_with_meta_char_path() -> Option<(tempfile::TempDir, PathBuf)> {
+        if !jj_available() {
+            return None;
+        }
+
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let root = temp_dir.path();
+
+        let output = jj_cmd()
+            .args(["git", "init"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to init jj repo");
+        if !output.status.success() {
+            return None;
+        }
+
+        // Vue so the diff goes through the container full-file highlight path,
+        // which batches paths into a single `jj file show`.
+        let rel = PathBuf::from("routes/(app)/+page.vue");
+        fs::create_dir_all(root.join(rel.parent().unwrap())).expect("Failed to create dir");
+        let initial = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hi')\nconst other = 1\n</script>\n";
+        fs::write(root.join(&rel), initial).expect("Failed to write Vue file");
+
+        jj_cmd()
+            .args(["commit", "-m", "Add Vue file"])
+            .current_dir(root)
+            .output()
+            .expect("Failed to commit");
+
+        let edited = "<template>\n  <div>{{ msg }}</div>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\nconst msg = ref('hello')\nconst other = 1\n</script>\n";
+        fs::write(root.join(&rel), edited).expect("Failed to modify Vue file");
+
+        Some((temp_dir, rel))
+    }
+
+    #[test]
+    fn test_jj_fileset_arg_quotes_meta_characters() {
+        assert_eq!(
+            jj_fileset_arg(Path::new("routes/(app)/+page.svelte")),
+            r#"root-file:"routes/(app)/+page.svelte""#
+        );
+        assert_eq!(
+            jj_fileset_arg(Path::new(r#"we"ird\name.txt"#)),
+            r#"root-file:"we\"ird\\name.txt""#
+        );
+    }
+
+    #[test]
+    fn test_jj_handles_paths_with_fileset_meta_characters() {
+        let Some((temp, rel)) = setup_test_repo_with_meta_char_path() else {
+            eprintln!("Skipping test: jj command not available");
+            return;
+        };
+
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
+
+        // The batched `jj file show` behind container highlighting must not
+        // choke on the parentheses in the path.
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("diff should succeed for a path with fileset meta characters");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].new_path.as_deref(), Some(rel.as_path()));
+
+        let lines = backend
+            .fetch_context_lines(&rel, FileStatus::Modified, Some("@-"), 1, 2)
+            .expect("context lines should be fetchable for a meta-character path");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].content, "<template>");
+
+        let count = backend
+            .file_line_count(&rel, FileStatus::Modified, Some("@-"))
+            .expect("line count should be readable for a meta-character path");
+        assert_eq!(count, 9);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #602.

## The jj bug (reported)

`jj` parses positional path arguments as [fileset expressions](https://docs.jj-vcs.dev/latest/filesets/), so a file name containing a meta character (`(`, `)`, `|`, `&`, `~`, whitespace, ...) aborts tuicr on startup:

```
Error: VCS command failed: jj file show -r @- -T "..." frontend/src/routes/(app)/+page.svelte
  failed: Error: Failed to parse fileset: Syntax error
```

SvelteKit route groups (`(app)`) hit this immediately.

## The hg bug (found while fixing the above)

`hg` has the same class of bug, but it fails **silently**. Positional arguments are patterns; the default notation is verbatim, so parens are fine, but a name starting with a recognized prefix is reinterpreted:

```console
$ hg cat -r . 're:weird.txt'      # → nothing at all, exit 1, empty stderr
$ hg cat -r . 'path:re:weird.txt' # → correct contents
```

A file named `re:.*` would have matched *every file in the repo* and concatenated them into what tuicr believes is one file's contents.

## The fix

Wrap each path in the notation that pins it to an exact repository-root-relative path, at all six `jj file show` / `hg cat` call sites (the batched container-highlight fetch, `fetch_context_lines`, and `file_line_count` in each backend):

- **jj** — `root-file:"<escaped>"`. Inside a jj double-quoted string literal only `\` and `"` are special, so escaping those two is complete rather than a heuristic subset; I verified against a real repo that parens, `+`, and even a raw newline pass through verbatim.
- **hg** — `path:<path>`, which takes the remainder verbatim, so nothing needs escaping.

### Why hand-rolled quoting

- `jj-lib` publishes the real parser, but tuicr deliberately shells out to the `jj` binary rather than linking jj; pulling in a pre-1.0 crate with its own git2/watchman tree to quote a string would also introduce skew between the linked lib and the user's installed `jj`.
- `shlex` is already a dependency but is the wrong grammar — for a name containing `'` it emits `'a'\''b'` (POSIX adjacent-string concatenation), which jj will not parse as one literal.
- There is no CLI escape hatch: jj's transition-era `ui.allow-filesets=false` is gone as of 0.37 (verified — same syntax error), and `jj file show` has no literal-path mode.

## Tests

- Unit tests for both quoting helpers.
- Integration tests against real repos: `routes/(app)/+page.vue` for jj and `re:App.vue` for hg, each exercising the batched diff path plus context-line and line-count fetches. `.vue` is deliberate — it routes through the container full-file highlight path, which is where the batched call in the original report lives.
- Both integration tests were confirmed to fail without their fix (the jj one reproduces the reported error verbatim). The hg test is `#[cfg(unix)]`-gated since `:` is reserved on Windows.

`cargo fmt` and `cargo clippy --all-targets` clean; full suite passes (1475 passed, 0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)