### PR TITLE
fix(test): assert the real 50ms first-poll drain timeout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -956,7 +956,7 @@ mod tests {
     fn drain_blocks_once_then_takes_only_queued_events() {
         assert_eq!(
             event_drain_timeout(0),
-            Some(Duration::from_millis(100)),
+            Some(Duration::from_millis(50)),
             "the first poll must block, or an idle TUI spins"
         );
         assert_eq!(event_drain_timeout(1), Some(Duration::ZERO));


### PR DESCRIPTION
`drain_blocks_once_then_takes_only_queued_events` fails on `main`.

`event_drain_timeout(0)` returns `Duration::from_millis(50)`, but the test added in #617 asserts `from_millis(100)`:

```
assertion `left == right` failed: the first poll must block, or an idle TUI spins
  left: Some(50ms)
 right: Some(100ms)
```

50ms is the intended value, so this aligns the assertion with the implementation rather than changing the timeout.

## Testing

- `cargo test --bin tuicr drain_blocks_once` passes
- `cargo fmt` clean, `cargo clippy --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)