### PR TITLE
fix: resolve nested GitLab group owners as the full namespace

### DIFF
--- a/docs/REVIEW_CLI.md
+++ b/docs/REVIEW_CLI.md
@@ -67,6 +67,15 @@ tuicr review list --repo git@ssh.dev.azure.com:v3/myorg/myproject/myrepo
 #   -> [ ..., { "slug": "az:myorg/myproject/myrepo/pr/123", "kind": "pr", ... } ]
 ```
 
+GitLab groups nest the same way, so a repo under `group/subgroup` has
+`group/subgroup` as its owner:
+
+```bash
+tuicr review list --repo https://gitlab.com/org/team/svc
+tuicr review list --repo git@gitlab.com:org/team/svc.git
+#   -> [ ..., { "slug": "gl:org/team/svc/pr/123", "kind": "pr", ... } ]
+```
+
 `--repo` for `add` / `comments` is only consulted when resolving a *local*
 slug; PR slugs and JSON paths ignore it.
 

--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -833,6 +833,16 @@ pub fn parse_pull_request_target_gitlab(input: &str) -> Result<PullRequestTarget
     malformed_target(input)
 }
 
+/// How far host recognition may go to decide a remote is GitLab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HostLookup {
+    /// Consult `glab`'s configured host and `~/.ssh/config` when the hostname
+    /// alone is inconclusive.
+    WithConfig,
+    /// Recognize GitLab by hostname only — no subprocess, no file read.
+    HostnameOnly,
+}
+
 /// Parse a GitLab remote URL into a `ForgeRepository`.
 ///
 /// Handles SCP-like (`git@gitlab.com:owner/repo.git`), HTTPS
@@ -842,23 +852,40 @@ pub fn parse_pull_request_target_gitlab(input: &str) -> Result<PullRequestTarget
 /// configured as a GitLab host in `glab`'s config file (self-hosted
 /// instances such as `git.example.com`).
 pub fn parse_gitlab_remote_url(remote_url: &str) -> Option<ForgeRepository> {
+    parse_gitlab_remote(remote_url, HostLookup::WithConfig)
+}
+
+/// Like [`parse_gitlab_remote_url`], but recognizes GitLab by hostname alone:
+/// no `glab config get host` subprocess and no `~/.ssh/config` read.
+///
+/// For callers on hot paths — [`crate::slug::resolve_owner_repo`] runs on every
+/// session save — where a process spawn per call is not affordable. The cost is
+/// coverage: a self-hosted instance on a custom domain like `git.example.com`
+/// is not recognized, so it keeps falling back to the caller's generic parser.
+pub fn parse_gitlab_remote_url_by_hostname(remote_url: &str) -> Option<ForgeRepository> {
+    parse_gitlab_remote(remote_url, HostLookup::HostnameOnly)
+}
+
+fn parse_gitlab_remote(remote_url: &str, lookup: HostLookup) -> Option<ForgeRepository> {
     let trimmed = trim_url_suffix(remote_url.trim());
     if trimmed.is_empty() {
         return None;
     }
 
     if let Some((host, path)) = parse_scp_like_remote(trimmed) {
-        let resolved = resolve_ssh_hostname(host);
-
-        let gitlab_host = if is_gitlab_host(host) {
-            host
-        } else if is_gitlab_host(&resolved) {
-            &resolved
-        } else {
+        if is_gitlab_host(host, lookup) {
+            return gitlab_repository_from_path(host, path);
+        }
+        if lookup == HostLookup::HostnameOnly {
             return None;
-        };
-
-        return gitlab_repository_from_path(gitlab_host, path);
+        }
+        // The remote may name an `~/.ssh/config` alias rather than the real
+        // host, so fall back to what that alias resolves to.
+        let resolved = resolve_ssh_hostname(host);
+        if !is_gitlab_host(&resolved, lookup) {
+            return None;
+        }
+        return gitlab_repository_from_path(&resolved, path);
     }
 
     let without_scheme = strip_scheme(trimmed).unwrap_or(trimmed);
@@ -868,19 +895,23 @@ pub fn parse_gitlab_remote_url(remote_url: &str) -> Option<ForgeRepository> {
         .unwrap_or(without_scheme);
     let (host, path) = without_user.split_once('/')?;
     let host = strip_port(host);
-    if !is_gitlab_host(host) {
+    if !is_gitlab_host(host, lookup) {
         return None;
     }
     gitlab_repository_from_path(host, path)
 }
 
 /// Returns `true` when `host` looks like a GitLab instance: either its name
-/// contains "gitlab" (covers `gitlab.com` and most public deployments) or
-/// matches the default host `glab` is configured against (covers self-hosted
-/// instances with custom domains like `git.example.com`).
-fn is_gitlab_host(host: &str) -> bool {
+/// contains "gitlab" (covers `gitlab.com` and most public deployments) or —
+/// under [`HostLookup::WithConfig`] — matches the default host `glab` is
+/// configured against (covers self-hosted instances with custom domains like
+/// `git.example.com`).
+fn is_gitlab_host(host: &str, lookup: HostLookup) -> bool {
     if host.contains("gitlab") {
         return true;
+    }
+    if lookup == HostLookup::HostnameOnly {
+        return false;
     }
 
     glab_default_host().is_some_and(|known| known.eq_ignore_ascii_case(host))

--- a/src/forge/mod.rs
+++ b/src/forge/mod.rs
@@ -24,7 +24,7 @@ use git2::Repository;
 use crate::forge::azure::az::parse_azure_remote_url;
 use crate::forge::bitbucket::bkt::parse_bitbucket_remote_url;
 use crate::forge::github::gh::parse_github_remote_url;
-use crate::forge::gitlab::glab::parse_gitlab_remote_url;
+use crate::forge::gitlab::glab::{parse_gitlab_remote_url, parse_gitlab_remote_url_by_hostname};
 use crate::forge::traits::ForgeRepository;
 
 /// Try to detect a GitHub forge repository for the local checkout at `repo_root`.
@@ -137,9 +137,11 @@ pub fn parse_any_remote_url(url: &str) -> Option<ForgeRepository> {
 /// two; letting it claim unknown hosts would turn
 /// `code.example.com/git/owner/repo` into `git/owner`. Bitbucket is left out
 /// because a workspace is always one segment, so the fallback already agrees
-/// with it.
+/// with it. GitLab enters as its hostname-only variant, which forgoes the
+/// `glab` config lookup that would otherwise recognize self-hosted instances on
+/// custom domains.
 pub fn parse_any_remote_url_by_hostname(url: &str) -> Option<ForgeRepository> {
-    parse_azure_remote_url(url)
+    parse_gitlab_remote_url_by_hostname(url).or_else(|| parse_azure_remote_url(url))
 }
 
 /// Detect the forge repository for the local checkout at `repo_root`.
@@ -188,6 +190,10 @@ mod tests {
                 "myorg/myproject",
                 "myrepo"
             ))
+        );
+        assert_eq!(
+            parse_any_remote_url_by_hostname("git@gitlab.com:org/team/svc.git"),
+            Some(ForgeRepository::gitlab("gitlab.com", "org/team", "svc"))
         );
         // The GitHub catch-all is excluded, so anything it would have claimed
         // falls through to the caller's own rule. Were it in the chain, its

--- a/src/persistence/storage.rs
+++ b/src/persistence/storage.rs
@@ -895,6 +895,16 @@ mod tests {
         )
     }
 
+    /// A repo in a nested GitLab group: the owner is the whole `org/team`
+    /// namespace, not just the group it sits directly under.
+    fn make_gitlab_pr_key(number: u64, head_sha: &str) -> PrSessionKey {
+        PrSessionKey::new(
+            ForgeRepository::gitlab("gitlab.com", "org/team", "svc"),
+            number,
+            head_sha.to_string(),
+        )
+    }
+
     /// A checkout with a real `origin`, so the selector's coordinate comes from
     /// the remote URL rather than the directory name.
     fn make_repo_with_origin(url: &str) -> tempfile::TempDir {
@@ -1555,6 +1565,53 @@ mod tests {
                 .iter()
                 .any(|s| s.starts_with("myorg/myproject/myrepo@main/worktree")),
             "expected the local session under an org/project owner, got {slugs:?}"
+        );
+    }
+
+    #[test]
+    fn should_find_gitlab_subgroup_pr_session_by_repo_url_coordinate() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+        let key = make_gitlab_pr_key(123, "abcdef0123456789");
+        save_session(&make_pr_session(&key)).unwrap();
+
+        let listed = list_sessions_for_selector_in_dir(
+            &reviews_dir,
+            Path::new("https://gitlab.com/org/team/svc"),
+        )
+        .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].0, "gl:org/team/svc/pr/123");
+    }
+
+    #[test]
+    fn should_surface_gitlab_subgroup_pr_session_from_its_checkout() {
+        let _g = with_test_reviews_dir();
+        let reviews_dir = get_reviews_dir().unwrap();
+
+        let checkout = make_repo_with_origin("git@gitlab.com:org/team/svc.git");
+        save_session(&make_local_session(
+            checkout.path().to_path_buf(),
+            "abc1234",
+            Some("main"),
+            SessionDiffSource::WorkingTree,
+            None,
+        ))
+        .unwrap();
+        let key = make_gitlab_pr_key(123, "abcdef0123456789");
+        save_session(&make_pr_session(&key)).unwrap();
+
+        let listed = list_sessions_for_selector_in_dir(&reviews_dir, checkout.path()).unwrap();
+        let slugs: Vec<&str> = listed.iter().map(|(slug, _)| slug.as_str()).collect();
+        assert!(
+            slugs.contains(&"gl:org/team/svc/pr/123"),
+            "expected the PR session, got {slugs:?}"
+        );
+        assert!(
+            slugs
+                .iter()
+                .any(|s| s.starts_with("org/team/svc@main/worktree")),
+            "expected the local session under the full namespace, got {slugs:?}"
         );
     }
 

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -868,10 +868,37 @@ mod tests {
     }
 
     #[test]
-    fn should_pick_last_two_segments_for_nested_subgroups() {
-        // GitLab subgroups: take last two segments as owner/repo.
+    fn should_keep_the_whole_namespace_for_nested_gitlab_groups() {
+        for url in [
+            "git@gitlab.com:org/team/svc.git",
+            "https://gitlab.com/org/team/svc",
+            "https://gitlab.com/org/team/svc.git",
+            "https://oauth2:token@gitlab.com/org/team/svc.git",
+            "ssh://git@gitlab.com:2222/org/team/svc.git",
+            "https://gitlab.example.com/org/team/svc",
+        ] {
+            assert_eq!(
+                parse_remote_owner_repo(url),
+                Some(("org/team".to_string(), "svc".to_string())),
+                "parsing {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_keep_deeply_nested_gitlab_groups() {
         assert_eq!(
-            parse_remote_owner_repo("git@gitlab.com:org/team/svc.git"),
+            parse_remote_owner_repo("git@gitlab.com:org/team/sub/svc.git"),
+            Some(("org/team/sub".to_string(), "svc".to_string()))
+        );
+    }
+
+    #[test]
+    fn should_pick_last_two_segments_for_nested_unrecognized_hosts() {
+        // Only a forge's own parser knows a leading segment is a namespace
+        // rather than a host, so unknown hosts keep degrading to the last two.
+        assert_eq!(
+            parse_remote_owner_repo("git@example.com:org/team/svc.git"),
             Some(("team".to_string(), "svc".to_string()))
         );
     }
@@ -1067,9 +1094,29 @@ mod tests {
     }
 
     #[test]
-    fn should_take_last_two_segments_for_nested_groups() {
+    fn should_parse_nested_gitlab_group_coordinate_forms() {
+        for input in [
+            "gitlab.com/org/team/svc",
+            "forge:gitlab.com/org/team/svc",
+            "https://gitlab.com/org/team/svc.git",
+            "git@gitlab.com:org/team/svc.git",
+            "ssh://git@gitlab.com/org/team/svc",
+            "gitlab.example.com/org/team/svc",
+        ] {
+            assert_eq!(
+                RepoCoordinate::parse(input),
+                Some(coord(Some("org/team"), "svc")),
+                "parsing {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn should_take_last_two_segments_for_a_hostless_nested_coordinate() {
+        // `org/team/svc` is indistinguishable from `host/owner/repo`, so it
+        // stays ambiguous — users name a nested repo by its URL.
         assert_eq!(
-            RepoCoordinate::parse("gitlab.com/org/team/svc"),
+            RepoCoordinate::parse("org/team/svc"),
             Some(coord(Some("team"), "svc"))
         );
     }


### PR DESCRIPTION
The GitLab half of the same bug class as #639, split out as suggested in #654 and rebased onto `main` now that #654 has landed.

`tuicr review list` in a nested-group checkout now surfaces that repo's PR sessions, not just the local ones, and `--repo gitlab.com/org/team/svc` matches them too.

A repo under `org/team` resolved to owner `team`: a checkout's owner came from the generic last-two-path-segments rule, while its PR sessions carry the whole namespace from the forge layer. `RepoCoordinate::matches` compares owners as one opaque string, so those PR entries were filtered out.

The fix adds GitLab to `parse_any_remote_url_by_hostname` as a hostname-only variant. The full `parse_gitlab_remote_url` also recognizes self-hosted instances on custom domains, but does so by spawning `glab config get host` and reading `~/.ssh/config`, and `resolve_owner_repo` runs on every session save. Those instances are therefore still missed and keep falling back to the generic rule.

Risk: local slugs in a subgroup checkout change shape (`team/svc@…` → `org/team/svc@…`), so existing sessions there won't be reattached by the TUI. They stay listed and readable by their old slug.

I have no GitLab instance to test against. The behavior is covered by unit tests at both layers, but a check against a real subgroup checkout would be welcome.
