### PR TITLE
feat(diff): review the commit message of every selected commit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,29 @@ Repository-managed agent integrations:
 - Keys are focus-scoped via `map_file_tree_mode`: the tree claims `i`/`e`/`I`/`E`/`/`, the
   diff keeps `i` = edit comment and `/` = search diff
 
+**Commit messages** (`App::insert_commit_messages_for_selection`, `src/app/diff_load.rs`):
+
+- Every commit in the inline selector's range gets a synthetic `DiffFile` ahead of the real
+  files, oldest first, so a branch review covers the commit messages as well as the code.
+  Narrowing the selector to one commit leaves that commit's message alone. Staged and
+  unstaged pseudo-commits are skipped — they have no message.
+- The entries are ordinary diff files from there on: all-`Context` lines in one hunk, so
+  file/line/range comments, `r`/`R` marks, persistence, the review CLI, and markdown export
+  need no special case. `content_hash` covers the message text, so rewording a commit
+  clears its reviewed mark like any other content change.
+- Identity is carried twice, deliberately. The display path holds the **short** id
+  (`Commit Message (<short_id>)`) and is the session key, keeping two commits' messages
+  apart; `DiffFile::commit_message_sha` holds the **full** id, which is what attributes a
+  comment to its commit. `commit_id_for_new_comment` reads that field first, because a
+  selection spanning several commits cannot name one and would otherwise stamp `None`.
+- Anything synthesizing or comparing diff files must account for them: they are never
+  *fetched*, so `apply_diff_files` rebuilds them after a reload (otherwise `:e` and every
+  diff-watch tick drop them) and `diff_files_fingerprint` excludes them (otherwise the
+  on-screen diff differs from every fetch of the same content and re-applies forever).
+- PR mode does not show them yet: `PullRequestCommit` carries no message body, so
+  `pr_commit_to_commit_info` maps `body: None`, and the PR diff-install paths do not call
+  the insert.
+
 **InputMode** (`src/app.rs`):
 
 - `Normal` - default navigation mode

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 - GitHub-style continuous diff in the terminal. Scroll through every changed file in one stream.
 - PR-style comments at the line, range, file, and review level. 
 - Review tracking at file or hunk granularity, persisted across sessions.
+- Commit messages are reviewable too. Each commit in the selection appears above the diff as its
+  own entry, ready to be commented on and marked reviewed.
 - Three export targets: push a real review to GitHub, GitLab, or Bitbucket, copy structured
   markdown to your clipboard, or pipe to stdout.
 - Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR,

--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -533,7 +533,18 @@ impl App {
     /// selector shows exactly one commit. `None` otherwise (full range,
     /// multi-commit subset, or no selector) — those comments get
     /// `commit_id = None` so they stay visible across selections.
+    ///
+    /// A comment on a commit message is the exception: that entry names its
+    /// own commit regardless of how wide the selection is, so it is attributed
+    /// to that commit and stays hidden when the selection excludes it.
     pub(in crate::app) fn commit_id_for_new_comment(&self) -> Option<String> {
+        if let Some(sha) = self
+            .current_file()
+            .and_then(|file| file.commit_message_sha.clone())
+        {
+            return Some(sha);
+        }
+
         let (start, end) = self.commit_selection_range?;
         if start != end {
             return None;
@@ -872,7 +883,7 @@ impl App {
         self.file_list_state = FileListState::default();
         self.expanded_top.clear();
         self.expanded_bottom.clear();
-        self.insert_commit_message_if_single();
+        self.insert_commit_messages_for_selection();
         self.sort_files_by_directory(true);
         self.expand_all_dirs();
         self.rebuild_annotations();

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -25,32 +25,48 @@ impl App {
         }
     }
 
-    /// If we are viewing a single commit, insert a "Commit Message" DiffFile at index 0.
+    /// Insert a "Commit Message" DiffFile for every commit in the current
+    /// selection, oldest first, ahead of the real files.
+    ///
+    /// Every selected commit gets its own entry, so reviewing a branch shows
+    /// the story its commits tell and not just the code: on "all commits" the
+    /// messages read top-to-bottom in commit order, and narrowing the selector
+    /// to one commit leaves exactly that commit's message.
     ///
     /// The synthetic path embeds the commit's short id (`Commit Message (<sha>)`)
     /// so that comments on different commits' messages get distinct session keys
-    /// (the session indexes comments by path) and the exported review records
-    /// which commit each commit-message comment belongs to.
-    pub(in crate::app) fn insert_commit_message_if_single(&mut self) {
+    /// (the session indexes comments by path), while `commit_message_sha` carries
+    /// the full id that attributes those comments to their commit. Staged and
+    /// unstaged pseudo-commits have no message and are skipped.
+    pub(in crate::app) fn insert_commit_messages_for_selection(&mut self) {
         self.diff_files.retain(|f| !f.is_commit_message());
 
-        let commit = if let Some((start, end)) = self.commit_selection_range {
-            if start == end {
-                self.review_commits.get(start)
-            } else {
-                None
+        // `review_commits` is newest-first, so walk the selected window in
+        // reverse: the inserted files then read oldest-first, matching the
+        // ascending order the inline selector lays the commits out in.
+        let selected = match self.commit_selection_range {
+            Some((start, end)) if start <= end && end < self.review_commits.len() => {
+                &self.review_commits[start..=end]
             }
-        } else if self.review_commits.len() == 1 {
-            self.review_commits.first()
-        } else {
-            None
+            Some(_) => return,
+            None => &self.review_commits[..],
         };
 
-        let Some(commit) = commit else { return };
-        if Self::is_special_commit(commit) {
-            return;
-        }
+        let commit_files: Vec<DiffFile> = selected
+            .iter()
+            .rev()
+            .filter(|commit| !Self::is_special_commit(commit))
+            .map(Self::build_commit_message_file)
+            .collect();
 
+        for (idx, file) in commit_files.into_iter().enumerate() {
+            self.diff_files.insert(idx, file);
+            self.session.add_diff_file(&self.diff_files[idx]);
+        }
+    }
+
+    /// Render one commit's message as a context-only, single-hunk DiffFile.
+    fn build_commit_message_file(commit: &CommitInfo) -> DiffFile {
         let mut full_message = commit.summary.clone();
         if let Some(ref body) = commit.body {
             full_message.push('\n');
@@ -79,7 +95,7 @@ impl App {
             new_count: line_count,
         }];
         let content_hash = DiffFile::compute_content_hash(&hunks);
-        let commit_msg_file = DiffFile {
+        DiffFile {
             old_path: None,
             new_path: Some(PathBuf::from(format!(
                 "Commit Message ({})",
@@ -91,9 +107,7 @@ impl App {
             is_too_large: false,
             commit_message_sha: Some(commit.id.clone()),
             content_hash,
-        };
-        self.diff_files.insert(0, commit_msg_file);
-        self.session.add_diff_file(&self.diff_files[0]);
+        }
     }
 
     pub(in crate::app) fn is_staged_commit(commit: &CommitInfo) -> bool {
@@ -738,10 +752,10 @@ impl App {
         self.diff_files = diff_files;
         self.clear_expanded_gaps();
 
-        // A fetched diff carries only real files, so the commit-message entry
-        // has to be rebuilt here or `:e` and every diff-watch tick would
-        // quietly drop it from a commit review.
-        self.insert_commit_message_if_single();
+        // A fetched diff carries only real files, so the commit-message
+        // entries have to be rebuilt here or `:e` and every diff-watch tick
+        // would quietly drop them from a commit review.
+        self.insert_commit_messages_for_selection();
 
         self.sort_files_by_directory(false);
         self.populate_file_line_count_cache();
@@ -933,7 +947,7 @@ impl App {
         {
             self.reload_inline_selection()?;
         } else {
-            self.insert_commit_message_if_single();
+            self.insert_commit_messages_for_selection();
             self.sort_files_by_directory(true);
             self.expand_all_dirs();
             self.rebuild_annotations();

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -1564,8 +1564,16 @@ fn file_fingerprint(file: &DiffFile) -> u64 {
 /// compares two lists as sets, which is required because the stored list is
 /// sorted by directory and a freshly fetched one is not (see
 /// `sort_files_by_directory`).
+///
+/// Commit-message entries are excluded: they are synthesized locally from the
+/// commit selection, never fetched, so counting them would make an on-screen
+/// diff differ from every fetch of the same content and re-apply forever.
 fn diff_files_fingerprint(files: &[DiffFile]) -> u64 {
-    let mut per_file: Vec<u64> = files.iter().map(file_fingerprint).collect();
+    let mut per_file: Vec<u64> = files
+        .iter()
+        .filter(|file| !file.is_commit_message)
+        .map(file_fingerprint)
+        .collect();
     per_file.sort_unstable();
     let mut hasher = crate::hash::Fnv1aHasher::new();
     for hash in per_file {

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -738,6 +738,11 @@ impl App {
         self.diff_files = diff_files;
         self.clear_expanded_gaps();
 
+        // A fetched diff carries only real files, so the commit-message entry
+        // has to be rebuilt here or `:e` and every diff-watch tick would
+        // quietly drop it from a commit review.
+        self.insert_commit_message_if_single();
+
         self.sort_files_by_directory(false);
         self.populate_file_line_count_cache();
         self.expand_all_dirs();

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -32,7 +32,7 @@ impl App {
     /// (the session indexes comments by path) and the exported review records
     /// which commit each commit-message comment belongs to.
     pub(in crate::app) fn insert_commit_message_if_single(&mut self) {
-        self.diff_files.retain(|f| !f.is_commit_message);
+        self.diff_files.retain(|f| !f.is_commit_message());
 
         let commit = if let Some((start, end)) = self.commit_selection_range {
             if start == end {
@@ -89,7 +89,7 @@ impl App {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: true,
+            commit_message_sha: Some(commit.id.clone()),
             content_hash,
         };
         self.diff_files.insert(0, commit_msg_file);
@@ -1571,7 +1571,7 @@ fn file_fingerprint(file: &DiffFile) -> u64 {
 fn diff_files_fingerprint(files: &[DiffFile]) -> u64 {
     let mut per_file: Vec<u64> = files
         .iter()
-        .filter(|file| !file.is_commit_message)
+        .filter(|file| !file.is_commit_message())
         .map(file_fingerprint)
         .collect();
     per_file.sort_unstable();
@@ -1600,7 +1600,7 @@ mod tests {
             hunks: vec![],
             is_binary,
             is_too_large,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -227,7 +227,7 @@ impl App {
                 ) {
                     app.reload_inline_selection()?;
                 } else {
-                    app.insert_commit_message_if_single();
+                    app.insert_commit_messages_for_selection();
                     app.sort_files_by_directory(true);
                     app.expand_all_dirs();
                     app.rebuild_annotations();
@@ -294,7 +294,7 @@ impl App {
             ) {
                 app.reload_inline_selection()?;
             } else {
-                app.insert_commit_message_if_single();
+                app.insert_commit_messages_for_selection();
                 app.sort_files_by_directory(true);
                 app.expand_all_dirs();
                 app.rebuild_annotations();

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -588,7 +588,7 @@ impl App {
             }
             AnnotatedLine::FileHeader { file_idx } => {
                 let file = self.diff_files.get(*file_idx)?;
-                if file.is_commit_message {
+                if file.is_commit_message() {
                     Some(file.display_path().display().to_string())
                 } else {
                     Some(format!(

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -140,7 +140,7 @@ impl App {
             self.set_warning("No file selected");
             return;
         };
-        if file.is_commit_message {
+        if file.is_commit_message() {
             self.set_warning("Commit message has no local file to open");
             return;
         }

--- a/src/app/tests/change_status_tests.rs
+++ b/src/app/tests/change_status_tests.rs
@@ -70,7 +70,7 @@ fn diff_file(path: &str) -> DiffFile {
         hunks: Vec::new(),
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash: 0,
     }
 }

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -447,3 +447,172 @@ fn should_comment_on_a_commit_only_file_after_narrowing_the_commit_pane() {
         "the comment must be stored against the file"
     );
 }
+
+fn commit_with_message(id: &str, summary: &str, body: Option<&str>) -> CommitInfo {
+    CommitInfo {
+        id: format!("{id}0123456789abcdef"),
+        short_id: id.to_string(),
+        branch_name: None,
+        summary: summary.to_string(),
+        body: body.map(str::to_string),
+        author: "Test".to_string(),
+        time: Utc::now(),
+    }
+}
+
+fn commit_message_paths(app: &App) -> Vec<PathBuf> {
+    app.diff_files
+        .iter()
+        .filter(|file| file.is_commit_message())
+        .map(|file| file.display_path().clone())
+        .collect()
+}
+
+/// Reviewing a branch means reading the story its commits tell, so every
+/// commit in the selection contributes its own message entry — not just the
+/// one commit a narrowed selector happens to show.
+#[test]
+fn should_show_a_commit_message_for_every_selected_commit_oldest_first() {
+    // given: three commits, stored newest-first as everywhere else
+    let mut app = build_app(vec![
+        commit_with_message("c3", "third", None),
+        commit_with_message("c2", "second", None),
+        commit_with_message("c1", "first", None),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_selection_range = Some((0, 2));
+
+    // when
+    app.insert_commit_messages_for_selection();
+
+    // then: one entry per commit, reading oldest-first down the tree
+    assert_eq!(
+        commit_message_paths(&app),
+        vec![
+            PathBuf::from("Commit Message (c1)"),
+            PathBuf::from("Commit Message (c2)"),
+            PathBuf::from("Commit Message (c3)"),
+        ]
+    );
+}
+
+/// The whole message has to be there, body included — a summary alone is what
+/// the commit selector already shows.
+#[test]
+fn should_render_the_summary_and_body_of_each_selected_commit() {
+    let mut app = build_app(vec![commit_with_message(
+        "c1",
+        "feat: add widget",
+        Some("Why: the old widget leaked.\n\nRefs: #42"),
+    )]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_selection_range = Some((0, 0));
+
+    app.insert_commit_messages_for_selection();
+
+    let lines: Vec<String> = app.diff_files[0].hunks[0]
+        .lines
+        .iter()
+        .map(|line| line.content.clone())
+        .collect();
+    assert_eq!(
+        lines,
+        vec![
+            "feat: add widget".to_string(),
+            String::new(),
+            "Why: the old widget leaked.".to_string(),
+            String::new(),
+            "Refs: #42".to_string(),
+        ]
+    );
+}
+
+/// Narrowing the selector is how you review one commit in isolation, so the
+/// other commits' messages have to go with their diffs.
+#[test]
+fn should_leave_only_the_selected_commits_message_when_the_selection_narrows() {
+    let mut app = build_app(vec![
+        commit_with_message("c2", "second", None),
+        commit_with_message("c1", "first", None),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_selection_range = Some((0, 1));
+    app.insert_commit_messages_for_selection();
+
+    // when: the selector narrows to the newest commit alone
+    app.commit_selection_range = Some((0, 0));
+    app.insert_commit_messages_for_selection();
+
+    // then
+    assert_eq!(
+        commit_message_paths(&app),
+        vec![PathBuf::from("Commit Message (c2)")]
+    );
+}
+
+/// Staged and unstaged rows are pseudo-commits with no message to review.
+#[test]
+fn should_not_synthesize_a_message_for_staged_or_unstaged_rows() {
+    let mut app = build_app(vec![
+        App::staged_commit_entry(),
+        App::unstaged_commit_entry(),
+        commit_with_message("c1", "first", None),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_selection_range = Some((0, 2));
+
+    app.insert_commit_messages_for_selection();
+
+    assert_eq!(
+        commit_message_paths(&app),
+        vec![PathBuf::from("Commit Message (c1)")],
+        "only the real commit has a message"
+    );
+}
+
+/// A comment on a commit message belongs to that commit however wide the
+/// selection is. `commit_id_for_new_comment` alone would stamp `None` here,
+/// because the selection spans three commits and cannot name one of them.
+#[test]
+fn should_attribute_a_commit_message_comment_to_its_own_commit() {
+    let mut app = build_app(vec![
+        commit_with_message("c3", "third", None),
+        commit_with_message("c2", "second", None),
+        commit_with_message("c1", "first", None),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_selection_range = Some((0, 2));
+    app.insert_commit_messages_for_selection();
+
+    // when: the cursor sits on the middle commit's message
+    let idx = app
+        .diff_files
+        .iter()
+        .position(|file| file.display_path() == &PathBuf::from("Commit Message (c2)"))
+        .expect("c2's message should be loaded");
+    app.diff_state.current_file_idx = idx;
+
+    // then: the comment is attributed to c2, not left unattributed
+    assert_eq!(
+        app.commit_id_for_new_comment().as_deref(),
+        Some("c20123456789abcdef")
+    );
+}
+
+/// A comment on a real file keeps the old rule: a selection spanning several
+/// commits cannot attribute it to one of them.
+#[test]
+fn should_still_leave_a_file_comment_unattributed_across_a_multi_commit_selection() {
+    let mut app = build_app(vec![
+        commit_with_message("c2", "second", None),
+        commit_with_message("c1", "first", None),
+    ]);
+    app.review_commits = app.commit_list.clone();
+    app.commit_selection_range = Some((0, 1));
+    app.insert_commit_messages_for_selection();
+    app.diff_files
+        .push(commit_only_file(&PathBuf::from("src/lib.rs"), Vec::new()));
+    app.diff_state.current_file_idx = app.diff_files.len() - 1;
+
+    assert_eq!(app.commit_id_for_new_comment(), None);
+}

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -279,7 +279,7 @@ fn commit_only_file(path: &Path, hunks: Vec<DiffHunk>) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash: 7,
     }
 }

--- a/src/app/tests/diff_reload_tests.rs
+++ b/src/app/tests/diff_reload_tests.rs
@@ -173,7 +173,7 @@ fn make_diff_file(path: &str, status: FileStatus, content_hash: u64) -> DiffFile
         hunks: Vec::new(),
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }
@@ -439,7 +439,7 @@ fn should_keep_commit_message_entries_across_a_reload() {
     app.reload_diff_files().expect("reload should succeed");
 
     assert!(
-        app.diff_files.iter().any(|file| file.is_commit_message),
+        app.diff_files.iter().any(|file| file.is_commit_message()),
         "the commit message must survive a reload, got {:?}",
         app.diff_files
             .iter()

--- a/src/app/tests/diff_reload_tests.rs
+++ b/src/app/tests/diff_reload_tests.rs
@@ -423,3 +423,27 @@ fn should_fetch_changed_diff_files_keeping_narrowed_commit_selection() {
         "diff-watch's probe fetch must use the narrowed selection, not the full commit range"
     );
 }
+/// Commit-message entries are synthesized locally from the commit selection,
+/// never fetched, so a reload that installs only real files has to rebuild
+/// them or `:e` silently drops the commit messages out of the review.
+#[test]
+fn should_keep_commit_message_entries_across_a_reload() {
+    let vcs = ScriptedVcs::new();
+    vcs.push_working_tree_diff(Ok(vec![make_diff_file("a.rs", FileStatus::Modified, 2)]));
+    let mut app =
+        build_app_with_scripted_vcs(vec![make_diff_file("a.rs", FileStatus::Modified, 1)], vcs);
+    app.review_commits = vec![make_commit_info("c1")];
+    app.commit_selection_range = Some((0, 0));
+    app.insert_commit_message_if_single();
+
+    app.reload_diff_files().expect("reload should succeed");
+
+    assert!(
+        app.diff_files.iter().any(|file| file.is_commit_message),
+        "the commit message must survive a reload, got {:?}",
+        app.diff_files
+            .iter()
+            .map(|f| f.display_path().clone())
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/app/tests/diff_reload_tests.rs
+++ b/src/app/tests/diff_reload_tests.rs
@@ -434,7 +434,7 @@ fn should_keep_commit_message_entries_across_a_reload() {
         build_app_with_scripted_vcs(vec![make_diff_file("a.rs", FileStatus::Modified, 1)], vcs);
     app.review_commits = vec![make_commit_info("c1")];
     app.commit_selection_range = Some((0, 0));
-    app.insert_commit_message_if_single();
+    app.insert_commit_messages_for_selection();
 
     app.reload_diff_files().expect("reload should succeed");
 
@@ -463,7 +463,7 @@ fn should_ignore_commit_message_entries_when_deciding_the_diff_changed() {
     let mut app = build_app_with_scripted_vcs(files, vcs);
     app.review_commits = vec![make_commit_info("c1")];
     app.commit_selection_range = Some((0, 0));
-    app.insert_commit_message_if_single();
+    app.insert_commit_messages_for_selection();
 
     let result = app.fetch_changed_diff_files();
 

--- a/src/app/tests/diff_reload_tests.rs
+++ b/src/app/tests/diff_reload_tests.rs
@@ -447,3 +447,28 @@ fn should_keep_commit_message_entries_across_a_reload() {
             .collect::<Vec<_>>()
     );
 }
+
+/// The change gate compares a fetched diff against what is on screen. The
+/// fetched side can never contain commit-message entries, so counting them
+/// would make every tick of a commit review look changed and re-apply forever.
+#[test]
+fn should_ignore_commit_message_entries_when_deciding_the_diff_changed() {
+    let files = vec![make_diff_file("a.rs", FileStatus::Modified, 1)];
+    let vcs = ScriptedVcs::new();
+    // Two identical responses: one for the cheap probe, and one the gate must
+    // not need. Scripting the second means a gate that wrongly reports a
+    // change fails on the assertion below rather than on a dry mock.
+    vcs.push_working_tree_diff(Ok(files.clone()));
+    vcs.push_working_tree_diff(Ok(files.clone()));
+    let mut app = build_app_with_scripted_vcs(files, vcs);
+    app.review_commits = vec![make_commit_info("c1")];
+    app.commit_selection_range = Some((0, 0));
+    app.insert_commit_message_if_single();
+
+    let result = app.fetch_changed_diff_files();
+
+    assert!(
+        matches!(result, Ok(None)),
+        "expected Ok(None) with only a commit message differing, got {result:?}"
+    );
+}

--- a/src/app/tests/diff_search_tests.rs
+++ b/src/app/tests/diff_search_tests.rs
@@ -66,7 +66,7 @@ fn file(path: &str, contents: &[&str]) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }

--- a/src/app/tests/diff_watch_tests.rs
+++ b/src/app/tests/diff_watch_tests.rs
@@ -111,7 +111,7 @@ fn make_diff_file(path: &str, content_hash: u64) -> DiffFile {
         hunks: Vec::new(),
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }
@@ -146,7 +146,7 @@ fn make_file_with_hunks(path: &str, hunks: Vec<DiffHunk>) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }

--- a/src/app/tests/expand_gap_tests.rs
+++ b/src/app/tests/expand_gap_tests.rs
@@ -112,7 +112,7 @@ fn make_file_with_hunks(path: &str, hunks: Vec<DiffHunk>) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }
@@ -1436,7 +1436,7 @@ fn should_not_show_eof_gap_for_deleted_files() {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     };
     let app = build_app_with_files(vec![file], 100);

--- a/src/app/tests/file_filter_tests.rs
+++ b/src/app/tests/file_filter_tests.rs
@@ -71,7 +71,7 @@ fn file(path: &str) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }

--- a/src/app/tests/pr_info_tests.rs
+++ b/src/app/tests/pr_info_tests.rs
@@ -96,7 +96,7 @@ fn build_pr_app() -> App {
             hunks: vec![],
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         }],
         session,

--- a/src/app/tests/render_perf_tests.rs
+++ b/src/app/tests/render_perf_tests.rs
@@ -87,7 +87,7 @@ fn file(path: &str, lines_per_file: usize) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }

--- a/src/app/tests/scroll_behavior_tests.rs
+++ b/src/app/tests/scroll_behavior_tests.rs
@@ -68,7 +68,7 @@ fn build_scroll_app(n: usize, viewport: usize, scroll_offset_config: usize) -> A
         hunks: vec![hunk],
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash: 0,
     };
 

--- a/src/app/tests/single_file_view_tests.rs
+++ b/src/app/tests/single_file_view_tests.rs
@@ -64,7 +64,7 @@ fn file(path: &str, hunks: Vec<DiffHunk>) -> DiffFile {
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     }
 }

--- a/src/app/tests/submit_flow_tests.rs
+++ b/src/app/tests/submit_flow_tests.rs
@@ -82,7 +82,7 @@ fn make_pr_app_with_single_modified_file(file_path: &str) -> App {
         }],
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash: 0,
     };
     let pr_source = PullRequestDiffSource {

--- a/src/app/tests/tree_tests.rs
+++ b/src/app/tests/tree_tests.rs
@@ -10,7 +10,7 @@ fn make_file(path: &str) -> DiffFile {
         hunks: vec![],
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash: 0,
     }
 }

--- a/src/app/tree.rs
+++ b/src/app/tree.rs
@@ -147,7 +147,7 @@ impl App {
         let mut commit_msg_files: Vec<DiffFile> = Vec::new();
 
         for file in self.diff_files.drain(..) {
-            if file.is_commit_message {
+            if file.is_commit_message() {
                 commit_msg_files.push(file);
                 continue;
             }

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -607,7 +607,7 @@ mod tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         }
     }

--- a/src/model/diff_types.rs
+++ b/src/model/diff_types.rs
@@ -105,7 +105,11 @@ pub struct DiffFile {
     pub hunks: Vec<DiffHunk>,
     pub is_binary: bool,
     pub is_too_large: bool,
-    pub is_commit_message: bool,
+    /// Full commit SHA when this entry is a synthetic commit-message view
+    /// rather than a real file, else `None`. The SHA lives here instead of a
+    /// bare flag so comment attribution never has to be re-parsed out of the
+    /// display path, which carries only the *short* id.
+    pub commit_message_sha: Option<String>,
     pub content_hash: u64,
 }
 
@@ -118,6 +122,14 @@ impl DiffHunk {
 }
 
 impl DiffFile {
+    /// True when this entry is a synthetic commit-message view rather than a
+    /// real file. Renderers, the file tree, and the editor-open path branch
+    /// on this; anything needing the commit itself reads
+    /// `commit_message_sha` directly.
+    pub fn is_commit_message(&self) -> bool {
+        self.commit_message_sha.is_some()
+    }
+
     /// Stable key for a reviewed hunk.
     ///
     /// Unique hunk content ignores hunk header line numbers so unrelated

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -276,7 +276,7 @@ mod tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -82,7 +82,7 @@ mod tests {
             hunks: Vec::new(),
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         }
     }
@@ -230,7 +230,7 @@ mod tests {
             hunks: Vec::new(),
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         };
         let kept = make_diff_file("src/lib.rs");

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -1146,7 +1146,7 @@ fn render_hunk_lines_side_by_side(
         .app
         .diff_files
         .get(file_idx)
-        .is_some_and(|f| f.is_commit_message);
+        .is_some_and(|f| f.is_commit_message());
 
     while i < hunk_lines.len() {
         let diff_line = &hunk_lines[i];
@@ -2109,7 +2109,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }
@@ -2264,7 +2264,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }
@@ -2293,7 +2293,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }
@@ -2462,7 +2462,7 @@ mod remote_comments_side_by_side_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: true,
+            commit_message_sha: Some("abc1234abcdef".to_string()),
             content_hash,
         }
     }

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -586,7 +586,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         let style = base_style;
                         // A commit message is prose, not code: render it without
                         // line numbers, matching the side-by-side view.
-                        let line_num_str = if file.is_commit_message {
+                        let line_num_str = if file.is_commit_message() {
                             " ".repeat(lw + 1)
                         } else if app.relative_line_numbers {
                             crate::ui::diff_view::relative_line_number_field(
@@ -1514,7 +1514,7 @@ mod remote_comments_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }
@@ -1529,7 +1529,7 @@ mod remote_comments_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }
@@ -1694,7 +1694,7 @@ mod remote_comments_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: true,
+            commit_message_sha: Some("abc1234abcdef".to_string()),
             content_hash,
         }
     }
@@ -1928,7 +1928,7 @@ mod remote_comments_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         };
         let mut app = make_revision_app(vec![file]);
@@ -1997,7 +1997,7 @@ mod remote_comments_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         };
         let mut app = make_revision_app(vec![file]);
@@ -2063,7 +2063,7 @@ mod remote_comments_snapshot_tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         };
         let mut app = make_revision_app(vec![file]);

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -35,7 +35,7 @@ pub(super) fn file_header_prefix_text(app: &App, file: &DiffFile) -> String {
     let path = file.display_path();
     let is_reviewed = app.session.is_file_reviewed(path);
     let review_mark = if is_reviewed { "✓ " } else { "" };
-    if file.is_commit_message || app.is_pristine_mode {
+    if file.is_commit_message() || app.is_pristine_mode {
         format!("═══ {}{} ", review_mark, path.display())
     } else {
         format!(

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -142,7 +142,7 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                     } else {
                         styles::pending_style(&app.theme)
                     };
-                    if file.is_commit_message {
+                    if file.is_commit_message() {
                         Line::from(vec![
                             Span::styled(format!("{checkbox} "), checkbox_style),
                             Span::raw(format!("  {}", path.display())),
@@ -317,7 +317,7 @@ mod tests {
             hunks: vec![],
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         }
     }

--- a/src/ui/row_height.rs
+++ b/src/ui/row_height.rs
@@ -541,7 +541,7 @@ mod tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }
@@ -554,7 +554,7 @@ mod tests {
             hunks: Vec::new(),
             is_binary: true,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         }
     }

--- a/src/ui/summary_popup.rs
+++ b/src/ui/summary_popup.rs
@@ -456,7 +456,7 @@ mod tests {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         }
     }

--- a/src/vcs/diff_parser.rs
+++ b/src/vcs/diff_parser.rs
@@ -49,7 +49,7 @@ fn materialize_file_patch(patch: FilePatch, highlighter: &SyntaxHighlighter) -> 
         hunks,
         is_binary: patch.is_binary,
         is_too_large: patch.is_too_large,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     })
 }

--- a/src/vcs/file.rs
+++ b/src/vcs/file.rs
@@ -184,7 +184,7 @@ impl FileBackend {
                 hunks,
                 is_binary: false,
                 is_too_large: true,
-                is_commit_message: false,
+                commit_message_sha: None,
                 content_hash,
             });
         }
@@ -275,7 +275,7 @@ impl FileBackend {
             hunks,
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         })
     }

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -846,7 +846,7 @@ fn build_untracked_diff_file(
         hunks,
         is_binary: false,
         is_too_large: false,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash,
     })
 }
@@ -859,7 +859,7 @@ fn diff_file_without_hunks(path: &Path, is_binary: bool, is_too_large: bool) -> 
         hunks: Vec::new(),
         is_binary,
         is_too_large,
-        is_commit_message: false,
+        commit_message_sha: None,
         content_hash: 0,
     }
 }

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -306,7 +306,7 @@ fn parse_diff(diff: &Diff, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFi
             hunks,
             is_binary,
             is_too_large,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash,
         });
     }

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -454,7 +454,7 @@ mod tests {
             hunks: vec![hunk],
             is_binary: false,
             is_too_large: false,
-            is_commit_message: false,
+            commit_message_sha: None,
             content_hash: 0,
         }
     }


### PR DESCRIPTION
- **fix(diff): rebuild the commit message after a diff reload**
- **fix(diff): ignore commit messages when fingerprinting a diff**
- **refactor(model): carry the commit sha on commit-message entries**
- **feat(diff): review the commit message of every selected commit**
