### PR TITLE
vcs/jj: use as_chunks to parse diff metadata

### DIFF
--- a/src/vcs/jj/mod.rs
+++ b/src/vcs/jj/mod.rs
@@ -178,7 +178,9 @@ fn parse_jj_diff_metadata(output: &str) -> Result<Vec<FileMetadata>> {
     }
 
     records
-        .chunks_exact(3)
+        .as_chunks::<3>()
+        .0
+        .iter()
         .map(|record| {
             let source = (!record[1].is_empty()).then(|| PathBuf::from(record[1]));
             let target = (!record[2].is_empty()).then(|| PathBuf::from(record[2]));


### PR DESCRIPTION
Replace `chunks_exact(3)` with `as_chunks::<3>()` when parsing Jujutsu null-delimited diff metadata records, addressing the Rust 1.98.0 `clippy::chunks_exact_to_as_chunks` lint.

Assisted-by: Antigravity