### PR TITLE
fix(tui): resume from an editor without querying the cursor

### DIFF
--- a/src/terminal_state.rs
+++ b/src/terminal_state.rs
@@ -134,6 +134,23 @@ impl<W: Write> TerminalSession<W> {
         self.active = false;
         Ok(())
     }
+
+    /// Clears the screen and drops the back buffer so the next draw repaints
+    /// every cell.
+    ///
+    /// `Terminal::clear` cannot be used here: it starts by reading the cursor
+    /// position, whose `ESC [ 6 n` query goes to stdout. When stdout is not
+    /// the terminal the reply never arrives, and the two-second timeout fails
+    /// the clear before it resets the back buffer, so the next draw diffs
+    /// against the pre-editor screen and paints nothing.
+    ///
+    /// Resizing to the current size clears and resets the same way, but sizes
+    /// itself from `/dev/tty`.
+    fn repaint_from_scratch(&mut self) -> anyhow::Result<()> {
+        let area = self.terminal.size()?.into();
+        self.terminal.resize(area)?;
+        Ok(())
+    }
 }
 
 impl<W: Write> Drop for TerminalSession<W> {
@@ -164,7 +181,7 @@ impl<W: Write> TerminalSuspension<'_, W> {
             return Ok(());
         };
         session.activate()?;
-        session.terminal.clear()?;
+        session.repaint_from_scratch()?;
         Ok(())
     }
 }
@@ -175,7 +192,7 @@ impl<W: Write> Drop for TerminalSuspension<'_, W> {
             return;
         };
         if session.activate().is_ok() {
-            let _ = session.terminal.clear();
+            let _ = session.repaint_from_scratch();
         }
     }
 }


### PR DESCRIPTION
Closing a full-screen editor could leave tuicr showing "Failed to
restore terminal: The cursor position could not be read within a
normal duration" over a screen that never repainted.

`TerminalSuspension::resume` called `Terminal::clear`, which starts by
reading the cursor position — an `ESC [ 6 n` query written to
`io::stdout()`, not to the writer the TUI draws on. When stdout is not
the terminal (`--stdout` redirects it to a file) no reply can arrive,
so the two-second timeout fires every time, aborting the clear before
it resets the back buffer. The next draw diffs against the pre-editor
screen and paints nothing.

Resize to the current size instead: the same clear and reset, but
sized from `/dev/tty`.
