### PR TITLE
fix: resolve Azure DevOps remote owners as org/project

### DIFF
--- a/docs/REVIEW_CLI.md
+++ b/docs/REVIEW_CLI.md
@@ -57,6 +57,16 @@ tuicr review list --repo slatedb/slatedb
 tuicr review comments --session gh:slatedb/slatedb/pr/1745
 ```
 
+Azure DevOps repos live under `organization/project/repository`, so their
+`owner` is `org/project` and a bare `owner/repo` selector cannot name them. Use
+a URL form, which is recognized by host:
+
+```bash
+tuicr review list --repo dev.azure.com/myorg/myproject/_git/myrepo
+tuicr review list --repo git@ssh.dev.azure.com:v3/myorg/myproject/myrepo
+#   -> [ ..., { "slug": "az:myorg/myproject/myrepo/pr/123", "kind": "pr", ... } ]
+```
+
 `--repo` for `add` / `comments` is only consulted when resolving a *local*
 slug; PR slugs and JSON paths ignore it.
 

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -123,6 +123,25 @@ pub fn parse_any_remote_url(url: &str) -> Option<ForgeRepository> {
         .or_else(|| parse_github_remote_url(url))
 }
 
+/// Parse `url` using only the forge parsers that decide from the URL alone —
+/// no subprocess, no `~/.ssh/config` read — and without the GitHub catch-all.
+///
+/// For hot paths such as [`crate::slug::resolve_owner_repo`], which runs on
+/// every session save, and only where an unrecognized remote has a usable
+/// fallback. Prefer [`parse_any_remote_url`] everywhere else: it recognizes
+/// more remotes, at the cost of a `glab config get host` spawn and up to three
+/// `~/.ssh/config` reads per call.
+///
+/// GitHub is excluded on purpose. Its parser accepts any host and reads the
+/// *first* two path segments, where `slug.rs`'s generic fallback reads the last
+/// two; letting it claim unknown hosts would turn
+/// `code.example.com/git/owner/repo` into `git/owner`. Bitbucket is left out
+/// because a workspace is always one segment, so the fallback already agrees
+/// with it.
+pub fn parse_any_remote_url_by_hostname(url: &str) -> Option<ForgeRepository> {
+    parse_azure_remote_url(url)
+}
+
 /// Detect the forge repository for the local checkout at `repo_root`.
 /// Returns `None` when no remote can be parsed.
 pub fn detect_forge_repository(repo_root: &Path) -> Option<ForgeRepository> {
@@ -157,6 +176,29 @@ mod tests {
         assert_eq!(
             detect_forge_repository(dir.path()),
             Some(ForgeRepository::github("github.com", "agavra", "tuicr"))
+        );
+    }
+
+    #[test]
+    fn hostname_only_parser_claims_azure_but_leaves_other_hosts_alone() {
+        assert_eq!(
+            parse_any_remote_url_by_hostname("https://dev.azure.com/myorg/myproject/_git/myrepo"),
+            Some(ForgeRepository::azure(
+                "dev.azure.com",
+                "myorg/myproject",
+                "myrepo"
+            ))
+        );
+        // The GitHub catch-all is excluded, so anything it would have claimed
+        // falls through to the caller's own rule. Were it in the chain, its
+        // first-two-segments reading would turn the last URL into `git/owner`.
+        assert_eq!(
+            parse_any_remote_url_by_hostname("https://github.com/agavra/tuicr"),
+            None
+        );
+        assert_eq!(
+            parse_any_remote_url_by_hostname("https://code.example.com/git/owner/repo"),
+            None
         );
     }
 

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -887,6 +887,23 @@ mod tests {
         )
     }
 
+    fn make_azure_pr_key(number: u64, head_sha: &str) -> PrSessionKey {
+        PrSessionKey::new(
+            ForgeRepository::azure("dev.azure.com", "myorg/myproject", "myrepo"),
+            number,
+            head_sha.to_string(),
+        )
+    }
+
+    /// A checkout with a real `origin`, so the selector's coordinate comes from
+    /// the remote URL rather than the directory name.
+    fn make_repo_with_origin(url: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        repo.remote("origin", url).unwrap();
+        dir
+    }
+
     fn make_pr_session(key: &PrSessionKey) -> ReviewSession {
         let mut s = ReviewSession::new(
             PathBuf::from(format!(
@@ -1487,6 +1504,56 @@ mod tests {
         assert!(slugs.contains(&"gh:agavra/tuicr/pr/125"));
 
         let _ = fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn should_find_azure_pr_session_by_repo_url_coordinate() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+        save_session(&make_pr_session(&make_azure_pr_key(123, "abcdef0123456789"))).unwrap();
+
+        let listed = list_sessions_for_selector_in_dir(
+            &reviews_dir,
+            Path::new("dev.azure.com/myorg/myproject/_git/myrepo"),
+        )
+        .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, "az:myorg/myproject/myrepo/pr/123");
+    }
+
+    #[test]
+    fn should_surface_azure_pr_session_from_its_checkout() {
+        // Regression for #639: the checkout's coordinate used to come out as
+        // owner `_git`, which never matched the `myorg/myproject` owner the PR
+        // slug carries, so `review list` in an Azure checkout showed only the
+        // local session.
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+        let checkout =
+            make_repo_with_origin("https://myorg@dev.azure.com/myorg/myproject/_git/myrepo");
+
+        save_session(&make_local_session(
+            checkout.path().to_path_buf(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        ))
+        .unwrap();
+        save_session(&make_pr_session(&make_azure_pr_key(123, "abcdef0123456789"))).unwrap();
+
+        let listed = list_sessions_for_selector_in_dir(&reviews_dir, checkout.path()).unwrap();
+        let slugs: Vec<&str> = listed.iter().map(|(slug, _)| slug.as_str()).collect();
+        assert!(
+            slugs.contains(&"az:myorg/myproject/myrepo/pr/123"),
+            "expected the PR session, got {slugs:?}"
+        );
+        assert!(
+            slugs
+                .iter()
+                .any(|s| s.starts_with("myorg/myproject/myrepo@main/worktree")),
+            "expected the local session under an org/project owner, got {slugs:?}"
+        );
     }
 
     #[test]

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -1510,7 +1510,8 @@ mod tests {
     fn should_find_azure_pr_session_by_repo_url_coordinate() {
         let _g = with_test_reviews_dir();
         let reviews_dir = get_reviews_dir().unwrap();
-        save_session(&make_pr_session(&make_azure_pr_key(123, "abcdef0123456789"))).unwrap();
+        let key = make_azure_pr_key(123, "abcdef0123456789");
+        save_session(&make_pr_session(&key)).unwrap();
 
         let listed = list_sessions_for_selector_in_dir(
             &reviews_dir,
@@ -1540,7 +1541,8 @@ mod tests {
             None,
         ))
         .unwrap();
-        save_session(&make_pr_session(&make_azure_pr_key(123, "abcdef0123456789"))).unwrap();
+        let key = make_azure_pr_key(123, "abcdef0123456789");
+        save_session(&make_pr_session(&key)).unwrap();
 
         let listed = list_sessions_for_selector_in_dir(&reviews_dir, checkout.path()).unwrap();
         let slugs: Vec<&str> = listed.iter().map(|(slug, _)| slug.as_str()).collect();

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -9,6 +9,11 @@
 //! - Local: `[<owner>/]<repo>@<anchor>/<source>`
 //! - PR:    `gh:<owner>/<repo>/pr/<number>`
 //!
+//! `<owner>` may itself contain `/`: Azure DevOps repos live under
+//! `organization/project/repository`, so their owner is `org/project` (the
+//! packing [`crate::forge::traits::ForgeRepository::azure`] uses). In both
+//! grammars the repo is the last segment before `@` / `/pr/`.
+//!
 //! Where `<anchor>` is either a sanitized branch/bookmark name (no `/`) or
 //! `~<short-sha>` for detached / anonymous heads, and `<source>` is one of the
 //! diff-source variants (`worktree/<head>`, `staged/<head>`,
@@ -27,6 +32,7 @@ use std::str::FromStr;
 
 use git2::Repository;
 
+use crate::forge::azure::az::parse_azure_remote_url;
 use crate::forge::traits::{ForgeKind, PrSessionKey};
 use crate::model::review::SessionDiffSource;
 
@@ -221,8 +227,11 @@ fn parse_local(s: &str) -> Result<LocalSlug, SlugParseError> {
         .split_once('@')
         .ok_or_else(|| SlugParseError::InvalidShape(s.to_string()))?;
 
-    let (owner, repo) = if let Some((o, r)) = project.split_once('/') {
-        if r.contains('/') || o.is_empty() || r.is_empty() {
+    // `<owner>` may contain slashes (Azure DevOps `org/project`), so the repo
+    // is the last segment and everything before it is the owner — the same rule
+    // `parse_pr` uses.
+    let (owner, repo) = if let Some((o, r)) = project.rsplit_once('/') {
+        if o.is_empty() || r.is_empty() {
             return Err(SlugParseError::InvalidShape(s.to_string()));
         }
         (Some(o.to_string()), r.to_string())
@@ -380,9 +389,21 @@ impl RepoCoordinate {
     /// segments become `owner/repo` (so nested GitLab subgroups degrade
     /// gracefully); a lone segment yields a repo with no owner. A trailing
     /// `.git` is stripped.
+    ///
+    /// Azure DevOps selectors are recognized by host and keep their full
+    /// `org/project` owner, so `dev.azure.com/org/project/_git/repo` matches
+    /// that repo's `az:` PR sessions. The bare `org/project/repo` form is
+    /// indistinguishable from `host/owner/repo` and falls back to the generic
+    /// rule.
     pub fn parse(input: &str) -> Option<Self> {
         let trimmed = input.trim();
         let without_forge = trimmed.strip_prefix("forge:").unwrap_or(trimmed);
+        if let Some(repo) = parse_azure_remote_url(without_forge) {
+            return Some(Self {
+                owner: Some(repo.owner),
+                repo: repo.name,
+            });
+        }
         let without_scheme = without_forge
             .split_once("://")
             .map(|(_, rest)| rest)
@@ -459,11 +480,21 @@ fn origin_owner_repo(repo: &Repository) -> Option<(String, String)> {
     parse_remote_owner_repo(url)
 }
 
-/// Forge-agnostic remote-URL parser. Handles HTTPS, SCP-style SSH
-/// (`git@host:path`), and SSH scheme URLs. Always takes the last two path
-/// segments as `owner/repo` so nested groupings (GitLab subgroups, etc.)
-/// degrade gracefully. Strips a trailing `.git`.
+/// Remote-URL parser. Handles HTTPS, SCP-style SSH (`git@host:path`), and SSH
+/// scheme URLs. Takes the last two path segments as `owner/repo` so nested
+/// groupings (GitLab subgroups, etc.) degrade gracefully. Strips a trailing
+/// `.git`.
 fn parse_remote_owner_repo(remote_url: &str) -> Option<(String, String)> {
+    // Azure DevOps remotes are `host/org/project/_git/repo` (HTTPS) or
+    // `v3/org/project/repo` (SSH), so the last-two-segments rule below would
+    // yield `_git` / `project` as the owner. Defer to the forge parser, which
+    // packs `org/project` into the owner exactly as PR sessions do — otherwise
+    // the two halves of a session identity disagree and `review list` in an
+    // Azure checkout hides that repo's PR sessions.
+    if let Some(repo) = parse_azure_remote_url(remote_url) {
+        return Some((repo.owner, repo.name));
+    }
+
     let url = remote_url.trim();
     if let Some(rest) = url.strip_prefix("https://") {
         parse_path_segments(rest)
@@ -683,6 +714,24 @@ mod tests {
         }
     }
 
+    #[test]
+    fn should_roundtrip_azure_local_slug_with_org_project_owner() {
+        // Azure packs `org/project` into the owner, so a local slug carries an
+        // extra `/`. parse_local must treat the repo as the last segment.
+        assert_roundtrip("myorg/myproject/myrepo@main/worktree/abc1234");
+        let parsed: Slug = "myorg/myproject/myrepo@main/worktree/abc1234"
+            .parse()
+            .unwrap();
+        match parsed {
+            Slug::Local(local) => {
+                assert_eq!(local.owner.as_deref(), Some("myorg/myproject"));
+                assert_eq!(local.repo, "myrepo");
+                assert_eq!(local.anchor, SlugAnchor::Branch("main".to_string()));
+            }
+            other => panic!("expected local slug, got {other:?}"),
+        }
+    }
+
     // ---------- Parse errors ----------
 
     #[test]
@@ -823,6 +872,23 @@ mod tests {
             parse_remote_owner_repo("git@gitlab.com:org/team/svc.git"),
             Some(("team".to_string(), "svc".to_string()))
         );
+    }
+
+    #[test]
+    fn should_parse_azure_remote_urls_with_org_project_owner() {
+        // Regression for #639: the last-two-segments rule yields `_git` (HTTPS)
+        // or the project (SSH) as the owner, which never matches the
+        // `org/project` owner an `az:` PR slug carries.
+        let expected = Some(("myorg/myproject".to_string(), "myrepo".to_string()));
+        for url in [
+            "https://dev.azure.com/myorg/myproject/_git/myrepo",
+            "https://myorg@dev.azure.com/myorg/myproject/_git/myrepo.git",
+            "https://myorg.visualstudio.com/myproject/_git/myrepo",
+            "https://myorg.visualstudio.com/DefaultCollection/myproject/_git/myrepo",
+            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo",
+        ] {
+            assert_eq!(parse_remote_owner_repo(url), expected, "parsing {url}");
+        }
     }
 
     #[test]
@@ -1007,6 +1073,24 @@ mod tests {
     }
 
     #[test]
+    fn should_parse_azure_repo_coordinate_forms() {
+        for input in [
+            "dev.azure.com/myorg/myproject/_git/myrepo",
+            "https://dev.azure.com/myorg/myproject/_git/myrepo",
+            "https://myorg@dev.azure.com/myorg/myproject/_git/myrepo.git",
+            "forge:dev.azure.com/myorg/myproject/_git/myrepo",
+            "myorg.visualstudio.com/myproject/_git/myrepo",
+            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo",
+        ] {
+            assert_eq!(
+                RepoCoordinate::parse(input),
+                Some(coord(Some("myorg/myproject"), "myrepo")),
+                "parsing {input}"
+            );
+        }
+    }
+
+    #[test]
     fn should_reject_empty_repo_coordinate() {
         assert_eq!(RepoCoordinate::parse(""), None);
         assert_eq!(RepoCoordinate::parse("forge:"), None);
@@ -1036,6 +1120,17 @@ mod tests {
         // A no-remote checkout (no owner) still matches an owner/repo selector.
         assert!(coord(Some("slatedb"), "slatedb").matches(&coord(None, "slatedb")));
         assert!(coord(None, "slatedb").matches(&coord(Some("slatedb"), "slatedb")));
+    }
+
+    #[test]
+    fn should_match_multi_segment_owner_both_directions() {
+        // An Azure checkout's coordinate and its `az:` PR slug's coordinate must
+        // agree, in either argument position.
+        let azure: Slug = "az:myorg/myproject/myrepo/pr/42".parse().unwrap();
+        let selector = coord(Some("myorg/myproject"), "myrepo");
+        assert!(selector.matches(&RepoCoordinate::from_slug(&azure)));
+        assert!(RepoCoordinate::from_slug(&azure).matches(&selector));
+        assert!(!selector.matches(&coord(Some("myproject"), "myrepo")));
     }
 
     #[test]

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -9,10 +9,12 @@
 //! - Local: `[<owner>/]<repo>@<anchor>/<source>`
 //! - PR:    `gh:<owner>/<repo>/pr/<number>`
 //!
-//! `<owner>` may itself contain `/`: Azure DevOps repos live under
+//! `<owner>` may itself contain `/`, because some forges put a multi-segment
+//! namespace there: Azure DevOps repos live under
 //! `organization/project/repository`, so their owner is `org/project` (the
-//! packing [`crate::forge::traits::ForgeRepository::azure`] uses). In both
-//! grammars the repo is the last segment before `@` / `/pr/`.
+//! packing [`crate::forge::traits::ForgeRepository::azure`] uses), and GitLab
+//! groups nest. In both grammars the repo is the last segment before `@` /
+//! `/pr/`.
 //!
 //! Where `<anchor>` is either a sanitized branch/bookmark name (no `/`) or
 //! `~<short-sha>` for detached / anonymous heads, and `<source>` is one of the
@@ -32,7 +34,7 @@ use std::str::FromStr;
 
 use git2::Repository;
 
-use crate::forge::azure::az::parse_azure_remote_url;
+use crate::forge::parse_any_remote_url_by_hostname;
 use crate::forge::traits::{ForgeKind, PrSessionKey};
 use crate::model::review::SessionDiffSource;
 
@@ -227,9 +229,9 @@ fn parse_local(s: &str) -> Result<LocalSlug, SlugParseError> {
         .split_once('@')
         .ok_or_else(|| SlugParseError::InvalidShape(s.to_string()))?;
 
-    // `<owner>` may contain slashes (Azure DevOps `org/project`), so the repo
-    // is the last segment and everything before it is the owner — the same rule
-    // `parse_pr` uses.
+    // `<owner>` may contain slashes (Azure DevOps `org/project`, nested GitLab
+    // groups), so the repo is the last segment and everything before it is the
+    // owner — the same rule `parse_pr` uses.
     let (owner, repo) = if let Some((o, r)) = project.rsplit_once('/') {
         if o.is_empty() || r.is_empty() {
             return Err(SlugParseError::InvalidShape(s.to_string()));
@@ -386,19 +388,18 @@ impl RepoCoordinate {
 
     /// Parse a user-supplied repo selector: `owner/repo`, `host/owner/repo`,
     /// `forge:host/owner/repo`, or an HTTPS / SSH / SCP URL. The last two path
-    /// segments become `owner/repo` (so nested GitLab subgroups degrade
-    /// gracefully); a lone segment yields a repo with no owner. A trailing
-    /// `.git` is stripped.
+    /// segments become `owner/repo`; a lone segment yields a repo with no
+    /// owner. A trailing `.git` is stripped.
     ///
-    /// Azure DevOps selectors are recognized by host and keep their full
-    /// `org/project` owner, so `dev.azure.com/org/project/_git/repo` matches
-    /// that repo's `az:` PR sessions. The bare `org/project/repo` form is
-    /// indistinguishable from `host/owner/repo` and falls back to the generic
-    /// rule.
+    /// A selector whose host a forge parser recognizes keeps that forge's whole
+    /// multi-segment owner instead, so `dev.azure.com/org/project/_git/repo`
+    /// matches that repo's `az:` PR sessions. The bare `org/project/repo` form
+    /// is indistinguishable from `host/owner/repo` and falls back to the
+    /// generic rule.
     pub fn parse(input: &str) -> Option<Self> {
         let trimmed = input.trim();
         let without_forge = trimmed.strip_prefix("forge:").unwrap_or(trimmed);
-        if let Some(repo) = parse_azure_remote_url(without_forge) {
+        if let Some(repo) = parse_any_remote_url_by_hostname(without_forge) {
             return Some(Self {
                 owner: Some(repo.owner),
                 repo: repo.name,
@@ -481,17 +482,18 @@ fn origin_owner_repo(repo: &Repository) -> Option<(String, String)> {
 }
 
 /// Remote-URL parser. Handles HTTPS, SCP-style SSH (`git@host:path`), and SSH
-/// scheme URLs. Takes the last two path segments as `owner/repo` so nested
-/// groupings (GitLab subgroups, etc.) degrade gracefully. Strips a trailing
+/// scheme URLs. Takes the last two path segments as `owner/repo` unless a
+/// forge's own parser recognizes the host and knows better. Strips a trailing
 /// `.git`.
 fn parse_remote_owner_repo(remote_url: &str) -> Option<(String, String)> {
-    // Azure DevOps remotes are `host/org/project/_git/repo` (HTTPS) or
-    // `v3/org/project/repo` (SSH), so the last-two-segments rule below would
-    // yield `_git` / `project` as the owner. Defer to the forge parser, which
-    // packs `org/project` into the owner exactly as PR sessions do — otherwise
-    // the two halves of a session identity disagree and `review list` in an
-    // Azure checkout hides that repo's PR sessions.
-    if let Some(repo) = parse_azure_remote_url(remote_url) {
+    // Some forges put a multi-segment namespace in the owner, which the
+    // last-two-segments rule below truncates: an Azure DevOps remote is
+    // `host/org/project/_git/repo` (HTTPS) or `v3/org/project/repo` (SSH), so
+    // it would yield `_git` / `project`. Ask the forge layer first — it packs
+    // the owner exactly as PR sessions do; otherwise the two halves of a
+    // session identity disagree and `review list` in such a checkout hides
+    // that repo's PR sessions.
+    if let Some(repo) = parse_any_remote_url_by_hostname(remote_url) {
         return Some((repo.owner, repo.name));
     }
 


### PR DESCRIPTION
Partially Fixes #639.

`tuicr review list` in an Azure DevOps checkout now surfaces that repo's PR sessions, not just the local ones.

`slug.rs` derived a checkout's owner with its own last-two-path-segments rule, which yields `_git` for Azure remotes. It now asks the forge layer first, through a new `forge::parse_any_remote_url_by_hostname` — the pure subset of the parser chain that already lives there — and `parse_local` accepts a multi-segment owner the way `parse_pr` already does. Other forges are untouched.

Not routed through `parse_any_remote_url` as the issue suggests: that chain ends in the GitHub parser, which accepts any host and reads the *first* two path segments where this reads the last two, so `code.example.com/git/owner/repo` would resolve to `git/owner`. Its GitLab gate also spawns `glab config get host`, and `resolve_owner_repo` runs on every session save.

Risk: Azure local slugs change shape (`_git/myrepo@…` → `myorg/myproject/myrepo@…`), so existing Azure local sessions won't be reattached by the TUI. They stay listed and readable by their old slug.

GitLab subgroups have the same class of bug — deliberately out of scope. (Suggest fixing in separate PR)
