### PR TITLE
feat(config): add confirm_quit to gate the bare q quit

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -225,6 +225,9 @@ In command mode,
 | `ZQ` | Quit without saving |
 | `?` | Toggle help |
 
+Pressing bare `q` no longer quits; it prints a reminder to use `:q` instead — a transitional
+affordance that will be removed in a future release.
+
 The summary replaces the diff while leaving the file sidebar visible when it is open. The first
 pending comment is selected when the summary opens. Use `j`/`k` to select the next
 or previous comment; the view scrolls automatically to keep the selection visible. `Enter` returns

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -224,7 +224,6 @@ In command mode,
 | `ZZ` | Save and quit |
 | `ZQ` | Quit without saving |
 | `?` | Toggle help |
-| `q` | Quick quit |
 
 The summary replaces the diff while leaving the file sidebar visible when it is open. The first
 pending comment is selected when the summary opens. Use `j`/`k` to select the next
@@ -246,7 +245,8 @@ losing their reviewed state.
 | `Enter` | Confirm local commit range, open PR, or load more PRs |
 | `/` | Filter currently loaded PR rows locally |
 | `r` | In Pull Requests tab, toggle all open PRs / PRs requesting your review |
-| `q` / `Esc` | Quit / return |
+| `Esc` | Return to the diff |
+| `:q` | Quit |
 
 ## Inline commit selector
 

--- a/src/app/tests/target_selector_tests.rs
+++ b/src/app/tests/target_selector_tests.rs
@@ -2503,6 +2503,20 @@ fn should_cancel_in_flight_open_when_pressing_esc_in_selector() {
     assert!(app.pr_open_state.is_none());
 }
 
+#[test]
+fn should_show_quit_hint_message_without_quitting_in_commit_select_mode() {
+    // given
+    let mut app = build_app();
+    // when
+    crate::handler::handle_commit_select_action(&mut app, crate::input::Action::QuitHint);
+    // then
+    assert!(!app.should_quit);
+    assert_eq!(
+        app.message.as_ref().map(|m| m.content.as_str()),
+        Some("q no longer quits — use :q to quit")
+    );
+}
+
 // -----------------------------------------------------------------
 // Remote review threads (PR 4)
 // -----------------------------------------------------------------

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -20,6 +20,10 @@ const WHEEL_LINES: usize = 3;
 /// interchangeable.
 const WHEEL_COLS: usize = 4;
 
+/// Shown when a bare `q` is pressed in a mode that used to quit on it.
+/// Transitional — drop this a few releases after the `q` removal has landed.
+const QUIT_HINT_MESSAGE: &str = "q no longer quits — use :q to quit";
+
 const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec::new(&["q", "quit"], CommandKind::Quit),
     CommandSpec::new(&["q!", "quit!"], CommandKind::ForceQuit),
@@ -1252,6 +1256,7 @@ pub fn handle_commit_select_action(app: &mut App, action: Action) {
         Action::TargetSelectorTabPrev => app.cycle_target_tab(false),
         Action::EnterCommandMode => app.enter_command_mode(),
         Action::Quit => app.should_quit = true,
+        Action::QuitHint => app.set_message(QUIT_HINT_MESSAGE),
         Action::ExitMode => {
             // Esc during an in-flight PR open aborts the load and stays
             // in the selector. Takes precedence over the
@@ -1410,6 +1415,7 @@ pub fn handle_visual_action(app: &mut App, action: Action) {
         }
         Action::ExitMode => app.exit_visual_mode(),
         Action::Quit => app.should_quit = true,
+        Action::QuitHint => app.set_message(QUIT_HINT_MESSAGE),
         Action::ScrollViewDown(n) | Action::MouseScrollDown(n) => app.scroll_view_down(n),
         Action::ScrollViewUp(n) | Action::MouseScrollUp(n) => app.scroll_view_up(n),
         Action::HalfPageDown => app.page_down(app.diff_state.viewport_height / 2),
@@ -1607,6 +1613,7 @@ fn handle_shared_normal_action(app: &mut App, action: Action) {
                 app.should_quit = true;
             }
         }
+        Action::QuitHint => app.set_message(QUIT_HINT_MESSAGE),
         Action::ExitMode => {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;
@@ -1759,6 +1766,7 @@ pub fn handle_submit_action_picker_action(app: &mut App, action: Action) {
         Action::SubmitPickerConfirm => app.submit_picker_confirm(),
         Action::ExitMode => app.cancel_submit_action_picker(),
         Action::Quit => app.should_quit = true,
+        Action::QuitHint => app.set_message(QUIT_HINT_MESSAGE),
         _ => {}
     }
 }

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -55,6 +55,10 @@ pub enum Action {
 
     // Session
     Quit,
+    /// Transitional hint for the removed `q`-quits binding: shows a message
+    /// pointing at `:q` instead of quitting. Drop this a few releases after
+    /// the `q` removal has had time to land.
+    QuitHint,
     ExportToClipboard,
     /// Copy just the comment under the cursor (`Y`), not the whole review.
     CopyCommentAtCursor,
@@ -238,6 +242,9 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
         (KeyCode::Char('/'), _) => Action::EnterSearchMode,
         (KeyCode::Char('?'), _) => Action::ToggleHelp,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ClearSearchHighlight,
+
+        // Transitional hint: q used to quit; now it just points at :q.
+        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
 
         (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleExpand,
         (KeyCode::Char('o'), KeyModifiers::NONE) => Action::ExpandAll,
@@ -428,6 +435,7 @@ fn map_submit_action_picker_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::SubmitPickerUp,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitPickerConfirm,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
         _ => Action::None,
     }
 }
@@ -439,6 +447,7 @@ fn map_commit_select_mode(key: KeyEvent) -> Action {
         (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleCommitSelect,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::ConfirmCommitSelect,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
         (KeyCode::Char(':'), _) => Action::EnterCommandMode,
         (KeyCode::Tab, KeyModifiers::NONE) => Action::TargetSelectorTabNext,
         (KeyCode::BackTab, _) => Action::TargetSelectorTabPrev,
@@ -512,6 +521,7 @@ fn map_visual_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('y'), KeyModifiers::NONE) => Action::ExportToClipboard,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Char('v') | KeyCode::Char('V'), _) => Action::ExitMode,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
         _ => Action::None,
     }
 }
@@ -993,21 +1003,21 @@ mod tests {
     }
 
     #[test]
-    fn should_not_map_q_to_quit_in_any_mode() {
+    fn should_map_q_to_quit_hint_instead_of_quitting() {
         // `q` only quits via `:q` now; the modes that used to bind it to
-        // Action::Quit leave it unmapped.
+        // Action::Quit now show a transitional hint instead.
         assert_eq!(
             map_normal_mode(key(KeyCode::Char('q')), DEFAULT_LEADER_KEY),
-            Action::None
+            Action::QuitHint
         );
-        assert_eq!(map_visual_mode(key(KeyCode::Char('q'))), Action::None);
+        assert_eq!(map_visual_mode(key(KeyCode::Char('q'))), Action::QuitHint);
         assert_eq!(
             map_commit_select_mode(key(KeyCode::Char('q'))),
-            Action::None
+            Action::QuitHint
         );
         assert_eq!(
             map_submit_action_picker_mode(key(KeyCode::Char('q'))),
-            Action::None
+            Action::QuitHint
         );
         // The overlays keep their own `q`, which closes them rather than tuicr.
         assert_eq!(map_help_mode(key(KeyCode::Char('q'))), Action::ToggleHelp);

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -239,9 +239,6 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
         (KeyCode::Char('?'), _) => Action::ToggleHelp,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ClearSearchHighlight,
 
-        // Quick quit
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
-
         (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleExpand,
         (KeyCode::Char('o'), KeyModifiers::NONE) => Action::ExpandAll,
         (KeyCode::Char('O'), _) => Action::CollapseAll,
@@ -431,7 +428,6 @@ fn map_submit_action_picker_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::SubmitPickerUp,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitPickerConfirm,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
         _ => Action::None,
     }
 }
@@ -443,7 +439,6 @@ fn map_commit_select_mode(key: KeyEvent) -> Action {
         (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleCommitSelect,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::ConfirmCommitSelect,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
         (KeyCode::Char(':'), _) => Action::EnterCommandMode,
         (KeyCode::Tab, KeyModifiers::NONE) => Action::TargetSelectorTabNext,
         (KeyCode::BackTab, _) => Action::TargetSelectorTabPrev,
@@ -517,7 +512,6 @@ fn map_visual_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('y'), KeyModifiers::NONE) => Action::ExportToClipboard,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Char('v') | KeyCode::Char('V'), _) => Action::ExitMode,
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::Quit,
         _ => Action::None,
     }
 }
@@ -630,7 +624,7 @@ mod tests {
             map_file_tree_prompt_mode(key(KeyCode::Char('a'))),
             Action::InsertChar('a')
         );
-        // Keys that would otherwise act (q quits, / filters) are just text
+        // Keys that would otherwise act (/ filters) are just text
         // while the prompt is open.
         assert_eq!(
             map_file_tree_prompt_mode(key(KeyCode::Char('q'))),
@@ -996,5 +990,27 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn should_not_map_q_to_quit_in_any_mode() {
+        // `q` only quits via `:q` now; the modes that used to bind it to
+        // Action::Quit leave it unmapped.
+        assert_eq!(
+            map_normal_mode(key(KeyCode::Char('q')), DEFAULT_LEADER_KEY),
+            Action::None
+        );
+        assert_eq!(map_visual_mode(key(KeyCode::Char('q'))), Action::None);
+        assert_eq!(
+            map_commit_select_mode(key(KeyCode::Char('q'))),
+            Action::None
+        );
+        assert_eq!(
+            map_submit_action_picker_mode(key(KeyCode::Char('q'))),
+            Action::None
+        );
+        // The overlays keep their own `q`, which closes them rather than tuicr.
+        assert_eq!(map_help_mode(key(KeyCode::Char('q'))), Action::ToggleHelp);
+        assert_eq!(map_summary_mode(key(KeyCode::Char('q'))), Action::ExitMode);
     }
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -342,10 +342,10 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
-                "  Esc/q     ",
+                "  Esc       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Quit / return"),
+            Span::raw("Return to the diff"),
         ]),
         Line::from(""),
         Line::from(Span::styled(


### PR DESCRIPTION
I'm not a regular vi/vim user. I hit `q` on reflex — not a deliberate quit, just muscle memory from my emacs transient setup — and it closed the review I'd been building, which caught me off guard. I'd like a way to make quitting something I opt into, rather than one keystroke away.

Thanks for tuicr — it's genuinely helpful, and this is the only rough edge I've hit.

The guard meant to catch this looks unreachable in practice: it needs `dirty && session.has_comments()` in `handle_shared_normal_action`, but adding a comment autosaves and clears `dirty`, so one `q` still exits. vim diverges here too — normal-mode `q` records a macro, and only `:q` quits. Refs #427, where someone hit the same surprise from another angle.

`confirm_quit` defaults to `false`, which is today's behavior unchanged. Set it to `true` and bare `q` asks first.

The gate sits on the single `Action::Quit` arm in
`handle_shared_normal_action`, so no explicit quit path can reach it: `:q`/`:q!`/`:wq`/`:x` dispatch through `CommandKind`, and `ZZ`/`ZQ` are handled inline in the main loop. The `q` bindings for the help overlay, summary view, and review target selector have their own actions and are untouched.

`ConfirmAction` now carries its own prompt, since a quit prompt asks whether to leave at all — "no" returns to the review, unlike `CopyAndQuit`, which only asks whether to export on the way out.

One pre-existing fix, found by dogfooding this change: the confirm dialog was sized `centered_rect(50, 20)`, a share of the terminal, which left a short prompt floating in a huge mostly-empty box on a large screen. It is now sized to its contents. This also tightens the existing clipboard prompt — happy to split it out if you'd rather keep this PR to the config key.

Written with claude-code. I tested and reviewed it myself, including reviewing this diff in tuicr per CONTRIBUTING — which is how the oversized confirm dialog turned up.