### PR TITLE
fix: Make commit branch columns responsive

### DIFF
--- a/src/ui/commit_row.rs
+++ b/src/ui/commit_row.rs
@@ -20,15 +20,20 @@ pub const UNSELECTED_BOX_GLYPH: &str = "\u{25a2}"; // ▢
 pub const REVIEWED_GLYPH: &str = "\u{2713}"; // ✓
 pub const REVIEWED_LABEL: &str = "✓ ";
 
-// Fixed column widths so author/date land at the same x across every row.
-// Branch column gets `[branch_name]` padded to width including brackets and a
-// trailing space; rows without a branch render the same number of blanks.
-const BRANCH_COL_WIDTH: usize = 16;
-const SUMMARY_COL_WIDTH: usize = 50;
+// Baseline column widths preserve the compact layout. Narrow rows shrink both
+// columns proportionally; wider rows give one third of their surplus to the
+// branch and two thirds to the commit summary.
+const COMPACT_BRANCH_COL_WIDTH: usize = 16;
+const COMPACT_SUMMARY_COL_WIDTH: usize = 50;
 const AUTHOR_COL_WIDTH: usize = 12;
+const CONTROL_COL_WIDTH: usize = 8;
+const HASH_COL_WIDTH: usize = 8;
+const RELATIVE_DATE_COL_WIDTH: usize = 8; // "just now"
+const METADATA_COL_WIDTH: usize = 2 + AUTHOR_COL_WIDTH + 3 + RELATIVE_DATE_COL_WIDTH;
 
 pub struct CommitRowSpec<'a> {
     pub commit: &'a CommitInfo,
+    pub available_width: u16,
     pub is_cursor: bool,
     pub is_selected: bool,
     pub is_reviewed: bool,
@@ -99,40 +104,76 @@ pub fn render_commit_row<'a>(spec: &CommitRowSpec<'a>) -> Line<'a> {
         return Line::from(spans);
     }
 
-    spans.push(Span::styled(
-        format!("{} ", spec.commit.short_id),
-        styles::hash_style(theme),
-    ));
+    let hash_content_width = (HASH_COL_WIDTH - 1).max(spec.commit.short_id.chars().count());
+    let hash = format!(
+        "{} ",
+        truncate_or_pad_column(&spec.commit.short_id, hash_content_width)
+    );
+    spans.push(Span::styled(hash, styles::hash_style(theme)));
 
-    // Branch column: always BRANCH_COL_WIDTH cells. With a branch we render
+    let when = format_relative_short(&spec.commit.time);
+    let metadata = format!(
+        "  {} \u{00b7} {}",
+        truncate_or_pad(&spec.commit.author, AUTHOR_COL_WIDTH),
+        when
+    );
+    let hash_col_width = hash_content_width + 1;
+    let (branch_col_width, summary_col_width) =
+        commit_column_widths(spec.available_width as usize, hash_col_width);
+
+    // Branch column: always branch_col_width cells. With a branch we render
     // `[<name>]` padded out with trailing spaces; without one we render
-    // BRANCH_COL_WIDTH spaces so the summary column starts at the same x.
+    // the same number of spaces so the summary column starts at the same x.
     if let Some(branch_name) = &spec.commit.branch_name {
-        let chip = format!("[{}]", truncate_str(branch_name, BRANCH_COL_WIDTH - 3));
+        let chip = format!(
+            "[{}]",
+            truncate_str(branch_name, branch_col_width.saturating_sub(3))
+        );
         spans.push(Span::styled(
-            truncate_or_pad(&chip, BRANCH_COL_WIDTH),
+            truncate_or_pad_column(&chip, branch_col_width),
             styles::branch_style(theme),
         ));
     } else {
-        spans.push(Span::raw(" ".repeat(BRANCH_COL_WIDTH)));
+        spans.push(Span::raw(" ".repeat(branch_col_width)));
     }
 
     spans.push(Span::styled(
-        truncate_or_pad(&spec.commit.summary, SUMMARY_COL_WIDTH),
+        truncate_or_pad_column(&spec.commit.summary, summary_col_width),
         row_text_style,
     ));
 
-    let when = format_relative_short(&spec.commit.time);
     spans.push(Span::styled(
-        format!(
-            "  {} \u{00b7} {}",
-            truncate_or_pad(&spec.commit.author, AUTHOR_COL_WIDTH),
-            when
-        ),
+        metadata,
         Style::default().fg(theme.fg_secondary),
     ));
 
     Line::from(spans)
+}
+
+fn commit_column_widths(available_width: usize, hash_col_width: usize) -> (usize, usize) {
+    let fixed_width = CONTROL_COL_WIDTH + hash_col_width + METADATA_COL_WIDTH;
+    let budget = available_width.saturating_sub(fixed_width);
+    let compact_width = COMPACT_BRANCH_COL_WIDTH + COMPACT_SUMMARY_COL_WIDTH;
+
+    if budget <= compact_width {
+        let branch_width = budget * COMPACT_BRANCH_COL_WIDTH / compact_width;
+        return (branch_width, budget - branch_width);
+    }
+
+    let surplus = budget - compact_width;
+    let branch_surplus = surplus / 3;
+    (
+        COMPACT_BRANCH_COL_WIDTH + branch_surplus,
+        COMPACT_SUMMARY_COL_WIDTH + surplus - branch_surplus,
+    )
+}
+
+fn truncate_or_pad_column(value: &str, width: usize) -> String {
+    if width < 3 {
+        value.chars().take(width).collect()
+    } else {
+        truncate_or_pad(value, width)
+    }
 }
 
 /// Compact relative time used in selector rows: `5m`, `3h`, `2d`, `6w`, `4mo`,
@@ -190,6 +231,36 @@ mod tests {
     }
 
     #[test]
+    fn should_preserve_compact_column_widths_and_split_surplus_toward_summary() {
+        assert_eq!(commit_column_widths(107, HASH_COL_WIDTH), (16, 50));
+        assert_eq!(commit_column_widths(137, HASH_COL_WIDTH), (26, 70));
+        assert_eq!(commit_column_widths(8, HASH_COL_WIDTH), (0, 0));
+    }
+
+    #[test]
+    fn should_preserve_backend_provided_short_hashes() {
+        // given
+        let theme = Theme::dark();
+        for short_id in ["abcdef12", "abcdef123456"] {
+            let mut c = commit("abcdef1234567890", "Add feature", Some("main"));
+            c.short_id = short_id.to_string();
+
+            // when
+            let text = line_text(&render_commit_row(&CommitRowSpec {
+                commit: &c,
+                available_width: 107,
+                is_cursor: false,
+                is_selected: false,
+                is_reviewed: false,
+                theme: &theme,
+            }));
+
+            // then
+            assert!(text.contains(short_id), "missing {short_id:?} in {text:?}");
+        }
+    }
+
+    #[test]
     fn should_render_cursor_arrow_when_is_cursor() {
         // given
         let theme = Theme::dark();
@@ -197,6 +268,7 @@ mod tests {
         // when
         let line = render_commit_row(&CommitRowSpec {
             commit: &c,
+            available_width: 107,
             is_cursor: true,
             is_selected: false,
             is_reviewed: false,
@@ -215,6 +287,7 @@ mod tests {
         // when
         let line = render_commit_row(&CommitRowSpec {
             commit: &c,
+            available_width: 107,
             is_cursor: false,
             is_selected: true,
             is_reviewed: false,
@@ -234,6 +307,7 @@ mod tests {
         // when
         let line = render_commit_row(&CommitRowSpec {
             commit: &c,
+            available_width: 107,
             is_cursor: false,
             is_selected: false,
             is_reviewed: false,
@@ -253,6 +327,7 @@ mod tests {
         // when
         let line = render_commit_row(&CommitRowSpec {
             commit: &c,
+            available_width: 107,
             is_cursor: false,
             is_selected: false,
             is_reviewed: true,
@@ -271,6 +346,7 @@ mod tests {
         // when
         let line = render_commit_row(&CommitRowSpec {
             commit: &c,
+            available_width: 107,
             is_cursor: false,
             is_selected: false,
             is_reviewed: false,
@@ -291,6 +367,7 @@ mod tests {
         // when
         let line = render_commit_row(&CommitRowSpec {
             commit: &c,
+            available_width: 107,
             is_cursor: false,
             is_selected: false,
             is_reviewed: false,
@@ -299,6 +376,156 @@ mod tests {
         // then
         let text = line_text(&line);
         assert!(text.contains("[feat/foo]"), "got: {text:?}");
+    }
+
+    #[test]
+    fn should_preserve_all_columns_at_the_compact_width() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "Add feature", Some("feat/foo"));
+        // when
+        let text = line_text(&render_commit_row(&CommitRowSpec {
+            commit: &c,
+            available_width: 107,
+            is_cursor: true,
+            is_selected: true,
+            is_reviewed: true,
+            theme: &theme,
+        }));
+        // then
+        for expected in [
+            CURSOR_GLYPH,
+            RANGE_BAR_GLYPH,
+            SELECTED_BOX_GLYPH,
+            REVIEWED_GLYPH,
+            "abc1234",
+            "[feat/foo]",
+            "Add feature",
+            "alice",
+            "·",
+        ] {
+            assert!(text.contains(expected), "missing {expected:?} in {text:?}");
+        }
+    }
+
+    #[test]
+    fn should_expand_branch_and_summary_columns_at_wide_widths() {
+        // given
+        let theme = Theme::dark();
+        let alpha = commit(
+            "abc1234",
+            "Keep the commit summary visible alongside its metadata",
+            Some("feat/responsive-branch-alpha"),
+        );
+        let beta = commit(
+            "def5678",
+            "Keep the commit summary visible alongside its metadata",
+            Some("feat/responsive-branch-beta"),
+        );
+        // when
+        let alpha = line_text(&render_commit_row(&CommitRowSpec {
+            commit: &alpha,
+            available_width: 160,
+            is_cursor: false,
+            is_selected: false,
+            is_reviewed: false,
+            theme: &theme,
+        }));
+        let beta = line_text(&render_commit_row(&CommitRowSpec {
+            commit: &beta,
+            available_width: 160,
+            is_cursor: false,
+            is_selected: false,
+            is_reviewed: false,
+            theme: &theme,
+        }));
+        // then
+        assert!(alpha.contains("branch-alpha]"), "got: {alpha:?}");
+        assert!(beta.contains("branch-beta]"), "got: {beta:?}");
+        assert!(alpha.contains("Keep the commit summary"), "got: {alpha:?}");
+        assert!(alpha.contains("alice"), "got: {alpha:?}");
+        assert!(alpha.contains('·'), "got: {alpha:?}");
+    }
+
+    #[test]
+    fn should_align_summaries_for_rows_with_and_without_branches() {
+        // given
+        let theme = Theme::dark();
+        let with_branch = commit("abc1234", "same summary", Some("feature/foo"));
+        let without_branch = commit("def5678", "same summary", None);
+        // when
+        let with_branch = line_text(&render_commit_row(&CommitRowSpec {
+            commit: &with_branch,
+            available_width: 120,
+            is_cursor: false,
+            is_selected: false,
+            is_reviewed: false,
+            theme: &theme,
+        }));
+        let without_branch = line_text(&render_commit_row(&CommitRowSpec {
+            commit: &without_branch,
+            available_width: 120,
+            is_cursor: false,
+            is_selected: false,
+            is_reviewed: false,
+            theme: &theme,
+        }));
+        // then
+        assert_eq!(
+            with_branch.find("same summary"),
+            without_branch.find("same summary")
+        );
+    }
+
+    #[test]
+    fn should_render_very_narrow_rows_without_panicking() {
+        // given
+        let theme = Theme::dark();
+        let c = commit("abc1234", "summary", Some("feature/foo"));
+        // when
+        let line = render_commit_row(&CommitRowSpec {
+            commit: &c,
+            available_width: 8,
+            is_cursor: false,
+            is_selected: false,
+            is_reviewed: false,
+            theme: &theme,
+        });
+        // then
+        assert!(!line_text(&line).is_empty());
+    }
+
+    #[test]
+    fn should_keep_pseudo_commit_content_stable_across_widths() {
+        // given
+        let theme = Theme::dark();
+        for (id, summary, tag) in [
+            (STAGED_SELECTION_ID, "Staged changes", "staged"),
+            (UNSTAGED_SELECTION_ID, "Unstaged changes", "unstaged"),
+        ] {
+            let c = commit(id, summary, None);
+            // when
+            let narrow = line_text(&render_commit_row(&CommitRowSpec {
+                commit: &c,
+                available_width: 20,
+                is_cursor: false,
+                is_selected: false,
+                is_reviewed: false,
+                theme: &theme,
+            }));
+            let wide = line_text(&render_commit_row(&CommitRowSpec {
+                commit: &c,
+                available_width: 160,
+                is_cursor: false,
+                is_selected: false,
+                is_reviewed: false,
+                theme: &theme,
+            }));
+            // then
+            assert_eq!(narrow, wide);
+            assert!(wide.contains(tag), "got: {wide:?}");
+            assert!(wide.contains(summary), "got: {wide:?}");
+        }
     }
 
     #[test]

--- a/src/ui/inline_commit_selector.rs
+++ b/src/ui/inline_commit_selector.rs
@@ -34,6 +34,7 @@ pub(super) fn render_inline_commit_selector(frame: &mut Frame, app: &mut App, ar
         .map(|(i, commit)| {
             render_commit_row(&CommitRowSpec {
                 commit,
+                available_width: inner.width,
                 is_cursor: i == app.commit_list_cursor,
                 is_selected: app.is_commit_selected(i),
                 is_reviewed: app.is_commit_reviewed_by_viewer(i),

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -191,6 +191,7 @@ fn render_local_target_tab(frame: &mut Frame, app: &mut App, area: Rect) {
         .map(|(i, commit)| {
             render_commit_row(&CommitRowSpec {
                 commit,
+                available_width: area.width,
                 is_cursor: i == app.commit_list_cursor,
                 is_selected: app.is_commit_selected(i),
                 is_reviewed: false,
@@ -598,12 +599,28 @@ mod selector_render_snapshot_tests {
         }
     }
 
-    fn draw(app: &mut App) -> Buffer {
-        let backend = TestBackend::new(120, 24);
+    fn draw_at(app: &mut App, width: u16, height: u16) -> Buffer {
+        let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| render(frame, app))
             .expect("draw frame");
+        terminal.backend().buffer().clone()
+    }
+
+    fn draw(app: &mut App) -> Buffer {
+        draw_at(app, 120, 24)
+    }
+
+    fn draw_inline_at(app: &mut App, width: u16) -> Buffer {
+        let backend = TestBackend::new(width, 5);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                crate::ui::inline_commit_selector::render_inline_commit_selector(frame, app, area);
+            })
+            .expect("draw inline selector");
         terminal.backend().buffer().clone()
     }
 
@@ -633,6 +650,28 @@ mod selector_render_snapshot_tests {
     }
 
     const TAB_STRIP_ROW: u16 = 0;
+
+    #[test]
+    fn should_resize_branch_columns_on_fullscreen_and_inline_selectors() {
+        // given
+        let mut wide_commit = commit(0);
+        wide_commit.branch_name = Some("feat/responsive-branch-alpha".to_string());
+        let mut fullscreen_app = make_app(vec![wide_commit.clone()]);
+        let mut inline_app = make_app(vec![wide_commit.clone()]);
+        inline_app.review_commits = vec![wide_commit];
+
+        // when
+        let compact_fullscreen = draw_at(&mut fullscreen_app, 100, 24);
+        let wide_fullscreen = draw_at(&mut fullscreen_app, 160, 24);
+        let compact_inline = draw_inline_at(&mut inline_app, 100);
+        let wide_inline = draw_inline_at(&mut inline_app, 160);
+
+        // then
+        assert!(!row_text(&compact_fullscreen, 2).contains("branch-alpha]"));
+        assert!(row_text(&wide_fullscreen, 2).contains("branch-alpha]"));
+        assert!(!row_text(&compact_inline, 1).contains("branch-alpha]"));
+        assert!(row_text(&wide_inline, 1).contains("branch-alpha]"));
+    }
 
     /// True when at least one cell in [x_start, x_end) on row `y` carries
     /// the given background color.


### PR DESCRIPTION
Commit rows always reserve 16 cells for the branch chip and 50 cells for the summary, regardless of the terminal width. Long prefixed branch names therefore collapse to indistinguishable chips even when the selector has substantial unused horizontal space. The shared row renderer affects both the startup review-target selector and the inline commit selector, so the correction must stay consistent across both surfaces. The owner has confirmed that making this layout responsive is the intended behavior.

## Summary

Extend the shared commit-row rendering input in `src/ui/commit_row.rs` with the content width available to that row, then derive aligned branch and summary column widths from a saturating horizontal budget after reserving the controls, hash, and author/date metadata. Preserve sensible minimum widths around the current compact layout, but distribute wider-screen surplus between branch and summary with the summary retaining the larger share; this reveals materially more of prefixed branch names without sacrificing the commit-message-first design. Keep the calculation in the production row renderer and use one width for every row so commits without a branch still pad to the same summary start.

## Validation

- Render a wide commit row containing two long branch names with the same prefix and verify the responsive branch column exposes distinguishing suffix characters while the summary and author/date remain present.
- Render at the existing compact-width budget and verify branch, summary, selection/review markers, hash, author, and relative date retain a stable aligned layout without arithmetic underflow or overflow.
- Render otherwise identical rows with and without a branch and verify their summaries begin in the same column for a given available width.
- Render a very narrow row and verify saturating width allocation produces a valid truncated line rather than panicking; the enclosing `Paragraph` may clip metadata that cannot fit.
- Render staged and unstaged pseudo-commit rows at multiple widths and verify their special tags and summaries remain unchanged by normal commit-column allocation.
- Draw both the fullscreen local target selector and bordered inline commit selector and verify each passes its actual usable width, so resizing either surface changes branch visibility consistently and borders are not counted as content space.

Fixes #618

AI was used for assistance.
