### PR TITLE
side-by-side: choose the comment side with ←/→, caret follows

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -109,8 +109,8 @@ considers files that pass the active filters.
 | Key | Action |
 |-----|--------|
 | `Tab` / `Shift-Tab` | Cycle focus forward / backward between file list, comment navigator, diff, and commit selector |
-| `<leader>h` | Focus file list (left panel) |
-| `<leader>l` | Focus diff view (right panel) |
+| `<leader>h` | Move focus one panel left (side-by-side: new side → old side → file list) |
+| `<leader>l` | Move focus one panel right (side-by-side: file list → diff → old side → new side) |
 | `<leader>k` | Move focus up (comments to files, or diff/files to commit selector when visible) |
 | `<leader>j` | Move focus down (files to comments when visible, otherwise diff) |
 | `<leader>e` | Toggle file list visibility |

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -487,6 +487,7 @@ impl App {
             focused_panel: FocusedPanel::Diff,
             diff_view_mode: DiffViewMode::Unified,
             relative_line_numbers: false,
+            cursor_side: LineSide::New,
             file_list_state: FileListState::default(),
             comment_navigator_state: CommentNavigatorState::default(),
             diff_state: DiffState::default(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1122,6 +1122,10 @@ pub struct App {
     pub focused_panel: FocusedPanel,
     pub diff_view_mode: DiffViewMode,
     pub relative_line_numbers: bool,
+    /// Which side the cursor targets in side-by-side view (old/left vs
+    /// new/right). Drives the `▶` caret placement and the side a new line
+    /// comment attaches to. Ignored in unified view. Defaults to `New`.
+    pub cursor_side: LineSide,
 
     pub file_list_state: FileListState,
     pub comment_navigator_state: CommentNavigatorState,

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -244,6 +244,44 @@ impl App {
         self.diff_state.scroll_x = self.diff_state.scroll_x.saturating_sub(cols);
     }
 
+    /// Whether the diff is focused and split into two commentable panes, so
+    /// the `<leader>` panel walk has a step to take inside it.
+    fn diff_panes_are_walkable(&self) -> bool {
+        self.focused_panel == FocusedPanel::Diff && self.diff_view_mode == DiffViewMode::SideBySide
+    }
+
+    /// `<leader>h` — move focus one panel left. In side-by-side view the two
+    /// diff columns are stops on that walk, so the order is
+    /// file list → old → new; from the new side this only steps to the old one.
+    pub fn focus_pane_left(&mut self) {
+        if self.diff_panes_are_walkable() && self.cursor_side == LineSide::New {
+            self.set_cursor_side(LineSide::Old);
+            return;
+        }
+        if self.show_file_list {
+            self.focused_panel = FocusedPanel::FileList;
+        }
+    }
+
+    /// `<leader>l` — move focus one panel right; the mirror of
+    /// [`focus_pane_left`]. Entering the diff from the file list keeps
+    /// whichever side was already active rather than resetting it.
+    pub fn focus_pane_right(&mut self) {
+        if self.diff_panes_are_walkable() {
+            if self.cursor_side == LineSide::Old {
+                self.set_cursor_side(LineSide::New);
+            }
+            return;
+        }
+        self.focused_panel = FocusedPanel::Diff;
+    }
+
+    /// Set the side the cursor targets in side-by-side view (drives the caret
+    /// and which side a new comment attaches to).
+    pub fn set_cursor_side(&mut self, side: LineSide) {
+        self.cursor_side = side;
+    }
+
     pub fn scroll_right(&mut self, cols: usize) {
         if self.diff_state.wrap_lines {
             return;
@@ -1475,13 +1513,39 @@ impl App {
                 old_lineno,
                 new_lineno,
                 ..
-            }) => {
-                // Prefer new line number (for added/context lines), fall back to old (for deleted)
-                new_lineno
-                    .map(|ln| (ln, LineSide::New))
-                    .or_else(|| old_lineno.map(|ln| (ln, LineSide::Old)))
-            }
+            }) => Self::line_for_side(self.effective_cursor_side(), *old_lineno, *new_lineno),
             _ => None,
+        }
+    }
+
+    /// The side the cursor effectively targets at its current line. In
+    /// side-by-side view it follows `cursor_side`; in unified view there is one
+    /// column, so `New` is preferred (falling back per line below). This is a
+    /// *preference*; [`line_for_side`] clamps it to the sides the line offers.
+    pub fn effective_cursor_side(&self) -> LineSide {
+        if self.diff_view_mode == DiffViewMode::SideBySide {
+            self.cursor_side
+        } else {
+            LineSide::New
+        }
+    }
+
+    /// Resolve a `(lineno, side)` for a diff line given a preferred side,
+    /// clamping to whichever side the line actually has. A pure addition has
+    /// only `new_lineno`; a pure deletion only `old_lineno`; a context line has
+    /// both, so the preference wins.
+    fn line_for_side(
+        prefer: LineSide,
+        old_lineno: Option<u32>,
+        new_lineno: Option<u32>,
+    ) -> Option<(u32, LineSide)> {
+        match prefer {
+            LineSide::Old => old_lineno
+                .map(|ln| (ln, LineSide::Old))
+                .or_else(|| new_lineno.map(|ln| (ln, LineSide::New))),
+            LineSide::New => new_lineno
+                .map(|ln| (ln, LineSide::New))
+                .or_else(|| old_lineno.map(|ln| (ln, LineSide::Old))),
         }
     }
 }

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -12,6 +12,7 @@ mod find_source_line_tests;
 mod persistence_merge_tests;
 mod pr_info_tests;
 mod render_perf_tests;
+mod sbs_comment_side_tests;
 mod scroll_behavior_tests;
 mod scroll_tests;
 mod single_file_view_tests;

--- a/src/app/tests/sbs_comment_side_tests.rs
+++ b/src/app/tests/sbs_comment_side_tests.rs
@@ -1,0 +1,214 @@
+//! Tests for choosing the comment side in side-by-side view: `<leader>h` /
+//! `<leader>l` walk the panes and set `cursor_side`, and `get_line_at_cursor`
+//! resolves that preference (clamped to the sides a line actually has). The
+//! plain horizontal keys keep scrolling in every view.
+
+use crate::app::*;
+use crate::input::Action;
+use crate::model::FileStatus;
+use crate::vcs::traits::VcsType;
+
+struct DummyVcs {
+    info: VcsInfo,
+}
+
+impl VcsBackend for DummyVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.info
+    }
+    fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        Err(TuicrError::NoChanges)
+    }
+    fn fetch_context_lines(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start_line: u32,
+        _end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+    fn file_line_count(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        Ok(0)
+    }
+}
+
+fn build_app() -> App {
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: "head".to_string(),
+        branch_name: Some("main".to_string()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+    App::build(
+        Box::new(DummyVcs {
+            info: vcs_info.clone(),
+        }),
+        vcs_info,
+        Theme::dark(),
+        None,
+        false,
+        Vec::new(),
+        session,
+        DiffSource::WorkingTree,
+        InputMode::Normal,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("failed to build test app")
+}
+
+fn sbs_line(old_lineno: Option<u32>, new_lineno: Option<u32>) -> AnnotatedLine {
+    AnnotatedLine::SideBySideLine {
+        file_idx: 0,
+        hunk_idx: 0,
+        del_line_idx: old_lineno.map(|_| 0),
+        add_line_idx: new_lineno.map(|_| 0),
+        old_lineno,
+        new_lineno,
+    }
+}
+
+#[test]
+fn context_line_honors_cursor_side_in_side_by_side() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.line_annotations = vec![sbs_line(Some(10), Some(20))];
+    app.diff_state.cursor_line = 0;
+
+    app.cursor_side = LineSide::New;
+    assert_eq!(app.get_line_at_cursor(), Some((20, LineSide::New)));
+
+    app.cursor_side = LineSide::Old;
+    assert_eq!(app.get_line_at_cursor(), Some((10, LineSide::Old)));
+}
+
+#[test]
+fn addition_line_clamps_to_new_even_when_old_preferred() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.line_annotations = vec![sbs_line(None, Some(20))];
+    app.diff_state.cursor_line = 0;
+
+    app.cursor_side = LineSide::Old; // no old side on this line
+    assert_eq!(app.get_line_at_cursor(), Some((20, LineSide::New)));
+}
+
+#[test]
+fn deletion_line_clamps_to_old_even_when_new_preferred() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.line_annotations = vec![sbs_line(Some(10), None)];
+    app.diff_state.cursor_line = 0;
+
+    app.cursor_side = LineSide::New; // no new side on this line
+    assert_eq!(app.get_line_at_cursor(), Some((10, LineSide::Old)));
+}
+
+#[test]
+fn unified_view_ignores_cursor_side_and_prefers_new() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::Unified;
+    app.line_annotations = vec![sbs_line(Some(10), Some(20))];
+    app.diff_state.cursor_line = 0;
+
+    app.cursor_side = LineSide::Old; // ignored in unified
+    assert_eq!(app.effective_cursor_side(), LineSide::New);
+    assert_eq!(app.get_line_at_cursor(), Some((20, LineSide::New)));
+}
+
+#[test]
+fn horizontal_keys_scroll_in_side_by_side_and_leave_side_unchanged() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.cursor_side = LineSide::New;
+    app.diff_state.wrap_lines = false;
+    app.diff_state.max_content_width = 200;
+    app.diff_state.viewport_width = 80;
+
+    // Reviewers expect the horizontal keys to scroll in every view; the side is
+    // switched with the `<leader>` panel walk instead.
+    crate::handler::handle_diff_action(&mut app, Action::ScrollRight(4));
+    assert_eq!(app.diff_state.scroll_x, 4);
+    assert_eq!(app.cursor_side, LineSide::New);
+
+    crate::handler::handle_diff_action(&mut app, Action::ScrollLeft(4));
+    assert_eq!(app.diff_state.scroll_x, 0);
+    assert_eq!(app.cursor_side, LineSide::New);
+}
+
+#[test]
+fn leader_walk_steps_through_the_side_by_side_panes() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.show_file_list = true;
+    app.focused_panel = FocusedPanel::Diff;
+    app.cursor_side = LineSide::New;
+
+    // new -> old inside the diff, then out to the file list.
+    app.focus_pane_left();
+    assert_eq!(app.focused_panel, FocusedPanel::Diff);
+    assert_eq!(app.cursor_side, LineSide::Old);
+
+    app.focus_pane_left();
+    assert_eq!(app.focused_panel, FocusedPanel::FileList);
+    assert_eq!(app.cursor_side, LineSide::Old);
+
+    // ... and back: file list -> diff (side kept) -> new.
+    app.focus_pane_right();
+    assert_eq!(app.focused_panel, FocusedPanel::Diff);
+    assert_eq!(app.cursor_side, LineSide::Old);
+
+    app.focus_pane_right();
+    assert_eq!(app.cursor_side, LineSide::New);
+
+    // Already rightmost: stays put.
+    app.focus_pane_right();
+    assert_eq!(app.focused_panel, FocusedPanel::Diff);
+    assert_eq!(app.cursor_side, LineSide::New);
+}
+
+#[test]
+fn leader_walk_ignores_the_sides_in_unified_view() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::Unified;
+    app.show_file_list = true;
+    app.focused_panel = FocusedPanel::Diff;
+    app.cursor_side = LineSide::New;
+
+    // Unified has a single pane, so the walk leaves the diff immediately.
+    app.focus_pane_left();
+    assert_eq!(app.focused_panel, FocusedPanel::FileList);
+    assert_eq!(app.cursor_side, LineSide::New);
+
+    app.focus_pane_right();
+    assert_eq!(app.focused_panel, FocusedPanel::Diff);
+    assert_eq!(app.cursor_side, LineSide::New);
+}
+
+#[test]
+fn horizontal_keys_scroll_in_unified_and_leave_side_unchanged() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::Unified;
+    app.cursor_side = LineSide::New;
+    app.diff_state.wrap_lines = false;
+    app.diff_state.max_content_width = 100;
+    app.diff_state.viewport_width = 10;
+
+    crate::handler::handle_diff_action(&mut app, Action::ScrollRight(4));
+    assert_eq!(app.diff_state.scroll_x, 4);
+    assert_eq!(app.cursor_side, LineSide::New);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -586,13 +586,11 @@ fn main() -> anyhow::Result<()> {
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('h') => {
-                                if app.show_file_list {
-                                    app.focused_panel = app::FocusedPanel::FileList;
-                                }
+                                app.focus_pane_left();
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('l') => {
-                                app.focused_panel = app::FocusedPanel::Diff;
+                                app.focus_pane_right();
                                 continue;
                             }
                             crossterm::event::KeyCode::Char('k') => {

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -154,6 +154,63 @@ fn sbs_row_prefixes(
     (left_prefix, right_prefix)
 }
 
+/// Move the `▶` caret onto the active side for the cursor row. The per-line
+/// builders always place the caret in the far-left slot (old side). When the
+/// cursor's effective side is `New`, blank that slot and redraw the caret in
+/// the divider's trailing space, just left of the new line number, so it
+/// points at the side a comment would attach to. Run as a post-render overlay
+/// so it's independent of the wrapped/unwrapped row-build paths.
+fn paint_sbs_active_side_caret(
+    frame: &mut Frame,
+    inner: Rect,
+    app: &App,
+    lw: usize,
+    content_width: usize,
+    row_heights: &[usize],
+) {
+    // Only the New side needs moving; Old keeps the left-slot caret.
+    if !matches!(app.get_line_at_cursor(), Some((_, LineSide::New))) {
+        return;
+    }
+    let scroll_offset = app.diff_state.scroll_offset;
+    let cursor_line = app.diff_state.cursor_line;
+    if cursor_line < scroll_offset {
+        return;
+    }
+    let logical_offset = cursor_line - scroll_offset;
+    if logical_offset >= app.diff_state.visible_line_count.max(1) {
+        return;
+    }
+    // First visual row of the cursor's logical line (wrap-aware).
+    let visual_row: u16 = if app.diff_state.wrap_lines {
+        (0..logical_offset)
+            .map(|i| row_heights.get(i).copied().unwrap_or(1) as u16)
+            .sum()
+    } else {
+        logical_offset as u16
+    };
+    if visual_row >= inner.height {
+        return;
+    }
+    let y = inner.y + visual_row;
+    let style = styles::current_line_indicator_style(&app.theme);
+
+    // Blank the far-left caret slot.
+    frame.buffer_mut()[(inner.x, y)].set_char(' ');
+
+    // Caret goes in the divider's trailing space: after the left gutter
+    // (`sbs_left_gutter`) and the left content column, `" │ "` occupies three
+    // cells and the third (index +2) is the space just left of the new lineno.
+    let caret_x = inner.x + crate::app::sbs_left_gutter(lw) + content_width as u16 + 2;
+    if caret_x < inner.x + inner.width {
+        let cell = &mut frame.buffer_mut()[(caret_x, y)];
+        cell.set_char('▶');
+        if let Some(fg) = style.fg {
+            cell.set_fg(fg);
+        }
+    }
+}
+
 /// Continuation-row prefixes shared by every wrapped line: blank in place of
 /// the line numbers (same width, so columns stay aligned) with the center
 /// divider preserved.
@@ -1031,6 +1088,9 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         &row_heights,
         app,
     );
+
+    // Move the `▶` caret onto the active side for the cursor row.
+    paint_sbs_active_side_caret(frame, inner, app, lw, content_width, &row_heights);
 
     // Painted last so the cell overlay wins over cursor-line bg on overlap.
     if let Some(sel) = app.visual_selection {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -198,7 +198,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 format!("  {}h/{}l     ", app.leader_key, app.leader_key),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Focus file list/diff"),
+            Span::raw("Move focus left/right (side-by-side: between the two sides)"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
In side-by-side view the side a new comment attaches to was auto-derived per
line (new preferred), and the `▶` caret sat at column 0 — so a line with both
sides could only be commented on the new one, and nothing on screen said which
side `c` would pick.

Adds an active `cursor_side` (default `New`). `get_line_at_cursor` resolves it,
clamped to the sides a line actually has, and a post-render overlay moves the
`▶` caret onto the active side's gutter.

The two columns are stops on the existing `<leader>h` / `<leader>l` panel walk
— file list ← old ← new — so arrows and `h`/`l` keep scrolling everywhere, as
today. Entering the diff from the file list keeps whichever side was active;
unified view is unchanged.

Tested with `src/app/tests/sbs_comment_side_tests.rs`; `cargo fmt --all
--check`, `cargo clippy --all-targets -- -D warnings` and `cargo test` (1534
passed) are green.
