### PR TITLE
fix(ui): render a visible stand-in for whitespace leader keys in help

### DIFF
--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -62,8 +62,22 @@ pub fn render_message_details(frame: &mut Frame, app: &mut App) {
     );
 }
 
+/// Printable stand-in for the configured leader key.
+///
+/// A whitespace leader (`leader = " "`) is a valid config value but renders as a
+/// blank in the help text, so substitute a visible glyph. The substitute must be
+/// exactly one display column wide: the help lines pad each chord to a fixed width.
+fn leader_display(leader: char) -> char {
+    if leader.is_whitespace() {
+        '\u{2423}'
+    } else {
+        leader
+    }
+}
+
 pub fn render_help(frame: &mut Frame, app: &mut App) {
     let theme = &app.theme;
+    let leader = leader_display(app.leader_key);
     // Center over the diff pane (matches the submit-modal anchoring) so the
     // file list doesn't tug the popup's visual centre off to one side. Fall
     // back to the full frame when no diff area is laid out yet.
@@ -195,35 +209,35 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
-                format!("  {}h/{}l     ", app.leader_key, app.leader_key),
+                format!("  {leader}h/{leader}l     "),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Focus file list/diff"),
         ]),
         Line::from(vec![
             Span::styled(
-                format!("  {}k/{}j     ", app.leader_key, app.leader_key),
+                format!("  {leader}k/{leader}j     "),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Move focus up/down between panes"),
         ]),
         Line::from(vec![
             Span::styled(
-                format!("  {}e        ", app.leader_key),
+                format!("  {leader}e        "),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle file list visibility"),
         ]),
         Line::from(vec![
             Span::styled(
-                format!("  {}s        ", app.leader_key),
+                format!("  {leader}s        "),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle commit selector visibility (also `:set commits!`)"),
         ]),
         Line::from(vec![
             Span::styled(
-                format!("  {}f        ", app.leader_key),
+                format!("  {leader}f        "),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Toggle single-file view (also `:focus` / `:f`)"),
@@ -248,7 +262,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(""),
         Line::from(Span::styled(
-            format!("Single-file view (`:focus`, `:f`, {}f)", app.leader_key),
+            format!("Single-file view (`:focus`, `:f`, {leader}f)"),
             Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
         )),
         Line::from(""),
@@ -505,7 +519,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
-                format!("  {}c        ", app.leader_key),
+                format!("  {leader}c        "),
                 Style::default().add_modifier(Modifier::BOLD),
             ),
             Span::raw("Add review comment"),
@@ -763,10 +777,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  :focus    ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw(format!(
-                "Toggle single-file view (alias `:f`, {}f)",
-                app.leader_key
-            )),
+            Span::raw(format!("Toggle single-file view (alias `:f`, {leader}f)")),
         ]),
         Line::from(vec![
             Span::styled(
@@ -1024,4 +1035,40 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
     let [area] = vertical.areas(area);
     let [area] = horizontal.areas(area);
     area
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use unicode_width::UnicodeWidthChar;
+
+    #[test]
+    fn should_substitute_a_visible_glyph_for_a_whitespace_leader() {
+        // given
+        let leader = ' ';
+        // when
+        let displayed = leader_display(leader);
+        // then
+        assert_eq!(displayed, '\u{2423}');
+    }
+
+    #[test]
+    fn should_leave_an_ordinary_leader_unchanged() {
+        // given
+        let leader = ',';
+        // when
+        let displayed = leader_display(leader);
+        // then
+        assert_eq!(displayed, ',');
+    }
+
+    #[test]
+    fn should_keep_the_substitute_one_display_column_wide() {
+        // given
+        let leader = '\t';
+        // when
+        let displayed = leader_display(leader);
+        // then
+        assert_eq!(displayed.width(), Some(1));
+    }
 }


### PR DESCRIPTION
Hey, first of all, great project! Hope you don't mind a small feature/fix pr.

**Symptom**

`leader` accepts any single character (`read_leader`, `src/config/mod.rs`), so `leader = " "` is a valid config - and it works correctly at the keymap level, space really does trigger the chords. 
The help popup (?), however, interpolated the raw char into its lines, so every leader chord rendered as a blank gap:

```
Tab/S-Tab Toggle focus next/previous panel
h/ l      Focus file list/diff
e         Toggle file list visibility
s         Toggle commit selector visibility
```


**On the column width**

The help lines pad each chord to a fixed width (`"  {leader}h/{leader}l     "`), so the substitute must occupy exactly one display column. a word like "Space" would shift the whole help block out of alignment. 
The helper returns `char` rather than `String` to make that structural, and a test asserts the substitute's display width is 1.
␣ (U+2423) is narrow in both `width` and `width_cjk`, so those columns hold everywhere. 


**Tests**

Adds a `mod tests` to `help_popup.rs`: whitespace leader -> stand-in, ordinary leader -> unchanged, and stand-in is one display column wide.

`cargo test` (1528 passed), `cargo clippy --all-targets -- -D warnings`, and `cargo fmt --all --check` are clean. 

Verified by hand in the TUI with both leader = " " and leader = ";".

No docs changed since this is neither a new keybinding nor a new config key.