### PR TITLE
feat(comments): compose the comment draft in `$EDITOR` with `Ctrl-o`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ src/
 │   └── file_filter.rs   # File-tree include/exclude regex filters + `/` path search
 ├── error.rs             # Error types (TuicrError enum)
 ├── editor.rs            # External $EDITOR command construction and launch helpers
+├── comment_draft.rs     # Comment-box drafts as $EDITOR buffers (scissors template + hunk context)
 ├── review_store.rs      # Library API for session listing/loading and shared comment insertion
 ├── review_cli.rs        # Non-interactive `tuicr review` subcommands over ReviewStore
 ├── update.rs            # Public update facade

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `r` | Toggle file reviewed |
 | `R` | Toggle hunk reviewed |
 | `e` | Open focused file in `$EDITOR` |
+| `Ctrl-o` (comment box) | Compose the comment in `$EDITOR`, with the hunk as context |
 | `y` | Copy review to clipboard |
 | `:edit` | Open focused file in `$EDITOR` |
 | `:submit` | Push review to GitHub, GitLab, or Bitbucket |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -168,7 +168,16 @@ editor back into the blocking behaviour.
 | `←` / `→` | Move cursor |
 | `Ctrl-w` / `Alt-Backspace` / `Cmd-Backspace` | Delete word |
 | `Ctrl-u` | Clear line |
+| `Ctrl-o` | Compose the draft in `$EDITOR` |
 | `Esc` / `Ctrl-c` | Cancel |
+
+`Ctrl-o` hands the draft to `$EDITOR` as a temporary Markdown file laid out like
+a `git commit` buffer: the comment body at the top, and the hunk being commented
+on below a `# ------ >8 ------` scissors line as `#`-prefixed context. Only the
+text above the scissors comes back, so `#` headings in the body are kept as
+typed. Saving an empty body leaves the draft as it was. Windowed editors
+(`code`, `cursor`, `zed`, …) are launched with `--wait`, because the draft cannot
+be read back until the editor exits.
 
 With `comment_vim = true` the box uses [`edtui`](https://github.com/preiter93/edtui)
 modal editing (Normal/Insert/Visual: `hjkl`, `w`/`b`/`e`, `dd`/`D`/`ciw`/`x`,

--- a/src/app/comment_draft.rs
+++ b/src/app/comment_draft.rs
@@ -1,0 +1,101 @@
+use crate::comment_draft::{self, DraftContext};
+
+use super::*;
+
+impl App {
+    /// Queues the comment draft for the external editor.
+    ///
+    /// The rendered buffer is left on `pending_comment_draft` for the main
+    /// event loop, which owns the terminal handoff, exactly like
+    /// `pending_editor_target`.
+    pub fn queue_comment_draft_editor(&mut self) {
+        if self.input_mode != InputMode::Comment {
+            return;
+        }
+        let context = self.comment_draft_context();
+        self.pending_comment_draft =
+            Some(comment_draft::render_draft(&self.comment_buffer, &context));
+    }
+
+    /// Takes the queued draft buffer after action dispatch.
+    pub fn take_pending_comment_draft(&mut self) -> Option<String> {
+        self.pending_comment_draft.take()
+    }
+
+    /// Adopts the comment body the editor wrote back.
+    ///
+    /// An empty body leaves the draft alone: an editor that was quit without
+    /// saving, or whose buffer was emptied, should not silently discard what
+    /// the user had already typed in the comment box.
+    pub fn apply_comment_draft(&mut self, edited: &str) {
+        if self.input_mode != InputMode::Comment {
+            return;
+        }
+        let body = comment_draft::parse_draft(edited);
+        if body.is_empty() {
+            self.set_warning("Draft unchanged: the editor returned an empty comment");
+            return;
+        }
+        if body == self.comment_buffer {
+            self.set_message("Draft unchanged");
+            return;
+        }
+        self.comment_buffer = body;
+        self.comment_cursor = self.comment_buffer.len();
+        // The vim overlay holds its own copy of the text; drop it so the next
+        // key reseeds it from what the editor returned.
+        self.comment_vim_editor = None;
+        self.comment_vim_command = None;
+        self.comment_vim_pending = CommentVimPending::None;
+        self.set_message("Comment draft updated from editor");
+    }
+
+    /// Describes what the draft is attached to, for the context block below
+    /// the scissors line.
+    fn comment_draft_context(&self) -> DraftContext {
+        if self.comment_is_review_level {
+            return DraftContext::targeting("the whole review");
+        }
+        let Some(path) = self.current_file_path().cloned() else {
+            return DraftContext::default();
+        };
+        let target = self.comment_line_range.or_else(|| {
+            self.comment_line
+                .map(|(line, side)| (LineRange::single(line), side))
+        });
+        let Some((range, side)) = target.filter(|_| !self.comment_is_file_level) else {
+            return DraftContext::targeting(format!("{} (whole file)", path.display()));
+        };
+
+        let side_label = match side {
+            LineSide::Old => "old",
+            LineSide::New => "new",
+        };
+        let target = if range.is_single() {
+            format!("{}:{} ({side_label})", path.display(), range.end)
+        } else {
+            format!(
+                "{}:{}-{} ({side_label})",
+                path.display(),
+                range.start,
+                range.end
+            )
+        };
+        DraftContext {
+            target,
+            lines: self.comment_draft_context_lines(range, side),
+        }
+    }
+
+    /// Diff rows around the commented lines, taken from the hunk that holds
+    /// them. Lines with no matching hunk (a comment carried over from an
+    /// earlier diff, say) simply get no context.
+    fn comment_draft_context_lines(&self, range: LineRange, side: LineSide) -> Vec<String> {
+        self.current_file()
+            .into_iter()
+            .flat_map(|file| file.hunks.iter())
+            .map(|hunk| comment_draft::context_lines(hunk, range, side))
+            .find(|lines| !lines.is_empty())
+            .unwrap_or_default()
+    }
+}

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -482,6 +482,7 @@ impl App {
             diff_files,
             diff_source,
             pending_editor_target: None,
+            pending_comment_draft: None,
             editor_launches: Vec::new(),
             input_mode,
             focused_panel: FocusedPanel::Diff,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1114,6 +1114,11 @@ pub struct App {
     pub diff_files: Vec<DiffFile>,
     pub diff_source: DiffSource,
     pub pending_editor_target: Option<EditorTarget>,
+    /// Comment-box draft queued for `$EDITOR`, as the full editor buffer
+    /// (body plus commented-out diff context). Consumed by the main event
+    /// loop, like `pending_editor_target`, because the handoff needs the
+    /// terminal.
+    pub pending_comment_draft: Option<String>,
     /// Windowed editors that have not exited yet; polled by
     /// `poll_editor_launches`.
     pub(crate) editor_launches: Vec<EditorLaunch>,
@@ -1755,6 +1760,7 @@ impl AppStartupOptions<'_> {
 }
 
 mod annotations;
+mod comment_draft;
 mod comment_vim;
 mod comments;
 mod commits;

--- a/src/app/tests/comment_draft_tests.rs
+++ b/src/app/tests/comment_draft_tests.rs
@@ -1,0 +1,276 @@
+use crate::app::*;
+use crate::comment_draft::SCISSORS;
+use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+use std::path::PathBuf;
+
+struct StubVcs(VcsInfo);
+impl VcsBackend for StubVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.0
+    }
+    fn get_working_tree_diff(
+        &self,
+        _hl: &crate::syntax::SyntaxHighlighter,
+    ) -> crate::error::Result<Vec<DiffFile>> {
+        Ok(Vec::new())
+    }
+    fn fetch_context_lines(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start: u32,
+        _end: u32,
+    ) -> crate::error::Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+    fn file_line_count(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> crate::error::Result<u32> {
+        Ok(0)
+    }
+}
+
+/// A three-line hunk: context at 10, a deletion of old 11, an addition at 11.
+fn hunk() -> DiffHunk {
+    let lines = vec![
+        DiffLine {
+            origin: LineOrigin::Context,
+            content: "    let cfg = load();".to_string(),
+            old_lineno: Some(10),
+            new_lineno: Some(10),
+            highlighted_spans: None,
+        },
+        DiffLine {
+            origin: LineOrigin::Deletion,
+            content: "    let old = 1;".to_string(),
+            old_lineno: Some(11),
+            new_lineno: None,
+            highlighted_spans: None,
+        },
+        DiffLine {
+            origin: LineOrigin::Addition,
+            content: "    let new = 2;".to_string(),
+            old_lineno: None,
+            new_lineno: Some(11),
+            highlighted_spans: None,
+        },
+    ];
+    DiffHunk {
+        header: "@@ -10,2 +10,2 @@".to_string(),
+        lines,
+        old_start: 10,
+        old_count: 2,
+        new_start: 10,
+        new_count: 2,
+    }
+}
+
+fn app_with(files: Vec<DiffFile>) -> App {
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: "head".into(),
+        branch_name: Some("main".into()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+    App::build(
+        Box::new(StubVcs(vcs_info.clone())),
+        vcs_info,
+        crate::theme::Theme::dark(),
+        None,
+        false,
+        files,
+        session,
+        DiffSource::WorkingTree,
+        InputMode::Normal,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("build app")
+}
+
+fn app_on_a_diff_line() -> App {
+    let hunks = vec![hunk()];
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+    let mut app = app_with(vec![DiffFile {
+        old_path: None,
+        new_path: Some(PathBuf::from("src/main.rs")),
+        status: FileStatus::Modified,
+        hunks,
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash,
+    }]);
+    // Park the cursor on a diff row so the comment target resolves to the file
+    // rather than the review overview.
+    app.diff_state.cursor_line = app
+        .line_annotations
+        .iter()
+        .position(|line| matches!(line, AnnotatedLine::DiffLine { .. }))
+        .expect("a diff row");
+    app
+}
+
+/// The context block, with its `# ` prefix stripped.
+fn context_block(buffer: &str) -> Vec<String> {
+    buffer
+        .lines()
+        .skip_while(|line| *line != SCISSORS)
+        .skip(1)
+        .map(|line| {
+            line.trim_start_matches('#')
+                .trim_start_matches(' ')
+                .to_string()
+        })
+        .collect()
+}
+
+#[test]
+fn a_line_comment_hands_over_the_commented_hunk() {
+    let mut app = app_on_a_diff_line();
+    app.enter_comment_mode(false, Some((11, LineSide::New)));
+    app.comment_buffer = "this can be null".to_string();
+
+    app.queue_comment_draft_editor();
+    let buffer = app.take_pending_comment_draft().expect("queued draft");
+
+    assert!(buffer.starts_with("this can be null\n"), "{buffer}");
+    let context = context_block(&buffer);
+    assert!(
+        context.contains(&"Commenting on src/main.rs:11 (new)".to_string()),
+        "{context:?}"
+    );
+    assert!(
+        context.iter().any(|line| line.ends_with("let new = 2;")),
+        "{context:?}"
+    );
+    assert!(
+        context
+            .iter()
+            .any(|line| line.ends_with("let cfg = load();")),
+        "{context:?}"
+    );
+}
+
+#[test]
+fn a_range_comment_names_both_ends() {
+    let mut app = app_on_a_diff_line();
+    app.enter_comment_mode(false, Some((11, LineSide::New)));
+    app.comment_line_range = Some((LineRange::new(10, 11), LineSide::New));
+
+    app.queue_comment_draft_editor();
+    let buffer = app.take_pending_comment_draft().expect("queued draft");
+
+    assert!(
+        context_block(&buffer).contains(&"Commenting on src/main.rs:10-11 (new)".to_string()),
+        "{buffer}"
+    );
+}
+
+#[test]
+fn a_file_comment_has_no_diff_context() {
+    let mut app = app_on_a_diff_line();
+    app.enter_comment_mode(true, None);
+
+    app.queue_comment_draft_editor();
+    let buffer = app.take_pending_comment_draft().expect("queued draft");
+
+    let context = context_block(&buffer);
+    assert!(
+        context.contains(&"Commenting on src/main.rs (whole file)".to_string()),
+        "{context:?}"
+    );
+    assert!(
+        !context.iter().any(|line| line.contains("let new = 2;")),
+        "{context:?}"
+    );
+}
+
+#[test]
+fn a_review_comment_targets_the_review() {
+    let mut app = app_on_a_diff_line();
+    app.enter_review_comment_mode();
+
+    app.queue_comment_draft_editor();
+    let buffer = app.take_pending_comment_draft().expect("queued draft");
+
+    assert!(
+        context_block(&buffer).contains(&"Commenting on the whole review".to_string()),
+        "{buffer}"
+    );
+}
+
+#[test]
+fn nothing_is_queued_outside_comment_mode() {
+    let mut app = app_on_a_diff_line();
+    app.queue_comment_draft_editor();
+    assert!(app.take_pending_comment_draft().is_none());
+}
+
+#[test]
+fn the_edited_body_becomes_the_draft() {
+    let mut app = app_on_a_diff_line();
+    app.enter_comment_mode(false, Some((11, LineSide::New)));
+    app.comment_buffer = "rough note".to_string();
+    app.comment_cursor = app.comment_buffer.len();
+    app.queue_comment_draft_editor();
+    let buffer = app.take_pending_comment_draft().expect("queued draft");
+
+    let edited = buffer.replace("rough note", "# Heading\n\npolished note");
+    app.apply_comment_draft(&edited);
+
+    assert_eq!(app.comment_buffer, "# Heading\n\npolished note");
+    assert_eq!(app.comment_cursor, app.comment_buffer.len());
+}
+
+#[test]
+fn an_emptied_buffer_leaves_the_draft_alone() {
+    let mut app = app_on_a_diff_line();
+    app.enter_comment_mode(false, Some((11, LineSide::New)));
+    app.comment_buffer = "keep me".to_string();
+
+    app.apply_comment_draft(&format!(
+        "\n{SCISSORS}\n# Commenting on src/main.rs:11 (new)\n"
+    ));
+
+    assert_eq!(app.comment_buffer, "keep me");
+}
+
+#[test]
+fn the_vim_overlay_is_reseeded_from_the_edited_body() {
+    let mut app = app_on_a_diff_line();
+    app.comment_vim_enabled = true;
+    app.enter_comment_mode(false, Some((11, LineSide::New)));
+    app.ensure_comment_vim_editor();
+    assert!(app.comment_vim_editor.is_some());
+
+    app.apply_comment_draft(&format!("from the editor\n{SCISSORS}\n"));
+
+    assert_eq!(app.comment_buffer, "from the editor");
+    assert!(
+        app.comment_vim_editor.is_none(),
+        "the stale overlay must be dropped so it reseeds"
+    );
+    app.ensure_comment_vim_editor();
+    app.comment_vim_feed_key(crossterm::event::KeyEvent::new(
+        crossterm::event::KeyCode::Char('!'),
+        crossterm::event::KeyModifiers::NONE,
+    ));
+    assert!(
+        app.comment_buffer.starts_with("from the editor"),
+        "{}",
+        app.comment_buffer
+    );
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -1,4 +1,5 @@
 mod change_status_tests;
+mod comment_draft_tests;
 mod commit_scoped_comment_tests;
 mod commit_selection_tests;
 mod decoration_skip_tests;

--- a/src/comment_draft.rs
+++ b/src/comment_draft.rs
@@ -1,0 +1,346 @@
+//! Composing a review comment in the user's `$EDITOR`.
+//!
+//! The comment box hands its draft to the editor as a temporary Markdown file
+//! laid out like a `git commit` buffer: the comment body sits at the top, and
+//! the diff being commented on follows below a scissors line as `#`-prefixed
+//! context. Only the text above the scissors comes back.
+//!
+//! Everything here is pure text: the terminal handoff lives in `main`, and the
+//! draft target is resolved by `App`.
+
+use crate::model::{DiffHunk, DiffLine, LineOrigin, LineRange, LineSide};
+
+/// Separates the comment body from the read-only context below it.
+///
+/// Matches `git commit --cleanup=scissors`, which the same editors and
+/// filetype plugins already recognize.
+pub const SCISSORS: &str = "# ------------------------ >8 ------------------------";
+
+/// Diff rows kept either side of the commented lines.
+///
+/// A whole hunk can run to hundreds of lines, which would bury the comment
+/// body; a window keeps the handoff readable while still showing what the
+/// commented lines sit between.
+const CONTEXT_RADIUS: usize = 20;
+
+/// Column width for the line numbers in the context block.
+const LINENO_WIDTH: usize = 5;
+
+/// The diff a draft is attached to, rendered below the scissors line.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DraftContext {
+    /// Human-readable target, such as `src/main.rs:142-145 (new)`.
+    pub target: String,
+    /// Formatted diff rows for the commented lines and their neighbours.
+    pub lines: Vec<String>,
+}
+
+impl DraftContext {
+    /// Context for a comment with no diff rows to show, such as a file-level
+    /// or review-level comment.
+    pub fn targeting(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            lines: Vec::new(),
+        }
+    }
+}
+
+/// Builds the editor buffer for `draft`.
+///
+/// The body is reproduced verbatim so a round-trip through the editor cannot
+/// reword what the user already typed.
+pub fn render_draft(draft: &str, context: &DraftContext) -> String {
+    let mut out = String::new();
+    if !draft.is_empty() {
+        out.push_str(draft);
+        if !draft.ends_with('\n') {
+            out.push('\n');
+        }
+    }
+    // A blank line above the scissors gives the cursor somewhere to land, and
+    // keeps the body from butting against the notes.
+    out.push('\n');
+    out.push_str(SCISSORS);
+    out.push('\n');
+    push_note(&mut out, "Write the comment above the scissors line.");
+    push_note(
+        &mut out,
+        "Everything below it is discarded, and an empty comment leaves the draft as it was.",
+    );
+    if !context.target.is_empty() {
+        push_note(&mut out, &format!("Commenting on {}", context.target));
+    }
+    if !context.lines.is_empty() {
+        push_note(&mut out, "");
+        for line in &context.lines {
+            push_note(&mut out, line);
+        }
+    }
+    out
+}
+
+/// Extracts the comment body from an edited buffer.
+///
+/// Only the scissors line terminates the body: a `#` heading is ordinary
+/// Markdown in a review comment, so `#`-prefixed lines above the scissors are
+/// kept as typed.
+pub fn parse_draft(text: &str) -> String {
+    text.lines()
+        .take_while(|line| line.trim_end() != SCISSORS)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+/// One-based line the editor should open on: the blank line under the body.
+pub fn cursor_line(buffer: &str) -> Option<u32> {
+    let scissors = buffer
+        .lines()
+        .position(|line| line.trim_end() == SCISSORS)?;
+    u32::try_from(scissors.max(1)).ok()
+}
+
+/// Formats the diff rows around `range` in `hunk` for the context block.
+///
+/// Rows outside the window are replaced by a count, so a clipped hunk never
+/// looks like the whole one.
+pub fn context_lines(hunk: &DiffHunk, range: LineRange, side: LineSide) -> Vec<String> {
+    let targeted: Vec<usize> = hunk
+        .lines
+        .iter()
+        .enumerate()
+        .filter(|(_, line)| line_in_range(line, range, side))
+        .map(|(idx, _)| idx)
+        .collect();
+    // Without a matching row there is nothing to centre the window on; the
+    // target header still names the lines.
+    let (Some(&first), Some(&last)) = (targeted.first(), targeted.last()) else {
+        return Vec::new();
+    };
+
+    let start = first.saturating_sub(CONTEXT_RADIUS);
+    let end = (last + CONTEXT_RADIUS + 1).min(hunk.lines.len());
+    let mut rows = Vec::new();
+    if start > 0 {
+        rows.push(elision(start));
+    }
+    rows.extend(hunk.lines[start..end].iter().map(format_row));
+    let trailing = hunk.lines.len() - end;
+    if trailing > 0 {
+        rows.push(elision(trailing));
+    }
+    rows
+}
+
+/// Whether `line` is one of the lines the comment targets.
+fn line_in_range(line: &DiffLine, range: LineRange, side: LineSide) -> bool {
+    let lineno = match side {
+        LineSide::Old => line.old_lineno,
+        LineSide::New => line.new_lineno,
+    };
+    lineno.is_some_and(|lineno| lineno >= range.start && lineno <= range.end)
+}
+
+/// Renders one diff row as `{origin}{lineno} {content}`.
+fn format_row(line: &DiffLine) -> String {
+    let origin = match line.origin {
+        LineOrigin::Context => ' ',
+        LineOrigin::Addition => '+',
+        LineOrigin::Deletion => '-',
+    };
+    let lineno = match line.origin {
+        LineOrigin::Deletion => line.old_lineno,
+        _ => line.new_lineno.or(line.old_lineno),
+    };
+    let lineno = lineno.map_or_else(
+        || " ".repeat(LINENO_WIDTH),
+        |lineno| format!("{lineno:>LINENO_WIDTH$}"),
+    );
+    let content = line.content.trim_end_matches(['\n', '\r']);
+    format!("{origin}{lineno} {content}")
+}
+
+fn elision(count: usize) -> String {
+    let plural = if count == 1 { "" } else { "s" };
+    format!("\u{2026} {count} more line{plural} in this hunk")
+}
+
+fn push_note(out: &mut String, text: &str) {
+    if text.is_empty() {
+        out.push_str("#\n");
+    } else {
+        out.push_str("# ");
+        out.push_str(text);
+        out.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(origin: LineOrigin, old: Option<u32>, new: Option<u32>, content: &str) -> DiffLine {
+        DiffLine {
+            origin,
+            content: content.to_string(),
+            old_lineno: old,
+            new_lineno: new,
+            highlighted_spans: None,
+        }
+    }
+
+    fn hunk(lines: Vec<DiffLine>) -> DiffHunk {
+        DiffHunk {
+            header: "@@ -1,1 +1,1 @@".to_string(),
+            lines,
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 1,
+        }
+    }
+
+    /// A hunk of `count` context lines numbered from 1 on both sides.
+    fn context_hunk(count: u32) -> DiffHunk {
+        hunk(
+            (1..=count)
+                .map(|n| line(LineOrigin::Context, Some(n), Some(n), &format!("line {n}")))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn the_draft_body_is_reproduced_above_the_scissors() {
+        let buffer = render_draft(
+            "first\nsecond",
+            &DraftContext::targeting("src/main.rs:1 (new)"),
+        );
+        assert!(buffer.starts_with("first\nsecond\n\n"), "{buffer}");
+        assert_eq!(parse_draft(&buffer), "first\nsecond");
+    }
+
+    #[test]
+    fn an_empty_draft_opens_on_an_empty_body() {
+        let buffer = render_draft("", &DraftContext::targeting("src/main.rs (whole file)"));
+        assert!(buffer.starts_with('\n'), "{buffer}");
+        assert_eq!(parse_draft(&buffer), "");
+    }
+
+    #[test]
+    fn the_target_and_context_are_commented_out() {
+        let context = DraftContext {
+            target: "src/main.rs:2 (new)".to_string(),
+            lines: context_lines(&context_hunk(3), LineRange::single(2), LineSide::New),
+        };
+        let buffer = render_draft("look here", &context);
+        let below: Vec<&str> = buffer
+            .lines()
+            .skip_while(|line| *line != SCISSORS)
+            .collect();
+        assert!(
+            below.iter().all(|line| line.starts_with('#')),
+            "context must stay commented: {below:?}"
+        );
+        assert!(
+            below.contains(&"# Commenting on src/main.rs:2 (new)"),
+            "{below:?}"
+        );
+        assert!(below.contains(&"#      2 line 2"), "{below:?}");
+        assert_eq!(parse_draft(&buffer), "look here");
+    }
+
+    #[test]
+    fn markdown_headings_survive_the_round_trip() {
+        let body = "# Heading\n\nnot a template note";
+        let buffer = render_draft(body, &DraftContext::targeting("src/main.rs:1 (new)"));
+        assert_eq!(parse_draft(&buffer), body);
+    }
+
+    #[test]
+    fn a_deleted_scissors_line_keeps_the_whole_buffer() {
+        let text = "body\n\n# a note that is really part of the comment";
+        assert_eq!(parse_draft(text), text);
+    }
+
+    #[test]
+    fn surrounding_blank_lines_are_trimmed() {
+        assert_eq!(parse_draft("\n\n  body  \n\n"), "body");
+    }
+
+    #[test]
+    fn the_cursor_lands_on_the_blank_line_under_the_body() {
+        let context = DraftContext::targeting("src/main.rs:1 (new)");
+        assert_eq!(cursor_line(&render_draft("", &context)), Some(1));
+        assert_eq!(cursor_line(&render_draft("one line", &context)), Some(2));
+        assert_eq!(cursor_line(&render_draft("two\nlines", &context)), Some(3));
+        assert_eq!(cursor_line("no scissors here"), None);
+    }
+
+    #[test]
+    fn context_rows_carry_the_origin_and_line_number() {
+        let hunk = hunk(vec![
+            line(
+                LineOrigin::Context,
+                Some(10),
+                Some(10),
+                "    let cfg = load();",
+            ),
+            line(LineOrigin::Deletion, Some(11), None, "    let old = 1;"),
+            line(LineOrigin::Addition, None, Some(11), "    let new = 2;"),
+        ]);
+        assert_eq!(
+            context_lines(&hunk, LineRange::single(11), LineSide::New),
+            vec![
+                "    10     let cfg = load();".to_string(),
+                "-   11     let old = 1;".to_string(),
+                "+   11     let new = 2;".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_long_hunk_is_windowed_around_the_commented_lines() {
+        let rows = context_lines(&context_hunk(200), LineRange::new(100, 101), LineSide::New);
+        assert_eq!(
+            rows.first().map(String::as_str),
+            Some("… 79 more lines in this hunk")
+        );
+        assert_eq!(
+            rows.last().map(String::as_str),
+            Some("… 79 more lines in this hunk")
+        );
+        assert!(rows.contains(&"   100 line 100".to_string()), "{rows:?}");
+        assert!(rows.contains(&"   101 line 101".to_string()), "{rows:?}");
+        // 20 rows either side of the two commented lines, plus both markers.
+        assert_eq!(rows.len(), CONTEXT_RADIUS * 2 + 2 + 2);
+    }
+
+    #[test]
+    fn a_short_hunk_is_shown_whole_without_markers() {
+        let rows = context_lines(&context_hunk(3), LineRange::single(2), LineSide::New);
+        assert_eq!(rows.len(), 3);
+        assert!(
+            !rows.iter().any(|row| row.contains("more line")),
+            "{rows:?}"
+        );
+    }
+
+    #[test]
+    fn old_side_targets_match_deleted_lines() {
+        let hunk = hunk(vec![
+            line(LineOrigin::Deletion, Some(7), None, "gone"),
+            line(LineOrigin::Addition, None, Some(7), "new"),
+        ]);
+        let rows = context_lines(&hunk, LineRange::single(7), LineSide::Old);
+        assert_eq!(rows.len(), 2);
+        assert!(rows[0].starts_with("-    7 gone"), "{rows:?}");
+    }
+
+    #[test]
+    fn a_target_outside_the_hunk_renders_no_context() {
+        let rows = context_lines(&context_hunk(3), LineRange::single(99), LineSide::New);
+        assert!(rows.is_empty(), "{rows:?}");
+    }
+}

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -45,6 +45,16 @@ impl EditorCommand {
         Self::from_editor(&editor, target)
     }
 
+    /// Builds an invocation from `$EDITOR` that always blocks until the file is
+    /// closed.
+    ///
+    /// Used when tuicr needs to read the file back afterwards, so a windowed
+    /// editor that would otherwise return immediately gets its wait flag.
+    pub fn blocking_from_env(target: &EditorTarget) -> Self {
+        let editor = std::env::var("EDITOR").unwrap_or_default();
+        Self::blocking_from_editor(&editor, target)
+    }
+
     /// Builds an invocation from an editor command string.
     ///
     /// The command is split with shell-like quoting rules,
@@ -56,11 +66,32 @@ impl EditorCommand {
     /// `vim -f` with line 42 becomes `vim -f +42 /repo/src/main.rs`,
     /// while `code` becomes `code --goto /repo/src/main.rs:42`.
     pub fn from_editor(editor: &str, target: &EditorTarget) -> Self {
+        Self::build(editor, target, false)
+    }
+
+    /// Builds a blocking invocation from an editor command string.
+    ///
+    /// Terminal editors already block; a known windowed editor gains its wait
+    /// flag (`code --wait /repo/src/main.rs`) unless the user has already
+    /// asked for one. An unrecognized windowed editor cannot be made to wait,
+    /// and is left as the user wrote it.
+    pub fn blocking_from_editor(editor: &str, target: &EditorTarget) -> Self {
+        Self::build(editor, target, true)
+    }
+
+    fn build(editor: &str, target: &EditorTarget, require_wait: bool) -> Self {
         let mut parts = shlex::split(editor)
             .filter(|parts| !parts.is_empty())
             .unwrap_or_else(|| vec!["vi".to_string()]);
         let program = parts.remove(0);
         let mut args: Vec<OsString> = parts.into_iter().map(OsString::from).collect();
+
+        if require_wait
+            && !waits_for_close(&args)
+            && let Some(flag) = wait_flag(&program)
+        {
+            args.push(OsString::from(flag));
+        }
 
         match (editor_family(&program), target.line) {
             (EditorFamily::PlusLine, Some(line)) => {
@@ -107,10 +138,7 @@ impl EditorCommand {
     pub fn surface(&self) -> EditorSurface {
         // An explicit wait flag means the user wants tuicr to block until the
         // file is closed, so the terminal has to be handed over either way.
-        let waits = self
-            .args
-            .iter()
-            .any(|arg| arg == "-w" || arg == "--wait" || arg == "--block");
+        let waits = waits_for_close(&self.args);
         if !waits && is_windowed_editor(&self.program) {
             EditorSurface::Gui
         } else {
@@ -164,18 +192,33 @@ pub enum EditorSurface {
     Gui,
 }
 
+/// Whether an argument list already asks the editor to block.
+fn waits_for_close(args: &[OsString]) -> bool {
+    args.iter()
+        .any(|arg| arg == "-w" || arg == "--wait" || arg == "--block")
+}
+
+/// Flag that makes a known windowed editor block until the file is closed.
+///
+/// Terminal editors need no flag, and unknown programs get none because a
+/// rejected flag would stop the editor from opening at all.
+fn wait_flag(program: &str) -> Option<&'static str> {
+    let name = executable_name(program);
+    match name {
+        "mate" => Some("-w"),
+        _ if is_windowed_editor(name) => Some("--wait"),
+        _ => None,
+    }
+}
+
 /// Whether a program is a known editor that opens its own window.
 ///
 /// Unrecognized editors are assumed to be terminal editors: suspending for a
 /// GUI editor costs a flicker, while not suspending for a terminal editor
 /// leaves two programs fighting over the same screen.
 fn is_windowed_editor(program: &str) -> bool {
-    let name = Path::new(program)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(program);
     matches!(
-        name,
+        executable_name(program),
         "code"
             | "code-insiders"
             | "codium"
@@ -196,6 +239,14 @@ fn is_windowed_editor(program: &str) -> bool {
     )
 }
 
+/// Executable name from a program path, for matching against known editors.
+fn executable_name(program: &str) -> &str {
+    Path::new(program)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(program)
+}
+
 /// Line-navigation syntax family for a recognized editor executable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum EditorFamily {
@@ -208,11 +259,7 @@ enum EditorFamily {
 }
 
 fn editor_family(program: &str) -> EditorFamily {
-    let name = Path::new(program)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(program);
-    match name {
+    match executable_name(program) {
         "vi" | "vim" | "nvim" | "nano" | "emacs" | "emacsclient" | "hx" => EditorFamily::PlusLine,
         "code" | "code-insiders" | "codium" | "cursor" => EditorFamily::GotoLine,
         _ => EditorFamily::Plain,
@@ -347,6 +394,37 @@ mod tests {
         for editor in ["code --wait", "code -w", "zed --wait"] {
             let command = EditorCommand::from_editor(editor, &target(Some(42)));
             assert_eq!(command.surface(), EditorSurface::Terminal, "{editor}");
+        }
+    }
+
+    #[test]
+    fn blocking_windowed_editors_gain_their_wait_flag() {
+        let command = EditorCommand::blocking_from_editor("code", &target(Some(42)));
+        assert_eq!(command.program, "code");
+        assert_eq!(
+            args(&command),
+            vec!["--wait", "--goto", "/repo/src/main.rs:42"]
+        );
+        assert_eq!(command.surface(), EditorSurface::Terminal);
+
+        let command = EditorCommand::blocking_from_editor("mate", &target(None));
+        assert_eq!(args(&command), vec!["-w", "/repo/src/main.rs"]);
+    }
+
+    #[test]
+    fn blocking_editors_keep_an_existing_wait_flag() {
+        let command = EditorCommand::blocking_from_editor("code --wait", &target(None));
+        assert_eq!(args(&command), vec!["--wait", "/repo/src/main.rs"]);
+    }
+
+    #[test]
+    fn blocking_terminal_editors_are_unchanged() {
+        for editor in ["vim", "nvim -f", "kak"] {
+            let blocking = EditorCommand::blocking_from_editor(editor, &target(Some(42)));
+            assert_eq!(
+                blocking,
+                EditorCommand::from_editor(editor, &target(Some(42)))
+            );
         }
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1157,6 +1157,7 @@ pub fn handle_comment_action(app: &mut App, action: Action) {
         }
         Action::ExitMode => app.exit_comment_mode(),
         Action::SubmitInput => app.save_comment(),
+        Action::EditCommentDraft => app.queue_comment_draft_editor(),
         Action::CycleCommentType => app.cycle_comment_type(),
         Action::CycleCommentTypeReverse => app.cycle_comment_type_reverse(),
         Action::TextCursorLeft => {

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -45,6 +45,9 @@ pub enum Action {
     EditCommentAtEnd,
     PendingDCommand,
     EditFile,
+    /// Comment mode: hand the draft to `$EDITOR` with the commented hunk as
+    /// context.
+    EditCommentDraft,
     SearchNext,
     SearchPrev,
     ClearSearchHighlight,
@@ -307,6 +310,9 @@ fn map_comment_mode(key: KeyEvent) -> Action {
         // Char('\t') instead of KeyCode::Tab.
         (KeyCode::Tab, _) | (KeyCode::Char('\t'), _) => Action::CycleCommentType,
         (KeyCode::BackTab, _) => Action::CycleCommentTypeReverse,
+        // Compose the draft in `$EDITOR`. Ctrl-o rather than Ctrl-e, which is
+        // already end-of-line here.
+        (KeyCode::Char('o'), KeyModifiers::CONTROL) => Action::EditCommentDraft,
         // Cursor movement
         (KeyCode::Char('a'), KeyModifiers::CONTROL) => Action::TextCursorLineStart,
         (KeyCode::Char('e'), KeyModifiers::CONTROL) => Action::TextCursorLineEnd,
@@ -747,6 +753,18 @@ mod tests {
     fn should_map_lowercase_e_to_edit_file_in_normal_mode() {
         let action = map_normal_mode(key(KeyCode::Char('e')), DEFAULT_LEADER_KEY);
         assert_eq!(action, Action::EditFile);
+    }
+
+    #[test]
+    fn should_map_ctrl_o_to_editor_handoff_in_comment_mode() {
+        let action = map_comment_mode(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+        assert_eq!(action, Action::EditCommentDraft);
+    }
+
+    #[test]
+    fn should_keep_ctrl_e_as_line_end_in_comment_mode() {
+        let action = map_comment_mode(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL));
+        assert_eq!(action, Action::TextCursorLineEnd);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app;
 pub mod cli;
+pub mod comment_draft;
 pub mod comment_vim;
 pub mod config;
 pub mod editor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,6 +636,7 @@ fn main() -> anyhow::Result<()> {
                     if app.input_mode == InputMode::Comment && app.comment_vim_enabled {
                         app.ensure_comment_vim_editor();
                         if handle_comment_vim_key(&mut app, key) {
+                            run_pending_editors(&mut app, &mut terminal);
                             continue;
                         }
                     }
@@ -741,47 +742,7 @@ fn main() -> anyhow::Result<()> {
                     }
 
                     dispatch_action(&mut app, action);
-                    if let Some(target) = app.take_pending_editor_target() {
-                        match run_editor_from_tui(&mut terminal, &target) {
-                            // The editor is still open, so there is nothing to
-                            // pick up yet; the user reloads once they are done.
-                            Ok(Ok(EditorOutcome::Detached(launch))) => {
-                                app.track_editor_launch(launch);
-                                let hint = if app.diff_source.includes_worktree_changes() {
-                                    " (:e to reload)"
-                                } else {
-                                    ""
-                                };
-                                app.set_message(format!("Opened {}{hint}", target.path.display()));
-                            }
-                            Ok(Ok(EditorOutcome::Finished)) => {
-                                if app.diff_source.includes_worktree_changes() {
-                                    match app.reload_diff_files() {
-                                        Ok((count, invalidated)) => {
-                                            let invalidated_suffix = if invalidated > 0 {
-                                                format!(", {invalidated} changed since last review")
-                                            } else {
-                                                String::new()
-                                            };
-                                            app.set_message(format!(
-                                                "Opened {} and reloaded {count} files{invalidated_suffix}",
-                                                target.path.display()
-                                            ));
-                                        }
-                                        Err(err) => {
-                                            app.set_error(format!(
-                                                "Reload after editor failed: {err}"
-                                            ));
-                                        }
-                                    }
-                                } else {
-                                    app.set_message(format!("Opened {}", target.path.display()));
-                                }
-                            }
-                            Ok(Err(err)) => app.set_error(err.to_string()),
-                            Err(err) => app.set_error(format!("Failed to restore terminal: {err}")),
-                        }
-                    }
+                    run_pending_editors(&mut app, &mut terminal);
                 }
                 Event::Mouse(mouse_event) => handle_mouse_event(&mut app, mouse_event),
                 Event::Paste(text) => {
@@ -916,6 +877,8 @@ fn handle_comment_vim_key(app: &mut App, key: crossterm::event::KeyEvent) -> boo
         // Save shortcut in any mode (Ctrl-C cancel is handled earlier).
         KeyCode::Char('s') if ctrl => app.save_comment(),
         KeyCode::Enter if ctrl => app.save_comment(),
+        // Compose the draft in `$EDITOR`, as in the non-vim comment box.
+        KeyCode::Char('o') if ctrl => app.queue_comment_draft_editor(),
         // Tab cycles the comment type in Normal mode; in Insert it inserts a
         // soft tab (`comment_tab_width` spaces).
         KeyCode::Tab | KeyCode::Char('\t') if normal => app.cycle_comment_type(),
@@ -927,6 +890,59 @@ fn handle_comment_vim_key(app: &mut App, key: crossterm::event::KeyEvent) -> boo
         _ => app.comment_vim_feed_key(key),
     }
     true
+}
+
+/// Runs any editor handoff queued by the action just dispatched.
+///
+/// `App` cannot do this itself: both handoffs need the terminal, which the
+/// event loop owns.
+fn run_pending_editors<W: Write>(app: &mut App, terminal: &mut TerminalSession<W>) {
+    if let Some(target) = app.take_pending_editor_target() {
+        match run_editor_from_tui(terminal, &target) {
+            // The editor is still open, so there is nothing to
+            // pick up yet; the user reloads once they are done.
+            Ok(Ok(EditorOutcome::Detached(launch))) => {
+                app.track_editor_launch(launch);
+                let hint = if app.diff_source.includes_worktree_changes() {
+                    " (:e to reload)"
+                } else {
+                    ""
+                };
+                app.set_message(format!("Opened {}{hint}", target.path.display()));
+            }
+            Ok(Ok(EditorOutcome::Finished)) => {
+                if app.diff_source.includes_worktree_changes() {
+                    match app.reload_diff_files() {
+                        Ok((count, invalidated)) => {
+                            let invalidated_suffix = if invalidated > 0 {
+                                format!(", {invalidated} changed since last review")
+                            } else {
+                                String::new()
+                            };
+                            app.set_message(format!(
+                                "Opened {} and reloaded {count} files{invalidated_suffix}",
+                                target.path.display()
+                            ));
+                        }
+                        Err(err) => {
+                            app.set_error(format!("Reload after editor failed: {err}"));
+                        }
+                    }
+                } else {
+                    app.set_message(format!("Opened {}", target.path.display()));
+                }
+            }
+            Ok(Err(err)) => app.set_error(err.to_string()),
+            Err(err) => app.set_error(format!("Failed to restore terminal: {err}")),
+        }
+    }
+    if let Some(buffer) = app.take_pending_comment_draft() {
+        match edit_comment_draft_from_tui(terminal, &buffer) {
+            Ok(Ok(edited)) => app.apply_comment_draft(&edited),
+            Ok(Err(err)) => app.set_error(err.to_string()),
+            Err(err) => app.set_error(format!("Comment draft handoff failed: {err}")),
+        }
+    }
 }
 
 /// How the editor handoff ended, so the caller knows whether the file could
@@ -952,6 +968,41 @@ fn run_editor_from_tui<W: Write>(
     let editor_result = tuicr::editor::run_editor(&command);
     suspension.resume()?;
     Ok(editor_result.map(|()| EditorOutcome::Finished))
+}
+
+/// Hands a comment draft to the editor and reads the edited buffer back.
+///
+/// The draft lives in a temporary Markdown file, so `$EDITOR` gets Markdown
+/// highlighting and the review session is never touched by a half-finished
+/// edit. Unlike opening a source file, this always waits for the editor: there
+/// is nothing to read back until it exits.
+fn edit_comment_draft_from_tui<W: Write>(
+    terminal: &mut TerminalSession<W>,
+    buffer: &str,
+) -> anyhow::Result<Result<String, EditorError>> {
+    let mut file = tempfile::Builder::new()
+        .prefix("tuicr-comment-")
+        .suffix(".md")
+        .tempfile()?;
+    file.write_all(buffer.as_bytes())?;
+    file.flush()?;
+    let target = EditorTarget {
+        path: file.path().to_path_buf(),
+        line: tuicr::comment_draft::cursor_line(buffer),
+    };
+    let command = EditorCommand::blocking_from_env(&target);
+
+    let suspension = terminal.suspend()?;
+    let editor_result = tuicr::editor::run_editor(&command);
+    suspension.resume()?;
+
+    match editor_result {
+        // Read by path rather than through the handle: editors that save by
+        // writing a new file and renaming it over the old one leave our handle
+        // pointing at the replaced inode.
+        Ok(()) => Ok(Ok(std::fs::read_to_string(file.path())?)),
+        Err(err) => Ok(Err(err)),
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -636,6 +636,13 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  Ctrl-O    ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Compose the draft in $EDITOR (with the hunk as context)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  Esc/Ctrl-C",
                 Style::default().add_modifier(Modifier::BOLD),
             ),


### PR DESCRIPTION
The inline comment box is a few rows tall, which is fine for a one-line
note but cramped for anything longer — a suggestion with a fenced code
block, or a comment that wants a couple of paragraphs. `e` already hands
a source file to `$EDITOR`, but from inside the box there was no way to
reach it.

`Ctrl-o` now writes the draft to a temporary Markdown file laid out like
a `git commit` buffer: the body at the top, and the hunk being commented
on below a scissors line as `#`-prefixed context, so the lines under
review stay visible while writing about them. Whatever sits above the
scissors when the editor exits becomes the draft.

Only the scissors line terminates the body, rather than stripping every
`#`-prefixed line as `git commit` does — a `#` heading is ordinary
Markdown in a review comment, and should survive the round trip. An
empty body leaves the draft as it was, so quitting the editor without
saving can't discard what was already typed.

`Ctrl-e` is already end-of-line in the box, hence `Ctrl-o`; it works in
the vim comment box too. Windowed editors (`code`, `cursor`, `zed`, …)
are launched with their wait flag, as there's nothing to read back until
they exit — the existing `e` handoff still lets them detach. The hunk
context is windowed to 20 rows either side of the commented lines, so a
long hunk can't bury the body.

Co-Authored-By: Claude Opus 5 <jamie.tanna+claude-code@mend.io>
