### PR TITLE
comment_panel: adapt newline hint to terminal

### DIFF
--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -119,6 +119,7 @@ pub fn format_comment_input_lines(
     is_editing: bool,
     width: usize,
     vim_mode: Option<(&str, bool)>,
+    supports_keyboard_enhancement: bool,
 ) -> (Vec<Line<'static>>, CommentCursorInfo) {
     let type_style = styles::comment_type_style(theme, comment_type.color);
     let border_style = styles::comment_border_style(theme, comment_type.color);
@@ -133,7 +134,11 @@ pub fn format_comment_input_lines(
         None => String::new(),
     };
 
-    let newline_hint = "Shift-Enter"; // requires extended-keys on in tmux; Alt-Enter also works
+    let newline_hint = if supports_keyboard_enhancement {
+        "Shift-Enter"
+    } else {
+        "Alt-Enter"
+    };
 
     // "    │  " is the per-line content prefix; everything past that is content.
     // Subtract two extra: one so ratatui never wraps an exact-fit line, and
@@ -751,6 +756,7 @@ mod tests {
             false,
             80,
             None,
+            true,
         );
 
         // then
@@ -779,6 +785,7 @@ mod tests {
             false,
             80,
             None,
+            true,
         );
 
         // then
@@ -806,6 +813,7 @@ mod tests {
             false,
             80,
             None,
+            true,
         );
 
         // then
@@ -834,6 +842,7 @@ mod tests {
             false,
             80,
             None,
+            true,
         );
 
         // then
@@ -861,6 +870,7 @@ mod tests {
             false,
             80,
             None,
+            true,
         );
 
         // then
@@ -889,12 +899,65 @@ mod tests {
             false,
             80,
             None,
+            true,
         );
 
         // then
         assert_eq!(cursor_info.line_offset, 1);
         // "a" = 1 display width, "좋" = 2 display width, total = 3
         assert_eq!(cursor_info.column, 7 + 3);
+    }
+
+    #[test]
+    fn should_show_shift_enter_hint_when_keyboard_enhancement_supported() {
+        let theme = test_theme();
+        let (lines, _) = format_comment_input_lines(
+            &theme,
+            CommentTypePresentation {
+                label: "NOTE".to_string(),
+                color: Color::Blue,
+            },
+            "",
+            0,
+            None,
+            false,
+            80,
+            None,
+            true,
+        );
+        let header = lines[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>();
+        assert!(header.contains("Shift-Enter:newline"));
+        assert!(!header.contains("Alt-Enter:newline"));
+    }
+
+    #[test]
+    fn should_show_alt_enter_hint_when_keyboard_enhancement_not_supported() {
+        let theme = test_theme();
+        let (lines, _) = format_comment_input_lines(
+            &theme,
+            CommentTypePresentation {
+                label: "NOTE".to_string(),
+                color: Color::Blue,
+            },
+            "",
+            0,
+            None,
+            false,
+            80,
+            None,
+            false,
+        );
+        let header = lines[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<String>();
+        assert!(header.contains("Alt-Enter:newline"));
+        assert!(!header.contains("Shift-Enter:newline"));
     }
 
     // -- markdown highlighting tests --
@@ -932,6 +995,7 @@ mod tests {
             false,
             80,
             None,
+            true,
         )
         .0
     }

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -356,6 +356,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 app.comment_vim_mode_label()
                     .as_ref()
                     .map(|(t, w)| (t.as_str(), *w)),
+                app.supports_keyboard_enhancement,
             );
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
             comment_cursor_column = 1 + cursor_info.column;
@@ -443,6 +444,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
             app.comment_vim_mode_label()
                 .as_ref()
                 .map(|(t, w)| (t.as_str(), *w)),
+            app.supports_keyboard_enhancement,
         );
         comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
         comment_cursor_column = 1 + cursor_info.column;
@@ -543,6 +545,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                         app.comment_vim_mode_label()
                             .as_ref()
                             .map(|(t, w)| (t.as_str(), *w)),
+                        app.supports_keyboard_enhancement,
                     );
                     comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
                     comment_cursor_column = 1 + cursor_info.column;
@@ -607,6 +610,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
                 app.comment_vim_mode_label()
                     .as_ref()
                     .map(|(t, w)| (t.as_str(), *w)),
+                app.supports_keyboard_enhancement,
             );
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
             comment_cursor_column = 1 + cursor_info.column;
@@ -1911,6 +1915,7 @@ fn add_comments_to_line(
                             .comment_vim_mode_label()
                             .as_ref()
                             .map(|(t, w)| (t.as_str(), *w)),
+                        ctx.app.supports_keyboard_enhancement,
                     );
                     let box_top_row = line_idx;
                     let box_end = line_idx + input_lines.len().saturating_sub(1);
@@ -1999,6 +2004,7 @@ fn add_comments_to_line(
                 .comment_vim_mode_label()
                 .as_ref()
                 .map(|(t, w)| (t.as_str(), *w)),
+            ctx.app.supports_keyboard_enhancement,
         );
         let box_top_row = line_idx;
         let box_end = line_idx + input_lines.len().saturating_sub(1);

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -140,6 +140,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 app.comment_vim_mode_label()
                     .as_ref()
                     .map(|(t, w)| (t.as_str(), *w)),
+                app.supports_keyboard_enhancement,
             );
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
             comment_cursor_column = 1 + cursor_info.column;
@@ -228,6 +229,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
             app.comment_vim_mode_label()
                 .as_ref()
                 .map(|(t, w)| (t.as_str(), *w)),
+            app.supports_keyboard_enhancement,
         );
         comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
         comment_cursor_column = 1 + cursor_info.column;
@@ -334,6 +336,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                         app.comment_vim_mode_label()
                             .as_ref()
                             .map(|(t, w)| (t.as_str(), *w)),
+                        app.supports_keyboard_enhancement,
                     );
                     // Track cursor position: logical line = current line_idx + cursor offset within input
                     comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
@@ -401,6 +404,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 app.comment_vim_mode_label()
                     .as_ref()
                     .map(|(t, w)| (t.as_str(), *w)),
+                app.supports_keyboard_enhancement,
             );
             // Track cursor position
             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
@@ -709,6 +713,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                                 app.comment_vim_mode_label()
                                                     .as_ref()
                                                     .map(|(t, w)| (t.as_str(), *w)),
+                                                app.supports_keyboard_enhancement,
                                             );
                                         comment_cursor_logical_line =
                                             Some(line_idx + cursor_info.line_offset);
@@ -836,6 +841,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                     app.comment_vim_mode_label()
                                         .as_ref()
                                         .map(|(t, w)| (t.as_str(), *w)),
+                                    app.supports_keyboard_enhancement,
                                 );
                             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
                             comment_cursor_column = 1 + cursor_info.column;
@@ -895,6 +901,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                                 app.comment_vim_mode_label()
                                                     .as_ref()
                                                     .map(|(t, w)| (t.as_str(), *w)),
+                                                app.supports_keyboard_enhancement,
                                             );
                                         comment_cursor_logical_line =
                                             Some(line_idx + cursor_info.line_offset);
@@ -1021,6 +1028,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                                     app.comment_vim_mode_label()
                                         .as_ref()
                                         .map(|(t, w)| (t.as_str(), *w)),
+                                    app.supports_keyboard_enhancement,
                                 );
                             comment_cursor_logical_line = Some(line_idx + cursor_info.line_offset);
                             comment_cursor_column = 1 + cursor_info.column;


### PR DESCRIPTION
Standard terminal protocols emit an unmodified carriage return for Shift-Enter unless the Kitty keyboard protocol or extended keys are supported. In environments without keyboard enhancements, Shift-Enter submits the comment instead of inserting a newline.

Display Alt-Enter in the comment header hint when keyboard enhancement support is not detected so users are guided toward the key combination that reliably works in their terminal.

Fixes https://github.com/agavra/tuicr/issues/640

Assisted-by: Antigravity