### PR TITLE
docs: add pacman installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 curl -fsSL tuicr.dev/install.sh | sh
 # or
 brew install tuicr
+# or
+sudo pacman -S tuicr
 ```
 
 <details>


### PR DESCRIPTION
im relatively new using tuicr, and while checking how to install it i found that it is also available in the official arch linux repositories and can be installed with pacman

it seems like a good idea to add that option to the README so other Arch users can find it easily

package: [arch linux `extra/tuicr`](https://archlinux.org/packages/extra/x86_64/tuicr/)
