### PR TITLE
Fix issues with reftable and bare repos in unit tests

### DIFF
--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -1277,7 +1277,12 @@ mod tests {
         // throwaway commits in these temp repos.
         let output = Command::new("git")
             .current_dir(workdir)
-            .args(["-c", "commit.gpgsign=false"])
+            .args([
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "init.defaultRefFormat=files",
+            ])
             .args(args)
             .output()
             .expect("failed to run git");

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -438,7 +438,9 @@ mod tests {
 
     #[test]
     fn should_return_no_changes_for_clean_repo() {
-        let repo = Repository::discover(".").unwrap();
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+        create_initial_commit(&repo, "file.txt", "content\n");
         let head = repo.head().unwrap().peel_to_tree().unwrap();
         let diff = repo
             .diff_tree_to_tree(Some(&head), Some(&head), None)
@@ -678,6 +680,12 @@ mod tests {
 
     fn run_git(dir: &Path, args: &[&str]) {
         let output = std::process::Command::new("git")
+            .args([
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "init.defaultRefFormat=files",
+            ])
             .args(args)
             .current_dir(dir)
             .output()

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -219,6 +219,8 @@ mod tests {
         // `-c commit.gpgsign=false` overrides any global signing config so
         // contributors with commit signing enabled aren't prompted to sign
         // throwaway commits in these temp repos.
+        // `-c safe.bareRepository=all` allows commands run inside bare test
+        // repositories to work on systems with `safe.bareRepository=explicit`.
         let output = Command::new("git")
             .current_dir(workdir)
             .args([
@@ -226,6 +228,8 @@ mod tests {
                 "commit.gpgsign=false",
                 "-c",
                 "init.defaultRefFormat=files",
+                "-c",
+                "safe.bareRepository=all",
             ])
             .args(args)
             .output()

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -221,7 +221,12 @@ mod tests {
         // throwaway commits in these temp repos.
         let output = Command::new("git")
             .current_dir(workdir)
-            .args(["-c", "commit.gpgsign=false"])
+            .args([
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "init.defaultRefFormat=files",
+            ])
             .args(args)
             .output()
             .expect("failed to run git");

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -196,10 +196,15 @@ fn run_git_command(workdir: &Path, args: &[&str]) -> Result<String> {
     // calls this makes in production, but it keeps the test-only `commit`
     // calls below from prompting contributors with commit signing enabled
     // globally to sign throwaway commits in temp repos.
-    let full_args: Vec<&str> = ["-c", "commit.gpgsign=false"]
-        .into_iter()
-        .chain(args.iter().copied())
-        .collect();
+    let full_args: Vec<&str> = [
+        "-c",
+        "commit.gpgsign=false",
+        "-c",
+        "init.defaultRefFormat=files",
+    ]
+    .into_iter()
+    .chain(args.iter().copied())
+    .collect();
     run_command_output(
         "git",
         Some(workdir),


### PR DESCRIPTION
Two commits:

## vcs/git: use files ref format in test helpers

libgit2 does not yet support reftable. Ensure temporary repositories for
unit tests use the files backend instead.

Update should_return_no_changes_for_clean_repo to create its own
temporary repository.

## vcs/git: allow bare repo discovery in libgit2 test

Allow bare repository discovery in libgit2 worktree tests on systems
with explicit bare repo hardening (safe.bareRepository=explicit).