### PR TITLE
feat(github): rebuild the PR diff when it exceeds 300 files

### DIFF
--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -233,7 +233,14 @@ where
     }
 
     fn pull_request_file_metadata(&self, pr: &PullRequestDetails) -> Result<Vec<FileMetadata>> {
-        let mut metadata = Vec::new();
+        self.pull_request_files(pr)?
+            .into_iter()
+            .map(GhPullRequestFile::into_metadata)
+            .collect()
+    }
+
+    fn pull_request_files(&self, pr: &PullRequestDetails) -> Result<Vec<GhPullRequestFile>> {
+        let mut rows_all: Vec<GhPullRequestFile> = Vec::new();
         for page in 1..=30 {
             let endpoint = format!(
                 "repos/{}/{}/pulls/{}/files?per_page=100&page={page}",
@@ -247,19 +254,24 @@ where
             let output = self.run_gh(args, &pr.repository.host)?;
             let rows: Vec<GhPullRequestFile> = serde_json::from_str(&output)?;
             let received = rows.len();
-            metadata.extend(
-                rows.into_iter()
-                    .map(GhPullRequestFile::into_metadata)
-                    .collect::<Result<Vec<_>>>()?,
-            );
+            rows_all.extend(rows);
             if received < 100 {
-                return Ok(metadata);
+                return Ok(rows_all);
             }
         }
         Err(TuicrError::Forge(
             "GitHub pull request exceeds the 3000-file REST API limit".into(),
         ))
     }
+}
+
+/// GitHub answers the diff media type with 406 once a pull request touches
+/// more than 300 files. Matched on the message because `gh` reports it as a
+/// command failure rather than a typed status.
+fn is_diff_too_large(err: &TuicrError) -> bool {
+    let msg = err.to_string();
+    msg.contains("exceeded the maximum number of files")
+        || (msg.contains("406") && msg.contains("diff"))
 }
 
 impl<R> ForgeBackend for GitHubGhBackend<R>
@@ -338,8 +350,13 @@ where
         // into duplicate `DiffFile`s. Plain `gh pr diff` (no `--patch`)
         // returns the single cumulative diff. Hard-won lesson; see the
         // duplicate-files-in-list bug.
-        let metadata = self.pull_request_file_metadata(pr)?;
-        let patch = self.run_gh(
+        let rows = self.pull_request_files(pr)?;
+        let metadata = rows
+            .iter()
+            .cloned()
+            .map(GhPullRequestFile::into_metadata)
+            .collect::<Result<Vec<_>>>()?;
+        let patch = match self.run_gh(
             vec![
                 "pr".to_string(),
                 "diff".to_string(),
@@ -350,7 +367,14 @@ where
                 "never".to_string(),
             ],
             &pr.repository.host,
-        )?;
+        ) {
+            Ok(patch) => patch,
+            // `gh pr diff` asks for the diff media type, which GitHub refuses
+            // above 300 files. The files endpoint has no such cap and carries
+            // the same hunks, so rebuild the diff from the rows already read.
+            Err(e) if is_diff_too_large(&e) => super::models::synthesize_patch(&rows),
+            Err(e) => return Err(e),
+        };
         pair_metadata_with_patch(metadata, patch.as_bytes())
     }
 

--- a/src/forge/github/models.rs
+++ b/src/forge/github/models.rs
@@ -10,12 +10,16 @@ use crate::model::FileStatus;
 use crate::vcs::git::raw::FileMetadata;
 
 /// Machine-readable entry from the pull-request files REST endpoint.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct GhPullRequestFile {
     pub filename: String,
     pub status: String,
     #[serde(default)]
     pub previous_filename: Option<String>,
+    /// Hunks for this file. GitHub omits it for binary files and for files
+    /// whose own diff is too large, so absent does not mean unchanged.
+    #[serde(default)]
+    pub patch: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -235,8 +239,114 @@ fn require_field(value: &str, field: &str) -> Result<()> {
     }
 }
 
+/// Rebuilds a unified diff from `pulls/<n>/files` rows.
+///
+/// `gh pr diff` refuses any pull request touching more than 300 files, but
+/// the files endpoint paginates and carries each file's hunks, so the diff
+/// can be reassembled client side. Emits exactly one `diff --git` block per
+/// row, including rows with no patch, because the caller pairs blocks with
+/// metadata positionally.
+pub(crate) fn synthesize_patch(files: &[GhPullRequestFile]) -> String {
+    let mut out = String::new();
+    for f in files {
+        let new_path = f.filename.as_str();
+        let old_path = match f.status.as_str() {
+            "renamed" => f.previous_filename.as_deref().unwrap_or(new_path),
+            _ => new_path,
+        };
+        out.push_str(&format!("diff --git a/{old_path} b/{new_path}\n"));
+        match f.status.as_str() {
+            "added" => {
+                out.push_str("--- /dev/null\n");
+                out.push_str(&format!("+++ b/{new_path}\n"));
+            }
+            "removed" => {
+                out.push_str(&format!("--- a/{old_path}\n"));
+                out.push_str("+++ /dev/null\n");
+            }
+            _ => {
+                out.push_str(&format!("--- a/{old_path}\n"));
+                out.push_str(&format!("+++ b/{new_path}\n"));
+            }
+        }
+        if let Some(patch) = f.patch.as_deref() {
+            out.push_str(patch);
+            if !patch.ends_with('\n') {
+                out.push('\n');
+            }
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
+
+    /// `gh pr diff` refuses a pull request over 300 files, so the diff is
+    /// rebuilt from the files endpoint. The caller pairs blocks with metadata
+    /// positionally, so every row must produce exactly one block, including
+    /// binary files, which carry no patch at all.
+    #[test]
+    fn should_emit_one_block_per_file_including_patchless_ones() {
+        let files = vec![
+            GhPullRequestFile {
+                filename: "a.rs".into(),
+                status: "modified".into(),
+                previous_filename: None,
+                patch: Some("@@ -1 +1 @@\n-a\n+b".into()),
+            },
+            GhPullRequestFile {
+                filename: "logo.png".into(),
+                status: "modified".into(),
+                previous_filename: None,
+                patch: None,
+            },
+        ];
+
+        let out = synthesize_patch(&files);
+
+        assert_eq!(out.matches("diff --git ").count(), 2);
+        assert!(out.contains("diff --git a/logo.png b/logo.png"));
+        assert!(out.ends_with('\n'));
+    }
+
+    #[test]
+    fn should_use_dev_null_for_added_and_removed_files() {
+        let files = vec![
+            GhPullRequestFile {
+                filename: "new.rs".into(),
+                status: "added".into(),
+                previous_filename: None,
+                patch: Some("@@ -0,0 +1 @@\n+x\n".into()),
+            },
+            GhPullRequestFile {
+                filename: "gone.rs".into(),
+                status: "removed".into(),
+                previous_filename: None,
+                patch: Some("@@ -1 +0,0 @@\n-y\n".into()),
+            },
+        ];
+
+        let out = synthesize_patch(&files);
+
+        assert!(out.contains("--- /dev/null\n+++ b/new.rs"));
+        assert!(out.contains("--- a/gone.rs\n+++ /dev/null"));
+    }
+
+    #[test]
+    fn should_name_both_sides_of_a_rename() {
+        let files = vec![GhPullRequestFile {
+            filename: "after.rs".into(),
+            status: "renamed".into(),
+            previous_filename: Some("before.rs".into()),
+            patch: None,
+        }];
+
+        let out = synthesize_patch(&files);
+
+        assert!(out.contains("diff --git a/before.rs b/after.rs"));
+        assert!(out.contains("--- a/before.rs\n+++ b/after.rs"));
+    }
     use super::*;
     use std::path::Path;
 


### PR DESCRIPTION
## The problem

`gh pr diff` asks GitHub for the diff media type, which answers 406 once a pull request touches more than 300 files:

```
could not find pull request diff: HTTP 406: Sorry, the diff exceeded the
maximum number of files (300). Consider using 'List pull requests files'
API or locally cloning the repository instead.
PullRequest.diff too_large
```

Such a pull request cannot be opened in tuicr at all. Large refactors and dependency sweeps are exactly the reviews where a file tree beside the diff helps most.

## The fix

GitHub's own error suggests the files endpoint, and tuicr already sweeps it: `pull_request_file_metadata` paginates `pulls/<n>/files` to 3000 files. That endpoint has no 300-file cap and each row carries the file's hunks in `patch`, which we were discarding.

So on that specific failure, reassemble the diff from rows already read rather than making a second trip:

- `pull_request_file_metadata` becomes a thin wrapper over a new `pull_request_files`, so one sweep serves both the metadata and the fallback
- `GhPullRequestFile` keeps `patch`
- `synthesize_patch` rebuilds a unified diff from the rows

`gh pr diff` remains the primary path and is unchanged for pull requests under the cap.

### One subtlety

`pair_metadata_with_patch` pairs blocks with metadata **positionally**, so `synthesize_patch` emits exactly one `diff --git` block per row, including rows with no patch. GitHub omits `patch` for binary files and for files whose own diff is too large; in one 648-file sample, 39 of the first 100 rows had none. Skipping them would shift every pairing after the first and mislabel the rest of the diff.

## Testing

- Three unit tests: one block per row including patchless ones, `/dev/null` on both sides of add and delete, and both names on a rename
- `cargo fmt` and `cargo clippy --all-targets` clean
- Full suite passes, except two pre-existing failures on this machine in `vcs::git` that are git-version dependent and unrelated
- Verified against a real 648-file pull request: previously refused with the 406 above, now opens with commits, description, and the full file list

## Notes

Binary and oversized files appear in the tree with their status and no hunks, which is what the endpoint reports about them.

The `is_diff_too_large` predicate matches on the message because `gh` surfaces this as a command failure rather than a typed status. If there is a preferred way to classify `gh` errors in this codebase I am happy to switch to it.
