### PR TITLE
fix(editor): open the PR revision with 'e', not the worktree copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ src/
 ├── config/
 │   └── mod.rs           # User config loading (XDG on Unix, %APPDATA% on Windows)
 ├── app.rs               # Application state (App struct, InputMode, etc.)
+│   ├── editor_target.rs # Read-only snapshots of a PR revision for `$EDITOR`
 │   └── file_filter.rs   # File-tree include/exclude regex filters + `/` path search
 ├── error.rs             # Error types (TuicrError enum)
 ├── editor.rs            # External $EDITOR command construction and launch helpers
@@ -59,6 +60,7 @@ src/
 │   ├── pr_open.rs       # Async pr-open flow: build session from details + diff
 │   ├── selector.rs      # Review target selector state (Local | Pull Requests tabs)
 │   ├── context.rs       # Remote context expansion via ForgeBackend::fetch_file_lines
+│   ├── local_git.rs     # Shared `git show <sha>:<path>` blob read for all backends
 │   ├── remote_comments.rs # RemoteReviewThread shape + visibility filter
 │   ├── submit.rs        # Submit pipeline: preflight mapping, resolver actions,
 │   │                    # InlineComment payload, build_review_body, SubmitEvent
@@ -343,6 +345,8 @@ These are non-obvious things the implementation chain hit. Worth preserving for 
 19. **Gitea clamps `limit` to its `MaxResponseItems` setting** (default 50, instance-configurable). Requesting `limit=100` and stopping when fewer than 100 rows come back silently truncates at the first page. Pagination must drive off `X-Total-Count` and fall back to reading until a page comes up short *relative to the first page's size*, never relative to what was asked for. A truncated `/pulls/{n}/files` list is especially bad: it is paired positionally with the `.diff` text, so a short read turns into a hard "metadata records but N patch blocks" mismatch.
 
 20. **Gitea reports a mode-only change as file status `unchanged`.** It still emits a `diff --git` block, so the file must stay in the metadata list or every later file pairs against the wrong patch.
+
+21. **`e` in PR mode must not resolve against the working tree.** PR review installs `PrNoopVcs`, so there is no local VCS to ask, and `vcs_info.root_path` is the synthetic `forge:host/owner/repo` identity — the checkout can be on any branch, or absent. Editor targets go through `App::pr_editor_target`, which reads the reviewed revision (local blob via `forge::local_git::read_blob`, else `ForgeBackend::fetch_file_content`) and only hands over the worktree file when its content matches. Related: `fetch_file_lines` runs content through `slice_context_lines`, which expands tabs, so it is never byte-faithful — anything that writes content back to disk must use `fetch_file_content`.
 
 ### Keeping Docs Updated
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `v` / `V` | Visual mode (range comment) |
 | `r` | Toggle file reviewed |
 | `R` | Toggle hunk reviewed |
-| `e` | Open focused file in `$EDITOR` |
+| `e` | Open focused file in `$EDITOR` (in PR review: the PR's revision, as a read-only copy when the checkout differs) |
 | `y` | Copy review to clipboard |
 | `:edit` | Open focused file in `$EDITOR` |
 | `:submit` | Push review to GitHub, GitLab, Gitea, Bitbucket, Azure DevOps, or Gerrit |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -151,6 +151,15 @@ screen; reload with `:e` after editing. Adding `--wait` to the editor command op
 windowed editor back into the blocking behaviour. Set the `editor` config key to
 override `$EDITOR`.
 
+In PR review `e` opens the revision under review, not whatever the checkout
+happens to hold. When the local file *is* that revision you get the real file and
+your edits land in it; otherwise — wrong branch checked out, file added or deleted
+by the PR, no checkout at all — tuicr writes a read-only copy of the PR's content
+to a temp directory and opens that, so the text and the line the cursor sits on
+match the diff. The status bar names which one you got, e.g.
+`Opened src/main.rs @ 1a2b3c4 (read-only PR copy)`. Binary files are only opened
+from the checkout, never copied.
+
 ## Visual mode
 
 | Key | Action |

--- a/src/app/editor_target.rs
+++ b/src/app/editor_target.rs
@@ -1,0 +1,188 @@
+//! Read-only snapshots of a reviewed revision for the external editor.
+//!
+//! In PR review the diff is the PR's revision, but `$EDITOR` can only open a
+//! file on disk. When the local checkout does not hold that revision — wrong
+//! branch, file added by the PR, file deleted by the PR — the reviewed content
+//! is written to a snapshot under the temp dir and the editor is pointed there,
+//! so the text and the line the cursor sits on agree with the diff.
+//!
+//! Snapshots are keyed by head SHA, so their contents never change; they are
+//! left in the temp dir for the OS to reclaim rather than deleted on exit,
+//! because a windowed editor may still have one open long after tuicr quits.
+
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use crate::forge::traits::PrSessionKey;
+
+/// Length of the abbreviated SHA used in snapshot directory names and status
+/// messages. Matches the short SHAs the PR panel already displays.
+pub(in crate::app) const SHORT_SHA_LEN: usize = 7;
+
+/// Abbreviate a revision for display.
+pub(in crate::app) fn short_sha(sha: &str) -> &str {
+    let len = sha.len().min(SHORT_SHA_LEN);
+    &sha[..len]
+}
+
+/// Directory holding one revision's snapshots.
+///
+/// Keyed by repository, PR number and head SHA so two PRs — or two pushes to
+/// the same PR — never collide.
+pub(in crate::app) fn snapshot_root(key: &PrSessionKey) -> PathBuf {
+    let slug = sanitize_component(&key.repository.slug());
+    std::env::temp_dir()
+        .join("tuicr")
+        .join("snapshots")
+        .join(format!(
+            "{slug}-pr{}-{}",
+            key.number,
+            short_sha(&key.head_sha)
+        ))
+}
+
+/// Fold a repository slug into one path-safe directory-name component.
+///
+/// Slugs carry slashes (`owner/name`, and `org/project/name` on Azure) plus
+/// whatever characters the forge allows in a project name.
+fn sanitize_component(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+/// Resolve `rel` inside `root`, or `None` when it would escape.
+///
+/// Diff paths come from a forge response, so a malicious or malformed one could
+/// carry `..` or an absolute path; that must not turn a snapshot write into an
+/// arbitrary-file write. Same intent as the confinement guard in
+/// `FileBackend::fetch_context_lines`, done before the file exists so
+/// `canonicalize` is not an option.
+pub(in crate::app) fn snapshot_path(root: &Path, rel: &Path) -> Option<PathBuf> {
+    let mut path = root.to_path_buf();
+    let mut pushed = false;
+    for component in rel.components() {
+        match component {
+            Component::Normal(part) => {
+                path.push(part);
+                pushed = true;
+            }
+            // Prefix/RootDir mean an absolute path; ParentDir escapes; CurDir
+            // is noise but harmless to drop.
+            Component::Prefix(_) | Component::RootDir | Component::ParentDir => return None,
+            Component::CurDir => {}
+        }
+    }
+    pushed.then_some(path)
+}
+
+/// Write `content` to `path` and mark it read-only.
+///
+/// An existing snapshot is left alone: contents are fixed by the SHA in the
+/// directory name, and Windows refuses to open a read-only file for writing.
+pub(in crate::app) fn materialize(path: &Path, content: &str) -> io::Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, content)?;
+    // Best-effort: a snapshot the user can edit invites losing that work in the
+    // temp dir, but failing to set the bit is no reason not to open the file.
+    if let Ok(metadata) = std::fs::metadata(path) {
+        let mut permissions = metadata.permissions();
+        permissions.set_readonly(true);
+        let _ = std::fs::set_permissions(path, permissions);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::forge::traits::ForgeRepository;
+
+    fn key() -> PrSessionKey {
+        PrSessionKey::new(
+            ForgeRepository::github("github.com", "agavra", "tuicr"),
+            624,
+            "1a2b3c4d5e6f7a8b",
+        )
+    }
+
+    #[test]
+    fn snapshot_root_names_the_repo_pr_and_revision() {
+        let root = snapshot_root(&key());
+        let name = root.file_name().expect("dir name").to_string_lossy();
+        assert_eq!(name, "agavra-tuicr-pr624-1a2b3c4");
+        assert!(root.starts_with(std::env::temp_dir().join("tuicr").join("snapshots")));
+    }
+
+    #[test]
+    fn snapshot_path_joins_a_relative_path() {
+        let root = PathBuf::from("/snap");
+        assert_eq!(
+            snapshot_path(&root, Path::new("src/app/mod.rs")),
+            Some(root.join("src").join("app").join("mod.rs"))
+        );
+    }
+
+    #[test]
+    fn snapshot_path_rejects_paths_that_escape_the_root() {
+        let root = PathBuf::from("/snap");
+        for rel in ["../etc/passwd", "src/../../etc/passwd", "", "."] {
+            assert_eq!(
+                snapshot_path(&root, Path::new(rel)),
+                None,
+                "{rel} must not resolve"
+            );
+        }
+        #[cfg(windows)]
+        assert_eq!(snapshot_path(&root, Path::new(r"C:\Windows\win.ini")), None);
+        #[cfg(unix)]
+        assert_eq!(snapshot_path(&root, Path::new("/etc/passwd")), None);
+    }
+
+    #[test]
+    fn materialize_writes_a_read_only_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("nested").join("main.tf");
+
+        materialize(&path, "resource {}\n").expect("write snapshot");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read back"),
+            "resource {}\n"
+        );
+        assert!(
+            std::fs::metadata(&path)
+                .expect("metadata")
+                .permissions()
+                .readonly()
+        );
+    }
+
+    #[test]
+    fn materialize_keeps_an_existing_snapshot() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("main.tf");
+        materialize(&path, "first\n").expect("write snapshot");
+
+        // Same SHA, same content: rewriting a read-only file would fail on
+        // Windows, so the second call must be a no-op.
+        materialize(&path, "second\n").expect("reuse snapshot");
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read back"),
+            "first\n"
+        );
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1804,6 +1804,7 @@ mod comment_vim;
 mod comments;
 mod commits;
 mod diff_load;
+mod editor_target;
 mod file_filter;
 mod gaps;
 mod init;

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -1,6 +1,21 @@
 use crate::editor::{EditorError, LaunchState};
+use crate::forge::local_git::read_blob;
+use crate::forge::traits::ForgeFileLinesRequest;
 
+use super::editor_target::{materialize, short_sha, snapshot_path, snapshot_root};
 use super::*;
+
+/// The parts of a `DiffFile` that editor-target resolution needs.
+///
+/// Copied out before resolving so the `&mut self` message setters stay usable
+/// with `self.diff_files` no longer borrowed.
+struct ReviewedFile {
+    display_path: PathBuf,
+    old_path: Option<PathBuf>,
+    new_path: Option<PathBuf>,
+    status: FileStatus,
+    is_binary: bool,
+}
 
 impl App {
     pub fn can_stage(&self) -> bool {
@@ -145,27 +160,45 @@ impl App {
             return;
         }
 
-        let display_path = file.display_path().clone();
+        let reviewed_file = ReviewedFile {
+            display_path: file.display_path().clone(),
+            old_path: file.old_path.clone(),
+            new_path: file.new_path.clone(),
+            status: file.status,
+            is_binary: file.is_binary,
+        };
         // PR mode's root_path is the synthetic forge:host/owner/repo
         // identity, never a real directory.
-        let root = if self.vcs_info.root_path.is_absolute() {
+        let checkout = if self.vcs_info.root_path.is_absolute() {
             Some(self.vcs_info.root_path.clone())
         } else {
             self.forge_backend
                 .as_deref()
                 .and_then(|backend| backend.local_checkout_path())
         };
-        let Some(root) = root else {
+
+        // A PR diff describes the PR's revision, which the checkout may not
+        // hold — resolving against the working tree would open the wrong text,
+        // at a line number computed for other content.
+        if let DiffSource::PullRequest(pr) = self.diff_source.clone() {
+            match self.pr_editor_target(&pr, &reviewed_file, checkout.as_deref(), line) {
+                Ok(target) => self.pending_editor_target = Some(target),
+                Err(warning) => self.set_warning(warning),
+            }
+            return;
+        }
+
+        let Some(root) = checkout else {
             self.set_warning(format!(
                 "Cannot open {}: no local checkout",
-                display_path.display()
+                reviewed_file.display_path.display()
             ));
             return;
         };
 
-        let path = root.join(&display_path);
-        // Deleted files and remote-only PR files have diff rows,
-        // but no worktree file the external editor can open.
+        let path = root.join(&reviewed_file.display_path);
+        // Deleted files have diff rows, but no worktree file the external
+        // editor can open.
         if !path.exists() {
             self.set_warning(format!(
                 "Cannot open {}: file does not exist",
@@ -174,7 +207,104 @@ impl App {
             return;
         }
 
-        self.pending_editor_target = Some(EditorTarget { path, line });
+        self.pending_editor_target = Some(EditorTarget {
+            label: reviewed_file.display_path.display().to_string(),
+            path,
+            line,
+        });
+    }
+
+    /// Resolve a PR file to something `$EDITOR` can open at the revision under
+    /// review.
+    ///
+    /// The worktree copy wins when it *is* that revision, because it is the only
+    /// file the user can edit. Otherwise the reviewed content goes to a
+    /// read-only snapshot, so the text and the line the cursor sits on match the
+    /// diff. `Err` carries the status-bar warning: nothing here is worth
+    /// stopping the review for.
+    fn pr_editor_target(
+        &self,
+        pr: &PullRequestDiffSource,
+        file: &ReviewedFile,
+        checkout: Option<&Path>,
+        line: Option<u32>,
+    ) -> std::result::Result<EditorTarget, String> {
+        let display_path = file.display_path.display().to_string();
+        let side = ForgeFileLinesRequest::side_for_status(file.status);
+        let Some(revision_path) = ForgeFileLinesRequest::path_for_side(
+            side,
+            file.old_path.as_ref(),
+            file.new_path.as_ref(),
+        ) else {
+            return Err(format!("Cannot open {display_path}: the diff has no path"));
+        };
+        let request = ForgeFileLinesRequest {
+            repository: pr.key.repository.clone(),
+            base_sha: pr.base_sha.clone(),
+            head_sha: pr.key.head_sha.clone(),
+            path: revision_path.clone(),
+            status: file.status,
+            side,
+            start_line: 0,
+            end_line: 0,
+        };
+        let sha = request.sha().to_string();
+        let short = short_sha(&sha).to_string();
+        let worktree = checkout.map(|root| root.join(&revision_path));
+
+        // Blob reads and forge responses are lossy UTF-8, so snapshotting a
+        // binary file would corrupt it; the worktree copy is the only one safe
+        // to hand over.
+        if file.is_binary {
+            return match worktree.filter(|path| path.exists()) {
+                Some(path) => Ok(EditorTarget {
+                    path,
+                    line,
+                    label: display_path,
+                }),
+                None => Err(format!(
+                    "Cannot open {display_path}: binary file is not in the local checkout"
+                )),
+            };
+        }
+
+        let content = match checkout.and_then(|root| read_blob(root, &sha, &revision_path)) {
+            Some(content) => content,
+            None => match self.forge_backend.as_deref() {
+                Some(backend) => backend
+                    .fetch_file_content(request)
+                    .map_err(|err| format!("Cannot read {display_path} at {short}: {err}"))?,
+                None => {
+                    return Err(format!(
+                        "Cannot open {display_path}: no local checkout and no forge backend"
+                    ));
+                }
+            },
+        };
+
+        if let Some(path) = worktree
+            && std::fs::read_to_string(&path).is_ok_and(|on_disk| on_disk == content)
+        {
+            return Ok(EditorTarget {
+                path,
+                line,
+                label: display_path,
+            });
+        }
+
+        let root = snapshot_root(&pr.key);
+        let Some(path) = snapshot_path(&root, &revision_path) else {
+            return Err(format!(
+                "Cannot open {display_path}: the path escapes the snapshot directory"
+            ));
+        };
+        materialize(&path, &content)
+            .map_err(|err| format!("Cannot write a {short} copy of {display_path}: {err}"))?;
+        Ok(EditorTarget {
+            path,
+            line,
+            label: format!("{display_path} @ {short} (read-only PR copy)"),
+        })
     }
 
     pub fn toggle_reviewed(&mut self) {

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -322,13 +322,15 @@ impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
     }
 }
 
-/// PR review app over `files`, with a checkout-relative diff and unique SHAs.
+/// PR review app over `files`, with a synthetic root as PR mode really has.
 ///
-/// The SHAs are per-run so snapshots (which are keyed by SHA and deliberately
-/// never overwritten) cannot leak between runs of the suite.
+/// These cases deliberately stop short of writing a revision snapshot — that
+/// would land in the real temp dir and outlive the run — so
+/// `editor_target::materialize` and friends are covered by their own unit tests
+/// instead.
 fn pr_app(backend: FakeForgeBackend, files: Vec<DiffFile>) -> (App, String, String) {
-    let head_sha = uuid::Uuid::new_v4().simple().to_string();
-    let base_sha = uuid::Uuid::new_v4().simple().to_string();
+    let head_sha = "1a2b3c4d5e6f7a8b".to_string();
+    let base_sha = "9f8e7d6c5b4a3928".to_string();
     let mut app = app_with_root(PathBuf::from("forge:github.com/agavra/tuicr"), files);
     app.diff_source = DiffSource::PullRequest(Box::new(PullRequestDiffSource {
         key: crate::forge::traits::PrSessionKey::new(
@@ -350,21 +352,6 @@ fn pr_app(backend: FakeForgeBackend, files: Vec<DiffFile>) -> (App, String, Stri
     (app, head_sha, base_sha)
 }
 
-fn deleted_file(path: &str) -> DiffFile {
-    let hunks = vec![hunk(1, 1)];
-    let content_hash = DiffFile::compute_content_hash(&hunks);
-    DiffFile {
-        old_path: Some(PathBuf::from(path)),
-        new_path: None,
-        status: FileStatus::Deleted,
-        hunks,
-        is_binary: false,
-        is_too_large: false,
-        is_commit_message: false,
-        content_hash,
-    }
-}
-
 #[test]
 fn pr_editor_target_prefers_a_worktree_copy_of_the_pr_revision() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -383,90 +370,6 @@ fn pr_editor_target_prefers_a_worktree_copy_of_the_pr_revision() {
     let target = app.take_pending_editor_target().expect("editor target");
     assert_eq!(target.path, path);
     assert_eq!(target.label, "main.rs");
-}
-
-#[test]
-fn pr_editor_target_snapshots_when_the_checkout_holds_another_revision() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let worktree_path = dir.path().join("main.rs");
-    fs::write(&worktree_path, "a different revision\n").expect("write file");
-
-    let (mut app, head_sha, _) = pr_app(
-        FakeForgeBackend::serving(Some(dir.path().to_path_buf())),
-        vec![file("main.rs", vec![hunk(1, 1)])],
-    );
-
-    app.queue_editor_for_focused_item();
-
-    let target = app.take_pending_editor_target().expect("editor target");
-    assert_ne!(target.path, worktree_path);
-    assert_eq!(
-        fs::read_to_string(&target.path).expect("snapshot content"),
-        revision_content(&head_sha)
-    );
-    assert!(
-        fs::metadata(&target.path)
-            .expect("snapshot metadata")
-            .permissions()
-            .readonly()
-    );
-    assert!(
-        target.label.contains(&head_sha[..7]) && target.label.contains("read-only"),
-        "label should name the revision: {}",
-        target.label
-    );
-}
-
-#[test]
-fn pr_editor_target_snapshots_a_file_the_checkout_does_not_have() {
-    let dir = tempfile::tempdir().expect("tempdir");
-
-    let (mut app, head_sha, _) = pr_app(
-        FakeForgeBackend::serving(Some(dir.path().to_path_buf())),
-        vec![file("added.rs", vec![hunk(1, 1)])],
-    );
-
-    app.queue_editor_for_focused_item();
-
-    let target = app.take_pending_editor_target().expect("editor target");
-    assert_eq!(
-        fs::read_to_string(&target.path).expect("snapshot content"),
-        revision_content(&head_sha)
-    );
-}
-
-#[test]
-fn pr_editor_target_snapshots_without_any_local_checkout() {
-    let (mut app, head_sha, _) = pr_app(
-        FakeForgeBackend::serving(None),
-        vec![file("main.rs", vec![hunk(1, 1)])],
-    );
-
-    app.queue_editor_for_focused_item();
-
-    let target = app.take_pending_editor_target().expect("editor target");
-    assert_eq!(
-        fs::read_to_string(&target.path).expect("snapshot content"),
-        revision_content(&head_sha)
-    );
-}
-
-#[test]
-fn pr_editor_target_reads_a_deleted_file_from_the_base_side() {
-    let (mut app, _, base_sha) = pr_app(
-        FakeForgeBackend::serving(None),
-        vec![deleted_file("gone.rs")],
-    );
-
-    app.queue_editor_for_focused_item();
-
-    let target = app.take_pending_editor_target().expect("editor target");
-    assert_eq!(
-        fs::read_to_string(&target.path).expect("snapshot content"),
-        revision_content(&base_sha),
-        "a file deleted by the PR only exists on the base side"
-    );
-    assert!(target.label.contains(&base_sha[..7]), "{}", target.label);
 }
 
 #[test]

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -225,8 +225,35 @@ fn editor_target_warns_for_missing_local_file() {
     );
 }
 
+/// Content the fake backend serves for a revision.
+///
+/// Echoing the SHA back lets a test assert *which* revision (and therefore
+/// which diff side) the editor target was resolved against.
+fn revision_content(sha: &str) -> String {
+    format!("content at {sha}\n")
+}
+
 struct FakeForgeBackend {
     local_checkout: Option<PathBuf>,
+    /// When set, `fetch_file_content` fails with this message instead of
+    /// serving `revision_content`.
+    error: Option<String>,
+}
+
+impl FakeForgeBackend {
+    fn serving(local_checkout: Option<PathBuf>) -> Self {
+        Self {
+            local_checkout,
+            error: None,
+        }
+    }
+
+    fn failing(message: &str) -> Self {
+        Self {
+            local_checkout: None,
+            error: Some(message.to_string()),
+        }
+    }
 }
 
 impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
@@ -281,41 +308,215 @@ impl crate::forge::traits::ForgeBackend for FakeForgeBackend {
     ) -> crate::error::Result<crate::forge::traits::GhCreateReviewResponse> {
         unimplemented!()
     }
+    fn fetch_file_content(
+        &self,
+        request: crate::forge::traits::ForgeFileLinesRequest,
+    ) -> crate::error::Result<String> {
+        match &self.error {
+            Some(message) => Err(crate::error::TuicrError::Forge(message.clone())),
+            None => Ok(revision_content(request.sha())),
+        }
+    }
     fn local_checkout_path(&self) -> Option<PathBuf> {
         self.local_checkout.clone()
     }
 }
 
+/// PR review app over `files`, with a checkout-relative diff and unique SHAs.
+///
+/// The SHAs are per-run so snapshots (which are keyed by SHA and deliberately
+/// never overwritten) cannot leak between runs of the suite.
+fn pr_app(backend: FakeForgeBackend, files: Vec<DiffFile>) -> (App, String, String) {
+    let head_sha = uuid::Uuid::new_v4().simple().to_string();
+    let base_sha = uuid::Uuid::new_v4().simple().to_string();
+    let mut app = app_with_root(PathBuf::from("forge:github.com/agavra/tuicr"), files);
+    app.diff_source = DiffSource::PullRequest(Box::new(PullRequestDiffSource {
+        key: crate::forge::traits::PrSessionKey::new(
+            crate::forge::traits::ForgeRepository::github("github.com", "agavra", "tuicr"),
+            7,
+            head_sha.clone(),
+        ),
+        base_sha: base_sha.clone(),
+        title: "a pull request".to_string(),
+        url: "https://github.com/agavra/tuicr/pull/7".to_string(),
+        head_ref_name: "feature".to_string(),
+        base_ref_name: "main".to_string(),
+        state: "OPEN".to_string(),
+        closed: false,
+        merged: false,
+    }));
+    app.forge_backend = Some(Box::new(backend));
+    app.focused_panel = FocusedPanel::FileList;
+    (app, head_sha, base_sha)
+}
+
+fn deleted_file(path: &str) -> DiffFile {
+    let hunks = vec![hunk(1, 1)];
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+    DiffFile {
+        old_path: Some(PathBuf::from(path)),
+        new_path: None,
+        status: FileStatus::Deleted,
+        hunks,
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash,
+    }
+}
+
 #[test]
-fn editor_target_falls_back_to_forge_backend_checkout_in_pr_mode() {
+fn pr_editor_target_prefers_a_worktree_copy_of_the_pr_revision() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join("main.rs");
-    fs::write(&path, "fn main() {}\n").expect("write file");
 
-    let mut app = app_with_root(
-        PathBuf::from("forge:github.com/agavra/tuicr"),
+    let (mut app, head_sha, _) = pr_app(
+        FakeForgeBackend::serving(Some(dir.path().to_path_buf())),
         vec![file("main.rs", vec![hunk(1, 1)])],
     );
-    app.forge_backend = Some(Box::new(FakeForgeBackend {
-        local_checkout: Some(dir.path().to_path_buf()),
-    }));
-    app.focused_panel = FocusedPanel::FileList;
+    // The checkout holds exactly the reviewed content, so the editor should get
+    // the real file — the only copy edits can land in.
+    fs::write(&path, revision_content(&head_sha)).expect("write file");
 
     app.queue_editor_for_focused_item();
 
     let target = app.take_pending_editor_target().expect("editor target");
     assert_eq!(target.path, path);
+    assert_eq!(target.label, "main.rs");
 }
 
 #[test]
-fn editor_target_warns_when_pr_mode_has_no_matching_checkout() {
+fn pr_editor_target_snapshots_when_the_checkout_holds_another_revision() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let worktree_path = dir.path().join("main.rs");
+    fs::write(&worktree_path, "a different revision\n").expect("write file");
+
+    let (mut app, head_sha, _) = pr_app(
+        FakeForgeBackend::serving(Some(dir.path().to_path_buf())),
+        vec![file("main.rs", vec![hunk(1, 1)])],
+    );
+
+    app.queue_editor_for_focused_item();
+
+    let target = app.take_pending_editor_target().expect("editor target");
+    assert_ne!(target.path, worktree_path);
+    assert_eq!(
+        fs::read_to_string(&target.path).expect("snapshot content"),
+        revision_content(&head_sha)
+    );
+    assert!(
+        fs::metadata(&target.path)
+            .expect("snapshot metadata")
+            .permissions()
+            .readonly()
+    );
+    assert!(
+        target.label.contains(&head_sha[..7]) && target.label.contains("read-only"),
+        "label should name the revision: {}",
+        target.label
+    );
+}
+
+#[test]
+fn pr_editor_target_snapshots_a_file_the_checkout_does_not_have() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let (mut app, head_sha, _) = pr_app(
+        FakeForgeBackend::serving(Some(dir.path().to_path_buf())),
+        vec![file("added.rs", vec![hunk(1, 1)])],
+    );
+
+    app.queue_editor_for_focused_item();
+
+    let target = app.take_pending_editor_target().expect("editor target");
+    assert_eq!(
+        fs::read_to_string(&target.path).expect("snapshot content"),
+        revision_content(&head_sha)
+    );
+}
+
+#[test]
+fn pr_editor_target_snapshots_without_any_local_checkout() {
+    let (mut app, head_sha, _) = pr_app(
+        FakeForgeBackend::serving(None),
+        vec![file("main.rs", vec![hunk(1, 1)])],
+    );
+
+    app.queue_editor_for_focused_item();
+
+    let target = app.take_pending_editor_target().expect("editor target");
+    assert_eq!(
+        fs::read_to_string(&target.path).expect("snapshot content"),
+        revision_content(&head_sha)
+    );
+}
+
+#[test]
+fn pr_editor_target_reads_a_deleted_file_from_the_base_side() {
+    let (mut app, _, base_sha) = pr_app(
+        FakeForgeBackend::serving(None),
+        vec![deleted_file("gone.rs")],
+    );
+
+    app.queue_editor_for_focused_item();
+
+    let target = app.take_pending_editor_target().expect("editor target");
+    assert_eq!(
+        fs::read_to_string(&target.path).expect("snapshot content"),
+        revision_content(&base_sha),
+        "a file deleted by the PR only exists on the base side"
+    );
+    assert!(target.label.contains(&base_sha[..7]), "{}", target.label);
+}
+
+#[test]
+fn pr_editor_target_warns_when_a_binary_file_is_not_in_the_checkout() {
+    let mut binary = file("logo.png", vec![hunk(1, 1)]);
+    binary.is_binary = true;
+    let (mut app, _, _) = pr_app(FakeForgeBackend::serving(None), vec![binary]);
+
+    app.queue_editor_for_focused_item();
+
+    assert!(app.take_pending_editor_target().is_none());
+    assert!(
+        app.message
+            .as_ref()
+            .expect("warning")
+            .content
+            .contains("binary file"),
+        "{:?}",
+        app.message
+    );
+}
+
+#[test]
+fn pr_editor_target_warns_with_the_forge_error() {
+    let (mut app, _, _) = pr_app(
+        FakeForgeBackend::failing("HTTP 404: no such path"),
+        vec![file("main.rs", vec![hunk(1, 1)])],
+    );
+
+    app.queue_editor_for_focused_item();
+
+    assert!(app.take_pending_editor_target().is_none());
+    assert!(
+        app.message
+            .as_ref()
+            .expect("warning")
+            .content
+            .contains("HTTP 404: no such path"),
+        "{:?}",
+        app.message
+    );
+}
+
+#[test]
+fn editor_target_warns_when_a_synthetic_root_has_no_checkout() {
+    // Not PR mode: nothing can resolve the synthetic root to a directory.
     let mut app = app_with_root(
         PathBuf::from("forge:github.com/agavra/tuicr"),
         vec![file("main.rs", vec![hunk(1, 1)])],
     );
-    app.forge_backend = Some(Box::new(FakeForgeBackend {
-        local_checkout: None,
-    }));
     app.focused_panel = FocusedPanel::FileList;
 
     app.queue_editor_for_focused_item();

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -17,10 +17,15 @@ const LAUNCH_FAILURE_WINDOW: Duration = Duration::from_secs(5);
 /// suspend/resume code does not need to know about repository-relative paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EditorTarget {
-    /// Absolute path to the local worktree file.
+    /// Absolute path handed to the editor: the local worktree file, or in PR
+    /// review a read-only snapshot of the reviewed revision.
     pub path: PathBuf,
     /// One-based source line to request from editors that support it.
     pub line: Option<u32>,
+    /// What the status bar calls the opened file. A snapshot lives at a
+    /// temp-dir path nobody wants to read, so the App supplies the repository
+    /// path here, plus the revision when it is not the worktree's.
+    pub label: String,
 }
 
 /// Fully expanded editor invocation.
@@ -269,6 +274,7 @@ mod tests {
         EditorTarget {
             path: PathBuf::from("/repo/src/main.rs"),
             line,
+            label: "src/main.rs".to_string(),
         }
     }
 

--- a/src/forge/azure/az.rs
+++ b/src/forge/azure/az.rs
@@ -23,6 +23,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::json;
 
 use crate::error::{Result, TuicrError};
+use crate::forge::local_git::read_blob;
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::submit::{GhSide, SubmitEvent};
 use crate::forge::traits::{
@@ -238,28 +239,6 @@ fn default_transport() -> Box<dyn AzHttp> {
 
 // ---------- Local git helpers (mirror gh/glab) ----------
 
-/// Read a git blob from a checkout via `git show <sha>:<path>`. `None` on any
-/// failure so callers fall back to the REST API.
-fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
-    let spec = format!("{}:{}", sha, path.to_string_lossy());
-    let exists = run_command_output(
-        "git",
-        Some(repo_root),
-        ["cat-file", "-e", spec.as_str()]
-            .iter()
-            .map(|s| OsStr::new(*s)),
-    );
-    if exists.is_err() {
-        return None;
-    }
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
-}
-
 /// `git diff <a><sep><b>` in `repo_root`, returning `None` when either SHA is
 /// absent locally or the command fails.
 fn local_diff(repo_root: &Path, a: &str, b: &str, sep: &str) -> Option<Vec<FilePatch>> {
@@ -447,18 +426,6 @@ impl AzureDevOpsBackend {
         );
         self.get(&request.repository, url)
     }
-
-    /// File content at the request's revision: local blob first, REST fallback.
-    fn file_content(&self, request: &ForgeFileLinesRequest) -> Result<String> {
-        let local = self
-            .local_checkout
-            .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
-        match local {
-            Some(content) => Ok(content),
-            None => self.fetch_file_via_api(request),
-        }
-    }
 }
 
 impl ForgeBackend for AzureDevOpsBackend {
@@ -545,16 +512,25 @@ impl ForgeBackend for AzureDevOpsBackend {
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
         }
-        let content = self.file_content(&request)?;
-        Ok(slice_context_lines(
-            &content,
-            request.start_line,
-            request.end_line,
-        ))
+        let (start_line, end_line) = (request.start_line, request.end_line);
+        let content = self.fetch_file_content(request)?;
+        Ok(slice_context_lines(&content, start_line, end_line))
+    }
+
+    /// File content at the request's revision: local blob first, REST fallback.
+    fn fetch_file_content(&self, request: ForgeFileLinesRequest) -> Result<String> {
+        match self
+            .local_checkout
+            .as_deref()
+            .and_then(|root| read_blob(root, request.sha(), request.path.as_path()))
+        {
+            Some(content) => Ok(content),
+            None => self.fetch_file_via_api(&request),
+        }
     }
 
     fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
-        let content = self.file_content(&request)?;
+        let content = self.fetch_file_content(request)?;
         Ok(content.lines().count() as u32)
     }
 

--- a/src/forge/bitbucket/bkt.rs
+++ b/src/forge/bitbucket/bkt.rs
@@ -18,6 +18,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
+use crate::forge::local_git::read_blob;
 use crate::forge::remote_comments::{RemoteReviewSummary, RemoteReviewThread};
 use crate::forge::submit::{GhSide, SubmitEvent};
 use crate::forge::traits::{
@@ -84,28 +85,6 @@ impl From<CommandOutputError> for BktCommandError {
             }
         }
     }
-}
-
-/// Read a git blob from a checkout at `repo_root` using `git show <sha>:<path>`.
-/// Returns `None` if the object is missing or the command fails for any reason.
-fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
-    let spec = format!("{}:{}", sha, path.to_string_lossy());
-    let exists = run_command_output(
-        "git",
-        Some(repo_root),
-        ["cat-file", "-e", spec.as_str()]
-            .iter()
-            .map(|s| OsStr::new(*s)),
-    );
-    if exists.is_err() {
-        return None;
-    }
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
 }
 
 /// Return `Some(diff)` when both SHAs exist locally, via `git diff <start>..<end>`.
@@ -518,30 +497,26 @@ where
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
         }
-        let content = match self
+        let (start_line, end_line) = (request.start_line, request.end_line);
+        let content = self.fetch_file_content(request)?;
+        Ok(slice_context_lines(&content, start_line, end_line))
+    }
+
+    /// Local blob when the checkout has the PR's SHA, REST otherwise. The PR's
+    /// exact SHAs may or may not be present locally; we silently fall back.
+    fn fetch_file_content(&self, request: ForgeFileLinesRequest) -> Result<String> {
+        match self
             .local_checkout
             .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()))
+            .and_then(|root| read_blob(root, request.sha(), request.path.as_path()))
         {
-            Some(content) => content,
-            None => self.fetch_file_via_api(&request)?,
-        };
-        Ok(slice_context_lines(
-            &content,
-            request.start_line,
-            request.end_line,
-        ))
+            Some(content) => Ok(content),
+            None => self.fetch_file_via_api(&request),
+        }
     }
 
     fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
-        let content = match self
-            .local_checkout
-            .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()))
-        {
-            Some(content) => content,
-            None => self.fetch_file_via_api(&request)?,
-        };
+        let content = self.fetch_file_content(request)?;
         Ok(content.lines().count() as u32)
     }
 

--- a/src/forge/gitea/tea.rs
+++ b/src/forge/gitea/tea.rs
@@ -27,6 +27,7 @@ use serde::de::DeserializeOwned;
 use serde_json::json;
 
 use crate::error::{Result, TuicrError};
+use crate::forge::local_git::read_blob;
 use crate::forge::remote_comments::{
     RemoteCommentSide, RemoteReviewComment, RemoteReviewState, RemoteReviewSummary,
     RemoteReviewThread,
@@ -628,18 +629,6 @@ where
         Ok(self.api(repo, "GET", &endpoint, None)?.body)
     }
 
-    /// File content at `request`'s revision, preferring a local clone.
-    fn file_content(&self, request: &ForgeFileLinesRequest) -> Result<String> {
-        if let Some(content) = self
-            .local_checkout
-            .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()))
-        {
-            return Ok(content);
-        }
-        self.raw_file(&request.repository, request.sha(), request.path.as_path())
-    }
-
     fn review_comments(
         &self,
         pr: &PullRequestDetails,
@@ -1000,16 +989,27 @@ where
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
         }
-        let content = self.file_content(&request)?;
-        Ok(slice_context_lines(
-            &content,
-            request.start_line,
-            request.end_line,
-        ))
+        let (start_line, end_line) = (request.start_line, request.end_line);
+        let content = self.fetch_file_content(request)?;
+        Ok(slice_context_lines(&content, start_line, end_line))
+    }
+
+    /// Local blob when the checkout has the PR's SHA, the raw endpoint
+    /// otherwise. The PR's exact SHAs may or may not be present locally; we
+    /// silently fall back.
+    fn fetch_file_content(&self, request: ForgeFileLinesRequest) -> Result<String> {
+        match self
+            .local_checkout
+            .as_deref()
+            .and_then(|root| read_blob(root, request.sha(), request.path.as_path()))
+        {
+            Some(content) => Ok(content),
+            None => self.raw_file(&request.repository, request.sha(), request.path.as_path()),
+        }
     }
 
     fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
-        let content = self.file_content(&request)?;
+        let content = self.fetch_file_content(request)?;
         Ok(content.lines().count() as u32)
     }
 
@@ -1471,26 +1471,6 @@ fn parse_diff_git_line(line: &str) -> Option<(String, String)> {
 }
 
 // ----- Local checkout helpers -----
-
-/// Read a blob out of a local clone. `None` for anything that is not a clean
-/// hit, so callers fall back to the API.
-fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
-    let spec = format!("{}:{}", sha, path.to_string_lossy());
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["cat-file", "-e", spec.as_str()]
-            .iter()
-            .map(|s| OsStr::new(*s)),
-    )
-    .ok()?;
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
-}
 
 /// `Some(diff)` when both SHAs are present locally.
 fn local_range_diff(repo_root: &Path, start_sha: &str, end_sha: &str) -> Option<Vec<FilePatch>> {

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::{Result, TuicrError};
+use crate::forge::local_git::read_blob;
 use crate::forge::remote_comments::{RemoteReviewSummary, RemoteReviewThread};
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
@@ -105,28 +106,6 @@ impl From<CommandOutputError> for GhCommandError {
             }
         }
     }
-}
-
-/// Read a git blob from a checkout at `repo_root` using `git show <sha>:<path>`.
-/// Returns `None` if the object is missing or the command fails for any reason.
-fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
-    let spec = format!("{}:{}", sha, path.to_string_lossy());
-    let exists = run_command_output(
-        "git",
-        Some(repo_root),
-        ["cat-file", "-e", spec.as_str()]
-            .iter()
-            .map(|s| OsStr::new(*s)),
-    );
-    if exists.is_err() {
-        return None;
-    }
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
 }
 
 /// Return `Some(diff)` when both `start_sha` and `end_sha` are present in
@@ -514,38 +493,26 @@ where
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
         }
+        let (start_line, end_line) = (request.start_line, request.end_line);
+        let content = self.fetch_file_content(request)?;
+        Ok(slice_context_lines(&content, start_line, end_line))
+    }
 
-        // Local optimization: read the blob from a configured checkout when
-        // we have it. The PR's exact SHAs may or may not be present locally;
-        // we silently fall back if they aren't.
-        let local_content = self
+    /// Local blob when the checkout has the PR's SHA, REST otherwise. The PR's
+    /// exact SHAs may or may not be present locally; we silently fall back.
+    fn fetch_file_content(&self, request: ForgeFileLinesRequest) -> Result<String> {
+        match self
             .local_checkout
             .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
-
-        let content = if let Some(content) = local_content {
-            content
-        } else {
-            self.fetch_file_via_api(&request)?
-        };
-
-        Ok(slice_context_lines(
-            &content,
-            request.start_line,
-            request.end_line,
-        ))
+            .and_then(|root| read_blob(root, request.sha(), request.path.as_path()))
+        {
+            Some(content) => Ok(content),
+            None => self.fetch_file_via_api(&request),
+        }
     }
 
     fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
-        let local_content = self
-            .local_checkout
-            .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
-        let content = if let Some(content) = local_content {
-            content
-        } else {
-            self.fetch_file_via_api(&request)?
-        };
+        let content = self.fetch_file_content(request)?;
         Ok(content.lines().count() as u32)
     }
 

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Utc};
 use sha1::{Digest, Sha1};
 
 use crate::error::{Result, TuicrError};
+use crate::forge::local_git::read_blob;
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::traits::{
     ForgeBackend, ForgeFileLinesRequest, ForgeRepository, GhCreateReviewResponse,
@@ -80,28 +81,6 @@ impl From<CommandOutputError> for GlabCommandError {
             }
         }
     }
-}
-
-/// Read a git blob from a checkout at `repo_root` using `git show <sha>:<path>`.
-/// Returns `None` if the object is missing or the command fails for any reason.
-fn read_blob_with_repo(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
-    let spec = format!("{}:{}", sha, path.to_string_lossy());
-    let exists = run_command_output(
-        "git",
-        Some(repo_root),
-        ["cat-file", "-e", spec.as_str()]
-            .iter()
-            .map(|s| OsStr::new(*s)),
-    );
-    if exists.is_err() {
-        return None;
-    }
-    run_command_output(
-        "git",
-        Some(repo_root),
-        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
-    )
-    .ok()
 }
 
 /// Return `Some(diff)` when both SHAs exist locally, via `git diff <start>..<end>`.
@@ -520,35 +499,26 @@ where
         if request.start_line == 0 || request.start_line > request.end_line {
             return Ok(Vec::new());
         }
+        let (start_line, end_line) = (request.start_line, request.end_line);
+        let content = self.fetch_file_content(request)?;
+        Ok(slice_context_lines(&content, start_line, end_line))
+    }
 
-        let local_content = self
+    /// Local blob when the checkout has the PR's SHA, REST otherwise. The PR's
+    /// exact SHAs may or may not be present locally; we silently fall back.
+    fn fetch_file_content(&self, request: ForgeFileLinesRequest) -> Result<String> {
+        match self
             .local_checkout
             .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
-
-        let content = if let Some(content) = local_content {
-            content
-        } else {
-            self.fetch_file_via_api(&request)?
-        };
-
-        Ok(slice_context_lines(
-            &content,
-            request.start_line,
-            request.end_line,
-        ))
+            .and_then(|root| read_blob(root, request.sha(), request.path.as_path()))
+        {
+            Some(content) => Ok(content),
+            None => self.fetch_file_via_api(&request),
+        }
     }
 
     fn file_line_count(&self, request: ForgeFileLinesRequest) -> Result<u32> {
-        let local_content = self
-            .local_checkout
-            .as_deref()
-            .and_then(|root| read_blob_with_repo(root, request.sha(), request.path.as_path()));
-        let content = if let Some(content) = local_content {
-            content
-        } else {
-            self.fetch_file_via_api(&request)?
-        };
+        let content = self.fetch_file_content(request)?;
         Ok(content.lines().count() as u32)
     }
 

--- a/src/forge/local_git.rs
+++ b/src/forge/local_git.rs
@@ -1,0 +1,85 @@
+//! Local git reads shared by the forge backends.
+//!
+//! Every backend prefers a blob from a local checkout over a REST round trip
+//! when the PR's SHAs happen to be present, and editor-target resolution needs
+//! the same read to open the reviewed revision. One copy lives here so those
+//! callers cannot drift apart.
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+use crate::process::run_command_output;
+
+/// Read a git blob from the checkout at `repo_root` using
+/// `git show <sha>:<path>`.
+///
+/// Returns `None` on any failure — the object is missing, `repo_root` is not a
+/// checkout, or `git` is not on PATH — so callers fall back to the forge API.
+/// The content is lossy UTF-8, so binary blobs come back mangled; callers that
+/// can see a file's binary flag should check it first.
+pub(crate) fn read_blob(repo_root: &Path, sha: &str, path: &Path) -> Option<String> {
+    // Diff paths arrive with forward slashes, but a path joined on Windows can
+    // carry backslashes, and git only resolves `<sha>:<path>` with slashes.
+    let spec = format!("{}:{}", sha, path.to_string_lossy().replace('\\', "/"));
+    let exists = run_command_output(
+        "git",
+        Some(repo_root),
+        ["cat-file", "-e", spec.as_str()]
+            .iter()
+            .map(|s| OsStr::new(*s)),
+    );
+    if exists.is_err() {
+        return None;
+    }
+    run_command_output(
+        "git",
+        Some(repo_root),
+        ["show", spec.as_str()].iter().map(|s| OsStr::new(*s)),
+    )
+    .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::process::run_command_output;
+    use std::path::PathBuf;
+
+    fn git(dir: &Path, args: &[&str]) {
+        run_command_output("git", Some(dir), args.iter().map(|s| OsStr::new(*s)))
+            .expect("git command");
+    }
+
+    #[test]
+    fn reads_a_blob_at_a_commit() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        git(root, &["init", "--quiet"]);
+        git(root, &["config", "user.email", "test@example.com"]);
+        git(root, &["config", "user.name", "test"]);
+        std::fs::write(root.join("file.txt"), "one\ntwo\n").expect("write");
+        git(root, &["add", "file.txt"]);
+        git(root, &["commit", "--quiet", "-m", "add file"]);
+        let sha = run_command_output(
+            "git",
+            Some(root),
+            ["rev-parse", "HEAD"].iter().map(|s| OsStr::new(*s)),
+        )
+        .expect("rev-parse");
+        let sha = sha.trim();
+
+        // The worktree copy changing must not change what the blob read
+        // returns — that difference is exactly what editor targets check.
+        std::fs::write(root.join("file.txt"), "clobbered\n").expect("write");
+
+        assert_eq!(
+            read_blob(root, sha, &PathBuf::from("file.txt")),
+            Some("one\ntwo\n".to_string())
+        );
+        assert_eq!(read_blob(root, sha, &PathBuf::from("missing.txt")), None);
+        assert_eq!(
+            read_blob(root, "deadbeef", &PathBuf::from("file.txt")),
+            None
+        );
+    }
+}

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -13,6 +13,7 @@ pub mod gerrit;
 pub mod gitea;
 pub mod github;
 pub mod gitlab;
+pub mod local_git;
 pub mod pr_open;
 pub mod remote_comments;
 pub mod selector;

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use crate::error::Result;
+use crate::error::{Result, TuicrError};
 use crate::forge::remote_comments::RemoteReviewThread;
 use crate::forge::submit::SubmitEvent;
 use crate::model::{DiffLine, FilePatch, FileStatus};
@@ -550,6 +550,16 @@ pub trait ForgeBackend {
     /// Implementations may optimize by reading from a local checkout when
     /// available; the trait does not require that path.
     fn fetch_file_lines(&self, request: ForgeFileLinesRequest) -> Result<Vec<DiffLine>>;
+    /// Return the whole file at the revision described by `request`, exactly as
+    /// stored: unlike [`Self::fetch_file_lines`], tabs are not expanded, so the
+    /// result is safe to write back out as a file. `start_line` and `end_line`
+    /// are ignored. The default errors; backends able to read a revision
+    /// override it.
+    fn fetch_file_content(&self, _request: ForgeFileLinesRequest) -> Result<String> {
+        Err(TuicrError::Forge(
+            "this backend cannot read file contents".to_string(),
+        ))
+    }
     /// Return the total number of lines in a file at the revision described by
     /// `request`. The `start_line` and `end_line` fields of the request are
     /// ignored. Default returns `Ok(0)`; real forge backends override this.

--- a/src/main.rs
+++ b/src/main.rs
@@ -768,7 +768,7 @@ fn main() -> anyhow::Result<()> {
                                 } else {
                                     ""
                                 };
-                                app.set_message(format!("Opened {}{hint}", target.path.display()));
+                                app.set_message(format!("Opened {}{hint}", target.label));
                             }
                             Ok(Ok(EditorOutcome::Finished)) => {
                                 if app.diff_source.includes_worktree_changes() {
@@ -781,7 +781,7 @@ fn main() -> anyhow::Result<()> {
                                             };
                                             app.set_message(format!(
                                                 "Opened {} and reloaded {count} files{invalidated_suffix}",
-                                                target.path.display()
+                                                target.label
                                             ));
                                         }
                                         Err(err) => {
@@ -791,7 +791,7 @@ fn main() -> anyhow::Result<()> {
                                         }
                                     }
                                 } else {
-                                    app.set_message(format!("Opened {}", target.path.display()));
+                                    app.set_message(format!("Opened {}", target.label));
                                 }
                             }
                             Ok(Err(err)) => app.set_error(err.to_string()),


### PR DESCRIPTION
Draft for issue #624

In PR review, `e` resolved its target as <checkout>/<path> and only checked that the path existed, so it opened whatever revision the working tree happened to hold — silently, at a line number computed from the PR diff — or refused with "file does not exist" when the checkout lacked the file at all.

`e` now opens the reviewed revision. The worktree file is still preferred when its content matches, since it is the only copy edits can land in; otherwise the PR content goes to a read-only snapshot under the temp dir, opened at the same line. Files deleted by the PR open from the base side. Binary files are only ever opened from the checkout — blob and API reads are lossy UTF-8.