### PR TITLE
fix(release): dynamically link GNU Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,22 +193,23 @@ jobs:
           echo "CARGO_TARGET_${cargo_target}_LINKER=musl-gcc" >> "$GITHUB_ENV"
           echo "CC_${cc_target}=musl-gcc" >> "$GITHUB_ENV"
 
-      - name: Configure static GNU runtime
-        if: runner.os == 'Linux' && endsWith(matrix.build_target, '-gnu')
-        shell: bash
-        run: echo 'RUSTFLAGS=-C target-feature=+crt-static' >> "$GITHUB_ENV"
-
       - name: Build
         run: cargo build --release --target ${{ matrix.build_target }}
 
-      - name: Verify static Linux binary
+      - name: Verify Linux binary linkage
         if: runner.os == 'Linux'
         shell: bash
         run: |
           binary=target/${{ matrix.build_target }}/release/tuicr
           test "$("$binary" --version)" = "tuicr ${{ steps.version.outputs.version }}"
-          if readelf -lW "$binary" | grep -Eq '(^|[[:space:]])INTERP([[:space:]]|$)'; then
-            echo "Linux release binary contains a dynamic interpreter" >&2
+          if [[ '${{ matrix.build_target }}' == *-musl ]]; then
+            if readelf -lW "$binary" | grep -Eq '(^|[[:space:]])INTERP([[:space:]]|$)'; then
+              echo "musl release binary contains a dynamic interpreter" >&2
+              readelf -lW "$binary" >&2
+              exit 1
+            fi
+          elif ! readelf -lW "$binary" | grep -Eq '(^|[[:space:]])INTERP([[:space:]]|$)'; then
+            echo "GNU release binary is missing its dynamic interpreter" >&2
             readelf -lW "$binary" >&2
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,8 @@ These are non-obvious things the implementation chain hit. Worth preserving for 
 
 14. **A diff file must be registered in the session before `r`, `R`, or a comment can land on it.** All three look the file up in `ReviewSession.files` by display path. The two review-mark toggles return silently when it is absent; `add_comment_to_session` returns `session does not contain file`. So any code path that assigns `self.diff_files` must also call `App::register_diff_files`. Narrowing the inline commit pane skipped this, so commit-only files could be neither marked nor commented on.
 
+15. **GNU Linux release binaries must stay dynamically linked.** Static glibc binaries can crash when hostname lookup loads a host NSS module (for example Fedora's `libnss_myhostname`). The musl artifacts are the supported static Linux builds. Direct updates must preserve the running binary's GNU/musl target environment when selecting an asset.
+
 ### Keeping Docs Updated
 
 When adding user-facing features, update the relevant documentation:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ mise use github:agavra/tuicr
 nix run github:agavra/tuicr
 ```
 
-Pre-built binaries: [GitHub Releases](https://github.com/agavra/tuicr/releases)
+Pre-built binaries: [GitHub Releases](https://github.com/agavra/tuicr/releases). Linux releases
+include dynamically linked GNU and static musl variants.
 
 From source:
 

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -100,6 +100,7 @@ struct UpdateContext {
     current_version: String,
     os: String,
     arch: String,
+    target_env: String,
 }
 
 impl UpdateContext {
@@ -116,6 +117,13 @@ impl UpdateContext {
             current_version: env!("CARGO_PKG_VERSION").to_string(),
             os: std::env::consts::OS.to_string(),
             arch: std::env::consts::ARCH.to_string(),
+            target_env: if cfg!(target_env = "musl") {
+                "musl".to_string()
+            } else if cfg!(target_env = "gnu") {
+                "gnu".to_string()
+            } else {
+                String::new()
+            },
         })
     }
 }
@@ -268,7 +276,12 @@ fn update_direct(
     }
 
     let release_version = release_version.to_string();
-    let asset_name = release_asset_name(&release_version, &context.os, &context.arch)?;
+    let asset_name = release_asset_name(
+        &release_version,
+        &context.os,
+        &context.arch,
+        &context.target_env,
+    )?;
     let asset = release
         .assets
         .iter()

--- a/src/update/install/source.rs
+++ b/src/update/install/source.rs
@@ -23,13 +23,16 @@ pub(super) fn release_asset_name(
     version: &str,
     os: &str,
     arch: &str,
+    target_env: &str,
 ) -> Result<String, UpdateError> {
-    let target = match (os, arch) {
-        ("linux", "x86_64") => "x86_64-unknown-linux-gnu",
-        ("linux", "aarch64") => "aarch64-unknown-linux-gnu",
-        ("macos", "x86_64") => "x86_64-apple-darwin",
-        ("macos", "aarch64") => "aarch64-apple-darwin",
-        ("windows", "x86_64") => "x86_64-pc-windows-msvc",
+    let target = match (os, arch, target_env) {
+        ("linux", "x86_64", "gnu") => "x86_64-unknown-linux-gnu",
+        ("linux", "x86_64", "musl") => "x86_64-unknown-linux-musl",
+        ("linux", "aarch64", "gnu") => "aarch64-unknown-linux-gnu",
+        ("linux", "aarch64", "musl") => "aarch64-unknown-linux-musl",
+        ("macos", "x86_64", _) => "x86_64-apple-darwin",
+        ("macos", "aarch64", _) => "aarch64-apple-darwin",
+        ("windows", "x86_64", _) => "x86_64-pc-windows-msvc",
         _ => {
             return Err(UpdateError::UnsupportedPlatform {
                 os: os.to_string(),

--- a/src/update/install/tests.rs
+++ b/src/update/install/tests.rs
@@ -71,6 +71,7 @@ fn context(executable: impl Into<PathBuf>) -> UpdateContext {
         current_version: "1.0.0".to_string(),
         os: "linux".to_string(),
         arch: "x86_64".to_string(),
+        target_env: "gnu".to_string(),
     }
 }
 
@@ -104,7 +105,18 @@ fn direct_runtime(
     archive: Vec<u8>,
     include_digest: bool,
 ) -> MockRuntime {
-    let asset_name = release_asset_name(version, os, arch).unwrap();
+    direct_runtime_for_target(version, os, arch, "gnu", archive, include_digest)
+}
+
+fn direct_runtime_for_target(
+    version: &str,
+    os: &str,
+    arch: &str,
+    target_env: &str,
+    archive: Vec<u8>,
+    include_digest: bool,
+) -> MockRuntime {
+    let asset_name = release_asset_name(version, os, arch, target_env).unwrap();
     let asset_url = release_asset_url(version, &asset_name);
     let digest = format!("sha256:{:x}", Sha256::digest(&archive));
     let metadata = serde_json::json!({
@@ -394,6 +406,27 @@ fn downloads_verifies_and_extracts_a_linux_direct_install() {
 }
 
 #[test]
+fn direct_musl_install_downloads_the_musl_asset() {
+    let binary = b"new-musl-binary";
+    let runtime = direct_runtime_for_target(
+        "1.1.0",
+        "linux",
+        "x86_64",
+        "musl",
+        tar_gz("tuicr", binary),
+        true,
+    );
+    let mut context = context("/home/alice/.local/bin/tuicr");
+    context.target_env = "musl".to_string();
+
+    assert!(matches!(
+        update_with_runtime(&runtime, context),
+        Ok(UpdateOutcome::Updated { .. })
+    ));
+    assert_eq!(runtime.replacement.into_inner().unwrap().1, binary);
+}
+
+#[test]
 fn downloads_verifies_and_extracts_a_windows_direct_install() {
     let binary = b"new-windows-binary";
     let runtime = direct_runtime(
@@ -528,21 +561,38 @@ fn rejects_bad_release_metadata_assets_and_digests() {
 fn maps_every_published_target_and_rejects_unsupported_targets() {
     assert_eq!(package_repository_url(), env!("CARGO_PKG_REPOSITORY"));
     let cases = [
-        ("linux", "x86_64", "x86_64-unknown-linux-gnu.tar.gz"),
-        ("linux", "aarch64", "aarch64-unknown-linux-gnu.tar.gz"),
-        ("macos", "x86_64", "x86_64-apple-darwin.tar.gz"),
-        ("macos", "aarch64", "aarch64-apple-darwin.tar.gz"),
-        ("windows", "x86_64", "x86_64-pc-windows-msvc.zip"),
+        ("linux", "x86_64", "gnu", "x86_64-unknown-linux-gnu.tar.gz"),
+        (
+            "linux",
+            "x86_64",
+            "musl",
+            "x86_64-unknown-linux-musl.tar.gz",
+        ),
+        (
+            "linux",
+            "aarch64",
+            "gnu",
+            "aarch64-unknown-linux-gnu.tar.gz",
+        ),
+        (
+            "linux",
+            "aarch64",
+            "musl",
+            "aarch64-unknown-linux-musl.tar.gz",
+        ),
+        ("macos", "x86_64", "", "x86_64-apple-darwin.tar.gz"),
+        ("macos", "aarch64", "", "aarch64-apple-darwin.tar.gz"),
+        ("windows", "x86_64", "msvc", "x86_64-pc-windows-msvc.zip"),
     ];
-    for (os, arch, suffix) in cases {
+    for (os, arch, target_env, suffix) in cases {
         assert!(
-            release_asset_name("1.2.3", os, arch)
+            release_asset_name("1.2.3", os, arch, target_env)
                 .unwrap()
                 .ends_with(suffix)
         );
     }
     assert!(matches!(
-        release_asset_name("1.2.3", "windows", "aarch64"),
+        release_asset_name("1.2.3", "windows", "aarch64", "msvc"),
         Err(UpdateError::UnsupportedPlatform { .. })
     ));
     assert_eq!(


### PR DESCRIPTION
## Summary

- build GNU Linux release artifacts with dynamic glibc linkage while keeping musl artifacts static
- verify the expected linkage mode for every Linux release target
- preserve the running binary's GNU or musl target environment during direct updates
- document the release contract and add updater regression coverage

## Root cause

The release workflow forced `+crt-static` for `*-unknown-linux-gnu`. During the startup update check, hostname resolution can load host NSS modules such as Fedora's `libnss_myhostname.so.2`. Loading that dynamic module into a static glibc process causes the reported `SIGFPE` crash.

The issue comments also identified that direct musl installations selected the GNU asset during `tuicr update`; asset selection now includes the compiled target environment.

## Reproduction and validation

In an amd64 Fedora 44 container using the published v0.22.0 GNU artifact:

- `ldd` reported `statically linked`
- starting the TUI with update checks enabled exited `136` (`SIGFPE`)

After rebuilding with this change:

- `ldd` resolved glibc and the other system libraries dynamically
- the same startup remained alive until the 10-second harness timeout (`124`), with no crash

Additional checks:

- `cargo test` — 1,475 passed, 2 ignored
- `cargo clippy -- -D warnings`
- `cargo fmt -- --check`
- release workflow YAML parsing
- 22 focused updater/install tests

Closes #609
