### PR TITLE
feat(layout): move the file list / diff boundary with <leader>L / <leader>H

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ mouse = true
 leader = ";"                  # configurable prefix for leader shortcuts
 comment_vim = false           # vim modal editing in the review comment box
 relative_line_numbers = false # show rendered-row distances in the diff gutter
+file_list_width = 20          # file list width as a % of the content area
 
 [[comment_types]]
 id = "issue"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -82,7 +82,7 @@ legend = true
 | `initial_commit_selection` | `all`        | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`.  |
 | `ignore_whitespace`        | `false`      | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged.                                                                              |
 | `show_file_list`           | `true`       | Whether the file list panel is visible on startup. Toggle with `<leader>e`.                                                                                |
-| `file_list_width`          | `20`         | Starting width of the file list, as a percentage of the content area. Clamped to 10-60. Adjust at runtime with `<leader>L` / `<leader>H`.                                   |
+| `file_list_width`          | `20`         | Starting width of the file list, as a percentage of the content area. Clamped to 10-60. Adjust at runtime with `<leader>L` / `<leader>H`, which repeat on a bare `L` / `H`.                                   |
 | `show_pr_checks`           | `false`      | Whether PR CI checks are fetched and shown. Set to `true` to include GitHub check rollups.                                                           |
 | `show_pr_comments`         | `true`       | Whether PR conversation comments are fetched and shown. Set to `false` to skip PR comments.                                                         |
 | `show_commits`             | `true`       | Whether the inline commit selector pane is visible on startup for multi-commit reviews. Toggle with `<leader>s` or `:set commits!`.                        |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,6 +27,7 @@ theme_light = "gruvbox-light"
 diff_view = "side-by-side"
 ignore_whitespace = false
 show_file_list = true
+file_list_width = 20
 show_pr_checks = false
 show_pr_comments = true
 show_reviewed = true
@@ -81,6 +82,7 @@ legend = true
 | `initial_commit_selection` | `all`        | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`.  |
 | `ignore_whitespace`        | `false`      | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged.                                                                              |
 | `show_file_list`           | `true`       | Whether the file list panel is visible on startup. Toggle with `<leader>e`.                                                                                |
+| `file_list_width`          | `20`         | Starting width of the file list, as a percentage of the content area. Clamped to 10-60. Adjust at runtime with `<leader>L` / `<leader>H`.                                   |
 | `show_pr_checks`           | `false`      | Whether PR CI checks are fetched and shown. Set to `true` to include GitHub check rollups.                                                           |
 | `show_pr_comments`         | `true`       | Whether PR conversation comments are fetched and shown. Set to `false` to skip PR comments.                                                         |
 | `show_commits`             | `true`       | Whether the inline commit selector pane is visible on startup for multi-commit reviews. Toggle with `<leader>s` or `:set commits!`.                        |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -113,6 +113,7 @@ considers files that pass the active filters.
 | `<leader>l` | Focus diff view (right panel) |
 | `<leader>k` | Move focus up (comments to files, or diff/files to commit selector when visible) |
 | `<leader>j` | Move focus down (files to comments when visible, otherwise diff) |
+| `<leader>L` / `<leader>H` | Move the file list / diff boundary right / left |
 | `<leader>e` | Toggle file list visibility |
 | `<leader>s` | Toggle commit selector visibility (also `:set commits!`) |
 | `Enter` | Select file (when file list is focused) |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -113,7 +113,7 @@ considers files that pass the active filters.
 | `<leader>l` | Focus diff view (right panel) |
 | `<leader>k` | Move focus up (comments to files, or diff/files to commit selector when visible) |
 | `<leader>j` | Move focus down (files to comments when visible, otherwise diff) |
-| `<leader>L` / `<leader>H` | Move the file list / diff boundary right / left |
+| `<leader>L` / `<leader>H` | Move the file list / diff boundary right / left. Repeats on a bare `L` / `H` until any other key, so `<leader>LL` is two steps |
 | `<leader>e` | Toggle file list visibility |
 | `<leader>s` | Toggle commit selector visibility (also `:set commits!`) |
 | `Enter` | Select file (when file list is focused) |

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -487,6 +487,7 @@ impl App {
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
             relative_line_numbers: false,
+            file_list_width_pct: crate::app::FILE_LIST_WIDTH_DEFAULT,
             file_list_state: FileListState::default(),
             comment_navigator_state: CommentNavigatorState::default(),
             diff_state: DiffState::default(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -35,6 +35,12 @@ pub const DEFAULT_REVIEW_WATCH_INTERVAL_MS: u64 = 1000;
 pub const STAGED_SELECTION_ID: &str = "__tuicr_staged__";
 pub const UNSTAGED_SELECTION_ID: &str = "__tuicr_unstaged__";
 pub const GAP_EXPAND_BATCH: usize = 20;
+/// File list width as a percentage of the content area: starting value,
+/// step per `H` / `L` press, and the bounds that keep both panes usable.
+pub const FILE_LIST_WIDTH_DEFAULT: u16 = 20;
+pub const FILE_LIST_WIDTH_STEP: u16 = 5;
+pub const FILE_LIST_WIDTH_MIN: u16 = 10;
+pub const FILE_LIST_WIDTH_MAX: u16 = 60;
 
 /// Create a forge backend for the given repository.
 /// Routes to the GitHub backend (via `gh`), the GitLab backend (via `glab`),
@@ -1122,6 +1128,10 @@ pub struct App {
     pub focused_panel: FocusedPanel,
     pub diff_view_mode: DiffViewMode,
     pub relative_line_numbers: bool,
+    /// Width of the file list as a percentage of the content area.
+    /// `<leader>L` / `<leader>H` move the boundary; `file_list_width` sets
+    /// the start value.
+    pub file_list_width_pct: u16,
 
     pub file_list_state: FileListState,
     pub comment_navigator_state: CommentNavigatorState,

--- a/src/app/modes.rs
+++ b/src/app/modes.rs
@@ -1,6 +1,28 @@
 use super::*;
 
 impl App {
+    /// Move the file list / diff boundary one step. `wider` grows the file
+    /// list at the diff's expense. Clamped so neither pane can be squeezed
+    /// to nothing — hiding the file list is `<leader>e`'s job, not this.
+    pub fn resize_file_list(&mut self, wider: bool) {
+        if !self.show_file_list {
+            self.set_message("File list is hidden — <leader>e shows it");
+            return;
+        }
+        let next = if wider {
+            self.file_list_width_pct + FILE_LIST_WIDTH_STEP
+        } else {
+            self.file_list_width_pct
+                .saturating_sub(FILE_LIST_WIDTH_STEP)
+        }
+        .clamp(FILE_LIST_WIDTH_MIN, FILE_LIST_WIDTH_MAX);
+        if next == self.file_list_width_pct {
+            return;
+        }
+        self.file_list_width_pct = next;
+        self.set_message(format!("File list width {next}%"));
+    }
+
     pub fn set_message(&mut self, msg: impl Into<String>) {
         self.set_message_inner(msg, MessageType::Info, Some(MESSAGE_TTL_INFO));
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,10 @@ pub struct AppConfig {
     pub backend: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
+    /// Starting width of the file list, as a percentage of the content
+    /// area. Clamped to 10-60. Defaults to 20; `<leader>L` / `<leader>H`
+    /// adjust at runtime.
+    pub file_list_width: Option<usize>,
     /// Whether pull-request CI checks are fetched and shown.
     /// Defaults to false.
     pub show_pr_checks: Option<bool>,
@@ -188,6 +192,7 @@ const KNOWN_KEYS: &[&str] = &[
     "backend",
     "comment_types",
     "show_file_list",
+    "file_list_width",
     "show_pr_checks",
     "show_pr_comments",
     "show_commits",
@@ -413,6 +418,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             .get("comment_types")
             .and_then(|v| parse_comment_types(v, &mut warnings)),
         show_file_list: read_bool(table, "show_file_list", &mut warnings),
+        file_list_width: read_usize(table, "file_list_width", &mut warnings),
         show_pr_checks: read_bool(table, "show_pr_checks", &mut warnings),
         show_pr_comments: read_bool(table, "show_pr_comments", &mut warnings),
         show_commits: read_bool(table, "show_commits", &mut warnings),
@@ -988,6 +994,28 @@ mod tests {
         let outcome = parse_config("show_commits = \"no\"\n");
         assert_eq!(
             outcome.config.as_ref().and_then(|cfg| cfg.show_commits),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+    }
+
+    // file_list_width
+
+    #[test]
+    fn should_parse_file_list_width() {
+        let outcome = parse_config("file_list_width = 35\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.file_list_width),
+            Some(35)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_on_non_integer_file_list_width() {
+        let outcome = parse_config("file_list_width = \"wide\"\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.file_list_width),
             None
         );
         assert_eq!(outcome.warnings.len(), 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -384,6 +384,10 @@ fn main() -> anyhow::Result<()> {
     let mut pending_d = false;
     // Track pending leader command for leader-prefixed actions.
     let mut pending_leader = false;
+    // Set by `<leader>L` / `<leader>H` so a bare `L` / `H` keeps moving the
+    // boundary. Any other key drops it, so `H` and `L` stay unbound in
+    // Normal mode and remain free for vim motions.
+    let mut resizing_panes = false;
     // Track pending Ctrl+C for "press twice to exit" (with timestamp for 2s timeout)
     let mut pending_ctrl_c: Option<Instant> = None;
     // Only re-render when state actually changed; the diff renderer rebuilds
@@ -583,6 +587,21 @@ fn main() -> anyhow::Result<()> {
                         // Otherwise fall through to normal handling
                     }
 
+                    // Repeat a resize without re-pressing the leader.
+                    if resizing_panes && !pending_leader {
+                        match key.code {
+                            crossterm::event::KeyCode::Char('L') => {
+                                app.resize_file_list(true);
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('H') => {
+                                app.resize_file_list(false);
+                                continue;
+                            }
+                            _ => resizing_panes = false,
+                        }
+                    }
+
                     // Handle pending leader command for panel focus, file list toggle, and review comments.
                     if pending_leader {
                         pending_leader = false;
@@ -606,10 +625,12 @@ fn main() -> anyhow::Result<()> {
                             // model covers both.
                             crossterm::event::KeyCode::Char('L') => {
                                 app.resize_file_list(true);
+                                resizing_panes = true;
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('H') => {
                                 app.resize_file_list(false);
+                                resizing_panes = true;
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('k') => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,12 @@ fn main() -> anyhow::Result<()> {
             app.diff_state.wrap_lines = wrap;
         }
         app.relative_line_numbers = cfg.relative_line_numbers.unwrap_or(false);
+        if let Some(width) = cfg.file_list_width {
+            // Clamp rather than reject: a width outside the usable range is
+            // a preference expressed badly, not a config error.
+            app.file_list_width_pct =
+                (width as u16).clamp(app::FILE_LIST_WIDTH_MIN, app::FILE_LIST_WIDTH_MAX);
+        }
         // Open in single-file view when the user opts in. Pristine
         // `--all-files` already turned it on inside `App::new`, so we
         // only toggle if it's still off.
@@ -593,6 +599,17 @@ fn main() -> anyhow::Result<()> {
                             }
                             crossterm::event::KeyCode::Char('l') => {
                                 app.focused_panel = app::FocusedPanel::Diff;
+                                continue;
+                            }
+                            // `;H` / `;L` move the file list boundary the same
+                            // direction `;h` / `;l` move focus, so one mental
+                            // model covers both.
+                            crossterm::event::KeyCode::Char('L') => {
+                                app.resize_file_list(true);
+                                continue;
+                            }
+                            crossterm::event::KeyCode::Char('H') => {
+                                app.resize_file_list(false);
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('k') => {

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -128,8 +128,8 @@ fn render_main_content(frame: &mut Frame, app: &mut App, area: Rect) {
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
-                Constraint::Percentage(20), // File list
-                Constraint::Percentage(80), // Diff view
+                Constraint::Percentage(app.file_list_width_pct), // File list
+                Constraint::Percentage(100 - app.file_list_width_pct), // Diff view
             ])
             .split(content_area);
 

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -270,7 +270,10 @@ fn filter_footer(app: &App) -> Option<Line<'static>> {
 mod tests {
     //! Render checks for the filter status/prompt line in the file tree's
     //! bottom border, driven through the real `ui::render`.
-    use crate::app::{App, DiffSource, FileTreePrompt, FocusedPanel, InputMode};
+    use crate::app::{
+        App, DiffSource, FILE_LIST_WIDTH_MAX, FILE_LIST_WIDTH_MIN, FILE_LIST_WIDTH_STEP,
+        FileTreePrompt, FocusedPanel, InputMode,
+    };
     use crate::model::{DiffFile, DiffLine, FileStatus, ReviewSession, SessionDiffSource};
     use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
     use ratatui::Terminal;
@@ -472,6 +475,63 @@ mod tests {
         assert!(
             !text.contains("reviewed hidden"),
             "default state should not advertise hiding, got:\n{text}"
+        );
+    }
+
+    #[test]
+    fn should_widen_and_narrow_the_file_list_within_bounds() {
+        let mut app = app_with(&["src/main.rs"]);
+        let start = app.file_list_width_pct;
+
+        app.resize_file_list(true);
+        assert_eq!(app.file_list_width_pct, start + FILE_LIST_WIDTH_STEP);
+
+        app.resize_file_list(false);
+        assert_eq!(app.file_list_width_pct, start);
+
+        for _ in 0..50 {
+            app.resize_file_list(true);
+        }
+        assert_eq!(app.file_list_width_pct, FILE_LIST_WIDTH_MAX);
+
+        for _ in 0..50 {
+            app.resize_file_list(false);
+        }
+        assert_eq!(app.file_list_width_pct, FILE_LIST_WIDTH_MIN);
+    }
+
+    #[test]
+    fn should_refuse_to_resize_a_hidden_file_list() {
+        let mut app = app_with(&["src/main.rs"]);
+        app.show_file_list = false;
+        let start = app.file_list_width_pct;
+
+        app.resize_file_list(true);
+
+        assert_eq!(app.file_list_width_pct, start);
+    }
+
+    #[test]
+    fn should_render_a_wider_tree_after_growing_it() {
+        let mut app = app_with(&["src/deeply/nested/some_long_file_name.rs"]);
+        let narrow = draw(&mut app);
+        let narrow_border = buffer_text(&narrow)
+            .lines()
+            .find_map(|l| l.find("┐"))
+            .expect("tree border");
+
+        for _ in 0..4 {
+            app.resize_file_list(true);
+        }
+        let wide = draw(&mut app);
+        let wide_border = buffer_text(&wide)
+            .lines()
+            .find_map(|l| l.find("┐"))
+            .expect("tree border");
+
+        assert!(
+            wide_border > narrow_border,
+            "expected the tree pane to grow: {narrow_border} -> {wide_border}"
         );
     }
 }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -212,7 +212,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 format!("  {}L/{}H     ", app.leader_key, app.leader_key),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Move the file list boundary right/left"),
+            Span::raw("Move the file list boundary right/left (repeats)"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -209,6 +209,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                format!("  {}L/{}H     ", app.leader_key, app.leader_key),
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Move the file list boundary right/left"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 format!("  {}e        ", app.leader_key),
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
## The problem

The file list is a fixed 20% of the content area. Long file names, deep nesting, and the `M`/`A`/`D` badge all compete for that space, so a path that does not fit can only be read by scrolling the pane horizontally. On a wide terminal the diff has room to spare while the tree is still truncating; on a narrow one the opposite. Neither is adjustable.

## The change

`<leader>L` and `<leader>H` move the file list / diff boundary right and left in 5 point steps, clamped to 10-60 so neither pane can collapse. Hiding the file list stays `<leader>e`'s job.

The direction matches `<leader>h` / `<leader>l` moving focus, so the leader family keeps one mental model: `h` is left, `l` is right, shift moves the wall instead of the cursor.

The chord arms a repeat, so a bare `L` or `H` keeps moving the boundary until any other key. `<leader>LLL` is three steps, not three chords. Any other key drops the repeat and is handled normally.

`file_list_width` sets the starting percentage. An out-of-range value is clamped rather than rejected, since it is a preference expressed badly rather than a config error.

## No new single-stroke keys

`H` and `L` stay unbound in the Normal keymap. The repeat state lives in the event loop next to the existing pending-leader state, not in `map_normal_mode`, so `should_leave_shift_h_unbound_for_vim_motions` still passes untouched and vim motions keep both keys.

I also looked at `<` / `>`, which would be one keystroke and repeat for free, but that spends two single-stroke keys and #348 suggested that is not the trade you want.

## What I left out

- **Vertical resizing.** The panes that stack (comment navigator, inline commit selector) are already sized from their content, so there is no fixed split to move.
- **`:set filewidth=N`.** It would fit the `:set` family, but `COMMAND_SPECS` is exact-match aliases with no argument parsing, so it needs plumbing that does not belong in this PR. Happy to follow up if you want it.
- **A status-bar hint.** The file-tree hint line already carries six items and the leader key is configurable, so adding it means converting the borrowed string to an owned one. Say the word and I will.

## Test plan

- [x] `cargo fmt --check` and `cargo clippy --all-targets` clean
- [x] `cargo test` — 1521 pass. Two pre-existing failures on my machine (`should_discover_worktree_with_relativeworktrees_extension`, `default_preference_routes_reftable_repo_to_cli`) fail identically on an unmodified checkout; they need a newer git than the 2.43 I have
- [x] Unit: `<leader>L` / `<leader>H` widen and narrow, and clamp at both bounds
- [x] Unit: resizing a hidden file list is refused
- [x] Unit: the rendered tree pane is wider after growing it
- [x] Unit: `file_list_width` parses, and a non-integer warns and falls back
- [x] Manual: `<leader>LLL` steps 20% to 35%; `<leader>LHH` overshoots and comes back
- [x] Manual: pressing `j` after a repeat scrolls rather than being swallowed
- [x] Dogfooded — reviewed this branch in tuicr with the boundary moved out to read the longer paths

The repeat itself lives in the `main.rs` event loop, which has no test harness, so it is covered by the manual checks above rather than a unit test.

## Docs

`README.md` config block, `docs/CONFIG.md` options table and example, `docs/KEYBINDINGS.md` panel-focus table, and the `?` help popup.
