### PR TITLE
refactor(diff): use structured file metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,11 @@ src/
 ├── vcs/                 # VCS abstraction layer
 │   ├── mod.rs           # detect_vcs(): auto-detect VCS (jj first, then git, then hg)
 │   ├── traits.rs        # VcsBackend trait, VcsInfo, VcsType, CommitInfo
-│   ├── diff_parser.rs   # Unified diff text parser (shared by hg/jj and Git CLI)
-│   │                    # DiffFormat enum: Hg (with timestamps), GitStyle (jj/git patches)
+│   ├── diff_parser.rs   # Strict, count-driven hunk parser over structured FilePatch values
 │   ├── git/             # Git backend selector (libgit2 by default, CLI for sparse/opt-in)
 │   │   ├── mod.rs       # GitBackend wrapper, backend preference, repo mode detection
 │   │   ├── cli.rs       # Git CLI backend used for sparse checkouts and backend = "cli"
+│   │   ├── raw.rs       # Exact `git diff --raw -z --patch` metadata/patch adapter
 │   │   ├── libgit2.rs   # libgit2-backed implementation used for normal Git repos by default
 │   │   ├── repository.rs # CommitInfo, get_recent_commits()
 │   │   ├── diff.rs      # get_working_tree_diff(), get_commit_range_diff()
@@ -224,11 +224,11 @@ Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbuck
 - `list_pull_requests` — paged list for the selector's Pull Requests tab.
 - `get_pull_request` — details for a `PullRequestTarget` (resolves to `PullRequestDetails`).
 - `get_pull_request_info` — extended PR metadata for the description panel (`PullRequestInfo`). GitHub fetches `reviewDecision`, `mergeable`, `mergeStateStatus`, `reviewRequests`, `latestReviews`, and `statusCheckRollup` in the same `gh pr view` call; other backends default to `PullRequestInfo::from_details`.
-- `get_pull_request_diff` — the cumulative PR diff as a unified-diff string.
+- `get_pull_request_diff` — cumulative PR changes as structured `FilePatch` values. Each forge obtains path/status metadata from its API and pairs it with patch bodies without decoding display headers.
 - `list_pull_request_commits` — commits on the PR for the inline subset selector.
 - `list_pull_request_review_metadata` — best-effort viewer login + review commit OIDs used to preselect commits since the viewer's latest submitted review and mark already-reviewed commits in the inline selector.
   GitHub uses review metadata; GitLab combines `/user`, MR diff versions, approvals, and discussions; Bitbucket reads the PR's `participants` and reports account UUIDs (Cloud returns no usernames), with no commit OIDs since it does not record which commit an approval covered.
-- `get_pull_request_commit_range_diff` — cumulative diff for a contiguous subrange (`start_sha` is the parent of the first selected commit; `end_sha` is the last).
+- `get_pull_request_commit_range_diff` — structured cumulative changes for a contiguous subrange (`start_sha` is the parent of the first selected commit; `end_sha` is the last).
 - `list_review_threads` — existing forge comments + resolved/outdated state.
 - `fetch_file_lines` — remote context expansion in the diff view.
 - `create_review` — POST a review with inline comments via `CreateReviewRequest`.
@@ -238,7 +238,7 @@ Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbuck
 Network calls run on a background thread. Parsing + state mutation run on the main thread. The pattern across `spawn_pr_open` / `spawn_pr_reload` / `spawn_pr_submit`:
 
 1. Snapshot the request inputs on the main thread (no `&App` lives across the spawn).
-2. Spawn a thread that returns only `Send` data — typically `Result<(PullRequestDetails, String, Vec<PullRequestCommit>)>` or similar tuples.
+2. Spawn a thread that returns only `Send` data — typically `Result<(PullRequestDetails, Vec<FilePatch>, Vec<PullRequestCommit>)>` or similar tuples.
 3. The thread sends the result on an `mpsc` channel; `poll_*_events()` drains the channel each tick.
 4. The main-thread `finish_*` function parses the diff and builds the `ReviewSession`. `SyntaxHighlighter` is not trivially `Send`, so parsing has to happen on the main thread.
 
@@ -269,33 +269,35 @@ These are non-obvious things the implementation chain hit. Worth preserving for 
 
 1. **`gh pr diff` must NOT use `--patch`.** That flag returns per-commit mbox patches and produces duplicate file entries. Plain `gh pr diff` returns the cumulative diff. Regression test: `should_not_pass_patch_flag_to_gh_pr_diff`.
 
-2. **GraphQL thread anchors live on `PullRequestReviewThread`, not the comment.** `path`, `line`, `originalLine`, `diffSide` are thread fields. Putting them on `PullRequestReviewComment` returns a schema error.
+2. **Patch display headers are never authoritative metadata.** Paths and statuses come from unambiguous sources: Git `--raw -z`, jj templates, Mercurial `status -0`, or forge JSON. `diff_parser` only consumes `@@` hunks and uses their declared old/new counts as the grammar. Do not add quoting or path-header heuristics there.
 
-3. **Network on the background thread, parsing on the main thread.** `SyntaxHighlighter` is not `Send`. Background threads return Send-safe data; the main thread parses and builds the session. Used by `spawn_pr_open` / `spawn_pr_reload` / `spawn_pr_submit`.
+3. **GraphQL thread anchors live on `PullRequestReviewThread`, not the comment.** `path`, `line`, `originalLine`, `diffSide` are thread fields. Putting them on `PullRequestReviewComment` returns a schema error.
 
-4. **`apply_initial_load(Err(...))` is a no-op when the tab is already `Loaded`.** It only transitions `Loading → Error`. For transient errors during reload or submit, use `App::set_error()` (the message bar) instead.
+4. **Network on the background thread, parsing on the main thread.** `SyntaxHighlighter` is not `Send`. Background threads return Send-safe data; the main thread parses and builds the session. Used by `spawn_pr_open` / `spawn_pr_reload` / `spawn_pr_submit`.
 
-5. **Anchor restore must scroll.** Setting `diff_state.cursor_line` without calling `move_cursor_to_annotation` leaves the viewport at the top.
+5. **`apply_initial_load(Err(...))` is a no-op when the tab is already `Loaded`.** It only transitions `Loading → Error`. For transient errors during reload or submit, use `App::set_error()` (the message bar) instead.
 
-6. **`Comment` line anchor lives in the `HashMap` key, not on `Comment.line_context`.** Production code creates comments via `Comment::new` without populating `line_context`. The submit mapper takes an explicit `CommentAnchor` parameter — never infer "file-level" from `line_context.is_none()`.
+6. **Anchor restore must scroll.** Setting `diff_state.cursor_line` without calling `move_cursor_to_annotation` leaves the viewport at the top.
 
-7. **`gh api --input -` over CLI args.** The only practical way to send a multi-comment payload. See `GhCommandRunner::run_with_stdin`.
+7. **`Comment` line anchor lives in the `HashMap` key, not on `Comment.line_context`.** Production code creates comments via `Comment::new` without populating `line_context`. The submit mapper takes an explicit `CommentAnchor` parameter — never infer "file-level" from `line_context.is_none()`.
 
-8. **`gh api` writes the response body to STDOUT on non-2xx**, while STDERR only carries the short status line. The error formatter combines both so the user sees the actual GitHub error.
+8. **`gh api --input -` over CLI args.** The only practical way to send a multi-comment payload. See `GhCommandRunner::run_with_stdin`.
 
-9. **Stale-result discard for submit needs (repo, PR#, head SHA).** A different PR opened mid-submit could otherwise consume the result and apply lifecycle writes to the wrong comments.
+9. **`gh api` writes the response body to STDOUT on non-2xx**, while STDERR only carries the short status line. The error formatter combines both so the user sees the actual GitHub error.
 
-10. **TestBackend modal sizing.** A 60%×40% modal on 120×24 is 72×9 (7 content rows after borders). The submit confirmation modal needs 70% height to fit. The submit-action picker needs 50% height to fit the footer line.
+10. **Stale-result discard for submit needs (repo, PR#, head SHA).** A different PR opened mid-submit could otherwise consume the result and apply lifecycle writes to the wrong comments.
 
-11. **Subset-mode `commit_id`.** When a strict subset of PR commits is selected, the payload's `commit_id` must be `pr_commits[start_idx].oid` (the newest selected commit). Using the cumulative PR head returns a misleading 422: `commitOID is not part of the pull request` — even though the SHA _is_ in the PR.
+11. **TestBackend modal sizing.** A 60%×40% modal on 120×24 is 72×9 (7 content rows after borders). The submit confirmation modal needs 70% height to fit. The submit-action picker needs 50% height to fit the footer line.
 
-12. **`cd` into the worktree before running `cargo`.** `cargo` resolves `Cargo.toml` from `pwd`. Running gates from the wrong worktree silently exercises the wrong tree.
+12. **Subset-mode `commit_id`.** When a strict subset of PR commits is selected, the payload's `commit_id` must be `pr_commits[start_idx].oid` (the newest selected commit). Using the cumulative PR head returns a misleading 422: `commitOID is not part of the pull request` — even though the SHA _is_ in the PR.
 
-13. **Comments are commit-scoped via `Comment::commit_id`.** When the inline commit selector shows exactly one commit, `App::save_comment` stamps that commit's SHA on the comment. Comments with `commit_id = Some(sha)` are hidden when a different commit (or a subset not containing `sha`) is selected; `commit_id = None` (legacy, review-level, or made against the full cumulative diff) is always visible. The filter runs in `rebuild_annotations`, both diff renderers, the comment navigator (via filtered annotations), and the submit preflight. `App::comment_visible(&Comment)` is the single predicate. `AnnotatedLine::LineComment`/`FileComment` `comment_idx` is the **absolute** index into the stored `Vec`/`HashMap` value — `delete_comment_at_cursor` and `enter_edit_mode` must look it up directly, not re-count by side.
+13. **`cd` into the worktree before running `cargo`.** `cargo` resolves `Cargo.toml` from `pwd`. Running gates from the wrong worktree silently exercises the wrong tree.
 
-14. **A diff file must be registered in the session before `r`, `R`, or a comment can land on it.** All three look the file up in `ReviewSession.files` by display path. The two review-mark toggles return silently when it is absent; `add_comment_to_session` returns `session does not contain file`. So any code path that assigns `self.diff_files` must also call `App::register_diff_files`. Narrowing the inline commit pane skipped this, so commit-only files could be neither marked nor commented on.
+14. **Comments are commit-scoped via `Comment::commit_id`.** When the inline commit selector shows exactly one commit, `App::save_comment` stamps that commit's SHA on the comment. Comments with `commit_id = Some(sha)` are hidden when a different commit (or a subset not containing `sha`) is selected; `commit_id = None` (legacy, review-level, or made against the full cumulative diff) is always visible. The filter runs in `rebuild_annotations`, both diff renderers, the comment navigator (via filtered annotations), and the submit preflight. `App::comment_visible(&Comment)` is the single predicate. `AnnotatedLine::LineComment`/`FileComment` `comment_idx` is the **absolute** index into the stored `Vec`/`HashMap` value — `delete_comment_at_cursor` and `enter_edit_mode` must look it up directly, not re-count by side.
 
-15. **GNU Linux release binaries must stay dynamically linked.** Static glibc binaries can crash when hostname lookup loads a host NSS module (for example Fedora's `libnss_myhostname`). The musl artifacts are the supported static Linux builds. Direct updates must preserve the running binary's GNU/musl target environment when selecting an asset.
+15. **A diff file must be registered in the session before `r`, `R`, or a comment can land on it.** All three look the file up in `ReviewSession.files` by display path. The two review-mark toggles return silently when it is absent; `add_comment_to_session` returns `session does not contain file`. So any code path that assigns `self.diff_files` must also call `App::register_diff_files`. Narrowing the inline commit pane skipped this, so commit-only files could be neither marked nor commented on.
+
+16. **GNU Linux release binaries must stay dynamically linked.** Static glibc binaries can crash when hostname lookup loads a host NSS module (for example Fedora's `libnss_myhostname`). The musl artifacts are the supported static Linux builds. Direct updates must preserve the running binary's GNU/musl target environment when selecting an asset.
 
 ### Keeping Docs Updated
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -816,16 +816,7 @@ pub enum PrOpenEvent {
         /// Network-only outcome. Parsing + session build runs on the main
         /// thread after this lands so `SyntaxHighlighter` does not need to
         /// cross thread boundaries.
-        result: std::result::Result<
-            (
-                crate::forge::traits::PullRequestDetails,
-                String,
-                Vec<crate::forge::traits::PullRequestCommit>,
-                crate::forge::traits::PullRequestReviewMetadata,
-                crate::forge::traits::PullRequestInfo,
-            ),
-            String,
-        >,
+        result: std::result::Result<crate::forge::pr_open::PrFetchData, String>,
     },
 }
 
@@ -858,16 +849,7 @@ pub struct PrReloadRequest {
 pub enum PrReloadEvent {
     Done {
         request: PrReloadRequest,
-        result: std::result::Result<
-            (
-                crate::forge::traits::PullRequestDetails,
-                String,
-                Vec<crate::forge::traits::PullRequestCommit>,
-                crate::forge::traits::PullRequestReviewMetadata,
-                crate::forge::traits::PullRequestInfo,
-            ),
-            String,
-        >,
+        result: std::result::Result<crate::forge::pr_open::PrFetchData, String>,
     },
 }
 
@@ -891,7 +873,7 @@ pub struct PrRangeReloadRequest {
 pub enum PrRangeReloadEvent {
     Done {
         request: PrRangeReloadRequest,
-        result: std::result::Result<String, String>,
+        result: std::result::Result<Vec<crate::model::FilePatch>, String>,
     },
 }
 

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -394,8 +394,8 @@ impl App {
         self.pr_range_reload_state = None;
 
         match result {
-            Ok(patch) => {
-                if let Err(e) = self.finish_pr_range_reload(&request, &patch) {
+            Ok(patches) => {
+                if let Err(e) = self.finish_pr_range_reload(&request, patches) {
                     self.set_error(format!("Range diff failed: {e}"));
                 }
             }
@@ -408,12 +408,12 @@ impl App {
     pub(in crate::app) fn finish_pr_range_reload(
         &mut self,
         request: &PrRangeReloadRequest,
-        patch: &str,
+        patches: Vec<crate::model::FilePatch>,
     ) -> Result<()> {
-        use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
+        use crate::vcs::diff_parser::parse_file_patches;
 
         let highlighter = self.theme.syntax_highlighter();
-        let parsed = match parse_unified_diff(patch, DiffFormat::GitStyle, highlighter) {
+        let parsed = match parse_file_patches(patches, highlighter) {
             Ok(files) => files,
             Err(TuicrError::NoChanges) => Vec::new(),
             Err(e) => return Err(e),
@@ -529,10 +529,10 @@ impl App {
             return;
         }
         match result {
-            Ok((details, patch, commits, review_metadata, pr_info)) => {
+            Ok((details, patches, commits, review_metadata, pr_info)) => {
                 if let Err(e) = self.finish_pr_reload(
                     details,
-                    patch,
+                    patches,
                     commits,
                     review_metadata,
                     pr_info,
@@ -550,7 +550,7 @@ impl App {
     pub(in crate::app) fn finish_pr_reload(
         &mut self,
         details: crate::forge::traits::PullRequestDetails,
-        patch: String,
+        patches: Vec<crate::model::FilePatch>,
         commits: Vec<crate::forge::traits::PullRequestCommit>,
         review_metadata: crate::forge::traits::PullRequestReviewMetadata,
         pr_info: crate::forge::traits::PullRequestInfo,
@@ -565,7 +565,7 @@ impl App {
         let highlighter = self.theme.syntax_highlighter();
         let opened = prepare_open_pr(
             details,
-            &patch,
+            patches,
             commits,
             review_metadata,
             pr_info,
@@ -964,10 +964,10 @@ impl App {
                     return;
                 }
                 match result {
-                    Ok((details, patch, commits, review_metadata, pr_info)) => {
+                    Ok((details, patches, commits, review_metadata, pr_info)) => {
                         if let Err(e) = self.finish_pr_open(
                             details,
-                            patch,
+                            patches,
                             commits,
                             review_metadata,
                             pr_info,
@@ -987,14 +987,14 @@ impl App {
         }
     }
 
-    /// Main-thread half of the PR open: parse the patch, build the
+    /// Main-thread half of the PR open: parse the structured patches, build the
     /// session, and enter PR diff mode. Mirrors what the previous synchronous
     /// `open_pr_with_backend` did, but the network fetch has already
     /// happened on the background thread.
     fn finish_pr_open(
         &mut self,
         details: crate::forge::traits::PullRequestDetails,
-        patch: String,
+        patches: Vec<crate::model::FilePatch>,
         commits: Vec<crate::forge::traits::PullRequestCommit>,
         review_metadata: crate::forge::traits::PullRequestReviewMetadata,
         pr_info: crate::forge::traits::PullRequestInfo,
@@ -1006,7 +1006,7 @@ impl App {
         let highlighter = self.theme.syntax_highlighter();
         let opened = prepare_open_pr(
             details.clone(),
-            &patch,
+            patches,
             commits,
             review_metadata,
             pr_info,

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -245,7 +245,7 @@ impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
     fn get_pull_request_diff(
         &self,
         _pr: &crate::forge::traits::PullRequestDetails,
-    ) -> crate::error::Result<String> {
+    ) -> crate::error::Result<Vec<crate::model::FilePatch>> {
         unimplemented!()
     }
     fn fetch_file_lines(
@@ -271,7 +271,7 @@ impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
         _pr: &crate::forge::traits::PullRequestDetails,
         _start_sha: &str,
         _end_sha: &str,
-    ) -> crate::error::Result<String> {
+    ) -> crate::error::Result<Vec<crate::model::FilePatch>> {
         unimplemented!()
     }
     fn create_review(

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -390,8 +390,8 @@ impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
     fn get_pull_request_diff(
         &self,
         _pr: &crate::forge::traits::PullRequestDetails,
-    ) -> Result<String> {
-        Ok(self.patch.clone())
+    ) -> Result<Vec<crate::model::FilePatch>> {
+        Ok(structured_patch(&self.patch))
     }
     fn fetch_file_lines(
         &self,
@@ -422,11 +422,10 @@ impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
         _pr: &crate::forge::traits::PullRequestDetails,
         _start_sha: &str,
         _end_sha: &str,
-    ) -> Result<String> {
-        Ok(self
-            .range_patch
-            .clone()
-            .unwrap_or_else(|| self.patch.clone()))
+    ) -> Result<Vec<crate::model::FilePatch>> {
+        Ok(structured_patch(
+            self.range_patch.as_deref().unwrap_or(&self.patch),
+        ))
     }
     fn create_review(
         &self,
@@ -760,6 +759,10 @@ fn first_hunk_patch() -> &'static str {
     include_str!("../../../tests/fixtures/pr_refresh/first_hunk.patch")
 }
 
+fn structured_patch(patch: &str) -> Vec<crate::model::FilePatch> {
+    crate::vcs::diff_parser::git_fixture_file_patches(patch)
+}
+
 fn two_file_patch(changed_replacement: &str) -> String {
     match changed_replacement {
         "new changed" => {
@@ -1000,7 +1003,7 @@ fn should_preserve_hunk_marks_hidden_by_pr_range_diff() {
         started_at: Instant::now(),
         anchor: None,
     };
-    app.finish_pr_range_reload(&request, first_hunk_patch())
+    app.finish_pr_range_reload(&request, structured_patch(first_hunk_patch()))
         .unwrap();
 
     assert!(app.session.is_hunk_reviewed(&path, &hidden_key));
@@ -1264,7 +1267,7 @@ fn should_reindex_recovered_pr_session() {
     let highlighter = app.theme.syntax_highlighter();
     let opened_b = crate::forge::pr_open::prepare_open_pr(
         details_b.clone(),
-        &two_file_patch("newer changed"),
+        structured_patch(&two_file_patch("newer changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         crate::forge::traits::PullRequestInfo::from_details(details_b.clone()),
@@ -1323,7 +1326,7 @@ fn should_error_on_corrupt_exact_session_file_when_reopening_pr() {
     let highlighter = theme.syntax_highlighter();
     let opened = crate::forge::pr_open::prepare_open_pr(
         details.clone(),
-        &two_file_patch("new changed"),
+        structured_patch(&two_file_patch("new changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         crate::forge::traits::PullRequestInfo::from_details(details.clone()),
@@ -1376,7 +1379,7 @@ fn should_keep_old_head_session_when_new_head_session_file_is_corrupt() {
     let highlighter = app.theme.syntax_highlighter();
     let opened_b = crate::forge::pr_open::prepare_open_pr(
         details_b.clone(),
-        &two_file_patch("newer changed"),
+        structured_patch(&two_file_patch("newer changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         crate::forge::traits::PullRequestInfo::from_details(details_b.clone()),
@@ -1458,7 +1461,7 @@ fn should_ignore_exact_session_file_when_pr_session_key_does_not_match() {
     let highlighter = theme.syntax_highlighter();
     let opened = crate::forge::pr_open::prepare_open_pr(
         details.clone(),
-        &two_file_patch("new changed"),
+        structured_patch(&two_file_patch("new changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         crate::forge::traits::PullRequestInfo::from_details(details.clone()),
@@ -1774,7 +1777,7 @@ fn should_build_new_head_session_by_carrying_only_unchanged_reviewed_state() {
     let pr_info_b = crate::forge::traits::PullRequestInfo::from_details(details_b.clone());
     let opened = crate::forge::pr_open::prepare_open_pr(
         details_b,
-        &two_file_patch("newer changed"),
+        structured_patch(&two_file_patch("newer changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         pr_info_b,
@@ -1831,7 +1834,7 @@ fn should_carry_unchanged_hunk_marks_inside_changed_file_when_pr_head_advances()
     let pr_info_b = crate::forge::traits::PullRequestInfo::from_details(details_b.clone());
     let opened = crate::forge::pr_open::prepare_open_pr(
         details_b,
-        &two_hunk_pr_patch("newer second"),
+        structured_patch(&two_hunk_pr_patch("newer second")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         pr_info_b,
@@ -1883,7 +1886,7 @@ fn should_carry_reviewed_state_through_finish_pr_reload_when_head_advances() {
     details_b.head_sha = "bbbbbbbbbbbbbbbb".to_string();
     app.finish_pr_reload(
         details_b.clone(),
-        two_file_patch("newer changed"),
+        structured_patch(&two_file_patch("newer changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         crate::forge::traits::PullRequestInfo::from_details(details_b),
@@ -1932,7 +1935,7 @@ fn should_keep_reviewed_state_through_finish_pr_reload_when_head_unchanged() {
     // when the async reload finish path refreshes the same head
     app.finish_pr_reload(
         details.clone(),
-        two_file_patch("new changed"),
+        structured_patch(&two_file_patch("new changed")),
         Vec::new(),
         PullRequestReviewMetadata::default(),
         crate::forge::traits::PullRequestInfo::from_details(details),
@@ -1990,7 +1993,7 @@ impl crate::forge::traits::ForgeBackend for FailingForgeBackend {
     fn get_pull_request_diff(
         &self,
         _pr: &crate::forge::traits::PullRequestDetails,
-    ) -> Result<String> {
+    ) -> Result<Vec<crate::model::FilePatch>> {
         unreachable!()
     }
     fn fetch_file_lines(
@@ -2016,7 +2019,7 @@ impl crate::forge::traits::ForgeBackend for FailingForgeBackend {
         _pr: &crate::forge::traits::PullRequestDetails,
         _start_sha: &str,
         _end_sha: &str,
-    ) -> Result<String> {
+    ) -> Result<Vec<crate::model::FilePatch>> {
         unreachable!()
     }
     fn create_review(
@@ -2546,8 +2549,8 @@ impl crate::forge::traits::ForgeBackend for ThreadAwareForgeBackend {
     fn get_pull_request_diff(
         &self,
         _p: &crate::forge::traits::PullRequestDetails,
-    ) -> Result<String> {
-        Ok(self.patch.clone())
+    ) -> Result<Vec<crate::model::FilePatch>> {
+        Ok(structured_patch(&self.patch))
     }
     fn fetch_file_lines(
         &self,
@@ -2573,7 +2576,7 @@ impl crate::forge::traits::ForgeBackend for ThreadAwareForgeBackend {
         _pr: &crate::forge::traits::PullRequestDetails,
         _start_sha: &str,
         _end_sha: &str,
-    ) -> Result<String> {
+    ) -> Result<Vec<crate::model::FilePatch>> {
         unreachable!()
     }
     fn create_review(

--- a/src/forge/azure/az.rs
+++ b/src/forge/azure/az.rs
@@ -30,8 +30,9 @@ use crate::forge::traits::{
     GhCreateReviewResponse, PagedPullRequests, PullRequestCommit, PullRequestDetails,
     PullRequestListQuery, PullRequestListScope, PullRequestTarget,
 };
-use crate::model::DiffLine;
+use crate::model::{DiffLine, FilePatch};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
+use crate::vcs::git::raw::run_git_diff;
 use crate::vcs::slice_context_lines;
 
 use super::models::{
@@ -261,7 +262,7 @@ fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<Strin
 
 /// `git diff <a><sep><b>` in `repo_root`, returning `None` when either SHA is
 /// absent locally or the command fails.
-fn local_diff(repo_root: &Path, a: &str, b: &str, sep: &str) -> Option<String> {
+fn local_diff(repo_root: &Path, a: &str, b: &str, sep: &str) -> Option<Vec<FilePatch>> {
     for sha in [a, b] {
         let exists = run_command_output(
             "git",
@@ -273,12 +274,7 @@ fn local_diff(repo_root: &Path, a: &str, b: &str, sep: &str) -> Option<String> {
         }
     }
     let range = format!("{a}{sep}{b}");
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["diff", range.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
+    run_git_diff(repo_root, &[range.as_str()]).ok()
 }
 
 // ---------- Coordinate helpers ----------
@@ -506,7 +502,7 @@ impl ForgeBackend for AzureDevOpsBackend {
         Ok(pr.into_details(&repository))
     }
 
-    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String> {
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
         // 3-dot diff (merge-base..head) matches PR review semantics, like the
         // GitHub compare API. Sourced from the local clone.
         let root = self
@@ -528,7 +524,7 @@ impl ForgeBackend for AzureDevOpsBackend {
         _pr: &PullRequestDetails,
         start_sha: &str,
         end_sha: &str,
-    ) -> Result<String> {
+    ) -> Result<Vec<FilePatch>> {
         let root = self
             .local_checkout
             .as_deref()

--- a/src/forge/bitbucket/bkt.rs
+++ b/src/forge/bitbucket/bkt.rs
@@ -25,12 +25,13 @@ use crate::forge::traits::{
     GhCreateReviewResponse, PagedPullRequests, PullRequestCommit, PullRequestDetails,
     PullRequestListQuery, PullRequestListScope, PullRequestReviewMetadata, PullRequestTarget,
 };
-use crate::model::DiffLine;
+use crate::model::{DiffLine, FilePatch};
 use crate::process::{CommandOutputError, CommandOutputErrorKind, run_command_output};
+use crate::vcs::git::raw::{pair_metadata_with_patch, run_git_diff};
 use crate::vcs::slice_context_lines;
 
 use super::models::{
-    BbComment, BbCommit, BbPaged, BbPullRequest, BbUser, group_into_review_threads,
+    BbComment, BbCommit, BbDiffStat, BbPaged, BbPullRequest, BbUser, group_into_review_threads,
     review_summaries,
 };
 
@@ -108,7 +109,7 @@ fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<Strin
 }
 
 /// Return `Some(diff)` when both SHAs exist locally, via `git diff <start>..<end>`.
-fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<String> {
+fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<Vec<FilePatch>> {
     for sha in [start_sha, end_sha] {
         let exists = run_command_output(
             "git",
@@ -120,12 +121,7 @@ fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<
         }
     }
     let range = format!("{start_sha}..{end_sha}");
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["diff", range.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
+    run_git_diff(repo_root, &[range.as_str()]).ok()
 }
 
 #[derive(Debug, Clone)]
@@ -417,12 +413,21 @@ where
         Ok(details)
     }
 
-    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String> {
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
+        let diffstat_path = format!(
+            "{}/pullrequests/{}/diffstat",
+            Self::repo_path(&pr.repository),
+            pr.number
+        );
+        let metadata = self
+            .collect_pages::<BbDiffStat>(diffstat_path)?
+            .into_iter()
+            .map(BbDiffStat::into_metadata)
+            .collect::<Result<Vec<_>>>()?;
         let mut args = vec!["pr".to_string(), "diff".to_string(), pr.number.to_string()];
         args.extend(Self::repo_args(&pr.repository));
-        // `bkt pr diff` already emits `diff --git` headers, so unlike the
-        // GitLab backend this needs no header injection.
-        self.run_bkt(args)
+        let patch = self.run_bkt(args)?;
+        pair_metadata_with_patch(metadata, patch.as_bytes())
     }
 
     fn local_checkout_path(&self) -> Option<PathBuf> {
@@ -469,7 +474,7 @@ where
         pr: &PullRequestDetails,
         start_sha: &str,
         end_sha: &str,
-    ) -> Result<String> {
+    ) -> Result<Vec<FilePatch>> {
         if let Some(root) = self.local_checkout.as_deref()
             && let Some(diff) = local_range_diff(root, start_sha, end_sha)
         {
@@ -478,13 +483,25 @@ where
         // Bitbucket's diff spec is `new..old` — the reverse of git's
         // `old..new`. Verified against the live API: the git-style order
         // returns an empty diff.
+        let diffstat_path = format!(
+            "{}/diffstat/{}..{}",
+            Self::repo_path(&pr.repository),
+            end_sha,
+            start_sha
+        );
+        let metadata = self
+            .collect_pages::<BbDiffStat>(diffstat_path)?
+            .into_iter()
+            .map(BbDiffStat::into_metadata)
+            .collect::<Result<Vec<_>>>()?;
         let path = format!(
             "{}/diff/{}..{}",
             Self::repo_path(&pr.repository),
             end_sha,
             start_sha
         );
-        self.run_api(path, &[])
+        let patch = self.run_api(path, &[])?;
+        pair_metadata_with_patch(metadata, patch.as_bytes())
     }
 
     fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>> {
@@ -962,6 +979,10 @@ mod tests {
       "links": { "html": { "href": "https://bitbucket.org/example-workspace/repo/pull-requests/830" } }
     }"#;
 
+    const DIFFSTAT_JSON: &str = r#"{"values":[{
+      "status":"modified","old":{"path":"x"},"new":{"path":"x"}
+    }]}"#;
+
     fn inline_comment(line: u32, side: GhSide, start_line: Option<u32>) -> InlineComment {
         InlineComment {
             path: PathBuf::from("src/lib.rs"),
@@ -982,12 +1003,12 @@ mod tests {
     #[test]
     fn should_always_pass_workspace_and_repo_to_first_class_commands() {
         // given — bkt hard-fails when the active context lacks these
-        let backend = backend(vec!["diff --git a/x b/x\n"]);
+        let backend = backend(vec![DIFFSTAT_JSON, "diff --git a/x b/x\n"]);
         // when
         backend.get_pull_request_diff(&details()).unwrap();
         // then
         assert_eq!(
-            backend.runner.calls.borrow()[0],
+            backend.runner.calls.borrow()[1],
             vec![
                 "pr",
                 "diff",
@@ -1267,14 +1288,14 @@ mod tests {
     #[test]
     fn should_reverse_the_diff_spec_for_a_commit_range() {
         // given — no local checkout, so it goes through the API
-        let backend = backend(vec!["diff --git a/x b/x\n"]);
+        let backend = backend(vec![DIFFSTAT_JSON, "diff --git a/x b/x\n"]);
         // when
         backend
             .get_pull_request_commit_range_diff(&details(), "oldsha", "newsha")
             .unwrap();
         // then — Bitbucket takes `new..old`, the reverse of git
         assert_eq!(
-            backend.runner.calls.borrow()[0][1],
+            backend.runner.calls.borrow()[1][1],
             "/2.0/repositories/example-workspace/repo/diff/newsha..oldsha"
         );
     }
@@ -1751,12 +1772,14 @@ mod tests {
         assert_eq!(details.head_sha.len(), 40, "head_sha was not promoted");
         assert_eq!(details.number, number);
 
-        let patch = backend
+        let patches = backend
             .get_pull_request_diff(&details)
             .expect("get_pull_request_diff");
         assert!(
-            patch.contains("diff --git "),
-            "patch is missing git headers, the shared parser needs them"
+            patches
+                .iter()
+                .any(|patch| patch.patch.contains("diff --git ")),
+            "structured patches are missing Git bodies"
         );
 
         let commits = backend

--- a/src/forge/bitbucket/models.rs
+++ b/src/forge/bitbucket/models.rs
@@ -23,6 +23,55 @@ use crate::forge::traits::{
     ForgeRepository, PullRequestCommit, PullRequestDetails, PullRequestReviewRecord,
     PullRequestSummary,
 };
+use crate::model::FileStatus;
+use crate::vcs::git::raw::FileMetadata;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct BbDiffStatFile {
+    #[serde(default)]
+    pub path: String,
+}
+
+/// One machine-readable entry from Bitbucket Cloud's diffstat endpoint.
+#[derive(Debug, Deserialize)]
+pub struct BbDiffStat {
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub old: Option<BbDiffStatFile>,
+    #[serde(default)]
+    pub new: Option<BbDiffStatFile>,
+}
+
+impl BbDiffStat {
+    pub(crate) fn into_metadata(self) -> Result<FileMetadata> {
+        let old_path = self
+            .old
+            .filter(|file| !file.path.is_empty())
+            .map(|file| std::path::PathBuf::from(file.path));
+        let new_path = self
+            .new
+            .filter(|file| !file.path.is_empty())
+            .map(|file| std::path::PathBuf::from(file.path));
+        let status = match self.status.to_ascii_lowercase().as_str() {
+            "added" => FileStatus::Added,
+            "removed" => FileStatus::Deleted,
+            "renamed" => FileStatus::Renamed,
+            "copied" => FileStatus::Copied,
+            "modified" => FileStatus::Modified,
+            status => {
+                return Err(TuicrError::Forge(format!(
+                    "Bitbucket returned unsupported diffstat status `{status}`"
+                )));
+            }
+        };
+        Ok(FileMetadata {
+            old_path,
+            new_path,
+            status,
+        })
+    }
+}
 
 /// Envelope Bitbucket Cloud wraps every paginated collection in. `next` is
 /// absent on the final page, which is how callers detect the end.
@@ -902,5 +951,28 @@ mod tests {
         assert_eq!(threads[0].comments.len(), 2);
         assert_eq!(threads[1].id, "2");
         assert_eq!(threads[1].comments.len(), 1);
+    }
+
+    #[test]
+    fn diffstat_metadata_preserves_renamed_unicode_paths() {
+        let row: BbDiffStat = serde_json::from_str(
+            r#"{
+              "status":"renamed",
+              "old":{"path":"旧 b/left and side.txt"},
+              "new":{"path":"新 b/right and side.txt"}
+            }"#,
+        )
+        .unwrap();
+        let metadata = row.into_metadata().unwrap();
+
+        assert_eq!(metadata.status, FileStatus::Renamed);
+        assert_eq!(
+            metadata.old_path.as_deref(),
+            Some(std::path::Path::new("旧 b/left and side.txt"))
+        );
+        assert_eq!(
+            metadata.new_path.as_deref(),
+            Some(std::path::Path::new("新 b/right and side.txt"))
+        );
     }
 }

--- a/src/forge/context.rs
+++ b/src/forge/context.rs
@@ -189,7 +189,10 @@ mod tests {
         fn get_pull_request(&self, _target: PullRequestTarget) -> Result<PullRequestDetails> {
             unimplemented!()
         }
-        fn get_pull_request_diff(&self, _pr: &PullRequestDetails) -> Result<String> {
+        fn get_pull_request_diff(
+            &self,
+            _pr: &PullRequestDetails,
+        ) -> Result<Vec<crate::model::FilePatch>> {
             unimplemented!()
         }
         fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
@@ -213,7 +216,7 @@ mod tests {
             _pr: &PullRequestDetails,
             _start_sha: &str,
             _end_sha: &str,
-        ) -> Result<String> {
+        ) -> Result<Vec<crate::model::FilePatch>> {
             unimplemented!()
         }
         fn create_review(

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -9,13 +9,14 @@ use crate::forge::traits::{
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestInfo,
     PullRequestListQuery, PullRequestListScope, PullRequestTarget,
 };
-use crate::model::DiffLine;
+use crate::model::{DiffLine, FilePatch};
 use crate::process::{
     CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
 };
+use crate::vcs::git::raw::{FileMetadata, pair_metadata_with_patch, run_git_diff};
 use crate::vcs::slice_context_lines;
 
-use super::models::{GhPrCommit, GhPullRequestSummary};
+use super::models::{GhCompare, GhPrCommit, GhPullRequestFile, GhPullRequestSummary};
 use super::review_summaries::{
     build_query as build_reviews_query, parse_graphql_page as parse_reviews_page,
 };
@@ -132,7 +133,7 @@ fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<Strin
 /// the local checkout at `repo_root`, by running `git diff <start>..<end>`.
 /// Returns `None` when the checkout is missing either SHA or the command
 /// fails — callers fall back to the forge in that case.
-fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<String> {
+fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<Vec<FilePatch>> {
     for sha in [start_sha, end_sha] {
         let exists = run_command_output(
             "git",
@@ -144,12 +145,7 @@ fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<
         }
     }
     let range = format!("{start_sha}..{end_sha}");
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["diff", range.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
+    run_git_diff(repo_root, &[range.as_str()]).ok()
 }
 
 #[derive(Debug, Clone)]
@@ -235,6 +231,35 @@ where
             .run(&args)
             .map_err(|err| map_gh_error(err, host))
     }
+
+    fn pull_request_file_metadata(&self, pr: &PullRequestDetails) -> Result<Vec<FileMetadata>> {
+        let mut metadata = Vec::new();
+        for page in 1..=30 {
+            let endpoint = format!(
+                "repos/{}/{}/pulls/{}/files?per_page=100&page={page}",
+                pr.repository.owner, pr.repository.name, pr.number
+            );
+            let mut args = vec!["api".to_string()];
+            if pr.repository.host != DEFAULT_GITHUB_HOST {
+                args.extend(["--hostname".to_string(), pr.repository.host.clone()]);
+            }
+            args.push(endpoint);
+            let output = self.run_gh(args, &pr.repository.host)?;
+            let rows: Vec<GhPullRequestFile> = serde_json::from_str(&output)?;
+            let received = rows.len();
+            metadata.extend(
+                rows.into_iter()
+                    .map(GhPullRequestFile::into_metadata)
+                    .collect::<Result<Vec<_>>>()?,
+            );
+            if received < 100 {
+                return Ok(metadata);
+            }
+        }
+        Err(TuicrError::Forge(
+            "GitHub pull request exceeds the 3000-file REST API limit".into(),
+        ))
+    }
 }
 
 impl<R> ForgeBackend for GitHubGhBackend<R>
@@ -305,7 +330,7 @@ where
         super::pr_info::parse_pull_request_info(&output, &repository)
     }
 
-    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String> {
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
         // We want the *cumulative* diff between base and head for the PR.
         // `gh pr diff --patch` returns mbox-style `git format-patch` output
         // — one patch per commit — so a 7-commit PR yields 7 separate
@@ -313,7 +338,8 @@ where
         // into duplicate `DiffFile`s. Plain `gh pr diff` (no `--patch`)
         // returns the single cumulative diff. Hard-won lesson; see the
         // duplicate-files-in-list bug.
-        self.run_gh(
+        let metadata = self.pull_request_file_metadata(pr)?;
+        let patch = self.run_gh(
             vec![
                 "pr".to_string(),
                 "diff".to_string(),
@@ -324,7 +350,8 @@ where
                 "never".to_string(),
             ],
             &pr.repository.host,
-        )
+        )?;
+        pair_metadata_with_patch(metadata, patch.as_bytes())
     }
 
     fn local_checkout_path(&self) -> Option<PathBuf> {
@@ -363,7 +390,7 @@ where
         pr: &PullRequestDetails,
         start_sha: &str,
         end_sha: &str,
-    ) -> Result<String> {
+    ) -> Result<Vec<FilePatch>> {
         // Fast path: when both SHAs live in the local checkout, `git diff`
         // gives us the cumulative diff in O(local-IO) without round-tripping
         // through GitHub. The PR diff text is the source of truth, but the
@@ -375,12 +402,26 @@ where
             return Ok(diff);
         }
 
-        // Fall back to GitHub's compare API. `Accept: application/vnd.github.diff`
-        // returns plain unified diff text instead of the JSON wrapper.
+        // The JSON response provides authoritative file metadata; a second
+        // request asks for the full patch. Their shared source order lets us
+        // pair them without inspecting display-oriented path headers.
         let endpoint = format!(
             "repos/{}/{}/compare/{}...{}",
             pr.repository.owner, pr.repository.name, start_sha, end_sha,
         );
+        let mut metadata_args = vec!["api".to_string()];
+        if pr.repository.host != DEFAULT_GITHUB_HOST {
+            metadata_args.extend(["--hostname".to_string(), pr.repository.host.clone()]);
+        }
+        metadata_args.push(endpoint.clone());
+        let metadata_output = self.run_gh(metadata_args, &pr.repository.host)?;
+        let compare: GhCompare = serde_json::from_str(&metadata_output)?;
+        let metadata = compare
+            .files
+            .into_iter()
+            .map(GhPullRequestFile::into_metadata)
+            .collect::<Result<Vec<_>>>()?;
+
         let mut args = vec![
             "api".to_string(),
             "-H".to_string(),
@@ -391,7 +432,8 @@ where
             args.push(pr.repository.host.clone());
         }
         args.push(endpoint);
-        self.run_gh(args, &pr.repository.host)
+        let patch = self.run_gh(args, &pr.repository.host)?;
+        pair_metadata_with_patch(metadata, patch.as_bytes())
     }
 
     fn list_review_threads(&self, pr: &PullRequestDetails) -> Result<Vec<RemoteReviewThread>> {
@@ -1131,13 +1173,27 @@ index 1111111..2222222 100644
                 Some("api")
                     if args
                         .iter()
+                        .any(|a| a.contains("/pulls/") && a.contains("/files")) =>
+                {
+                    Ok(PR_FILES_JSON.to_string())
+                }
+                Some("api")
+                    if args
+                        .iter()
                         .any(|a| a.contains("/pulls/") && a.contains("/commits")) =>
                 {
                     Ok(PR_COMMITS_JSON.to_string())
                 }
                 // gh api repos/.../compare/<base>...<head> (range diff).
                 Some("api") if args.iter().any(|a| a.contains("/compare/")) => {
-                    Ok(COMPARE_DIFF.to_string())
+                    if args
+                        .iter()
+                        .any(|a| a == "Accept: application/vnd.github.diff")
+                    {
+                        Ok(COMPARE_DIFF.to_string())
+                    } else {
+                        Ok(COMPARE_JSON.to_string())
+                    }
                 }
                 _ => Err(GhCommandError::Failed {
                     status: Some(1),
@@ -1184,6 +1240,10 @@ index 1111111..2222222 100644
             }
         }
     ]"##;
+
+    const PR_FILES_JSON: &str = r##"[{"filename":"src/lib.rs","status":"modified"}]"##;
+
+    const COMPARE_JSON: &str = r##"{"files":[{"filename":"src/lib.rs","status":"modified"}]}"##;
 
     const COMPARE_DIFF: &str = r##"diff --git a/src/lib.rs b/src/lib.rs
 index 1111111..2222222 100644
@@ -1744,15 +1804,20 @@ Match host github-work
     }
 
     #[test]
-    fn get_pull_request_diff_returns_patch_text() {
+    fn get_pull_request_diff_pairs_metadata_with_patch_text() {
         let runner = FakeGhRunner::default();
         let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
         let details = backend
             .get_pull_request(parse_pull_request_target("125").unwrap())
             .unwrap();
-        let patch = backend.get_pull_request_diff(&details).unwrap();
+        let patches = backend.get_pull_request_diff(&details).unwrap();
 
-        assert_eq!(patch, PR_PATCH);
+        assert_eq!(patches.len(), 1);
+        assert_eq!(
+            patches[0].new_path.as_deref(),
+            Some(Path::new("src/lib.rs"))
+        );
+        assert_eq!(patches[0].patch, PR_PATCH.trim_start());
     }
 
     #[test]
@@ -1913,7 +1978,8 @@ Match host github-work
             .get_pull_request_commit_range_diff(&details, "baseaaa", "headbbb")
             .unwrap();
         // then
-        assert!(diff.contains("diff --git a/src/lib.rs"));
+        assert_eq!(diff.len(), 1);
+        assert!(diff[0].patch.contains("diff --git a/src/lib.rs"));
         // and — the call hit the compare endpoint with the Accept diff header.
         let calls = backend.runner.calls.borrow();
         let compare_call = calls
@@ -1921,6 +1987,9 @@ Match host github-work
             .find(|args| {
                 args.iter()
                     .any(|a| a.contains("/compare/baseaaa...headbbb"))
+                    && args
+                        .iter()
+                        .any(|a| a == "Accept: application/vnd.github.diff")
             })
             .expect("expected a compare api call");
         assert!(compare_call.contains(&"Accept: application/vnd.github.diff".to_string()));

--- a/src/forge/github/models.rs
+++ b/src/forge/github/models.rs
@@ -1,10 +1,78 @@
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
 use crate::forge::traits::{
     ForgeRepository, PullRequestCommit, PullRequestDetails, PullRequestSummary,
 };
+use crate::model::FileStatus;
+use crate::vcs::git::raw::FileMetadata;
+
+/// Machine-readable entry from the pull-request files REST endpoint.
+#[derive(Debug, Deserialize)]
+pub struct GhPullRequestFile {
+    pub filename: String,
+    pub status: String,
+    #[serde(default)]
+    pub previous_filename: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GhCompare {
+    #[serde(default)]
+    pub files: Vec<GhPullRequestFile>,
+}
+
+impl GhPullRequestFile {
+    pub(crate) fn into_metadata(self) -> Result<FileMetadata> {
+        let new_path = PathBuf::from(&self.filename);
+        let metadata = match self.status.as_str() {
+            "added" => FileMetadata {
+                old_path: None,
+                new_path: Some(new_path),
+                status: FileStatus::Added,
+            },
+            "removed" => FileMetadata {
+                old_path: Some(new_path),
+                new_path: None,
+                status: FileStatus::Deleted,
+            },
+            "renamed" => FileMetadata {
+                old_path: Some(PathBuf::from(self.previous_filename.ok_or_else(|| {
+                    TuicrError::Forge(format!(
+                        "GitHub renamed file `{}` has no previous_filename",
+                        self.filename
+                    ))
+                })?)),
+                new_path: Some(new_path),
+                status: FileStatus::Renamed,
+            },
+            "copied" => FileMetadata {
+                old_path: Some(PathBuf::from(self.previous_filename.ok_or_else(|| {
+                    TuicrError::Forge(format!(
+                        "GitHub copied file `{}` has no previous_filename",
+                        self.filename
+                    ))
+                })?)),
+                new_path: Some(new_path),
+                status: FileStatus::Copied,
+            },
+            "modified" | "changed" | "unchanged" => FileMetadata {
+                old_path: Some(new_path.clone()),
+                new_path: Some(new_path),
+                status: FileStatus::Modified,
+            },
+            status => {
+                return Err(TuicrError::Forge(format!(
+                    "GitHub returned unsupported file status `{status}` for `{}`",
+                    self.filename
+                )));
+            }
+        };
+        Ok(metadata)
+    }
+}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -164,5 +232,41 @@ fn require_field(value: &str, field: &str) -> Result<()> {
         )))
     } else {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn file_metadata_uses_json_paths_verbatim() {
+        let file: GhPullRequestFile = serde_json::from_str(
+            r#"{
+                "filename":"新 b/right and side.txt",
+                "previous_filename":"旧 b/left and side.txt",
+                "status":"renamed"
+            }"#,
+        )
+        .unwrap();
+        let metadata = file.into_metadata().unwrap();
+
+        assert_eq!(metadata.status, FileStatus::Renamed);
+        assert_eq!(
+            metadata.old_path.as_deref(),
+            Some(Path::new("旧 b/left and side.txt"))
+        );
+        assert_eq!(
+            metadata.new_path.as_deref(),
+            Some(Path::new("新 b/right and side.txt"))
+        );
+    }
+
+    #[test]
+    fn renamed_file_requires_previous_filename() {
+        let file: GhPullRequestFile =
+            serde_json::from_str(r#"{"filename":"new.txt","status":"renamed"}"#).unwrap();
+        assert!(file.into_metadata().is_err());
     }
 }

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -12,15 +12,16 @@ use crate::forge::traits::{
     PagedPullRequests, PullRequestCommit, PullRequestDetails, PullRequestListQuery,
     PullRequestListScope, PullRequestReviewMetadata, PullRequestReviewRecord, PullRequestTarget,
 };
-use crate::model::{DiffLine, LineOrigin};
+use crate::model::{DiffLine, FilePatch, LineOrigin};
 use crate::process::{
     CommandOutputError, CommandOutputErrorKind, run_command_output, run_command_output_with_stdin,
 };
+use crate::vcs::git::raw::run_git_diff;
 use crate::vcs::slice_context_lines;
 
 use super::models::{
-    GlabApprovalState, GlabCommit, GlabDiscussion, GlabMrDetails, GlabMrSummary, GlabMrVersion,
-    GlabUser,
+    GlabApprovalState, GlabCommit, GlabDiff, GlabDiscussion, GlabMrDetails, GlabMrSummary,
+    GlabMrVersion, GlabUser,
 };
 use crate::forge::submit::{DiffAnchor, GhSide, SubmitEvent};
 use crate::forge::traits::CreateReviewRequest;
@@ -104,7 +105,7 @@ fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<Strin
 }
 
 /// Return `Some(diff)` when both SHAs exist locally, via `git diff <start>..<end>`.
-fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<String> {
+fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<Vec<FilePatch>> {
     for sha in [start_sha, end_sha] {
         let exists = run_command_output(
             "git",
@@ -116,12 +117,7 @@ fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<
         }
     }
     let range = format!("{start_sha}..{end_sha}");
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["diff", range.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
+    run_git_diff(repo_root, &[range.as_str()]).ok()
 }
 
 /// Percent-encode `owner/repo` as `owner%2Frepo` for GitLab project API paths.
@@ -396,17 +392,25 @@ where
         mr.into_details(&repository)
     }
 
-    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String> {
-        let args = vec![
-            "mr".to_string(),
-            "diff".to_string(),
-            pr.number.to_string(),
-            "--repo".to_string(),
-            Self::repo_arg(&pr.repository),
-            "--color=never".to_string(),
-        ];
-        let raw = self.run_glab(args, &pr.repository.host)?;
-        Ok(inject_git_diff_headers(&raw))
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
+        let project = gl_project_path(&pr.repository.owner, &pr.repository.name);
+        let mut patches = Vec::new();
+        for page in 1..=100 {
+            let endpoint = format!(
+                "projects/{project}/merge_requests/{}/diffs?per_page=100&page={page}",
+                pr.number
+            );
+            let output = self.run_api(&pr.repository, endpoint)?;
+            let rows: Vec<GlabDiff> = serde_json::from_str(&output)?;
+            let received = rows.len();
+            patches.extend(rows.into_iter().map(GlabDiff::into_file_patch));
+            if received < 100 {
+                return Ok(patches);
+            }
+        }
+        Err(TuicrError::Forge(
+            "GitLab merge request diff exceeded 10000 files".into(),
+        ))
     }
 
     fn local_checkout_path(&self) -> Option<PathBuf> {
@@ -459,7 +463,7 @@ where
         _pr: &PullRequestDetails,
         start_sha: &str,
         end_sha: &str,
-    ) -> Result<String> {
+    ) -> Result<Vec<FilePatch>> {
         if let Some(root) = self.local_checkout.as_deref()
             && let Some(diff) = local_range_diff(root, start_sha, end_sha)
         {
@@ -1010,38 +1014,6 @@ fn strip_git_suffix(value: &str) -> &str {
     value.strip_suffix(".git").unwrap_or(value)
 }
 
-/// Convert a bare unified diff (as output by `glab mr diff`) into git-style
-/// by injecting `diff --git a/X b/X` headers before each `--- ` / `+++ ` pair.
-///
-/// `glab mr diff` emits plain unified diffs without git file headers, but the
-/// tuicr parser requires `diff --git ` to detect file boundaries.
-fn inject_git_diff_headers(diff: &str) -> String {
-    let mut result = String::with_capacity(diff.len() + diff.lines().count() * 64);
-    let mut lines = diff.lines().peekable();
-    while let Some(line) = lines.next() {
-        if let Some(old_raw) = line.strip_prefix("--- ") {
-            // Peek at the next line to get the new path for added files.
-            let new_raw = lines
-                .peek()
-                .and_then(|l| l.strip_prefix("+++ "))
-                .unwrap_or(old_raw);
-            // Determine the canonical path: prefer the non-/dev/null side.
-            let path = if old_raw == "/dev/null" {
-                new_raw
-            } else {
-                old_raw
-            };
-            // Strip a/ or b/ prefix if already present (shouldn't be for glab,
-            // but be defensive).
-            let path = path.trim_start_matches("a/").trim_start_matches("b/");
-            result.push_str(&format!("diff --git a/{path} b/{path}\n"));
-        }
-        result.push_str(line);
-        result.push('\n');
-    }
-    result
-}
-
 fn parse_scp_like_remote(remote_url: &str) -> Option<(&str, &str)> {
     if remote_url.contains("://") {
         return None;
@@ -1460,6 +1432,37 @@ mod tests {
             merged_at: None,
             diff_start_sha: Some("startsha1".to_string()),
         }
+    }
+
+    #[test]
+    fn should_fetch_structured_merge_request_diffs_instead_of_injecting_headers() {
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let runner = RecordingRunner::new_with_responses(vec![
+            r#"[{
+              "old_path":"日本語 b/and file.sql",
+              "new_path":"日本語 b/and file.sql",
+              "diff":"@@ -1,2 +1 @@\n--- count rows\n SELECT 1;\n"
+            }]"#
+            .to_string(),
+        ]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        let patches = backend.get_pull_request_diff(&pr).unwrap();
+
+        assert_eq!(patches.len(), 1);
+        assert_eq!(
+            patches[0].new_path.as_deref(),
+            Some(Path::new("日本語 b/and file.sql"))
+        );
+        let calls = backend.runner.calls.borrow();
+        assert!(
+            calls[0]
+                .0
+                .iter()
+                .any(|arg| arg.contains("/merge_requests/42/diffs?"))
+        );
+        assert!(!calls[0].0.iter().any(|arg| arg == "mr"));
     }
 
     #[test]

--- a/src/forge/gitlab/models.rs
+++ b/src/forge/gitlab/models.rs
@@ -1,11 +1,54 @@
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
+use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
 use crate::forge::remote_comments::{RemoteCommentSide, RemoteReviewComment, RemoteReviewThread};
 use crate::forge::traits::{
     ForgeRepository, PullRequestCommit, PullRequestDetails, PullRequestSummary,
 };
+use crate::model::{FilePatch, FileStatus};
+use crate::vcs::git::raw::is_binary_patch;
+
+/// One entry from GitLab's merge-request diffs API.
+#[derive(Debug, Deserialize)]
+pub struct GlabDiff {
+    pub old_path: String,
+    pub new_path: String,
+    #[serde(default)]
+    pub new_file: bool,
+    #[serde(default)]
+    pub renamed_file: bool,
+    #[serde(default)]
+    pub deleted_file: bool,
+    #[serde(default)]
+    pub diff: String,
+    #[serde(default)]
+    pub too_large: bool,
+    #[serde(default)]
+    pub collapsed: bool,
+}
+
+impl GlabDiff {
+    pub fn into_file_patch(self) -> FilePatch {
+        let old_path = PathBuf::from(self.old_path);
+        let new_path = PathBuf::from(self.new_path);
+        let (old_path, new_path, status) = if self.new_file {
+            (None, Some(new_path), FileStatus::Added)
+        } else if self.deleted_file {
+            (Some(old_path), None, FileStatus::Deleted)
+        } else if self.renamed_file {
+            (Some(old_path), Some(new_path), FileStatus::Renamed)
+        } else {
+            (Some(old_path), Some(new_path), FileStatus::Modified)
+        };
+        let binary = is_binary_patch(self.diff.as_bytes());
+        let mut patch = FilePatch::new(old_path, new_path, status, self.diff);
+        patch.is_binary = binary;
+        patch.is_too_large = self.too_large || self.collapsed;
+        patch
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct GlabMrSummary {
@@ -335,9 +378,44 @@ fn normalize_state(state: &str) -> String {
 mod tests {
     use super::*;
     use crate::forge::traits::ForgeRepository;
+    use crate::syntax::SyntaxHighlighter;
+    use crate::vcs::diff_parser::parse_file_patches;
 
     fn gitlab_repo() -> ForgeRepository {
         ForgeRepository::gitlab("gitlab.com", "owner", "repo")
+    }
+
+    #[test]
+    fn diff_api_keeps_structured_paths_and_header_like_hunk_content() {
+        let json = r#"{
+            "old_path":"日本語 b/and old.sql",
+            "new_path":"日本語 b/and new.sql",
+            "renamed_file":true,
+            "diff":"@@ -1,2 +1 @@\n--- count rows\n SELECT 1;\n"
+        }"#;
+        let diff: GlabDiff = serde_json::from_str(json).unwrap();
+        let files = parse_file_patches(vec![diff.into_file_patch()], &SyntaxHighlighter::default())
+            .unwrap();
+
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(
+            files[0].old_path.as_deref(),
+            Some(std::path::Path::new("日本語 b/and old.sql"))
+        );
+        assert_eq!(files[0].hunks[0].lines[0].content, "-- count rows");
+        assert_eq!(files[0].hunks[0].lines[1].old_lineno, Some(2));
+    }
+
+    #[test]
+    fn collapsed_diff_is_marked_too_large() {
+        let json = r#"{
+            "old_path":"large.txt","new_path":"large.txt",
+            "collapsed":true,"diff":""
+        }"#;
+        let patch = serde_json::from_str::<GlabDiff>(json)
+            .unwrap()
+            .into_file_patch();
+        assert!(patch.is_too_large);
     }
 
     #[test]

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -6,7 +6,7 @@
 //!
 //! Key invariants enforced here:
 //! - The current local checkout is never treated as the source of truth.
-//!   Diffs are parsed from `gh pr diff`; SHAs are captured from PR metadata.
+//!   File identity comes from forge metadata; SHAs come from PR metadata.
 //! - `.tuicrignore` is applied only when the caller supplies a local
 //!   checkout path. Outside a checkout, the unfiltered diff is shown.
 //! - No checkout mutation. We never spawn `git checkout/fetch/reset/stash`
@@ -19,10 +19,10 @@ use crate::forge::traits::{
     ForgeBackend, PrSessionKey, PullRequestCommit, PullRequestDetails, PullRequestInfo,
     PullRequestReviewMetadata, PullRequestTarget,
 };
-use crate::model::{DiffFile, ReviewSession, SessionDiffSource};
+use crate::model::{DiffFile, FilePatch, ReviewSession, SessionDiffSource};
 use crate::syntax::SyntaxHighlighter;
 use crate::tuicrignore;
-use crate::vcs::diff_parser::{DiffFormat, parse_unified_diff};
+use crate::vcs::diff_parser::parse_file_patches;
 
 /// Everything the App needs to enter PR review mode.
 #[derive(Debug)]
@@ -42,6 +42,15 @@ pub struct OpenedPullRequest {
     pub pr_info: PullRequestInfo,
 }
 
+/// Send-safe data fetched before the main thread materializes diff hunks.
+pub type PrFetchData = (
+    PullRequestDetails,
+    Vec<FilePatch>,
+    Vec<PullRequestCommit>,
+    PullRequestReviewMetadata,
+    PullRequestInfo,
+);
+
 /// Open a PR target through a forge backend and prepare review state.
 ///
 /// `local_checkout` is optional: when provided, `.tuicrignore` rules at the
@@ -53,10 +62,10 @@ pub fn open_pull_request(
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
-    let (details, patch, commits, review_metadata, pr_info) = fetch_pr_data(backend, target)?;
+    let (details, patches, commits, review_metadata, pr_info) = fetch_pr_data(backend, target)?;
     prepare_open_pr(
         details,
-        &patch,
+        patches,
         commits,
         review_metadata,
         pr_info,
@@ -65,48 +74,39 @@ pub fn open_pull_request(
     )
 }
 
-/// Network-only half of the PR open path: fetch PR metadata, the raw
-/// patch text, and the commit list. Safe to run on a background thread
+/// Network-only half of the PR open path: fetch PR metadata, structured file
+/// patches, and the commit list. Safe to run on a background thread
 /// because it does no syntax parsing and holds nothing that isn't `Send`.
 ///
 /// The commit list is best-effort: if the forge fails on that endpoint
 /// only, we still return the diff so PR review proceeds without the
 /// inline selector. The first two calls remain required.
-pub fn fetch_pr_data(
-    backend: &dyn ForgeBackend,
-    target: PullRequestTarget,
-) -> Result<(
-    PullRequestDetails,
-    String,
-    Vec<PullRequestCommit>,
-    PullRequestReviewMetadata,
-    PullRequestInfo,
-)> {
+pub fn fetch_pr_data(backend: &dyn ForgeBackend, target: PullRequestTarget) -> Result<PrFetchData> {
     let pr_info = backend.get_pull_request_info(target)?;
     let details = pr_info.details.clone();
-    let patch = backend.get_pull_request_diff(&details)?;
+    let patches = backend.get_pull_request_diff(&details)?;
     let commits = backend
         .list_pull_request_commits(&details)
         .unwrap_or_default();
     let review_metadata = backend
         .list_pull_request_review_metadata(&details)
         .unwrap_or_default();
-    Ok((details, patch, commits, review_metadata, pr_info))
+    Ok((details, patches, commits, review_metadata, pr_info))
 }
 
-/// CPU-only half of the PR open path: parse the patch, apply
+/// CPU-only half of the PR open path: parse the hunks, apply
 /// `.tuicrignore`, and build the session. Runs on the main thread because
 /// `SyntaxHighlighter` is not trivially `Send`-cloneable.
 pub fn prepare_open_pr(
     details: PullRequestDetails,
-    patch: &str,
+    patches: Vec<FilePatch>,
     commits: Vec<PullRequestCommit>,
     review_metadata: PullRequestReviewMetadata,
     pr_info: PullRequestInfo,
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
-    let parsed = match parse_unified_diff(patch, DiffFormat::GitStyle, highlighter) {
+    let parsed = match parse_file_patches(patches, highlighter) {
         Ok(files) => files,
         Err(TuicrError::NoChanges) => {
             return Err(TuicrError::Forge(format!(
@@ -224,9 +224,11 @@ mod tests {
             self.calls.borrow_mut().push("get_pull_request");
             Ok(self.details.clone())
         }
-        fn get_pull_request_diff(&self, _pr: &PullRequestDetails) -> Result<String> {
+        fn get_pull_request_diff(&self, _pr: &PullRequestDetails) -> Result<Vec<FilePatch>> {
             self.calls.borrow_mut().push("get_pull_request_diff");
-            Ok(self.patch.clone())
+            Ok(crate::vcs::diff_parser::git_fixture_file_patches(
+                &self.patch,
+            ))
         }
         fn fetch_file_lines(&self, _req: ForgeFileLinesRequest) -> Result<Vec<DiffLine>> {
             unimplemented!()
@@ -248,8 +250,10 @@ mod tests {
             _pr: &PullRequestDetails,
             _start_sha: &str,
             _end_sha: &str,
-        ) -> Result<String> {
-            Ok(self.patch.clone())
+        ) -> Result<Vec<FilePatch>> {
+            Ok(crate::vcs::diff_parser::git_fixture_file_patches(
+                &self.patch,
+            ))
         }
         fn create_review(
             &self,
@@ -303,10 +307,9 @@ index 1111111..2222222 100644
         );
     }
 
-    /// Patch fixture covering add/modify/delete/rename in a single PR
-    /// diff, mirroring what `gh pr diff --patch --color never` would
-    /// emit. Acts as a regression guard against future changes to the
-    /// shared diff parser.
+    /// Patch fixture covering add/modify/delete/rename in a single PR diff.
+    /// Tests pair its file blocks with explicit metadata before invoking the
+    /// shared hunk parser.
     const MULTI_STATUS_PATCH: &str = r##"diff --git a/added.rs b/added.rs
 new file mode 100644
 index 0000000..abc1234

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use crate::error::Result;
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::submit::SubmitEvent;
-use crate::model::{DiffLine, FileStatus};
+use crate::model::{DiffLine, FilePatch, FileStatus};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -487,7 +487,7 @@ pub trait ForgeBackend {
         let details = self.get_pull_request(target)?;
         Ok(PullRequestInfo::from_details(details))
     }
-    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<String>;
+    fn get_pull_request_diff(&self, pr: &PullRequestDetails) -> Result<Vec<FilePatch>>;
     /// Fetch the requested file lines from the forge for context expansion.
     /// Implementations may optimize by reading from a local checkout when
     /// available; the trait does not require that path.
@@ -535,7 +535,7 @@ pub trait ForgeBackend {
         pr: &PullRequestDetails,
         start_sha: &str,
         end_sha: &str,
-    ) -> Result<String>;
+    ) -> Result<Vec<FilePatch>>;
     /// Optional path to a local checkout the backend may consult as an
     /// optimization. The default returns `None`; callers must never treat
     /// this path as the source of truth for PR contents.

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -5,6 +5,42 @@ use std::{collections::HashMap, path::PathBuf};
 use crate::hash::Fnv1aHasher;
 use crate::model::comment::LineSide;
 
+/// Backend-provided file metadata paired with that file's opaque patch text.
+///
+/// Paths and status come from a machine-readable VCS or forge channel; the
+/// patch is used only to materialize hunks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilePatch {
+    pub old_path: Option<PathBuf>,
+    pub new_path: Option<PathBuf>,
+    pub status: FileStatus,
+    pub patch: String,
+    pub is_binary: bool,
+    pub is_too_large: bool,
+}
+
+impl FilePatch {
+    pub fn new(
+        old_path: Option<PathBuf>,
+        new_path: Option<PathBuf>,
+        status: FileStatus,
+        patch: impl Into<String>,
+    ) -> Self {
+        Self {
+            old_path,
+            new_path,
+            status,
+            patch: patch.into(),
+            is_binary: false,
+            is_too_large: false,
+        }
+    }
+
+    pub fn display_path(&self) -> Option<&std::path::Path> {
+        self.new_path.as_deref().or(self.old_path.as_deref())
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FileStatus {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -3,5 +3,5 @@ pub mod diff_types;
 pub mod review;
 
 pub use comment::{Comment, CommentType, LineRange, LineSide};
-pub use diff_types::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+pub use diff_types::{DiffFile, DiffHunk, DiffLine, FilePatch, FileStatus, LineOrigin};
 pub use review::{ClearScope, ReviewSession, SessionDiffSource};

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -1,329 +1,182 @@
-//! Unified diff parser for text-based VCS backends (hg, jj, sparse Git).
+//! Materialize structured file patches into the diff model.
 //!
-//! Parses unified diff format output from CLI tools into DiffFile structures.
-//! Standard Git uses the native git2 library; sparse Git feeds CLI diff output
-//! through this parser to avoid sparse-index limitations in libgit2.
+//! File identity is deliberately outside this module. Each backend obtains
+//! paths and status from a machine-readable source (`git --raw -z`, jj
+//! templates, Mercurial status templates, or forge JSON) and supplies them in
+//! [`FilePatch`]. This module only parses unified-diff hunks, where the `@@`
+//! header's line counts make the grammar unambiguous.
 
-use std::borrow::Cow;
+use std::path::Path;
+#[cfg(test)]
 use std::path::PathBuf;
 
 use crate::error::{Result, TuicrError};
-use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+#[cfg(test)]
+use crate::model::FileStatus;
+use crate::model::{DiffFile, DiffHunk, DiffLine, FilePatch, LineOrigin};
 use crate::syntax::{SyntaxHighlighter, needs_full_file_highlight};
 
-/// Diff format variants for different VCS tools.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DiffFormat {
-    /// Mercurial format: "diff -r" headers, paths may have timestamps
-    Hg,
-    /// Git-style format: "diff --git" headers (used by jj, git patches)
-    GitStyle,
-}
-
-/// Parse unified diff output into DiffFile structures.
-pub fn parse_unified_diff(
-    diff_text: &str,
-    format: DiffFormat,
+/// Convert backend-structured file patches into renderable diff files.
+pub fn parse_file_patches(
+    patches: Vec<FilePatch>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    parse_unified_diff_lines(
-        diff_text.lines().map(|line| Ok(Cow::Borrowed(line))),
-        format,
-        highlighter,
-    )
-}
-
-/// Parse unified diff lines into DiffFile structures.
-///
-/// This entry point is used by Git's sparse-checkout backend so large diffs can
-/// be parsed directly from command stdout instead of buffering the whole patch.
-pub fn parse_unified_diff_lines<'a, I>(
-    diff_lines: I,
-    format: DiffFormat,
-    highlighter: &SyntaxHighlighter,
-) -> Result<Vec<DiffFile>>
-where
-    I: Iterator<Item = Result<Cow<'a, str>>>,
-{
-    let mut files: Vec<DiffFile> = Vec::new();
-    let mut lines = diff_lines.peekable();
-
-    let header_prefix = match format {
-        DiffFormat::Hg => "diff ",
-        DiffFormat::GitStyle => "diff --git ",
-    };
-
-    // `diff_lines` may stream from a child process, so each read can fail. Use
-    // `next_line` instead of `lines.next()` to propagate I/O errors.
-    while let Some(line) = next_line(&mut lines)? {
-        if line.starts_with(header_prefix) {
-            let (mut old_path, mut new_path, status) = parse_file_header(&mut lines, format)?;
-
-            // For git-style diffs (jj, git patches), if parse_file_header didn't find
-            // ---/+++ or rename/copy lines (e.g. empty new files, mode-only changes),
-            // fall back to parsing paths from the "diff --git a/X b/X" header.
-            if old_path.is_none()
-                && new_path.is_none()
-                && let Some((a, b)) = parse_diff_git_header(&line)
-            {
-                match status {
-                    FileStatus::Deleted => old_path = Some(a),
-                    FileStatus::Added => new_path = Some(b),
-                    _ => {
-                        old_path = Some(a);
-                        new_path = Some(b);
-                    }
-                }
-            }
-
-            // Check if binary. `git diff --binary` can emit lowercase
-            // "GIT binary patch", so keep this check explicit instead of a
-            // case-sensitive substring search.
-            if peek_line(&mut lines)?.is_some_and(is_binary_patch_line) {
-                next_line(&mut lines)?; // consume binary message
-                files.push(DiffFile {
-                    old_path,
-                    new_path,
-                    status,
-                    hunks: Vec::new(),
-                    is_binary: true,
-                    is_too_large: false,
-                    is_commit_message: false,
-                    content_hash: 0,
-                });
-                continue;
-            }
-
-            let file_path = new_path.as_ref().or(old_path.as_ref());
-            let mut hunks = Vec::new();
-
-            // Parse hunks until next file or end
-            while let Some(line) = peek_line(&mut lines)? {
-                if line.starts_with("diff ") {
-                    break;
-                } else if line.starts_with("@@") {
-                    if let Some(hunk) = parse_hunk(&mut lines, file_path, highlighter)? {
-                        hunks.push(hunk);
-                    }
-                } else {
-                    next_line(&mut lines)?; // skip non-hunk, non-diff lines
-                }
-            }
-
-            let content_hash = DiffFile::compute_content_hash(&hunks);
-            files.push(DiffFile {
-                old_path,
-                new_path,
-                status,
-                hunks,
-                is_binary: false,
-                is_too_large: false,
-                is_commit_message: false,
-                content_hash,
-            });
-        }
-    }
-
-    if files.is_empty() {
+    if patches.is_empty() {
         return Err(TuicrError::NoChanges);
     }
 
-    Ok(files)
+    patches
+        .into_iter()
+        .map(|patch| materialize_file_patch(patch, highlighter))
+        .collect()
 }
 
-fn next_line<'a, I>(lines: &mut std::iter::Peekable<I>) -> Result<Option<Cow<'a, str>>>
-where
-    I: Iterator<Item = Result<Cow<'a, str>>>,
-{
-    lines.next().transpose()
+fn materialize_file_patch(patch: FilePatch, highlighter: &SyntaxHighlighter) -> Result<DiffFile> {
+    let file_path = patch.display_path().ok_or_else(|| {
+        TuicrError::VcsCommand("structured diff entry has neither an old nor a new path".into())
+    })?;
+    let hunks = if patch.is_binary || patch.is_too_large {
+        Vec::new()
+    } else {
+        parse_hunks(&patch.patch, file_path, highlighter)?
+    };
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+
+    Ok(DiffFile {
+        old_path: patch.old_path,
+        new_path: patch.new_path,
+        status: patch.status,
+        hunks,
+        is_binary: patch.is_binary,
+        is_too_large: patch.is_too_large,
+        is_commit_message: false,
+        content_hash,
+    })
 }
 
-fn peek_line<'lines, 'a, I>(
-    lines: &'lines mut std::iter::Peekable<I>,
-) -> Result<Option<&'lines str>>
-where
-    I: Iterator<Item = Result<Cow<'a, str>>>,
-    'a: 'lines,
-{
-    if matches!(lines.peek(), Some(Err(_)))
-        && let Some(Err(err)) = lines.next()
-    {
-        return Err(err);
-    }
+fn parse_hunks(
+    patch: &str,
+    file_path: &Path,
+    highlighter: &SyntaxHighlighter,
+) -> Result<Vec<DiffHunk>> {
+    let mut hunks = Vec::new();
+    let mut lines = patch.lines().peekable();
+    let mut parsed_hunk = false;
 
-    Ok(lines.peek().map(|line| {
-        line.as_ref()
-            .expect("peeked line errors are consumed before borrowing")
-            .as_ref()
-    }))
-}
-
-fn is_binary_patch_line(line: &str) -> bool {
-    // A loose `contains("Binary")` also matches an ordinary `@@ ... @@` hunk
-    // header whose context text contains "Binary", so require the real
-    // marker shape instead: real markers always start the line (git's
-    // "Binary files ... differ", hg's "Binary file ... has changed", or
-    // "GIT binary patch"), never a `@@` hunk header.
-    line.starts_with("Binary file") || line.starts_with("GIT binary patch")
-}
-
-fn parse_file_header<'a, I>(
-    lines: &mut std::iter::Peekable<I>,
-    format: DiffFormat,
-) -> Result<(Option<PathBuf>, Option<PathBuf>, FileStatus)>
-where
-    I: Iterator<Item = Result<Cow<'a, str>>>,
-{
-    let mut old_path: Option<PathBuf> = None;
-    let mut new_path: Option<PathBuf> = None;
-    let mut status = FileStatus::Modified;
-
-    // Parse --- and +++ lines and metadata
-    while let Some(line) = peek_line(lines)?.map(str::to_string) {
-        if line.starts_with("---") {
-            let path_str = line.trim_start_matches("--- ").trim_start_matches("a/");
-            if path_str != "/dev/null" {
-                // Hg format may include timestamps after tab
-                let path = if format == DiffFormat::Hg {
-                    path_str.split('\t').next().unwrap_or(path_str)
-                } else {
-                    path_str
-                };
-                old_path = Some(PathBuf::from(path));
-            }
-            next_line(lines)?;
-        } else if line.starts_with("+++") {
-            let path_str = line.trim_start_matches("+++ ").trim_start_matches("b/");
-            if path_str != "/dev/null" {
-                let path = if format == DiffFormat::Hg {
-                    path_str.split('\t').next().unwrap_or(path_str)
-                } else {
-                    path_str
-                };
-                new_path = Some(PathBuf::from(path));
-            }
-            next_line(lines)?;
-            break; // Done with file header
-        } else if line.starts_with("new file") {
-            status = FileStatus::Added;
-            next_line(lines)?;
-        } else if line.starts_with("deleted file") {
-            status = FileStatus::Deleted;
-            next_line(lines)?;
-        } else if let Some(path) = line.strip_prefix("rename from ") {
-            status = FileStatus::Renamed;
-            old_path = Some(PathBuf::from(path));
-            next_line(lines)?;
-        } else if let Some(path) = line.strip_prefix("rename to ") {
-            new_path = Some(PathBuf::from(path));
-            next_line(lines)?;
-        } else if let Some(path) = line.strip_prefix("copy from ") {
-            status = FileStatus::Copied;
-            old_path = Some(PathBuf::from(path));
-            next_line(lines)?;
-        } else if let Some(path) = line.strip_prefix("copy to ") {
-            new_path = Some(PathBuf::from(path));
-            next_line(lines)?;
-        } else if line.starts_with("@@") || line.starts_with("diff ") {
-            break;
-        } else if line.starts_with("Binary file") || line.starts_with("GIT binary patch") {
-            // Hg format: "Binary file <path> has changed"
-            // Git format: "Binary files a/<old> and b/<new> differ"
-            if let Some((old, new)) = parse_binary_file_line(&line) {
-                if old_path.is_none() {
-                    old_path = old;
-                }
-                if new_path.is_none() {
-                    new_path = new;
-                }
-            }
-            break;
-        } else {
-            next_line(lines)?; // Skip other metadata lines (rename to, copy to, index, etc.)
+    while let Some(line) = lines.next() {
+        if line.starts_with("@@ ") {
+            hunks.push(parse_hunk(line, &mut lines, file_path, highlighter)?);
+            parsed_hunk = true;
+        } else if line.starts_with("@@") {
+            return Err(invalid_patch(
+                file_path,
+                format!("unsupported or malformed hunk header `{line}`"),
+            ));
+        } else if parsed_hunk
+            && !line.starts_with('\\')
+            && matches!(line.as_bytes().first(), Some(b' ' | b'+' | b'-'))
+        {
+            return Err(invalid_patch(
+                file_path,
+                format!("body line appears outside its declared hunk range: `{line}`"),
+            ));
         }
     }
 
-    // Determine status from paths if not already set by metadata
-    if status == FileStatus::Modified {
-        if old_path.is_none() && new_path.is_some() {
-            status = FileStatus::Added;
-        } else if old_path.is_some() && new_path.is_none() {
-            status = FileStatus::Deleted;
-        }
-    }
-
-    Ok((old_path, new_path, status))
+    Ok(hunks)
 }
 
 fn parse_hunk<'a, I>(
+    header: &str,
     lines: &mut std::iter::Peekable<I>,
-    file_path: Option<&PathBuf>,
+    file_path: &Path,
     highlighter: &SyntaxHighlighter,
-) -> Result<Option<DiffHunk>>
+) -> Result<DiffHunk>
 where
-    I: Iterator<Item = Result<Cow<'a, str>>>,
+    I: Iterator<Item = &'a str>,
 {
-    let Some(header_line) = next_line(lines)? else {
-        return Ok(None);
-    };
+    let (old_start, old_count, new_start, new_count) = parse_hunk_header(header)
+        .ok_or_else(|| invalid_patch(file_path, format!("malformed hunk header `{header}`")))?;
+    if !range_fits_u32(old_start, old_count) || !range_fits_u32(new_start, new_count) {
+        return Err(invalid_patch(
+            file_path,
+            format!("hunk range overflows a 32-bit line number in `{header}`"),
+        ));
+    }
 
-    // Parse @@ -old_start,old_count +new_start,new_count @@
-    let Some((old_start, old_count, new_start, new_count)) = parse_hunk_header(&header_line) else {
-        return Ok(None);
-    };
-
-    let mut line_contents: Vec<String> = Vec::new();
-    let mut line_origins: Vec<LineOrigin> = Vec::new();
-    let mut line_numbers: Vec<(Option<u32>, Option<u32>)> = Vec::new();
-
+    let mut line_contents = Vec::new();
+    let mut line_origins = Vec::new();
+    let mut line_numbers = Vec::new();
     let mut old_lineno = old_start;
     let mut new_lineno = new_start;
+    let mut old_remaining = old_count;
+    let mut new_remaining = new_count;
 
-    // Collect lines until next hunk or file
-    while let Some(line) = peek_line(lines)?.map(str::to_string) {
-        if line.starts_with("@@") || line.starts_with("diff ") {
-            break;
-        }
-
-        next_line(lines)?;
+    // Counts from the hunk header are the grammar. Prefix-looking content is
+    // still content: deleting `-- comment` yields `--- comment`, and adding
+    // `++i` yields `+++i`. We consume until both declared sides are complete,
+    // rather than looking for path-like sentinel strings inside the body.
+    while old_remaining > 0 || new_remaining > 0 {
+        let line = lines.next().ok_or_else(|| {
+            invalid_patch(
+                file_path,
+                format!(
+                    "hunk `{header}` ended early (missing {old_remaining} old and {new_remaining} new lines)"
+                ),
+            )
+        })?;
 
         if line.starts_with('\\') {
-            // "\ No newline at end of file" - skip
+            // `\ No newline at end of file` does not consume either side.
             continue;
         }
 
-        // No `---`/`+++` header check here: a hunk body line is never a file
-        // header. The outer loop only starts a file on a `diff --git `/`diff `
-        // line, `parse_file_header` consumes the `---`/`+++` pair before the
-        // first `@@`, and this loop breaks on the next `diff `/`@@` above. A
-        // check here would instead match *content*: deleting a line beginning
-        // with `--` (a SQL/Lua/Haskell comment, a YAML `---` separator, a
-        // Markdown front-matter fence) emits `---…`, and skipping it would drop
-        // the line and desynchronize every following line number in the hunk.
-        let (origin, content, old_ln, new_ln) = if let Some(stripped) = line.strip_prefix('+') {
-            let ln = new_lineno;
+        let (origin, content, old_ln, new_ln) = if let Some(content) = line.strip_prefix('+') {
+            if new_remaining == 0 {
+                return Err(invalid_patch(
+                    file_path,
+                    format!("hunk `{header}` contains too many new-side lines"),
+                ));
+            }
+            let line_number = new_lineno;
             new_lineno += 1;
-            (LineOrigin::Addition, stripped, None, Some(ln))
-        } else if let Some(stripped) = line.strip_prefix('-') {
-            let ln = old_lineno;
+            new_remaining -= 1;
+            (LineOrigin::Addition, content, None, Some(line_number))
+        } else if let Some(content) = line.strip_prefix('-') {
+            if old_remaining == 0 {
+                return Err(invalid_patch(
+                    file_path,
+                    format!("hunk `{header}` contains too many old-side lines"),
+                ));
+            }
+            let line_number = old_lineno;
             old_lineno += 1;
-            (LineOrigin::Deletion, stripped, Some(ln), None)
-        } else if let Some(stripped) = line.strip_prefix(' ') {
-            let old_ln = old_lineno;
-            let new_ln = new_lineno;
+            old_remaining -= 1;
+            (LineOrigin::Deletion, content, Some(line_number), None)
+        } else if let Some(content) = line.strip_prefix(' ') {
+            if old_remaining == 0 || new_remaining == 0 {
+                return Err(invalid_patch(
+                    file_path,
+                    format!("hunk `{header}` contains too many context lines"),
+                ));
+            }
+            let old_line_number = old_lineno;
+            let new_line_number = new_lineno;
             old_lineno += 1;
             new_lineno += 1;
-            (LineOrigin::Context, stripped, Some(old_ln), Some(new_ln))
-        } else if line.is_empty() {
-            // Empty line in diff (context line with no content after space)
-            let old_ln = old_lineno;
-            let new_ln = new_lineno;
-            old_lineno += 1;
-            new_lineno += 1;
-            (LineOrigin::Context, "", Some(old_ln), Some(new_ln))
+            old_remaining -= 1;
+            new_remaining -= 1;
+            (
+                LineOrigin::Context,
+                content,
+                Some(old_line_number),
+                Some(new_line_number),
+            )
         } else {
-            // Unknown format, skip
-            continue;
+            return Err(invalid_patch(
+                file_path,
+                format!("hunk `{header}` contains an unprefixed body line `{line}`"),
+            ));
         };
 
         line_contents.push(super::tabify(content));
@@ -331,933 +184,268 @@ where
         line_numbers.push((old_ln, new_ln));
     }
 
-    // Apply syntax highlighting by side-specific sequence to keep parser state valid.
-    // Container grammars skip per-hunk highlighting; the full-file post-pass
-    // (`enhance_with_full_file_highlight`) overwrites these spans anyway.
     let highlight_sequences =
         SyntaxHighlighter::split_diff_lines_for_highlighting(&line_contents, &line_origins);
-    let (old_highlighted_lines, new_highlighted_lines) = match file_path {
-        Some(path) if !needs_full_file_highlight(path) => (
-            highlighter.highlight_file_lines(path, &highlight_sequences.old_lines),
-            highlighter.highlight_file_lines(path, &highlight_sequences.new_lines),
-        ),
-        _ => (None, None),
+    let (old_highlighted_lines, new_highlighted_lines) = if !needs_full_file_highlight(file_path) {
+        (
+            highlighter.highlight_file_lines(file_path, &highlight_sequences.old_lines),
+            highlighter.highlight_file_lines(file_path, &highlight_sequences.new_lines),
+        )
+    } else {
+        (None, None)
     };
 
-    // Build DiffLines
-    let mut diff_lines: Vec<DiffLine> = Vec::with_capacity(line_contents.len());
-    for (idx, content) in line_contents.into_iter().enumerate() {
-        let origin = line_origins[idx];
-        let (old_lineno, new_lineno) = line_numbers[idx];
+    let lines = line_contents
+        .into_iter()
+        .enumerate()
+        .map(|(index, content)| {
+            let origin = line_origins[index];
+            let (old_lineno, new_lineno) = line_numbers[index];
+            let highlighted_spans = highlighter.highlighted_line_for_diff_with_background(
+                old_highlighted_lines.as_deref(),
+                new_highlighted_lines.as_deref(),
+                highlight_sequences.old_line_indices[index],
+                highlight_sequences.new_line_indices[index],
+                origin,
+            );
+            DiffLine {
+                origin,
+                content,
+                old_lineno,
+                new_lineno,
+                highlighted_spans,
+            }
+        })
+        .collect();
 
-        let highlighted_spans = highlighter.highlighted_line_for_diff_with_background(
-            old_highlighted_lines.as_deref(),
-            new_highlighted_lines.as_deref(),
-            highlight_sequences.old_line_indices[idx],
-            highlight_sequences.new_line_indices[idx],
-            origin,
-        );
-
-        diff_lines.push(DiffLine {
-            origin,
-            content,
-            old_lineno,
-            new_lineno,
-            highlighted_spans,
-        });
-    }
-
-    Ok(Some(DiffHunk {
-        header: header_line.to_string(),
-        lines: diff_lines,
+    Ok(DiffHunk {
+        header: header.to_string(),
+        lines,
         old_start,
         old_count,
         new_start,
         new_count,
-    }))
+    })
+}
+
+fn invalid_patch(path: &Path, detail: String) -> TuicrError {
+    TuicrError::VcsCommand(format!(
+        "invalid unified diff for {}: {detail}",
+        path.display()
+    ))
 }
 
 fn parse_hunk_header(line: &str) -> Option<(u32, u32, u32, u32)> {
-    // Format: @@ -old_start,old_count +new_start,new_count @@
-    // or: @@ -old_start +new_start @@ (count defaults to 1)
-
-    let parts: Vec<&str> = line.split_whitespace().collect();
-    if parts.len() < 3 || parts[0] != "@@" {
+    let tail = line.strip_prefix("@@ ")?;
+    let (ranges, _) = tail.split_once(" @@")?;
+    let mut parts = ranges.split_whitespace();
+    let old = parts.next()?.strip_prefix('-')?;
+    let new = parts.next()?.strip_prefix('+')?;
+    if parts.next().is_some() {
         return None;
     }
-
-    let old_part = parts[1].trim_start_matches('-');
-    let new_part = parts[2].trim_start_matches('+');
-
-    let (old_start, old_count) = parse_range(old_part);
-    let (new_start, new_count) = parse_range(new_part);
-
+    let (old_start, old_count) = parse_range(old)?;
+    let (new_start, new_count) = parse_range(new)?;
     Some((old_start, old_count, new_start, new_count))
 }
 
-fn parse_range(s: &str) -> (u32, u32) {
-    if let Some((start, count)) = s.split_once(',') {
-        (start.parse().unwrap_or(1), count.parse().unwrap_or(1))
-    } else {
-        (s.parse().unwrap_or(1), 1)
+fn parse_range(range: &str) -> Option<(u32, u32)> {
+    match range.split_once(',') {
+        Some((start, count)) => Some((start.parse().ok()?, count.parse().ok()?)),
+        None => Some((range.parse().ok()?, 1)),
     }
 }
 
-/// Parse paths from a "diff --git a/X b/X" header line.
-/// Returns (old_path, new_path) extracted from the a/ and b/ prefixes.
-fn parse_diff_git_header(line: &str) -> Option<(PathBuf, PathBuf)> {
-    let rest = line.strip_prefix("diff --git ")?;
-    // The format is "a/<path> b/<path>". Since paths can contain spaces,
-    // we find the " b/" separator. For paths without spaces, a simple split works.
-    // Try finding " b/" as separator (handles most cases).
-    if let Some(pos) = rest.find(" b/") {
-        let old_part = &rest[..pos];
-        let new_part = &rest[pos + 1..];
-        let old_path = old_part.strip_prefix("a/").unwrap_or(old_part);
-        let new_path = new_part.strip_prefix("b/").unwrap_or(new_part);
-        Some((PathBuf::from(old_path), PathBuf::from(new_path)))
-    } else {
-        None
-    }
+fn range_fits_u32(start: u32, count: u32) -> bool {
+    count == 0 || start.checked_add(count - 1).is_some()
 }
 
-/// Parse paths from a binary file line.
-/// Git format: "Binary files a/<old> and b/<new> differ"
-/// Hg format: "Binary file <path> has changed"
-/// Returns (old_path, new_path) where either can be None for /dev/null
-fn parse_binary_file_line(line: &str) -> Option<(Option<PathBuf>, Option<PathBuf>)> {
-    // Git format: "Binary files a/path/to/file and b/path/to/file differ"
-    if let Some(content) = line.strip_prefix("Binary files ") {
-        let content = content.strip_suffix(" differ")?;
-        let (old_part, new_part) = content.split_once(" and ")?;
-
-        let old_path = if old_part == "/dev/null" {
-            None
-        } else {
-            Some(PathBuf::from(
-                old_part.strip_prefix("a/").unwrap_or(old_part),
-            ))
-        };
-
-        let new_path = if new_part == "/dev/null" {
-            None
-        } else {
-            Some(PathBuf::from(
-                new_part.strip_prefix("b/").unwrap_or(new_part),
-            ))
-        };
-
-        return Some((old_path, new_path));
-    }
-
-    // Hg format: "Binary file image.png has changed"
-    if let Some(content) = line.strip_prefix("Binary file ") {
-        let path = content.strip_suffix(" has changed")?;
-        // For hg, the same path is used for both old and new
-        let path = PathBuf::from(path);
-        return Some((Some(path.clone()), Some(path)));
-    }
-
-    None
+/// Adapt compact hand-written Git fixtures used throughout the unit tests.
+/// Production code must obtain metadata from its backend instead.
+#[cfg(test)]
+pub(crate) fn git_fixture_file_patches(patch: &str) -> Vec<FilePatch> {
+    crate::vcs::git::raw::split_patch_blocks(patch.as_bytes())
+        .into_iter()
+        .map(|block| {
+            let text = String::from_utf8(block.to_vec()).expect("test patch must be UTF-8");
+            let mut lines = text.lines();
+            let header = lines.next().expect("test patch block needs a header");
+            let paths = header
+                .strip_prefix("diff --git a/")
+                .and_then(|rest| rest.split_once(" b/"))
+                .expect("test patch header must use simple a/ and b/ paths");
+            let mut old_path = Some(PathBuf::from(paths.0));
+            let mut new_path = Some(PathBuf::from(paths.1));
+            let mut status = FileStatus::Modified;
+            for line in text.lines() {
+                if line.starts_with("new file mode") {
+                    old_path = None;
+                    status = FileStatus::Added;
+                } else if line.starts_with("deleted file mode") {
+                    new_path = None;
+                    status = FileStatus::Deleted;
+                } else if let Some(path) = line.strip_prefix("rename from ") {
+                    old_path = Some(PathBuf::from(path));
+                    status = FileStatus::Renamed;
+                } else if let Some(path) = line.strip_prefix("rename to ") {
+                    new_path = Some(PathBuf::from(path));
+                } else if let Some(path) = line.strip_prefix("copy from ") {
+                    old_path = Some(PathBuf::from(path));
+                    status = FileStatus::Copied;
+                } else if let Some(path) = line.strip_prefix("copy to ") {
+                    new_path = Some(PathBuf::from(path));
+                }
+            }
+            FilePatch::new(old_path, new_path, status, text)
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    // ============ Common tests ============
+    fn parse(patch: &str) -> Result<Vec<DiffFile>> {
+        parse_file_patches(
+            vec![FilePatch::new(
+                Some(PathBuf::from("file.txt")),
+                Some(PathBuf::from("file.txt")),
+                FileStatus::Modified,
+                patch,
+            )],
+            &SyntaxHighlighter::default(),
+        )
+    }
 
     #[test]
-    fn should_return_no_changes_for_empty_diff() {
+    fn returns_no_changes_for_empty_patch_set() {
         assert!(matches!(
-            parse_unified_diff("", DiffFormat::Hg, &SyntaxHighlighter::default()),
+            parse_file_patches(Vec::new(), &SyntaxHighlighter::default()),
             Err(TuicrError::NoChanges)
         ));
-        assert!(matches!(
-            parse_unified_diff("", DiffFormat::GitStyle, &SyntaxHighlighter::default()),
-            Err(TuicrError::NoChanges)
-        ));
     }
 
     #[test]
-    fn should_parse_hunk_header() {
-        let result = parse_hunk_header("@@ -1,3 +1,4 @@");
-        assert_eq!(result, Some((1, 3, 1, 4)));
-
-        let result = parse_hunk_header("@@ -10,5 +20,8 @@ context");
-        assert_eq!(result, Some((10, 5, 20, 8)));
-    }
-
-    #[test]
-    fn should_parse_hunk_header_without_count() {
-        let (old_start, old_count, new_start, new_count) =
-            parse_hunk_header("@@ -5 +10 @@").unwrap();
-        assert_eq!(old_start, 5);
-        assert_eq!(old_count, 1);
-        assert_eq!(new_start, 10);
-        assert_eq!(new_count, 1);
-    }
-
-    #[test]
-    fn should_reject_invalid_hunk_header() {
-        assert!(parse_hunk_header("not a hunk header").is_none());
-        assert!(parse_hunk_header("@@ invalid").is_none());
-    }
-
-    #[test]
-    fn should_parse_range_with_comma() {
-        assert_eq!(parse_range("10,5"), (10, 5));
-        assert_eq!(parse_range("1,100"), (1, 100));
-    }
-
-    #[test]
-    fn should_parse_range_without_comma() {
-        assert_eq!(parse_range("42"), (42, 1));
-        assert_eq!(parse_range("1"), (1, 1));
-    }
-
-    #[test]
-    fn should_handle_invalid_range() {
-        assert_eq!(parse_range("abc"), (1, 1));
-        assert_eq!(parse_range("abc,def"), (1, 1));
-    }
-
-    // ============ Hg format tests ============
-
-    #[test]
-    fn hg_should_parse_simple_diff() {
-        let diff = r#"diff -r abc123 test.rs
---- a/test.rs	Thu Jan 01 00:00:00 1970 +0000
-+++ b/test.rs	Thu Jan 01 00:00:00 1970 +0000
-@@ -1,3 +1,4 @@
- fn main() {
-+    println!("hello");
-     println!("world");
- }
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Modified);
-        assert_eq!(result[0].hunks.len(), 1);
-        assert_eq!(result[0].hunks[0].lines.len(), 4);
-    }
-
-    #[test]
-    fn hg_should_expand_tabs_to_spaces_in_hunk_lines() {
-        let diff = r#"diff -r abc123 test.rs
---- a/test.rs	Thu Jan 01 00:00:00 1970 +0000
-+++ b/test.rs	Thu Jan 01 00:00:00 1970 +0000
-@@ -1,2 +1,2 @@
--	old
-+	new
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        let lines = &result[0].hunks[0].lines;
-
-        assert_eq!(lines[0].content, "    old");
-        assert_eq!(lines[1].content, "    new");
-        assert!(lines.iter().all(|l| !l.content.contains('\t')));
-    }
-
-    #[test]
-    fn hg_should_parse_new_file() {
-        let diff = r#"diff -r 000000000000 new_file.rs
---- /dev/null
-+++ b/new_file.rs
-@@ -0,0 +1,2 @@
-+fn new() {
-+}
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Added);
-        assert!(result[0].old_path.is_none());
-        assert_eq!(
-            result[0].new_path.as_ref().unwrap().to_str().unwrap(),
-            "new_file.rs"
-        );
-    }
-
-    #[test]
-    fn hg_should_parse_deleted_file() {
-        let diff = r#"diff -r abc123 old_file.rs
---- a/old_file.rs
-+++ /dev/null
-@@ -1,2 +0,0 @@
--fn old() {
--}
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Deleted);
-        assert_eq!(
-            result[0].old_path.as_ref().unwrap().to_str().unwrap(),
-            "old_file.rs"
-        );
-        assert!(result[0].new_path.is_none());
-    }
-
-    #[test]
-    fn hg_should_parse_multiple_files() {
-        let diff = r#"diff -r abc123 file1.rs
---- a/file1.rs
-+++ b/file1.rs
-@@ -1,1 +1,2 @@
- line1
-+line2
-diff -r abc123 file2.rs
---- a/file2.rs
-+++ b/file2.rs
-@@ -1,2 +1,1 @@
- keep
--remove
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 2);
-        assert_eq!(
-            result[0].new_path.as_ref().unwrap().to_str().unwrap(),
-            "file1.rs"
-        );
-        assert_eq!(
-            result[1].new_path.as_ref().unwrap().to_str().unwrap(),
-            "file2.rs"
-        );
-    }
-
-    #[test]
-    fn hg_should_parse_multiple_hunks() {
-        let diff = r#"diff -r abc123 multi.rs
---- a/multi.rs
-+++ b/multi.rs
-@@ -1,3 +1,4 @@
- fn first() {
-+    // added
- }
-
-@@ -10,3 +11,4 @@
- fn second() {
-+    // also added
- }
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].hunks.len(), 2);
-        assert_eq!(result[0].hunks[0].old_start, 1);
-        assert_eq!(result[0].hunks[1].old_start, 10);
-    }
-
-    #[test]
-    fn hg_should_parse_renamed_file() {
-        let diff = r#"diff -r abc123 new_name.rs
-rename from old_name.rs
-rename to new_name.rs
---- a/old_name.rs
-+++ b/new_name.rs
-@@ -1,1 +1,1 @@
--old content
-+new content
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Renamed);
-        assert_eq!(
-            result[0].old_path.as_ref().unwrap().to_str().unwrap(),
-            "old_name.rs"
-        );
-        assert_eq!(
-            result[0].new_path.as_ref().unwrap().to_str().unwrap(),
-            "new_name.rs"
-        );
-    }
-
-    #[test]
-    fn hg_should_parse_binary_file() {
-        let diff = r#"diff -r abc123 image.png
-Binary file image.png has changed
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].is_binary);
-        assert!(result[0].hunks.is_empty());
-    }
-
-    #[test]
-    fn hg_should_parse_renamed_file_without_content_changes() {
-        // Pure rename with no content changes - no ---/+++ lines
-        let diff = r#"diff -r abc123 new_name.rs
-rename from old_name.rs
-rename to new_name.rs
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Renamed);
-        assert_eq!(result[0].old_path, Some(PathBuf::from("old_name.rs")));
-        assert_eq!(result[0].new_path, Some(PathBuf::from("new_name.rs")));
-        assert!(result[0].hunks.is_empty());
-    }
-
-    #[test]
-    fn hg_should_parse_copied_file_without_content_changes() {
-        // Pure copy with no content changes
-        let diff = r#"diff -r abc123 dest.rs
-copy from source.rs
-copy to dest.rs
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Copied);
-        assert_eq!(result[0].old_path, Some(PathBuf::from("source.rs")));
-        assert_eq!(result[0].new_path, Some(PathBuf::from("dest.rs")));
-        assert!(result[0].hunks.is_empty());
-    }
-
-    #[test]
-    fn hg_should_parse_copied_file_with_content_changes() {
-        // Copy with content changes
-        let diff = r#"diff -r abc123 dest.rs
-copy from source.rs
-copy to dest.rs
---- a/source.rs	Thu Jan 01 00:00:00 1970 +0000
-+++ b/dest.rs	Thu Jan 01 00:00:00 1970 +0000
-@@ -1 +1,2 @@
- original
-+added line
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].status, FileStatus::Copied);
-        assert_eq!(result[0].old_path, Some(PathBuf::from("source.rs")));
-        assert_eq!(result[0].new_path, Some(PathBuf::from("dest.rs")));
-        assert_eq!(result[0].hunks.len(), 1);
-    }
-
-    #[test]
-    fn hg_should_handle_no_newline_marker() {
-        let diff = r#"diff -r abc123 no_newline.rs
---- a/no_newline.rs
-+++ b/no_newline.rs
-@@ -1,1 +1,1 @@
+    fn uses_structured_metadata_instead_of_display_headers() {
+        let patch = r#"diff --git \"a/\\346\\227\\245.txt\" \"b/\\346\\227\\245.txt\"
+--- \"a/\\346\\227\\245.txt\"
++++ \"b/\\346\\227\\245.txt\"
+@@ -1 +1 @@
 -old
-\ No newline at end of file
 +new
-\ No newline at end of file
 "#;
+        let expected = PathBuf::from("日.txt");
+        let files = parse_file_patches(
+            vec![FilePatch::new(
+                Some(expected.clone()),
+                Some(expected.clone()),
+                FileStatus::Modified,
+                patch,
+            )],
+            &SyntaxHighlighter::default(),
+        )
+        .unwrap();
 
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(result.len(), 1);
-        assert_eq!(result[0].hunks[0].lines.len(), 2);
+        assert_eq!(files[0].old_path.as_ref(), Some(&expected));
+        assert_eq!(files[0].new_path.as_ref(), Some(&expected));
     }
 
     #[test]
-    fn hg_should_parse_line_numbers_correctly() {
-        let diff = r#"diff -r abc123 nums.rs
---- a/nums.rs
-+++ b/nums.rs
-@@ -5,4 +5,5 @@
- context at 5
--deleted at 6
-+added at 6
-+added at 7
- context at 7->8
-"#;
-
-        let result =
-            parse_unified_diff(diff, DiffFormat::Hg, &SyntaxHighlighter::default()).unwrap();
-        let lines = &result[0].hunks[0].lines;
-
-        assert_eq!(lines[0].origin, LineOrigin::Context);
-        assert_eq!(lines[0].old_lineno, Some(5));
-        assert_eq!(lines[0].new_lineno, Some(5));
-
-        assert_eq!(lines[1].origin, LineOrigin::Deletion);
-        assert_eq!(lines[1].old_lineno, Some(6));
-        assert_eq!(lines[1].new_lineno, None);
-
-        assert_eq!(lines[2].origin, LineOrigin::Addition);
-        assert_eq!(lines[2].old_lineno, None);
-        assert_eq!(lines[2].new_lineno, Some(6));
-
-        assert_eq!(lines[3].origin, LineOrigin::Addition);
-        assert_eq!(lines[3].old_lineno, None);
-        assert_eq!(lines[3].new_lineno, Some(7));
-
-        assert_eq!(lines[4].origin, LineOrigin::Context);
-        assert_eq!(lines[4].old_lineno, Some(7));
-        assert_eq!(lines[4].new_lineno, Some(8));
-    }
-
-    #[test]
-    fn should_keep_deleted_lines_whose_content_starts_with_dashes() {
-        // Deleting a YAML front-matter fence emits `----` (the `-` origin plus
-        // the `---` content); it must not be mistaken for a `---` file header.
-        let diff = r#"diff --git a/post.md b/post.md
---- a/post.md
-+++ b/post.md
-@@ -1,5 +1,2 @@
-----
--title: hello
-----
- intro
--old body
-+new body
-"#;
+    fn keeps_deleted_lines_whose_content_looks_like_headers() {
         let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+            parse("@@ -1,5 +1,2 @@\n----\n-title: hello\n----\n intro\n-old body\n+new body\n")
+                .unwrap();
         let lines = &files[0].hunks[0].lines;
-        assert_eq!(lines.len(), 6);
 
-        assert_eq!(lines[0].origin, LineOrigin::Deletion);
+        assert_eq!(lines.len(), 6);
         assert_eq!(lines[0].content, "---");
         assert_eq!(lines[0].old_lineno, Some(1));
-
-        assert_eq!(lines[2].origin, LineOrigin::Deletion);
-        assert_eq!(lines[2].content, "---");
-        assert_eq!(lines[2].old_lineno, Some(3));
-
-        // Line numbers after the skipped lines must not shift.
-        assert_eq!(lines[3].origin, LineOrigin::Context);
         assert_eq!(lines[3].old_lineno, Some(4));
-        assert_eq!(lines[3].new_lineno, Some(1));
-
-        assert_eq!(lines[4].origin, LineOrigin::Deletion);
         assert_eq!(lines[4].old_lineno, Some(5));
     }
 
     #[test]
-    fn should_keep_deleted_sql_comment_lines() {
-        // `--` is the line-comment token in SQL, Lua, Haskell, Ada and Elm.
-        let diff = r#"diff --git a/q.sql b/q.sql
---- a/q.sql
-+++ b/q.sql
-@@ -1,2 +1,1 @@
---- count the rows
- SELECT 1;
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        let lines = &files[0].hunks[0].lines;
-        assert_eq!(lines.len(), 2);
-        assert_eq!(lines[0].origin, LineOrigin::Deletion);
-        assert_eq!(lines[0].content, "-- count the rows");
-        assert_eq!(lines[0].old_lineno, Some(1));
-        assert_eq!(lines[1].old_lineno, Some(2));
-    }
-
-    #[test]
-    fn should_keep_added_lines_whose_content_starts_with_plus_signs() {
-        let diff = r#"diff --git a/loop.c b/loop.c
---- a/loop.c
-+++ b/loop.c
-@@ -1,1 +1,3 @@
- int i = 0;
-+++i;
-+return i;
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        let lines = &files[0].hunks[0].lines;
-        assert_eq!(lines.len(), 3);
-
-        assert_eq!(lines[1].origin, LineOrigin::Addition);
-        assert_eq!(lines[1].content, "++i;");
-        assert_eq!(lines[1].new_lineno, Some(2));
-
-        // The following addition must not reuse the skipped line's number.
-        assert_eq!(lines[2].new_lineno, Some(3));
-    }
-
-    // ============ Jujutsu (jj) format tests - uses DiffFormat::GitStyle ============
-
-    #[test]
-    fn jj_should_parse_simple_diff() {
-        let diff = r#"diff --git a/file.txt b/file.txt
---- a/file.txt
-+++ b/file.txt
-@@ -1,3 +1,4 @@
- line1
-+added
- line2
- line3
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].new_path, Some(PathBuf::from("file.txt")));
-        assert_eq!(files[0].status, FileStatus::Modified);
-        assert_eq!(files[0].hunks.len(), 1);
-        assert_eq!(files[0].hunks[0].lines.len(), 4);
-    }
-
-    #[test]
-    fn jj_should_expand_tabs_to_spaces_in_hunk_lines() {
-        let diff = r#"diff --git a/file.txt b/file.txt
---- a/file.txt
-+++ b/file.txt
-@@ -1,2 +1,2 @@
--	old
-+	new
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
+    fn keeps_added_lines_whose_content_starts_with_plus_signs() {
+        let files = parse("@@ -1,2 +1,3 @@\n line\n-old\n+++i;\n+ tail\n").unwrap();
         let lines = &files[0].hunks[0].lines;
 
-        assert_eq!(lines[0].content, "    old");
-        assert_eq!(lines[1].content, "    new");
-        assert!(lines.iter().all(|l| !l.content.contains('\t')));
+        assert_eq!(lines.len(), 4);
+        assert_eq!(lines[2].content, "++i;");
+        assert_eq!(lines[2].new_lineno, Some(2));
+        assert_eq!(lines[3].new_lineno, Some(3));
     }
 
     #[test]
-    fn jj_should_keep_highlighting_for_interleaved_typescript_hunk() {
-        let diff = r#"diff --git a/file.ts b/file.ts
---- a/file.ts
-+++ b/file.ts
-@@ -1,3 +1,4 @@
- const msg = getMsg(
--    "old argument"
-+    "new argument",
-+    { extra: true }
- );
-"#;
+    fn parses_multiple_hunks_by_declared_counts() {
+        let files = parse(
+            "metadata\n@@ -1 +1 @@ first\n-old\n+new\n@@ -10,2 +10,2 @@ second\n a\n-b\n+c\n",
+        )
+        .unwrap();
 
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        let lines = &files[0].hunks[0].lines;
-
-        assert_eq!(lines.len(), 5);
-        for (idx, line) in lines.iter().enumerate() {
-            assert!(
-                line.highlighted_spans.is_some(),
-                "line {idx} should retain highlighting"
-            );
-        }
+        assert_eq!(files[0].hunks.len(), 2);
+        assert_eq!(files[0].hunks[1].lines[1].old_lineno, Some(11));
+        assert_eq!(files[0].hunks[1].lines[2].new_lineno, Some(11));
     }
 
     #[test]
-    fn jj_should_parse_new_file() {
-        let diff = r#"diff --git a/new.txt b/new.txt
-new file mode 100644
---- /dev/null
-+++ b/new.txt
-@@ -0,0 +1,2 @@
-+line1
-+line2
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Added);
-    }
+    fn skips_no_newline_markers_without_consuming_a_side() {
+        let files = parse(
+            "@@ -1 +1 @@\n-old\n\\ No newline at end of file\n+new\n\\ No newline at end of file\n",
+        )
+        .unwrap();
 
-    #[test]
-    fn jj_should_parse_deleted_file() {
-        let diff = r#"diff --git a/old.txt b/old.txt
-deleted file mode 100644
---- a/old.txt
-+++ /dev/null
-@@ -1,2 +0,0 @@
--line1
--line2
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Deleted);
-    }
-
-    #[test]
-    fn jj_should_parse_renamed_file_without_content_changes() {
-        // Pure rename with no content changes - no ---/+++ lines
-        let diff = r#"diff --git a/old.txt b/new.txt
-rename from old.txt
-rename to new.txt
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Renamed);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("old.txt")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("new.txt")));
-        assert!(files[0].hunks.is_empty());
-    }
-
-    #[test]
-    fn jj_should_parse_renamed_file_with_content_changes() {
-        // Rename with content changes - has ---/+++ lines
-        let diff = r#"diff --git a/old.txt b/new.txt
-rename from old.txt
-rename to new.txt
---- a/old.txt
-+++ b/new.txt
-@@ -1 +1 @@
--old content
-+new content
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Renamed);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("old.txt")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("new.txt")));
-        assert_eq!(files[0].hunks.len(), 1);
-    }
-
-    #[test]
-    fn jj_should_parse_copied_file_without_content_changes() {
-        // Pure copy with no content changes
-        let diff = r#"diff --git a/source.txt b/dest.txt
-copy from source.txt
-copy to dest.txt
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Copied);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("source.txt")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("dest.txt")));
-        assert!(files[0].hunks.is_empty());
-    }
-
-    #[test]
-    fn jj_should_parse_copied_file_with_content_changes() {
-        // Copy with content changes
-        let diff = r#"diff --git a/source.txt b/dest.txt
-copy from source.txt
-copy to dest.txt
---- a/source.txt
-+++ b/dest.txt
-@@ -1 +1,2 @@
- original
-+added line
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Copied);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("source.txt")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("dest.txt")));
-        assert_eq!(files[0].hunks.len(), 1);
-    }
-
-    #[test]
-    fn jj_should_parse_binary_file_added() {
-        let diff = r#"diff --git a/image.png b/image.png
-new file mode 100644
-index 0000000000..abc1234567
-Binary files /dev/null and b/image.png differ
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert!(files[0].is_binary);
-        assert_eq!(files[0].status, FileStatus::Added);
-        assert!(files[0].old_path.is_none());
-        assert_eq!(files[0].new_path, Some(PathBuf::from("image.png")));
-    }
-
-    #[test]
-    fn jj_should_parse_binary_file_deleted() {
-        let diff = r#"diff --git a/image.png b/image.png
-deleted file mode 100644
-index abc1234567..0000000000
-Binary files a/image.png and /dev/null differ
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert!(files[0].is_binary);
-        assert_eq!(files[0].status, FileStatus::Deleted);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("image.png")));
-        assert!(files[0].new_path.is_none());
-    }
-
-    #[test]
-    fn jj_should_parse_binary_file_modified() {
-        let diff = r#"diff --git a/image.png b/image.png
-index abc1234567..def7890123 100644
-Binary files a/image.png and b/image.png differ
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert!(files[0].is_binary);
-        assert_eq!(files[0].status, FileStatus::Modified);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("image.png")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("image.png")));
-    }
-
-    #[test]
-    fn jj_should_not_treat_hunk_context_containing_binary_as_binary_marker() {
-        // Regression test: the hunk-header context text (the enclosing
-        // symbol name that `git diff` appends after the second `@@`) can
-        // contain the substring "Binary" without the file being binary.
-        let diff = r#"diff --git a/f.txt b/f.txt
-index 1111111..2222222 100644
---- a/f.txt
-+++ b/f.txt
-@@ -1,2 +1,3 @@ someBinaryThing(
- aaa
-+bbb
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert!(!files[0].is_binary);
-        assert_eq!(files[0].hunks.len(), 1);
-    }
-
-    #[test]
-    fn jj_should_parse_multiple_files() {
-        let diff = r#"diff --git a/a.txt b/a.txt
---- a/a.txt
-+++ b/a.txt
-@@ -1 +1 @@
--old
-+new
-diff --git a/b.txt b/b.txt
---- a/b.txt
-+++ b/b.txt
-@@ -1 +1 @@
--foo
-+bar
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 2);
-        assert_eq!(files[0].new_path, Some(PathBuf::from("a.txt")));
-        assert_eq!(files[1].new_path, Some(PathBuf::from("b.txt")));
-    }
-
-    #[test]
-    fn jj_should_calculate_line_numbers() {
-        let diff = r#"diff --git a/file.txt b/file.txt
---- a/file.txt
-+++ b/file.txt
-@@ -5,4 +5,5 @@
- context
--deleted
-+added1
-+added2
- more
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        let hunk = &files[0].hunks[0];
-
-        assert_eq!(hunk.lines[0].old_lineno, Some(5));
-        assert_eq!(hunk.lines[0].new_lineno, Some(5));
-
-        assert_eq!(hunk.lines[1].old_lineno, Some(6));
-        assert_eq!(hunk.lines[1].new_lineno, None);
-
-        assert_eq!(hunk.lines[2].old_lineno, None);
-        assert_eq!(hunk.lines[2].new_lineno, Some(6));
-
-        assert_eq!(hunk.lines[3].old_lineno, None);
-        assert_eq!(hunk.lines[3].new_lineno, Some(7));
-
-        assert_eq!(hunk.lines[4].old_lineno, Some(7));
-        assert_eq!(hunk.lines[4].new_lineno, Some(8));
-    }
-
-    #[test]
-    fn jj_should_parse_empty_new_file() {
-        // Empty new file: has "new file mode" and "index" lines but no ---/+++ or hunks
-        let diff = r#"diff --git a/empty.toml b/empty.toml
-new file mode 100644
-index 0000000000..e69de29bb2
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Added);
-        assert!(files[0].old_path.is_none());
-        assert_eq!(files[0].new_path, Some(PathBuf::from("empty.toml")));
-        assert!(files[0].hunks.is_empty());
-        // Must not panic
-        let _path = files[0].display_path();
-    }
-
-    #[test]
-    fn jj_should_parse_mode_only_change() {
-        // Mode-only change: no ---/+++ or hunks
-        let diff = r#"diff --git a/script.sh b/script.sh
-old mode 100644
-new mode 100755
-"#;
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].status, FileStatus::Modified);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("script.sh")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("script.sh")));
-        assert!(files[0].hunks.is_empty());
-        let _path = files[0].display_path();
-    }
-
-    #[test]
-    fn git_should_parse_binary_patch_as_binary_file() {
-        let diff = r#"diff --git a/image.bin b/image.bin
-index 1234567..89abcde 100644
-GIT binary patch
-literal 4
-LcmeZB000M*0RR91
-
-literal 4
-LcmeZB000M*0RR91
-"#;
-
-        let files =
-            parse_unified_diff(diff, DiffFormat::GitStyle, &SyntaxHighlighter::default()).unwrap();
-
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].old_path, Some(PathBuf::from("image.bin")));
-        assert_eq!(files[0].new_path, Some(PathBuf::from("image.bin")));
-        assert!(files[0].is_binary);
-        assert!(files[0].hunks.is_empty());
-    }
-
-    #[test]
-    fn should_parse_unified_diff_from_streamed_lines() {
-        let lines = [
-            "diff --git a/file.txt b/file.txt",
-            "--- a/file.txt",
-            "+++ b/file.txt",
-            "@@ -1 +1 @@",
-            "-old",
-            "+new",
-        ]
-        .into_iter()
-        .map(|line| Ok(Cow::Owned(line.to_string())));
-
-        let files =
-            parse_unified_diff_lines(lines, DiffFormat::GitStyle, &SyntaxHighlighter::default())
-                .unwrap();
-
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].new_path, Some(PathBuf::from("file.txt")));
         assert_eq!(files[0].hunks[0].lines.len(), 2);
+    }
+
+    #[test]
+    fn rejects_truncated_hunks_instead_of_stealing_the_next_header() {
+        let error = parse("@@ -1,2 +1,2 @@\n a\n@@ -5 +5 @@\n-b\n+c\n").unwrap_err();
+        assert!(error.to_string().contains("unprefixed body line"));
+    }
+
+    #[test]
+    fn rejects_malformed_ranges_instead_of_defaulting_to_line_one() {
+        let error = parse("@@ -wat +1 @@\n-old\n+new\n").unwrap_err();
+        assert!(error.to_string().contains("malformed hunk header"));
+    }
+
+    #[test]
+    fn rejects_body_lines_beyond_the_declared_counts() {
+        let error = parse("@@ -1 +1 @@\n-old\n+new\n+extra\n").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("outside its declared hunk range")
+        );
+    }
+
+    #[test]
+    fn rejects_line_ranges_that_would_overflow() {
+        let error = parse("@@ -4294967295,2 +1 @@\n-a\n-b\n+c\n").unwrap_err();
+        assert!(error.to_string().contains("overflows"));
+    }
+
+    #[test]
+    fn binary_and_too_large_files_do_not_parse_patch_text() {
+        let mut binary = FilePatch::new(
+            Some(PathBuf::from("image.png")),
+            Some(PathBuf::from("image.png")),
+            FileStatus::Modified,
+            "GIT binary patch\n@@ malformed",
+        );
+        binary.is_binary = true;
+        let mut large = FilePatch::new(
+            Some(PathBuf::from("large.txt")),
+            Some(PathBuf::from("large.txt")),
+            FileStatus::Modified,
+            "@@ malformed",
+        );
+        large.is_too_large = true;
+
+        let files = parse_file_patches(vec![binary, large], &SyntaxHighlighter::default()).unwrap();
+        assert!(files[0].is_binary);
+        assert!(files[0].hunks.is_empty());
+        assert!(files[1].is_too_large);
+        assert!(files[1].hunks.is_empty());
     }
 }

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -626,33 +626,14 @@ fn run_git_diff_command(
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     let output = run_git_diff_bytes(workdir, &args, &[])?;
-    let mut patches = match parse_raw_patch_output(&output) {
+    let patches = match parse_raw_patch_output(&output) {
         Ok(patches) => patches,
         Err(_) if suppress_header_only_content_changes => {
             parse_whitespace_filtered_patches(workdir, &args, &output)?
         }
         Err(error) => return Err(error),
     };
-    if suppress_header_only_content_changes {
-        // Git versions differ here: some omit the patch block for a
-        // whitespace-only modification, while others emit a block containing
-        // only display headers. The fallback above handles the omitted form;
-        // normalize the header-only form before materializing DiffFiles.
-        patches.retain(whitespace_filtered_patch_is_visible);
-    }
     diff_parser::parse_file_patches(patches, highlighter)
-}
-
-fn whitespace_filtered_patch_is_visible(patch: &crate::model::FilePatch) -> bool {
-    patch.status != FileStatus::Modified
-        || patch.is_binary
-        || patch.patch.lines().any(|line| {
-            !line.is_empty()
-                && !line.starts_with("diff --git ")
-                && !line.starts_with("index ")
-                && !line.starts_with("--- ")
-                && !line.starts_with("+++ ")
-        })
 }
 
 fn run_git_diff_bytes(workdir: &Path, args: &[String], pathspecs: &[&Path]) -> Result<Vec<u8>> {
@@ -1937,46 +1918,5 @@ mod tests {
             files[0].new_path.as_deref(),
             Some(Path::new(substantive_path))
         );
-    }
-
-    #[test]
-    fn whitespace_filter_discards_header_only_git_blocks() {
-        let header_only = crate::model::FilePatch::new(
-            Some(PathBuf::from("file.txt")),
-            Some(PathBuf::from("file.txt")),
-            FileStatus::Modified,
-            "diff --git a/file.txt b/file.txt\nindex 1111111..2222222 100644\n--- a/file.txt\n+++ b/file.txt\n",
-        );
-        assert!(!whitespace_filtered_patch_is_visible(&header_only));
-    }
-
-    #[test]
-    fn whitespace_filter_preserves_non_content_git_blocks() {
-        let mut mode_change = crate::model::FilePatch::new(
-            Some(PathBuf::from("script.sh")),
-            Some(PathBuf::from("script.sh")),
-            FileStatus::Modified,
-            "diff --git a/script.sh b/script.sh\nold mode 100644\nnew mode 100755\n",
-        );
-        assert!(whitespace_filtered_patch_is_visible(&mode_change));
-
-        mode_change.patch =
-            "diff --git a/file.txt b/file.txt\n@@ -1 +1 @@\n-old\n+new\n".to_string();
-        assert!(whitespace_filtered_patch_is_visible(&mode_change));
-
-        mode_change.patch = "diff --git a/sub b/sub\nSubmodule sub changed\n".to_string();
-        assert!(whitespace_filtered_patch_is_visible(&mode_change));
-
-        mode_change.patch = "diff --git a/image b/image\n".to_string();
-        mode_change.is_binary = true;
-        assert!(whitespace_filtered_patch_is_visible(&mode_change));
-
-        let rename = crate::model::FilePatch::new(
-            Some(PathBuf::from("old.txt")),
-            Some(PathBuf::from("new.txt")),
-            FileStatus::Renamed,
-            "diff --git a/old.txt b/new.txt\n",
-        );
-        assert!(whitespace_filtered_patch_is_visible(&rename));
     }
 }

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;
@@ -11,7 +10,11 @@ use chrono::{TimeZone, Utc};
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide};
 use crate::syntax::SyntaxHighlighter;
-use crate::vcs::diff_parser::{self, DiffFormat};
+use crate::vcs::diff_parser;
+use crate::vcs::git::raw::{
+    pair_metadata_with_patch, parse_raw_metadata_from_patch_output, parse_raw_patch_output,
+    patch_text_from_raw_patch_output, split_patch_blocks,
+};
 use crate::vcs::{
     ChangeKind, CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget,
     VcsBackend, VcsChangeStatus, VcsInfo,
@@ -93,16 +96,21 @@ impl GitCliBackend {
         new_source: GitContentSource<'_>,
         highlighter: &SyntaxHighlighter,
     ) -> Result<Vec<DiffFile>> {
-        // Force the traditional "a/" and "b/" path prefixes. The user's Git config
-        // can change this: diff.mnemonicPrefix emits mnemonic prefixes (i/, w/, c/,
-        // o/) and diff.noprefix drops prefixes entirely. The diff parser only strips
-        // "a/" and "b/", so these flags override the config to keep output parseable.
-        args.insert(1, "--src-prefix=a/".to_string());
-        args.insert(2, "--dst-prefix=b/".to_string());
+        // Paths and status come from Git's NUL-delimited raw records. Patch
+        // headers remain display-only and may follow any user quoting/prefix
+        // configuration without affecting file identity.
+        args.insert(1, "-z".to_string());
+        args.insert(1, "--raw".to_string());
+        args.insert(1, "--patch".to_string());
         if self.whitespace_mode.ignores_all() {
             args.insert(1, "--ignore-all-space".to_string());
         }
-        let mut files = match run_git_diff_command(&self.root_path, args, highlighter) {
+        let mut files = match run_git_diff_command(
+            &self.root_path,
+            args,
+            self.whitespace_mode.ignores_all(),
+            highlighter,
+        ) {
             Ok(files) => files,
             Err(TuicrError::NoChanges) => Vec::new(),
             Err(err) => return Err(err),
@@ -614,17 +622,35 @@ fn has_untracked_changes(workdir: &Path, pathspecs: &[String]) -> Result<bool> {
 fn run_git_diff_command(
     workdir: &Path,
     args: Vec<String>,
+    suppress_header_only_content_changes: bool,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
-    let mut child = Command::new("git")
-        .current_dir(workdir)
-        .args(&args)
+    let output = run_git_diff_bytes(workdir, &args, &[])?;
+    let patches = match parse_raw_patch_output(&output) {
+        Ok(patches) => patches,
+        Err(_) if suppress_header_only_content_changes => {
+            parse_whitespace_filtered_patches(workdir, &args, &output)?
+        }
+        Err(error) => return Err(error),
+    };
+    diff_parser::parse_file_patches(patches, highlighter)
+}
+
+fn run_git_diff_bytes(workdir: &Path, args: &[String], pathspecs: &[&Path]) -> Result<Vec<u8>> {
+    let mut command = Command::new("git");
+    command.current_dir(workdir);
+    if !pathspecs.is_empty() {
+        command.arg("--literal-pathspecs");
+    }
+    let mut child = command
+        .args(args)
+        .args(pathspecs)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
 
-    let stdout = child
+    let mut stdout = child
         .stdout
         .take()
         .ok_or_else(|| TuicrError::VcsCommand("git diff stdout unavailable".into()))?;
@@ -638,11 +664,8 @@ fn run_git_diff_command(
         bytes
     });
 
-    let diff_lines = BufReader::new(stdout)
-        .lines()
-        .map(|line| line.map(Cow::Owned).map_err(TuicrError::from));
-    let parse_result =
-        diff_parser::parse_unified_diff_lines(diff_lines, DiffFormat::GitStyle, highlighter);
+    let mut output = Vec::new();
+    stdout.read_to_end(&mut output)?;
 
     let status = child.wait()?;
     let stderr = stderr_reader
@@ -657,7 +680,48 @@ fn run_git_diff_command(
         )));
     }
 
-    parse_result
+    Ok(output)
+}
+
+fn parse_whitespace_filtered_patches(
+    workdir: &Path,
+    args: &[String],
+    combined_output: &[u8],
+) -> Result<Vec<crate::model::FilePatch>> {
+    // Raw records are not filtered by `--ignore-all-space`, while patch
+    // bodies are. If that makes the two ordered streams differ, ask Git for
+    // each authoritative path independently. A zero-block result is a
+    // whitespace-only content change; one block can be paired without ever
+    // decoding a display header.
+    let metadata = parse_raw_metadata_from_patch_output(combined_output)?;
+    let mut patches = Vec::new();
+
+    for file in metadata {
+        let mut paths = Vec::new();
+        if let Some(path) = file.old_path.as_deref() {
+            paths.push(path);
+        }
+        if let Some(path) = file.new_path.as_deref()
+            && !paths.contains(&path)
+        {
+            paths.push(path);
+        }
+
+        let output = run_git_diff_bytes(workdir, args, &paths)?;
+        let blocks = split_patch_blocks(patch_text_from_raw_patch_output(&output)?);
+        match blocks.as_slice() {
+            [] => {}
+            [block] => patches.extend(pair_metadata_with_patch(vec![file], block)?),
+            _ => {
+                return Err(TuicrError::VcsCommand(format!(
+                    "structured diff path query emitted {} patch blocks for one file",
+                    blocks.len()
+                )));
+            }
+        }
+    }
+
+    Ok(patches)
 }
 
 fn append_untracked_cli_diffs(
@@ -1493,6 +1557,62 @@ mod tests {
     }
 
     #[test]
+    fn reads_verbatim_paths_that_are_ambiguous_in_display_headers() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+
+        git(workdir, &["init"]);
+        git(workdir, &["config", "user.email", "test@example.com"]);
+        git(workdir, &["config", "user.name", "Test User"]);
+        write_file(workdir, "日本語 b/and name.txt", "base\n");
+        write_file(workdir, "old b/left and right.txt", "rename me\n");
+        let binary_path = workdir.join("binary and b/image and data.bin");
+        fs::create_dir_all(binary_path.parent().unwrap()).unwrap();
+        fs::write(&binary_path, [0, 1, 2, 3]).unwrap();
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "initial"]);
+
+        write_file(workdir, "日本語 b/and name.txt", "base\nchanged\n");
+        fs::create_dir_all(workdir.join("renamed b")).unwrap();
+        git(
+            workdir,
+            &[
+                "mv",
+                "old b/left and right.txt",
+                "renamed b/right and left.txt",
+            ],
+        );
+        fs::write(&binary_path, [0, 1, 9, 3]).unwrap();
+
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+            .expect("failed to discover CLI backend");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("failed to parse structured Git diff");
+
+        assert!(files.iter().any(|file| {
+            file.new_path.as_deref() == Some(Path::new("日本語 b/and name.txt"))
+        }));
+        let renamed = files
+            .iter()
+            .find(|file| {
+                file.new_path.as_deref() == Some(Path::new("renamed b/right and left.txt"))
+            })
+            .expect("renamed path should come from raw metadata");
+        assert_eq!(
+            renamed.old_path.as_deref(),
+            Some(Path::new("old b/left and right.txt"))
+        );
+        let binary = files
+            .iter()
+            .find(|file| {
+                file.new_path.as_deref() == Some(Path::new("binary and b/image and data.bin"))
+            })
+            .expect("binary file should be present");
+        assert!(binary.is_binary);
+    }
+
+    #[test]
     fn reads_staged_diff_and_stages_files_in_sparse_index() {
         let (temp_dir, backend, _ids) = setup_sparse_index_repo();
         let workdir = temp_dir.path();
@@ -1767,5 +1887,36 @@ mod tests {
             .get_working_tree_diff(&SyntaxHighlighter::default())
             .expect("non-whitespace edit should still produce a diff");
         assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn whitespace_filter_pairs_remaining_patch_with_its_verbatim_path() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let workdir = temp_dir.path();
+        let substantive_path = "dir b/literal [and] name.txt";
+
+        git(workdir, &["init"]);
+        git(workdir, &["config", "user.email", "test@example.com"]);
+        git(workdir, &["config", "user.name", "Test User"]);
+        git(workdir, &["config", "commit.gpgsign", "false"]);
+        write_file(workdir, "whitespace.txt", "alpha\nbeta\n");
+        write_file(workdir, substantive_path, "before\n");
+        git(workdir, &["add", "."]);
+        git(workdir, &["commit", "-m", "initial"]);
+
+        write_file(workdir, "whitespace.txt", " alpha \n beta\n");
+        write_file(workdir, substantive_path, "after\n");
+
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::IgnoreAll)
+            .expect("failed to discover cli backend");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("substantive edit should produce a diff");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new(substantive_path))
+        );
     }
 }

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -626,14 +626,33 @@ fn run_git_diff_command(
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     let output = run_git_diff_bytes(workdir, &args, &[])?;
-    let patches = match parse_raw_patch_output(&output) {
+    let mut patches = match parse_raw_patch_output(&output) {
         Ok(patches) => patches,
         Err(_) if suppress_header_only_content_changes => {
             parse_whitespace_filtered_patches(workdir, &args, &output)?
         }
         Err(error) => return Err(error),
     };
+    if suppress_header_only_content_changes {
+        // Git versions differ here: some omit the patch block for a
+        // whitespace-only modification, while others emit a block containing
+        // only display headers. The fallback above handles the omitted form;
+        // normalize the header-only form before materializing DiffFiles.
+        patches.retain(whitespace_filtered_patch_is_visible);
+    }
     diff_parser::parse_file_patches(patches, highlighter)
+}
+
+fn whitespace_filtered_patch_is_visible(patch: &crate::model::FilePatch) -> bool {
+    patch.status != FileStatus::Modified
+        || patch.is_binary
+        || patch.patch.lines().any(|line| {
+            !line.is_empty()
+                && !line.starts_with("diff --git ")
+                && !line.starts_with("index ")
+                && !line.starts_with("--- ")
+                && !line.starts_with("+++ ")
+        })
 }
 
 fn run_git_diff_bytes(workdir: &Path, args: &[String], pathspecs: &[&Path]) -> Result<Vec<u8>> {
@@ -1918,5 +1937,46 @@ mod tests {
             files[0].new_path.as_deref(),
             Some(Path::new(substantive_path))
         );
+    }
+
+    #[test]
+    fn whitespace_filter_discards_header_only_git_blocks() {
+        let header_only = crate::model::FilePatch::new(
+            Some(PathBuf::from("file.txt")),
+            Some(PathBuf::from("file.txt")),
+            FileStatus::Modified,
+            "diff --git a/file.txt b/file.txt\nindex 1111111..2222222 100644\n--- a/file.txt\n+++ b/file.txt\n",
+        );
+        assert!(!whitespace_filtered_patch_is_visible(&header_only));
+    }
+
+    #[test]
+    fn whitespace_filter_preserves_non_content_git_blocks() {
+        let mut mode_change = crate::model::FilePatch::new(
+            Some(PathBuf::from("script.sh")),
+            Some(PathBuf::from("script.sh")),
+            FileStatus::Modified,
+            "diff --git a/script.sh b/script.sh\nold mode 100644\nnew mode 100755\n",
+        );
+        assert!(whitespace_filtered_patch_is_visible(&mode_change));
+
+        mode_change.patch =
+            "diff --git a/file.txt b/file.txt\n@@ -1 +1 @@\n-old\n+new\n".to_string();
+        assert!(whitespace_filtered_patch_is_visible(&mode_change));
+
+        mode_change.patch = "diff --git a/sub b/sub\nSubmodule sub changed\n".to_string();
+        assert!(whitespace_filtered_patch_is_visible(&mode_change));
+
+        mode_change.patch = "diff --git a/image b/image\n".to_string();
+        mode_change.is_binary = true;
+        assert!(whitespace_filtered_patch_is_visible(&mode_change));
+
+        let rename = crate::model::FilePatch::new(
+            Some(PathBuf::from("old.txt")),
+            Some(PathBuf::from("new.txt")),
+            FileStatus::Renamed,
+            "diff --git a/old.txt b/new.txt\n",
+        );
+        assert!(whitespace_filtered_patch_is_visible(&rename));
     }
 }

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -2,6 +2,7 @@ mod cli;
 pub mod context;
 pub mod diff;
 mod libgit2;
+pub(crate) mod raw;
 pub mod repository;
 pub mod staging;
 

--- a/src/vcs/git/raw.rs
+++ b/src/vcs/git/raw.rs
@@ -1,0 +1,318 @@
+//! Git's machine-readable `--raw -z` metadata paired with `--patch` output.
+//!
+//! With `-z`, path bytes are emitted verbatim and NUL-delimited; `core.quotepath`
+//! and every ambiguity in `diff --git` display headers are therefore irrelevant.
+
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::error::{Result, TuicrError};
+use crate::model::{FilePatch, FileStatus};
+
+/// Parse one `git diff --raw -z --patch` byte stream.
+pub(crate) fn parse_raw_patch_output(output: &[u8]) -> Result<Vec<FilePatch>> {
+    if output.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let separator = raw_patch_separator(output)?;
+    let metadata = parse_raw_records(&output[..=separator])?;
+    let patch_text = &output[separator + 2..];
+    let patch_blocks = split_patch_blocks(patch_text);
+
+    if metadata.len() != patch_blocks.len() {
+        return Err(malformed(format!(
+            "Git emitted {} raw records but {} patch blocks",
+            metadata.len(),
+            patch_blocks.len()
+        )));
+    }
+
+    pair_metadata_with_blocks(metadata, patch_blocks)
+}
+
+/// Run Git with the structured diff flags used by non-CLI-backend callers.
+pub(crate) fn run_git_diff(root: &Path, diff_args: &[&str]) -> Result<Vec<FilePatch>> {
+    let output = Command::new("git")
+        .current_dir(root)
+        .args([
+            "diff",
+            "--no-ext-diff",
+            "--raw",
+            "-z",
+            "--patch",
+            "--binary",
+        ])
+        .args(diff_args)
+        .output()
+        .map_err(|error| TuicrError::VcsCommand(format!("Failed to run git: {error}")))?;
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+    parse_raw_patch_output(&output.stdout)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct FileMetadata {
+    pub old_path: Option<PathBuf>,
+    pub new_path: Option<PathBuf>,
+    pub status: FileStatus,
+}
+
+/// Read the authoritative records from the raw section of a combined diff.
+///
+/// This is also useful when a diff option (notably `--ignore-all-space`)
+/// suppresses some patch bodies but Git still emits raw records for them.
+pub(crate) fn parse_raw_metadata_from_patch_output(output: &[u8]) -> Result<Vec<FileMetadata>> {
+    let separator = raw_patch_separator(output)?;
+    parse_raw_records(&output[..=separator])
+}
+
+pub(crate) fn patch_text_from_raw_patch_output(output: &[u8]) -> Result<&[u8]> {
+    let separator = raw_patch_separator(output)?;
+    Ok(&output[separator + 2..])
+}
+
+fn raw_patch_separator(output: &[u8]) -> Result<usize> {
+    output
+        .windows(2)
+        .position(|window| window == b"\0\0")
+        .ok_or_else(|| malformed("missing NUL boundary between raw metadata and patch text"))
+}
+
+/// Pair authoritative metadata with file blocks from a Git-style patch.
+///
+/// Both inputs must use the source's file order. No path is read from the
+/// patch text; a mismatch is an error rather than an invitation to guess.
+pub(crate) fn pair_metadata_with_patch(
+    metadata: Vec<FileMetadata>,
+    patch: &[u8],
+) -> Result<Vec<FilePatch>> {
+    let patch_blocks = split_patch_blocks(patch);
+    if metadata.len() != patch_blocks.len() {
+        return Err(pairing_error(format!(
+            "source emitted {} metadata records but {} patch blocks",
+            metadata.len(),
+            patch_blocks.len()
+        )));
+    }
+    pair_metadata_with_blocks(metadata, patch_blocks)
+}
+
+fn pair_metadata_with_blocks(
+    metadata: Vec<FileMetadata>,
+    patch_blocks: Vec<&[u8]>,
+) -> Result<Vec<FilePatch>> {
+    Ok(metadata
+        .into_iter()
+        .zip(patch_blocks)
+        .map(|(metadata, patch)| {
+            let mut file = FilePatch::new(
+                metadata.old_path,
+                metadata.new_path,
+                metadata.status,
+                String::from_utf8_lossy(patch).into_owned(),
+            );
+            file.is_binary = is_binary_patch(patch);
+            file
+        })
+        .collect())
+}
+
+fn parse_raw_records(raw: &[u8]) -> Result<Vec<FileMetadata>> {
+    let mut fields = raw.split(|byte| *byte == 0).peekable();
+    let mut records = Vec::new();
+
+    while let Some(header) = fields.next() {
+        if header.is_empty() {
+            break;
+        }
+        let header = std::str::from_utf8(header)
+            .map_err(|_| malformed("raw metadata header is not ASCII"))?;
+        let status_token = header
+            .strip_prefix(':')
+            .and_then(|rest| rest.split_whitespace().nth(4))
+            .ok_or_else(|| malformed(format!("invalid raw metadata header `{header}`")))?;
+        let status_code = status_token
+            .as_bytes()
+            .first()
+            .copied()
+            .ok_or_else(|| malformed("raw metadata record has no status"))?;
+        let first_path = fields
+            .next()
+            .filter(|path| !path.is_empty())
+            .ok_or_else(|| malformed(format!("raw `{status_token}` record has no path")))?;
+        let first_path = path_buf_from_bytes(first_path);
+
+        let record = match status_code {
+            b'A' => FileMetadata {
+                old_path: None,
+                new_path: Some(first_path),
+                status: FileStatus::Added,
+            },
+            b'D' => FileMetadata {
+                old_path: Some(first_path),
+                new_path: None,
+                status: FileStatus::Deleted,
+            },
+            b'R' | b'C' => {
+                let second_path =
+                    fields
+                        .next()
+                        .filter(|path| !path.is_empty())
+                        .ok_or_else(|| {
+                            malformed(format!("raw `{status_token}` record has one path"))
+                        })?;
+                FileMetadata {
+                    old_path: Some(first_path),
+                    new_path: Some(path_buf_from_bytes(second_path)),
+                    status: if status_code == b'R' {
+                        FileStatus::Renamed
+                    } else {
+                        FileStatus::Copied
+                    },
+                }
+            }
+            b'M' | b'T' | b'U' | b'X' | b'B' => FileMetadata {
+                old_path: Some(first_path.clone()),
+                new_path: Some(first_path),
+                status: FileStatus::Modified,
+            },
+            other => {
+                return Err(malformed(format!(
+                    "unsupported raw Git status `{}`",
+                    char::from(other)
+                )));
+            }
+        };
+        records.push(record);
+    }
+
+    Ok(records)
+}
+
+/// Split only on top-level Git file markers. Hunk body lines always carry a
+/// ` `, `+`, or `-` prefix, so file content cannot produce this column-zero
+/// sentinel. Git binary-patch payload lines contain no spaces.
+pub(crate) fn split_patch_blocks(patch: &[u8]) -> Vec<&[u8]> {
+    const MARKER: &[u8] = b"diff --git ";
+    let starts: Vec<usize> = (0..patch.len())
+        .filter(|&index| {
+            patch[index..].starts_with(MARKER) && (index == 0 || patch[index - 1] == b'\n')
+        })
+        .collect();
+
+    starts
+        .iter()
+        .enumerate()
+        .map(|(index, start)| {
+            let end = starts.get(index + 1).copied().unwrap_or(patch.len());
+            &patch[*start..end]
+        })
+        .collect()
+}
+
+pub(crate) fn is_binary_patch(patch: &[u8]) -> bool {
+    patch.split(|byte| *byte == b'\n').any(|line| {
+        line.starts_with(b"Binary files ")
+            || line.starts_with(b"Binary file ")
+            || line == b"GIT binary patch"
+    })
+}
+
+fn malformed(detail: impl Into<String>) -> TuicrError {
+    TuicrError::VcsCommand(format!(
+        "invalid `git diff --raw -z --patch` output: {}",
+        detail.into()
+    ))
+}
+
+fn pairing_error(detail: impl Into<String>) -> TuicrError {
+    TuicrError::VcsCommand(format!(
+        "structured diff metadata/patch mismatch: {}",
+        detail.into()
+    ))
+}
+
+#[cfg(unix)]
+pub(crate) fn path_buf_from_bytes(bytes: &[u8]) -> PathBuf {
+    use std::os::unix::ffi::OsStringExt;
+    PathBuf::from(OsString::from_vec(bytes.to_vec()))
+}
+
+#[cfg(not(unix))]
+pub(crate) fn path_buf_from_bytes(bytes: &[u8]) -> PathBuf {
+    PathBuf::from(String::from_utf8_lossy(bytes).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parses_verbatim_paths_without_reading_display_headers() {
+        let output = b":100644 100644 aaaaaaa bbbbbbb R100\0old b/ and name.txt\0\xe6\x97\xa5 new.txt\0\0diff --git a/wrong b/wrong\nrename from wrong\nrename to wrong\n";
+        let files = parse_raw_patch_output(output).unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].status, FileStatus::Renamed);
+        assert_eq!(
+            files[0].old_path.as_deref(),
+            Some(Path::new("old b/ and name.txt"))
+        );
+        assert_eq!(files[0].new_path.as_deref(), Some(Path::new("日 new.txt")));
+    }
+
+    #[test]
+    fn maps_added_deleted_modified_and_copied_records() {
+        let output = b":000000 100644 0000000 aaaaaaa A\0added\0:100644 000000 aaaaaaa 0000000 D\0deleted\0:100644 100644 aaaaaaa bbbbbbb M\0modified\0:100644 100644 aaaaaaa bbbbbbb C75\0source\0copy\0\0diff --git a/ignored b/ignored\nnew file mode 100644\ndiff --git a/ignored b/ignored\ndeleted file mode 100644\ndiff --git a/ignored b/ignored\nindex a..b\ndiff --git a/ignored b/ignored\nsimilarity index 75%\n";
+        let files = parse_raw_patch_output(output).unwrap();
+
+        assert_eq!(files.len(), 4);
+        assert_eq!(files[0].status, FileStatus::Added);
+        assert_eq!(files[1].status, FileStatus::Deleted);
+        assert_eq!(files[2].status, FileStatus::Modified);
+        assert_eq!(files[3].status, FileStatus::Copied);
+        assert_eq!(files[3].old_path.as_deref(), Some(Path::new("source")));
+        assert_eq!(files[3].new_path.as_deref(), Some(Path::new("copy")));
+    }
+
+    #[test]
+    fn marks_binary_patch_from_body_without_parsing_its_paths() {
+        let output = b":100644 100644 aaaaaaa bbbbbbb M\0photo and image.png\0\0diff --git a/nonsense b/nonsense\nBinary files a/nonsense and b/nonsense differ\n";
+        let files = parse_raw_patch_output(output).unwrap();
+        assert!(files[0].is_binary);
+        assert_eq!(
+            files[0].new_path.as_deref(),
+            Some(Path::new("photo and image.png"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn preserves_non_utf8_path_bytes_on_unix() {
+        use std::os::unix::ffi::OsStrExt;
+
+        let output = b":100644 100644 aaaaaaa bbbbbbb M\0bad-\xff-name\0\0diff --git a/x b/x\n";
+        let files = parse_raw_patch_output(output).unwrap();
+        assert_eq!(
+            files[0].new_path.as_ref().unwrap().as_os_str().as_bytes(),
+            b"bad-\xff-name"
+        );
+    }
+
+    #[test]
+    fn rejects_metadata_and_patch_count_mismatch() {
+        let output = b":100644 100644 aaaaaaa bbbbbbb M\0one\0\0";
+        let error = parse_raw_patch_output(output).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("1 raw records but 0 patch blocks")
+        );
+    }
+}

--- a/src/vcs/git/raw.rs
+++ b/src/vcs/git/raw.rs
@@ -12,13 +12,8 @@ use crate::model::{FilePatch, FileStatus};
 
 /// Parse one `git diff --raw -z --patch` byte stream.
 pub(crate) fn parse_raw_patch_output(output: &[u8]) -> Result<Vec<FilePatch>> {
-    if output.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let separator = raw_patch_separator(output)?;
-    let metadata = parse_raw_records(&output[..=separator])?;
-    let patch_text = &output[separator + 2..];
+    let (raw, patch_text) = split_raw_patch_sections(output)?;
+    let metadata = parse_raw_records(raw)?;
     let patch_blocks = split_patch_blocks(patch_text);
 
     if metadata.len() != patch_blocks.len() {
@@ -67,20 +62,31 @@ pub(crate) struct FileMetadata {
 /// This is also useful when a diff option (notably `--ignore-all-space`)
 /// suppresses some patch bodies but Git still emits raw records for them.
 pub(crate) fn parse_raw_metadata_from_patch_output(output: &[u8]) -> Result<Vec<FileMetadata>> {
-    let separator = raw_patch_separator(output)?;
-    parse_raw_records(&output[..=separator])
+    let (raw, _) = split_raw_patch_sections(output)?;
+    parse_raw_records(raw)
 }
 
 pub(crate) fn patch_text_from_raw_patch_output(output: &[u8]) -> Result<&[u8]> {
-    let separator = raw_patch_separator(output)?;
-    Ok(&output[separator + 2..])
+    let (_, patch) = split_raw_patch_sections(output)?;
+    Ok(patch)
 }
 
-fn raw_patch_separator(output: &[u8]) -> Result<usize> {
-    output
+fn split_raw_patch_sections(output: &[u8]) -> Result<(&[u8], &[u8])> {
+    if output.is_empty() {
+        return Ok((output, output));
+    }
+
+    // Git may emit a lone NUL for an empty `--raw -z` section when another
+    // diff option (for example `--ignore-all-space`) filters every change.
+    if output == b"\0" {
+        return Ok((output, &output[1..]));
+    }
+
+    let separator = output
         .windows(2)
         .position(|window| window == b"\0\0")
-        .ok_or_else(|| malformed("missing NUL boundary between raw metadata and patch text"))
+        .ok_or_else(|| malformed("missing NUL boundary between raw metadata and patch text"))?;
+    Ok((&output[..=separator], &output[separator + 2..]))
 }
 
 /// Pair authoritative metadata with file blocks from a Git-style patch.
@@ -265,6 +271,17 @@ mod tests {
             Some(Path::new("old b/ and name.txt"))
         );
         assert_eq!(files[0].new_path.as_deref(), Some(Path::new("日 new.txt")));
+    }
+
+    #[test]
+    fn parses_empty_nul_terminated_raw_section() {
+        assert!(parse_raw_patch_output(b"\0").unwrap().is_empty());
+        assert!(
+            parse_raw_metadata_from_patch_output(b"\0")
+                .unwrap()
+                .is_empty()
+        );
+        assert!(patch_text_from_raw_patch_output(b"\0").unwrap().is_empty());
     }
 
     #[test]

--- a/src/vcs/hg/mod.rs
+++ b/src/vcs/hg/mod.rs
@@ -8,7 +8,10 @@ use chrono::{TimeZone, Utc};
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
-use crate::vcs::diff_parser::{self, DiffFormat};
+use crate::vcs::diff_parser;
+use crate::vcs::git::raw::{
+    FileMetadata, pair_metadata_with_patch, path_buf_from_bytes, split_patch_blocks,
+};
 use crate::vcs::traits::{
     CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsInfo,
     VcsType,
@@ -96,6 +99,157 @@ impl HgBackend {
         args_with_whitespace.extend_from_slice(&args[1..]);
         Cow::Owned(args_with_whitespace)
     }
+
+    fn load_diff(
+        &self,
+        diff_args: &[&str],
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        let args = self.diff_args(diff_args);
+        let mut patch_args: Vec<&str> = args.iter().copied().collect();
+        patch_args.insert(1, "--git");
+        let patch = run_hg_command(&self.info.root_path, &patch_args)?;
+        if patch.trim().is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        let status_args = hg_status_args(diff_args);
+        let metadata_output = run_hg_command_bytes(&self.info.root_path, &status_args)?;
+        let metadata = parse_hg_diff_metadata(&metadata_output)?;
+
+        let patches = if metadata.len() == split_patch_blocks(patch.as_bytes()).len() {
+            pair_metadata_with_patch(metadata, patch.as_bytes())?
+        } else {
+            // `hg status` has no whitespace-filter option. If the requested
+            // diff hides only some whitespace-only files, ask hg for each
+            // exact structured path and retain the non-empty patches.
+            let mut patches = Vec::new();
+            for file in metadata {
+                let path = file
+                    .new_path
+                    .as_deref()
+                    .or(file.old_path.as_deref())
+                    .ok_or_else(|| {
+                        TuicrError::VcsCommand(
+                            "Mercurial status entry has neither an old nor a new path".into(),
+                        )
+                    })?;
+                let pattern = hg_path_pattern(path);
+                let mut file_args = patch_args.clone();
+                file_args.push(&pattern);
+                let file_patch = run_hg_command(&self.info.root_path, file_args)?;
+                if !file_patch.trim().is_empty() {
+                    patches.extend(pair_metadata_with_patch(vec![file], file_patch.as_bytes())?);
+                }
+            }
+            patches
+        };
+
+        diff_parser::parse_file_patches(patches, highlighter)
+    }
+}
+
+fn hg_status_args<'a>(diff_args: &'a [&'a str]) -> Vec<&'a str> {
+    let mut args = vec![
+        "status",
+        "--modified",
+        "--added",
+        "--removed",
+        "--deleted",
+        "--copies",
+        "-0",
+    ];
+    let mut index = 1;
+    while index < diff_args.len() {
+        if matches!(diff_args[index], "-r" | "--rev")
+            && let Some(revision) = diff_args.get(index + 1)
+        {
+            args.extend(["--rev", *revision]);
+            index += 2;
+        } else {
+            index += 1;
+        }
+    }
+    args
+}
+
+fn parse_hg_diff_metadata(output: &[u8]) -> Result<Vec<FileMetadata>> {
+    #[derive(Debug)]
+    struct Entry {
+        status: u8,
+        path: PathBuf,
+        copy_source: Option<PathBuf>,
+    }
+
+    let mut entries: Vec<Entry> = Vec::new();
+    for record in output.split(|byte| *byte == 0).filter(|r| !r.is_empty()) {
+        if record.len() < 3 || record[1] != b' ' {
+            return Err(TuicrError::VcsCommand(
+                "invalid NUL-delimited Mercurial status record".into(),
+            ));
+        }
+        if record[0] == b' ' {
+            let previous = entries.last_mut().ok_or_else(|| {
+                TuicrError::VcsCommand(
+                    "Mercurial copy-source record has no preceding target".into(),
+                )
+            })?;
+            previous.copy_source = Some(path_buf_from_bytes(&record[2..]));
+        } else {
+            entries.push(Entry {
+                status: record[0],
+                path: path_buf_from_bytes(&record[2..]),
+                copy_source: None,
+            });
+        }
+    }
+
+    let removed: std::collections::HashSet<PathBuf> = entries
+        .iter()
+        .filter(|entry| matches!(entry.status, b'R' | b'!'))
+        .map(|entry| entry.path.clone())
+        .collect();
+    let copied_sources: std::collections::HashSet<PathBuf> = entries
+        .iter()
+        .filter_map(|entry| entry.copy_source.clone())
+        .collect();
+
+    entries
+        .into_iter()
+        .filter_map(|entry| {
+            let metadata = match entry.status {
+                b'M' => Some(FileMetadata {
+                    old_path: Some(entry.path.clone()),
+                    new_path: Some(entry.path),
+                    status: FileStatus::Modified,
+                }),
+                b'A' => match entry.copy_source {
+                    Some(source) => Some(FileMetadata {
+                        status: if removed.contains(&source) {
+                            FileStatus::Renamed
+                        } else {
+                            FileStatus::Copied
+                        },
+                        old_path: Some(source),
+                        new_path: Some(entry.path),
+                    }),
+                    None => Some(FileMetadata {
+                        old_path: None,
+                        new_path: Some(entry.path),
+                        status: FileStatus::Added,
+                    }),
+                },
+                b'R' | b'!' if copied_sources.contains(&entry.path) => None,
+                b'R' | b'!' => Some(FileMetadata {
+                    old_path: Some(entry.path),
+                    new_path: None,
+                    status: FileStatus::Deleted,
+                }),
+                _ => None,
+            };
+            metadata.map(Ok)
+        })
+        .collect()
 }
 
 impl VcsBackend for HgBackend {
@@ -104,14 +258,7 @@ impl VcsBackend for HgBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        let args = self.diff_args(&["diff"]);
-        let diff_output = run_hg_command(&self.info.root_path, args.iter().copied())?;
-
-        if diff_output.trim().is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
+        let mut files = self.load_diff(&["diff"], highlighter)?;
         apply_container_full_file_highlight(
             &self.info.root_path,
             ".",
@@ -300,14 +447,7 @@ impl VcsBackend for HgBackend {
         };
 
         let diff_args = ["diff", "-r", &from_rev, "-r", newest_short];
-        let args = self.diff_args(&diff_args);
-        let diff_output = run_hg_command(&self.info.root_path, args.iter().copied())?;
-
-        if diff_output.trim().is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
+        let mut files = self.load_diff(&diff_args, highlighter)?;
         apply_container_full_file_highlight(
             &self.info.root_path,
             &from_rev,
@@ -415,14 +555,7 @@ impl VcsBackend for HgBackend {
         };
 
         let diff_args = ["diff", "-r", &from_rev];
-        let args = self.diff_args(&diff_args);
-        let diff_output = run_hg_command(&self.info.root_path, args.iter().copied())?;
-
-        if diff_output.trim().is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        let mut files = diff_parser::parse_unified_diff(&diff_output, DiffFormat::Hg, highlighter)?;
+        let mut files = self.load_diff(&diff_args, highlighter)?;
         apply_container_full_file_highlight(
             &self.info.root_path,
             &from_rev,
@@ -472,6 +605,15 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<std::ffi::OsStr>,
 {
+    Ok(String::from_utf8_lossy(&run_hg_command_bytes(root, args)?).into_owned())
+}
+
+/// Run an hg command without forcing NUL-delimited path bytes through UTF-8.
+fn run_hg_command_bytes<I, S>(root: &Path, args: I) -> Result<Vec<u8>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
     let args: Vec<S> = args.into_iter().collect();
     let output = Command::new("hg")
         .current_dir(root)
@@ -492,7 +634,7 @@ where
         )));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
 #[cfg(test)]
@@ -612,6 +754,37 @@ mod tests {
             "hello.txt"
         );
         assert_eq!(files[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn test_hg_uses_nul_status_paths_instead_of_diff_headers() {
+        let Some(temp) = setup_test_repo() else {
+            eprintln!("Skipping test: hg command not available");
+            return;
+        };
+        let path = PathBuf::from("日本語 b/left and right.txt");
+        fs::create_dir_all(temp.path().join(path.parent().unwrap())).unwrap();
+        fs::write(temp.path().join(&path), "base\n").unwrap();
+        Command::new("hg")
+            .args(["add", path.to_str().unwrap()])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        Command::new("hg")
+            .args(["commit", "-m", "add ambiguous path"])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        fs::write(temp.path().join(&path), "base\nchanged\n").unwrap();
+
+        let backend = HgBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create hg backend");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("structured hg diff should parse");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].new_path.as_deref(), Some(path.as_path()));
     }
 
     #[test]

--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -10,7 +10,8 @@ use chrono::{DateTime, Utc};
 use crate::error::{Result, TuicrError};
 use crate::model::{DiffFile, DiffLine, FileStatus};
 use crate::syntax::SyntaxHighlighter;
-use crate::vcs::diff_parser::{self, DiffFormat};
+use crate::vcs::diff_parser;
+use crate::vcs::git::raw::{FileMetadata, pair_metadata_with_patch};
 use crate::vcs::traits::{
     CommitInfo, DiffWhitespaceMode, ResolvedRevisionRange, RevisionDiffTarget, VcsBackend, VcsInfo,
     VcsType,
@@ -137,6 +138,69 @@ impl JjBackend {
         args_with_whitespace.extend_from_slice(&args[1..]);
         Cow::Owned(args_with_whitespace)
     }
+
+    fn load_diff(
+        &self,
+        diff_args: &[&str],
+        highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        let args = self.diff_args(diff_args);
+        let mut metadata_args: Vec<&str> = args.iter().copied().collect();
+        metadata_args.extend(["-T", JJ_DIFF_METADATA_TEMPLATE]);
+        // This first command snapshots the working copy when needed. The
+        // patch command then reads that exact operation without another
+        // snapshot, keeping metadata and hunks in lockstep.
+        let metadata_output = run_jj_command(&self.info.root_path, metadata_args)?;
+        let metadata = parse_jj_diff_metadata(&metadata_output)?;
+        if metadata.is_empty() {
+            return Err(TuicrError::NoChanges);
+        }
+
+        let mut patch_args: Vec<&str> = args.iter().copied().collect();
+        patch_args.extend(["--git", "--ignore-working-copy"]);
+        let patch = run_jj_command(&self.info.root_path, patch_args)?;
+        let patches = pair_metadata_with_patch(metadata, patch.as_bytes())?;
+        diff_parser::parse_file_patches(patches, highlighter)
+    }
+}
+
+const JJ_DIFF_METADATA_TEMPLATE: &str =
+    r#"status_char ++ "\0" ++ source.path() ++ "\0" ++ target.path() ++ "\0""#;
+
+fn parse_jj_diff_metadata(output: &str) -> Result<Vec<FileMetadata>> {
+    let fields: Vec<&str> = output.split('\0').collect();
+    let records = fields.strip_suffix(&[""]).unwrap_or(&fields);
+    if !records.len().is_multiple_of(3) {
+        return Err(TuicrError::VcsCommand(format!(
+            "invalid jj diff metadata: expected status/source/target triples, got {} fields",
+            records.len()
+        )));
+    }
+
+    records
+        .chunks_exact(3)
+        .map(|record| {
+            let source = (!record[1].is_empty()).then(|| PathBuf::from(record[1]));
+            let target = (!record[2].is_empty()).then(|| PathBuf::from(record[2]));
+            let (old_path, new_path, status) = match record[0] {
+                "A" => (None, target, FileStatus::Added),
+                "D" => (source, None, FileStatus::Deleted),
+                "M" => (source, target, FileStatus::Modified),
+                "R" => (source, target, FileStatus::Renamed),
+                "C" => (source, target, FileStatus::Copied),
+                status => {
+                    return Err(TuicrError::VcsCommand(format!(
+                        "invalid jj diff metadata status `{status}`"
+                    )));
+                }
+            };
+            Ok(FileMetadata {
+                old_path,
+                new_path,
+                status,
+            })
+        })
+        .collect()
 }
 
 impl VcsBackend for JjBackend {
@@ -145,15 +209,7 @@ impl VcsBackend for JjBackend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        let args = self.diff_args(&["diff", "--git"]);
-        let diff_output = run_jj_command(&self.info.root_path, args.iter().copied())?;
-
-        if diff_output.trim().is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        let mut files =
-            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
+        let mut files = self.load_diff(&["diff"], highlighter)?;
         apply_container_full_file_highlight(
             &self.info.root_path,
             "@-",
@@ -322,16 +378,8 @@ impl VcsBackend for JjBackend {
         // Get the parent of the oldest commit to include its changes
         // In jj, we use {commit}- to get the parent(s)
         let from_rev = format!("{}-", oldest);
-        let diff_args = ["diff", "--from", &from_rev, "--to", newest, "--git"];
-        let args = self.diff_args(&diff_args);
-        let diff_output = run_jj_command(&self.info.root_path, args.iter().copied())?;
-
-        if diff_output.trim().is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        let mut files =
-            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
+        let diff_args = ["diff", "--from", &from_rev, "--to", newest];
+        let mut files = self.load_diff(&diff_args, highlighter)?;
         apply_container_full_file_highlight(
             &self.info.root_path,
             &from_rev,
@@ -408,16 +456,8 @@ impl VcsBackend for JjBackend {
 
         // Diff from the parent of the oldest commit to the working copy (@)
         let from_rev = format!("{}-", oldest);
-        let diff_args = ["diff", "--from", &from_rev, "--to", "@", "--git"];
-        let args = self.diff_args(&diff_args);
-        let diff_output = run_jj_command(&self.info.root_path, args.iter().copied())?;
-
-        if diff_output.trim().is_empty() {
-            return Err(TuicrError::NoChanges);
-        }
-
-        let mut files =
-            diff_parser::parse_unified_diff(&diff_output, DiffFormat::GitStyle, highlighter)?;
+        let diff_args = ["diff", "--from", &from_rev, "--to", "@"];
+        let mut files = self.load_diff(&diff_args, highlighter)?;
         apply_container_full_file_highlight(
             &self.info.root_path,
             &from_rev,
@@ -668,6 +708,32 @@ mod tests {
             "hello.txt"
         );
         assert_eq!(files[0].status, FileStatus::Modified);
+    }
+
+    #[test]
+    fn test_jj_uses_template_paths_instead_of_git_headers() {
+        let Some(temp) = setup_test_repo() else {
+            eprintln!("Skipping test: jj command not available");
+            return;
+        };
+        let path = PathBuf::from("日本語 b/left and right.txt");
+        fs::create_dir_all(temp.path().join(path.parent().unwrap())).unwrap();
+        fs::write(temp.path().join(&path), "base\n").unwrap();
+        jj_cmd()
+            .args(["commit", "-m", "add ambiguous path"])
+            .current_dir(temp.path())
+            .output()
+            .unwrap();
+        fs::write(temp.path().join(&path), "base\nchanged\n").unwrap();
+
+        let backend = JjBackend::from_path(temp.path().to_path_buf(), DiffWhitespaceMode::Normal)
+            .expect("Failed to create jj backend");
+        let files = backend
+            .get_working_tree_diff(&SyntaxHighlighter::default())
+            .expect("structured jj diff should parse");
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].new_path.as_deref(), Some(path.as_path()));
     }
 
     #[test]

--- a/src/vcs/pr_noop.rs
+++ b/src/vcs/pr_noop.rs
@@ -1,6 +1,6 @@
 //! Placeholder VCS backend used in PR diff mode.
 //!
-//! When the App enters PR mode, the diff comes from the forge (`gh pr diff`),
+//! When the App enters PR mode, structured file patches come from the forge,
 //! not from a local working tree. The `VcsBackend` slot still needs to be
 //! filled because the App and a number of other call sites assume one is
 //! always present. `PrNoopVcs` satisfies that requirement without doing any


### PR DESCRIPTION
## Summary

- introduce a structured `FilePatch` boundary so file identity and status come from backend metadata
- obtain exact paths from Git `--raw -z`, jj templates, Mercurial `status -0`, and forge JSON APIs
- reduce the shared diff parser to strict, count-driven hunk parsing
- remove GitLab's synthetic header injection and avoid decoding display-oriented patch headers
- add regressions for Unicode and non-UTF-8 paths, ambiguous ` b/` and ` and ` names, renames, binary files, whitespace filtering, and header-like source lines

## Why

The previous parser inferred paths, statuses, and hunk contents from the same human-readable patch stream. Git quoting rules, configurable prefixes, backend-specific headers, and source lines beginning with `---` or `+++` made that approach inherently ambiguous. Fixing each example added another heuristic without removing the ambiguity.

This change separates the concerns: each backend supplies authoritative structured file metadata, while the shared parser only consumes `@@` hunks using their declared old/new line counts as the grammar. It is intended as the principled alternative to the path-decoder approach in #608 and builds on the hunk-content fix merged in #534.

## Impact

Paths and statuses no longer depend on display-header quoting or delimiter guesses. Malformed and truncated hunks now produce explicit errors instead of silently shifting line anchors, while binary, mode-only, rename, and too-large entries remain representable without hunks.

## Validation

- `cargo fmt`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib`: 1,482 passed, 4 ignored
- backend-specific and adversarial parser regressions

The repository-wide `cargo test` reaches the same pre-existing binary-test mismatch present on `main`: `event_drain_timeout(0)` returns 50 ms while its test asserts 100 ms.
