### PR TITLE
perf(comments): parse comment markdown with pulldown-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,6 +2888,7 @@ dependencies = [
  "flate2",
  "git2",
  "ignore",
+ "pulldown-cmark",
  "ratatui",
  "regex",
  "self-replace",
@@ -2923,6 +2935,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ two-face = { version = "0.5", default-features = false, features = ["syntect-def
 
 # Terminal background detection
 terminal-colorsaurus = "1"
+pulldown-cmark = { version = "0.13.4", default-features = false }
 
 # Git operations
 [target.'cfg(not(target_env = "musl"))'.dependencies]

--- a/src/syntax/cmark.rs
+++ b/src/syntax/cmark.rs
@@ -1,0 +1,358 @@
+//! Markdown highlighting for review comment bodies, via a CommonMark parser.
+//!
+//! Comment bodies used to go through syntect's `Markdown.sublime-syntax` — the
+//! same path as code highlighting. That grammar is interpreted by oniguruma, a
+//! backtracking regex engine, and its inline rules are ambiguous about how to
+//! pair backtick delimiters. A line carrying several inline code spans drives
+//! exponential backtracking: measured on a 125-byte line, cost grew from 0.17 ms
+//! at two spans to 82 ms at eight, then flattened — the shape of a regex engine
+//! exhausting its retry budget and giving up. The same spans spread one-per-line
+//! cost 0.15 ms, so it is per-line ambiguity, not volume.
+//!
+//! `pulldown-cmark` is a single-pass CommonMark parser with no regex and no
+//! backtracking, so it cannot exhibit that behaviour. It is flat at ~0.01 ms
+//! across every span count, and faster than the grammar on ordinary prose too.
+//!
+//! syntect is still used for the *contents* of fenced code blocks, where the
+//! language is known and its grammars are being asked to do what they are good
+//! at. Only the markdown layer changes.
+
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag, TagEnd};
+use ratatui::style::Style;
+use syntect::highlighting::{Highlighter, Theme};
+use syntect::parsing::Scope;
+
+use super::{HighlightedLines, SyntaxHighlighter};
+
+/// Styles for markdown constructs, resolved once from the active syntect theme
+/// so colours match what the grammar produced for the same text.
+///
+/// Resolved at construction rather than per call: building a `Highlighter` and
+/// walking the theme's selectors for nine scopes is small but strictly wasted
+/// work on a path that runs for every comment on every frame.
+pub(super) struct MarkdownPalette {
+    base: Style,
+    heading: Style,
+    bold: Style,
+    italic: Style,
+    code: Style,
+    link: Style,
+    quote: Style,
+    list: Style,
+    strike: Style,
+}
+
+impl MarkdownPalette {
+    pub(super) fn resolve(theme: &Theme) -> Self {
+        let highlighter = Highlighter::new(theme);
+        // Resolve against the scope *stacks* the Sublime grammar produces, not
+        // bare scope names: themes routinely key on an enclosing `meta.*` scope
+        // (links resolve through `meta.link.inline`, not `markup.underline.link`),
+        // so a single-scope lookup silently falls back to the default colour.
+        let style_for = |scopes: &[&str]| -> Style {
+            let stack: Vec<Scope> = scopes.iter().filter_map(|s| Scope::new(s).ok()).collect();
+            SyntaxHighlighter::syntect_to_ratatui_style(highlighter.style_for_stack(&stack))
+        };
+        const ROOT: &str = "text.html.markdown";
+        Self {
+            base: style_for(&[ROOT]),
+            heading: style_for(&[
+                ROOT,
+                "markup.heading.markdown",
+                "entity.name.section.markdown",
+            ]),
+            bold: style_for(&[ROOT, "markup.bold.markdown"]),
+            italic: style_for(&[ROOT, "markup.italic.markdown"]),
+            code: style_for(&[ROOT, "markup.raw.inline.markdown"]),
+            link: style_for(&[
+                ROOT,
+                "meta.link.inline.markdown",
+                "markup.underline.link.markdown",
+            ]),
+            quote: style_for(&[ROOT, "markup.quote.markdown"]),
+            list: style_for(&[ROOT, "markup.list.unnumbered.markdown"]),
+            strike: style_for(&[ROOT, "markup.strikethrough.markdown"]),
+        }
+    }
+}
+
+/// Markdown-highlight `content` (a whole `\n`-separated body).
+///
+/// Returns exactly one entry per line of `content`, in order, so callers can
+/// index the result by line. Every entry is `Some`: unlike the grammar path
+/// there is no per-line failure mode to report.
+pub(super) fn highlight(hl: &SyntaxHighlighter, content: &str) -> HighlightedLines {
+    let palette = &hl.markdown_palette;
+
+    // One style slot per byte of the source. Events arrive in document order,
+    // each `Start` precedes the content it encloses, and inner ranges are
+    // subsets of outer ones — so painting in event order yields inner-wins
+    // nesting (`**bold with `code`**`) without maintaining a style stack.
+    let mut styles: Vec<Style> = vec![palette.base; content.len()];
+    let mut paint = |range: std::ops::Range<usize>, style: Style| {
+        let end = range.end.min(content.len());
+        if let Some(slots) = styles.get_mut(range.start..end) {
+            slots.fill(style);
+        }
+    };
+
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    // syntect state for the fenced block currently being walked, if any.
+    let mut code_block: Option<syntect::easy::HighlightLines> = None;
+
+    for (event, range) in Parser::new_ext(content, options).into_offset_iter() {
+        match event {
+            Event::Start(Tag::Heading { .. }) => paint(range, palette.heading),
+            Event::Start(Tag::Strong) => paint(range, palette.bold),
+            Event::Start(Tag::Emphasis) => paint(range, palette.italic),
+            Event::Start(Tag::Strikethrough) => paint(range, palette.strike),
+            Event::Start(Tag::BlockQuote(_)) => paint(range, palette.quote),
+            Event::Start(Tag::Link { .. }) => paint(range, palette.link),
+            // The grammar scoped the whole item as `markup.list`, not just the
+            // bullet; nested inline events repaint their own ranges.
+            Event::Start(Tag::Item) => paint(range, palette.list),
+            Event::TaskListMarker(_) => paint(range, palette.list),
+            Event::Code(_) => paint(range, palette.code),
+            Event::Start(Tag::CodeBlock(kind)) => {
+                // The ``` fence itself stays at the theme default, matching the
+                // grammar. The block's contents are painted from `Event::Text`.
+                let token = match &kind {
+                    CodeBlockKind::Fenced(lang) => lang.split_whitespace().next().unwrap_or(""),
+                    CodeBlockKind::Indented => "",
+                };
+                code_block = (!token.is_empty())
+                    .then(|| hl.syntax_set.find_syntax_by_token(token))
+                    .flatten()
+                    .map(|syntax| syntect::easy::HighlightLines::new(syntax, &hl.theme));
+            }
+            Event::End(TagEnd::CodeBlock) => code_block = None,
+            Event::Text(text) => {
+                // Only fenced-block text needs painting; prose inherits the
+                // style its enclosing tag already applied.
+                let Some(block) = code_block.as_mut() else {
+                    continue;
+                };
+                let Ok(runs) = block.highlight_line(&text, &hl.syntax_set) else {
+                    continue;
+                };
+                let mut at = range.start;
+                for (style, piece) in runs {
+                    let style = SyntaxHighlighter::syntect_to_ratatui_style(style);
+                    paint(at..at + piece.len(), style);
+                    at += piece.len();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Slice the per-byte styles back into per-line runs, coalescing adjacent
+    // characters that share a style.
+    let mut out: HighlightedLines = Vec::new();
+    let mut offset = 0usize;
+    for line in content.split('\n') {
+        let mut runs: Vec<(Style, String)> = Vec::new();
+        for (i, ch) in line.char_indices() {
+            let style = styles.get(offset + i).copied().unwrap_or(palette.base);
+            match runs.last_mut() {
+                Some((prev, text)) if *prev == style => text.push(ch),
+                _ => runs.push((style, ch.to_string())),
+            }
+        }
+        out.push(Some(runs));
+        // +1 for the '\n' that `split` consumed.
+        offset += line.len() + 1;
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Bodies exercising the shapes review comments actually take, plus the
+    /// degenerate ones. Reused by the structural invariant tests below.
+    const BODIES: &[&str] = &[
+        "",
+        "plain prose",
+        "line one\nline two\nline three",
+        "trailing newline\n",
+        "\n\nleading blanks",
+        "# Heading\n\ntext under it",
+        "- item one\n- item two with `code`",
+        "1. first\n2. second",
+        "> quoted line\n> second quoted",
+        "**bold** *italic* ~~struck~~ `code` [link](https://example.com)",
+        "before\n```rust\nfn main() { let x = 1; }\n```\nafter",
+        "unterminated\n```rust\nfn main() {}",
+        "```\nno language\n```",
+        "| a | b |\n| --- | --- |\n| 1 | 2 |",
+        "- [x] done\n- [ ] not done",
+        "日本語のテキストです\nemoji 🎉 and `código` mixed",
+        "`a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l`",
+        "**bold with `code` inside** and trailing",
+    ];
+
+    fn highlighter() -> SyntaxHighlighter {
+        SyntaxHighlighter::default()
+    }
+
+    fn line_text(line: &Option<Vec<(Style, String)>>) -> String {
+        line.as_ref()
+            .map(|runs| runs.iter().map(|(_, t)| t.as_str()).collect())
+            .unwrap_or_default()
+    }
+
+    /// Callers index the result by line number and wrap the run text directly,
+    /// so the highlight must reproduce the body exactly, line for line.
+    #[test]
+    fn should_round_trip_every_body_exactly() {
+        let hl = highlighter();
+        for body in BODIES {
+            let out = highlight(&hl, body);
+            let expected: Vec<&str> = body.split('\n').collect();
+            assert_eq!(out.len(), expected.len(), "line count for {body:?}");
+            for (idx, want) in expected.iter().enumerate() {
+                assert_eq!(&line_text(&out[idx]), want, "line {idx} of {body:?}");
+            }
+        }
+    }
+
+    /// Every line is highlighted; there is no per-line failure mode to report.
+    #[test]
+    fn should_highlight_every_line() {
+        let hl = highlighter();
+        for body in BODIES {
+            assert!(
+                highlight(&hl, body).iter().all(Option::is_some),
+                "unhighlighted line in {body:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_style_inline_code_distinctly_from_prose() {
+        let hl = highlighter();
+        let out = highlight(&hl, "plain `code` plain");
+        let runs = out[0].as_ref().expect("line highlighted");
+
+        let code = runs
+            .iter()
+            .find(|(_, t)| t.contains("code"))
+            .expect("inline code is its own run");
+        let prose = runs
+            .iter()
+            .find(|(_, t)| t.starts_with("plain"))
+            .expect("prose is its own run");
+
+        assert_ne!(
+            code.0.fg, prose.0.fg,
+            "inline code should not match surrounding prose"
+        );
+    }
+
+    /// The regression this module exists for: a line packed with inline code
+    /// spans used to drive syntect's grammar into exponential backtracking.
+    /// Every span must still resolve to the code colour.
+    #[test]
+    fn should_style_many_inline_code_spans_on_one_line() {
+        let hl = highlighter();
+        let body = "Rename `a` `b` `c` `d` `e` `f` `g` `h` `i` `j` `k` `l` please.";
+        let runs = highlight(&hl, body)[0]
+            .as_ref()
+            .expect("line highlighted")
+            .clone();
+
+        let prose = runs
+            .iter()
+            .find(|(_, t)| t.starts_with("Rename"))
+            .map(|(s, _)| s.fg);
+        let coloured = runs
+            .iter()
+            .filter(|(s, t)| t.starts_with('`') && Some(s.fg) != prose)
+            .count();
+        assert_eq!(coloured, 12, "every code span should be coloured: {runs:?}");
+    }
+
+    #[test]
+    fn should_style_bold_italic_heading_quote_and_list_distinctly() {
+        let hl = highlighter();
+        let base = highlight(&hl, "plain")[0].as_ref().unwrap()[0].0;
+
+        for body in [
+            "**bold**",
+            "*italic*",
+            "# Heading",
+            "> quoted",
+            "- item",
+            "[text](https://example.com)",
+        ] {
+            let runs = highlight(&hl, body)[0].as_ref().unwrap().clone();
+            assert!(
+                runs.iter().any(|(s, _)| *s != base),
+                "{body:?} should differ from plain prose"
+            );
+        }
+    }
+
+    /// Fenced blocks delegate to syntect, which is the point of keeping it:
+    /// the language is known and its grammars are good at code.
+    #[test]
+    fn should_delegate_fenced_code_blocks_to_syntect() {
+        let hl = highlighter();
+        let out = highlight(&hl, "text\n```rust\nfn main() { let x = 1; }\n```\ntext");
+        let code = out[2].as_ref().expect("code line highlighted");
+
+        let keyword = code
+            .iter()
+            .find(|(_, t)| t == "fn")
+            .expect("`fn` is its own run");
+        let plain = code
+            .iter()
+            .find(|(_, t)| t.contains('('))
+            .expect("punctuation run");
+        assert_ne!(
+            keyword.0.fg, plain.0.fg,
+            "syntect should colour the rust keyword"
+        );
+    }
+
+    /// Multi-line constructs need document-wide state: a fenced block's second
+    /// line is only code because the fence opened on an earlier line.
+    #[test]
+    fn should_carry_state_across_lines_in_fenced_blocks() {
+        let hl = highlighter();
+        let body = "```rust\nlet a = 1;\nlet b = 2;\n```";
+        let out = highlight(&hl, body);
+
+        for idx in [1usize, 2] {
+            let runs = out[idx].as_ref().expect("code line highlighted");
+            assert!(
+                runs.iter().any(|(_, t)| t == "let"),
+                "line {idx} should be tokenised as rust: {runs:?}"
+            );
+        }
+    }
+
+    /// Byte-offset painting must not split multibyte characters.
+    #[test]
+    fn should_preserve_multibyte_content() {
+        let hl = highlighter();
+        let body = "日本語 `コード` です\n🎉 emoji `x` 🎉";
+        let out = highlight(&hl, body);
+
+        assert_eq!(line_text(&out[0]), "日本語 `コード` です");
+        assert_eq!(line_text(&out[1]), "🎉 emoji `x` 🎉");
+    }
+    #[test]
+    fn should_handle_empty_body() {
+        let hl = highlighter();
+        let out = highlight(&hl, "");
+        assert_eq!(out.len(), 1);
+        assert_eq!(line_text(&out[0]), "");
+    }
+}

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -1,3 +1,5 @@
+mod cmark;
+
 use ratatui::style::{Color, Modifier, Style};
 use std::path::Path;
 use two_face::theme::EmbeddedThemeName;
@@ -50,6 +52,8 @@ pub struct SyntaxHighlighter {
     pub add_bg: Color,
     /// Background color for deleted lines
     pub del_bg: Color,
+    /// Markdown construct colours, resolved from `theme` once at construction.
+    markdown_palette: cmark::MarkdownPalette,
 }
 
 pub(crate) struct DiffHighlightSequences {
@@ -81,11 +85,13 @@ impl SyntaxHighlighter {
     /// Create a new syntax highlighter with a preloaded syntect theme.
     pub fn with_theme(theme: syntect::highlighting::Theme, add_bg: Color, del_bg: Color) -> Self {
         let syntax_set = two_face::syntax::extra_newlines();
+        let markdown_palette = cmark::MarkdownPalette::resolve(&theme);
         Self {
             syntax_set,
             theme,
             add_bg,
             del_bg,
+            markdown_palette,
         }
     }
 
@@ -98,11 +104,14 @@ impl SyntaxHighlighter {
     /// way fingerprints identically to a highlighted one. Measured at 3.1ms against
     /// 197ms for the same 4,000-line diff.
     pub(crate) fn plain() -> Self {
+        let theme = syntect::highlighting::Theme::default();
+        let markdown_palette = cmark::MarkdownPalette::resolve(&theme);
         Self {
             syntax_set: syntect::parsing::SyntaxSet::new(),
-            theme: syntect::highlighting::Theme::default(),
+            theme,
             add_bg: Color::Reset,
             del_bg: Color::Reset,
+            markdown_palette,
         }
     }
 
@@ -127,15 +136,15 @@ impl SyntaxHighlighter {
         Some(self.highlight_lines_with(syntax, lines))
     }
 
-    /// Highlight `lines` as Markdown, for the in-progress review comment box.
-    /// Colors come from the active syntect theme, matching code highlighting.
-    pub(crate) fn highlight_markdown_lines(&self, lines: &[String]) -> HighlightedLines {
-        let syntax = self
-            .syntax_set
-            .find_syntax_by_extension("md")
-            .or_else(|| self.syntax_set.find_syntax_by_name("Markdown"))
-            .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text());
-        self.highlight_lines_with(syntax, lines)
+    /// Highlight a review comment body (`\n`-separated) as Markdown, returning
+    /// one entry per line. Colors come from the active syntect theme, matching
+    /// code highlighting.
+    ///
+    /// Parsed with `pulldown-cmark` rather than syntect's Markdown grammar; see
+    /// the `cmark` module for why. Fenced code blocks are still handed to
+    /// syntect for their contents.
+    pub(crate) fn highlight_markdown_body(&self, content: &str) -> HighlightedLines {
+        cmark::highlight(self, content)
     }
 
     /// Run syntect line-by-line against a resolved syntax, converting to

--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -196,10 +196,7 @@ pub fn format_comment_input_lines(
         let buffer_lines: Vec<&str> = buffer.split('\n').collect();
         // Markdown-highlight the in-progress text; colors come from the active
         // syntect theme (same engine/theme as diff code highlighting).
-        let owned_lines: Vec<String> = buffer_lines.iter().map(|s| s.to_string()).collect();
-        let highlighted = theme
-            .syntax_highlighter()
-            .highlight_markdown_lines(&owned_lines);
+        let highlighted = theme.syntax_highlighter().highlight_markdown_body(buffer);
         let mut byte_offset = 0;
         // Tracks how many visual lines have been pushed so far (not counting the header).
         let mut total_visual_lines: usize = 0;
@@ -447,10 +444,9 @@ fn markdown_body_lines(
     border_style: Style,
 ) -> Vec<Line<'static>> {
     let lines: Vec<&str> = content.split('\n').collect();
-    let owned: Vec<String> = lines.iter().map(|s| s.to_string()).collect();
-    // Highlight all lines together so multi-line constructs (e.g. fenced code)
+    // Highlight the body as a whole so multi-line constructs (e.g. fenced code)
     // carry state across lines.
-    let highlighted = theme.syntax_highlighter().highlight_markdown_lines(&owned);
+    let highlighted = theme.syntax_highlighter().highlight_markdown_body(content);
 
     let mut out = Vec::new();
     for (idx, text) in lines.iter().enumerate() {


### PR DESCRIPTION
## Summary

- markdown-highlight review comment bodies with `pulldown-cmark` instead of syntect's `Markdown.sublime-syntax`
- keep syntect for the *contents* of fenced code blocks, where the language is known
- resolve construct colours from the scope stacks the Sublime grammar produced, so the rendering is visually unchanged
- drop a `Vec<String>` clone of the body at both call sites — the parser takes the document directly

Refs #552. This is the highlighting half only; culling off-screen comment boxes is deliberately left for a separate PR.

## Root cause

syntect interprets Sublime-syntax grammars through oniguruma, a **backtracking** regex engine. The Markdown grammar's inline rules are ambiguous about how to pair backtick delimiters, and with *N* delimiters on one line there are exponentially many ways to pair them.

Cold highlight of a single line of `` `id` `` spans:

| spans | line | grammar | pulldown-cmark | |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 18 B | 0.054 ms | 0.002 ms | 33× |
| 2 | 24 B | 0.117 | 0.002 | 53× |
| 4 | 36 B | 1.168 | 0.003 | 452× |
| 6 | 48 B | 8.090 | 0.002 | 4,413× |
| 8 | 60 B | 80.688 | 0.002 | 38,736× |
| 16 | 114 B | 81.267 | 0.004 | 22,950× |

Two things worth reading off that table:

1. **It flattens at ~81 ms**, independent of span count *and* line length. That is the shape of the regex engine exhausting a fixed step budget and giving up, not of a search completing.
2. **The output is correct at every count** — all 16 spans get the code colour. So the 81 ms buys nothing: the engine burns its whole retry budget on a rule that then fails, and a later rule produces the same answer it would have produced immediately.

It is per-line ambiguity, not volume. The same 16 spans spread one per line cost **0.145 ms**, and a single 200-character code span costs 0.026 ms.

## Why a parser fixes it

`pulldown-cmark` is a single-pass CommonMark parser — no regex, no backtracking — so this failure mode is structurally impossible. It is also faster on the ordinary cases:

| body | grammar | cmark | |
| --- | ---: | ---: | ---: |
| prose, 10 lines (270 B) | 0.063 ms | 0.004 ms | 15× |
| 16 spans, one per line | 0.145 | 0.006 | 23× |
| typical review comment | 0.154 | 0.031 | 5× |
| fenced `rust` block | 0.118 | 0.032 | 4× |

The fenced-block row is the narrowest because that path still calls syntect for the block's contents — which is the point. syntect is good at code; it was only the markdown layer that was pathological.

## Measurements

`cargo test --release render_perf_with_comments -- --ignored`, 20 files × 200 lines, same machine, `main` at 3847fa1:

| comments | before | after |
| ---: | ---: | ---: |
| 0 | 0.55 ms | 0.50 ms |
| 20 | 5.18 | 1.76 |
| 60 | 13.76 | 3.96 |
| 200 | 44.16 | 11.80 |

Still linear in comment count — every comment in the session is formatted every frame regardless of whether it is on screen. That is the separate concern left for the follow-up.

## Design notes

- **Colours are resolved from scope *stacks*, not bare scope names.** Themes routinely key on an enclosing `meta.*` scope: markdown links resolve through `meta.link.inline`, and looking up `markup.underline.link` alone silently returns the default foreground. Heading *text* likewise resolves through `entity.name.section`, not `markup.heading` (which selects the leading `#`). Getting this wrong is invisible until you diff the colours, so the palette resolves `text.html.markdown` + the construct's own scopes, exactly as the grammar stacked them.
- **The palette is resolved once per `SyntaxHighlighter`**, not per call — building a `Highlighter` and walking the theme for nine scopes is small but strictly wasted on a path that runs for every comment on every frame.
- **Styles are painted over a per-byte buffer in event order.** Each `Start` precedes the content it encloses and inner ranges are subsets of outer ones, so painting in order yields inner-wins nesting (`**bold with `code`**`) without maintaining a style stack.
- **Fenced blocks keep their delegation to syntect**, resolved by the fence's info string. The ``` fence itself stays at the theme default, matching the grammar.

## Validation

- full suite green (1518 tests), `cargo fmt` and `cargo clippy --all-targets` clean
- `should_round_trip_every_body_exactly` pins the invariant callers actually depend on: one entry per line, and the concatenated run text of each line equals the input line — across 18 bodies including empty, trailing newline, leading blanks, unterminated fences, tables, task lists, CJK and emoji
- `should_style_many_inline_code_spans_on_one_line` is the regression guard for the case above
- `should_delegate_fenced_code_blocks_to_syntect` and `should_carry_state_across_lines_in_fenced_blocks` cover the delegation and the document-wide state that motivated highlighting bodies as a whole

## Notes

- Adds one dependency, `pulldown-cmark` (`default-features = false`, so no HTML renderer), plus `unicase`.
- Strikethrough resolves to the default foreground because the bundled themes define no `markup.strikethrough`. That matches the previous behaviour — the grammar did not style it either — so it is left alone rather than fixed here.
- Only the two comment-body call sites change. File and diff highlighting are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
