### PR TITLE
fix: detect self-hosted GitLab before resolving SSH host

### DIFF
--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -849,10 +849,16 @@ pub fn parse_gitlab_remote_url(remote_url: &str) -> Option<ForgeRepository> {
 
     if let Some((host, path)) = parse_scp_like_remote(trimmed) {
         let resolved = resolve_ssh_hostname(host);
-        if !is_gitlab_host(&resolved) {
+
+        let gitlab_host = if is_gitlab_host(host) {
+            host
+        } else if is_gitlab_host(&resolved) {
+            &resolved
+        } else {
             return None;
-        }
-        return gitlab_repository_from_path(&resolved, path);
+        };
+
+        return gitlab_repository_from_path(gitlab_host, path);
     }
 
     let without_scheme = strip_scheme(trimmed).unwrap_or(trimmed);


### PR DESCRIPTION
## Summary

Fix self-hosted GitLab detection for SCP-style SSH remotes when the hostname configured in `glab` resolves to a different SSH host or IP.

## Problem

For a self-hosted GitLab remote such as:

```text
git@code.example.com:group/repo.git
```

with:

```text
glab config get host
# code.example.com
```

`parse_gitlab_remote_url()` resolves the SSH hostname **before** checking whether it is a known GitLab host.

If `code.example.com` resolves to another hostname or IP, `is_gitlab_host()` compares that resolved value against the `glab` host and fails to recognize the repository as GitLab.

The remote can then fall through to the generic GitHub parser, causing `tuicr` to use `gh` instead of `glab`.

## Fix

Check the original SSH hostname before resolving it:

1. If the original host is recognized by `glab`, use it.
2. Otherwise, resolve the SSH hostname.
3. Check the resolved hostname as before.

This preserves SSH alias support while correctly detecting self-hosted GitLab instances configured in `glab`.

## Validation

Tested against a self-hosted GitLab instance using an SCP-style SSH remote.

Before the fix, `tuicr` incorrectly selected the GitHub backend.

After the fix, `tuicr` correctly:

* detects the repository as GitLab;
* uses `glab`;
* opens merge requests;
* populates the MR selector.
