### PR TITLE
feat: gutter-aligned word wrap behind wrap_style = "gutter"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,6 +2907,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "two-face",
+ "unicode-segmentation",
  "unicode-width",
  "ureq",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ zip = { version = "4", default-features = false, features = ["deflate-flate2"] }
 # Syntax highlighting
 syntect = "5.2"
 two-face = { version = "0.5", default-features = false, features = ["syntect-default-fancy"] }
+unicode-segmentation = "1.13.3"
 
 # Terminal background detection
 terminal-colorsaurus = "1"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -35,6 +35,7 @@ leader = ","
 comment_vim = false
 comment_tab_width = 4
 wrap = false
+wrap_style = "flow"
 relative_line_numbers = false
 cursor_line = true
 search_highlight = true
@@ -90,6 +91,7 @@ legend = true
 | `comment_vim`              | `false`      | Vim modal editing in the comment box; toggle at runtime with `:vim`. When off, default emacs/readline bindings.                                            |
 | `comment_tab_width`        | `4`          | Spaces inserted by Tab while typing in the vim comment box (Insert mode).                                                                                  |
 | `wrap`                     | `false`      | Line wrap in the diff view. Toggle with `:set wrap!`.                                                                                                      |
+| `wrap_style`               | `flow`       | How wrapped lines render. `flow` uses word wrap with continuation rows starting at column 0. `gutter` wraps at word boundaries within the content column so continuation rows keep the line-number gutter, showing `↪` plus the line's `+`/`-` prefix; tokens longer than the content column hard-cut, and decoration lines (file headers) never split. |
 | `relative_line_numbers`    | `false`      | Show gutter numbers as rendered-row distances from the cursor. Toggle with `:set relativenumber!`.                                                         |
 | `cursor_line`              | `true`       | Highlight the current cursor line and visual selection.                                                                                                    |
 | `search_highlight`         | `true`       | Highlight `/` search matches in the diff view. Clear at runtime with `Esc`; `n` / `N` re-enable.                                                           |

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -583,6 +583,7 @@ impl App {
             diff_inner_area: None,
             commit_list_inner_area: None,
             diff_row_to_annotation: Vec::new(),
+            gutter_sel_ranges: HashMap::new(),
             expanded_dirs: HashSet::new(),
             expanded_top: HashMap::new(),
             expanded_bottom: HashMap::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -990,6 +990,17 @@ pub enum DiffViewMode {
     SideBySide,
 }
 
+/// How wrapped diff lines render. `Flow` delegates to the renderer's word
+/// wrap (continuation rows start at column 0). `Gutter` pre-expands logical
+/// lines so continuation rows keep the line-number gutter with a wrap marker
+/// and the diff origin prefix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WrapStyle {
+    #[default]
+    Flow,
+    Gutter,
+}
+
 /// Display order for the inline commit selector. The stored `review_commits`
 /// list is always newest-first; this only flips presentation (render + input
 /// mapping), never the underlying data model.
@@ -1342,6 +1353,12 @@ pub struct App {
     /// Visual-row -> annotation-index map for the diff viewport. Wrapped
     /// logical lines repeat their annotation index across multiple rows.
     pub diff_row_to_annotation: Vec<usize>,
+    /// Gutter-wrap only: per-annotation content char ranges of each visual
+    /// row, emitted by the expansion (word-boundary rows hold fewer chars
+    /// than the content column). Selection painting and cell-to-char
+    /// mapping consult this; absent entries fall back to the uniform
+    /// `which_row * content_width` model. Repopulated every render.
+    pub gutter_sel_ranges: HashMap<usize, Vec<(usize, usize)>>,
     pub expanded_dirs: HashSet<String>,
     /// Stores lines expanded downward from the upper boundary of each gap
     pub expanded_top: HashMap<GapId, Vec<DiffLine>>,
@@ -1521,6 +1538,12 @@ pub struct DiffState {
     pub viewport_width: usize,
     pub max_content_width: usize,
     pub wrap_lines: bool,
+    pub wrap_style: WrapStyle,
+    /// Cursor motion (`ensure_cursor_visible`) arms this flag while wrap
+    /// is on. The renderer consumes it, applies the stale-geometry
+    /// catch-up, and stays armed while corrections still occur. View
+    /// scrolls disarm it, so the catch-up cannot fight ctrl-e/ctrl-y.
+    pub scroll_catchup_armed: bool,
     /// Number of logical lines that fit in the viewport (set during render).
     /// When wrapping is enabled, this accounts for lines expanding to multiple visual rows.
     pub visible_line_count: usize,
@@ -1557,6 +1580,8 @@ impl Default for DiffState {
             viewport_width: 0,
             max_content_width: 0,
             wrap_lines: true,
+            wrap_style: WrapStyle::default(),
+            scroll_catchup_armed: false,
             visible_line_count: 0,
         }
     }

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -212,6 +212,9 @@ impl App {
     }
 
     pub fn scroll_view_down(&mut self, lines: usize) {
+        // A view scroll is deliberate: disarm the renderer's catch-up so
+        // it cannot move the view against this gesture.
+        self.diff_state.scroll_catchup_armed = false;
         let max_scroll = self.max_scroll_offset();
         self.diff_state.scroll_offset = (self.diff_state.scroll_offset + lines).min(max_scroll);
         let scroll_margin = self.diff_state.effective_scroll_margin(self.scroll_offset);
@@ -224,6 +227,9 @@ impl App {
     }
 
     pub fn scroll_view_up(&mut self, lines: usize) {
+        // A view scroll is deliberate: disarm the renderer's catch-up so
+        // it cannot move the view against this gesture.
+        self.diff_state.scroll_catchup_armed = false;
         self.diff_state.scroll_offset = self.diff_state.scroll_offset.saturating_sub(lines);
         let visible_lines = if self.diff_state.visible_line_count > 0 {
             self.diff_state.visible_line_count
@@ -274,9 +280,41 @@ impl App {
         self.set_message(format!("Diff wrapping: {status}"));
     }
 
+    /// True when wrapped lines render through the gutter-aligned pre-expansion
+    /// path instead of the flow wrap pass.
+    pub fn gutter_wrap_active(&self) -> bool {
+        self.diff_state.wrap_lines && self.diff_state.wrap_style == crate::app::WrapStyle::Gutter
+    }
+
+    /// Content char range of visual row `which_row` of an annotation. In
+    /// gutter wrap mode word-boundary rows hold fewer chars than the
+    /// content column, so the expansion's recorded ranges are authoritative;
+    /// otherwise rows pack uniformly at `content_width` chars per row.
+    pub fn sel_row_char_range(
+        &self,
+        ann_idx: usize,
+        which_row: usize,
+        content_width: usize,
+        total_chars: usize,
+    ) -> (usize, usize) {
+        if let Some(ranges) = self.gutter_sel_ranges.get(&ann_idx) {
+            return ranges
+                .get(which_row)
+                .copied()
+                .unwrap_or((total_chars, total_chars));
+        }
+        let start = (which_row * content_width).min(total_chars);
+        (start, (start + content_width).min(total_chars))
+    }
+
     /// Adjusts scroll_offset so the cursor stays within the visible viewport,
     /// respecting the configured scroll margin (minimum lines from edge).
     pub(in crate::app) fn ensure_cursor_visible(&mut self) {
+        // The cursor moved: arm the renderer's one-frame catch-up. The
+        // stale visible_line_count below can leave the cursor under the
+        // fresh fold after wrap recomputes. The renderer corrects that at
+        // end of frame, only for cursor motion, never for view scrolls.
+        self.diff_state.scroll_catchup_armed = self.diff_state.wrap_lines;
         // Use visible_line_count which is computed during render based on actual line widths.
         // Falls back to viewport_height if not yet set (before first render).
         let visible_lines = self.diff_state.effective_visible_lines();
@@ -708,7 +746,9 @@ impl App {
         }
         let which_row = rel - walker;
         let total_chars = content.chars().count();
-        let char_offset = (which_row * geom.content_width + col_in_row).min(total_chars);
+        let (row_start, row_end) =
+            self.sel_row_char_range(idx, which_row, geom.content_width, total_chars);
+        let char_offset = (row_start + col_in_row).min(row_end).min(total_chars);
         Some(SelPoint {
             annotation_idx: idx,
             char_offset,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,6 +128,10 @@ pub struct AppConfig {
     pub initial_commit_selection: Option<String>,
     pub ignore_whitespace: Option<bool>,
     pub wrap: Option<bool>,
+    /// How wrapped diff lines render: "flow" (ratatui word wrap, continuation
+    /// rows start at column 0) or "gutter" (continuation rows keep the
+    /// line-number gutter with a wrap marker). Defaults to "flow".
+    pub wrap_style: Option<String>,
     pub relative_line_numbers: Option<bool>,
     pub export_legend: Option<bool>,
     pub cursor_line: Option<bool>,
@@ -197,6 +201,7 @@ const KNOWN_KEYS: &[&str] = &[
     "initial_commit_selection",
     "ignore_whitespace",
     "wrap",
+    "wrap_style",
     "relative_line_numbers",
     "export_legend",
     "cursor_line",
@@ -438,6 +443,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         ),
         ignore_whitespace: read_bool(table, "ignore_whitespace", &mut warnings),
         wrap: read_bool(table, "wrap", &mut warnings),
+        wrap_style: read_enum(table, "wrap_style", &["flow", "gutter"], &mut warnings),
         export_legend: read_bool(table, "export_legend", &mut warnings),
         cursor_line: read_bool(table, "cursor_line", &mut warnings),
         search_highlight: read_bool(table, "search_highlight", &mut warnings),
@@ -812,6 +818,39 @@ mod tests {
             Some("libgit2")
         );
         assert!(libgit2.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_wrap_style_option() {
+        let gutter = parse_config("wrap_style = \"gutter\"\n");
+        assert_eq!(
+            gutter
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.wrap_style.as_deref()),
+            Some("gutter")
+        );
+        assert!(gutter.warnings.is_empty());
+
+        let flow = parse_config("wrap_style = \"flow\"\n");
+        assert_eq!(
+            flow.config
+                .as_ref()
+                .and_then(|cfg| cfg.wrap_style.as_deref()),
+            Some("flow")
+        );
+        assert!(flow.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_invalid_wrap_style_option() {
+        let outcome = parse_config("wrap_style = \"hanging\"\n");
+        assert_eq!(outcome.config, Some(AppConfig::default()));
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'wrap_style' must be \"flow\" or \"gutter\"; got \"hanging\", ignoring"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,9 @@ fn main() -> anyhow::Result<()> {
         if let Some(wrap) = cfg.wrap {
             app.diff_state.wrap_lines = wrap;
         }
+        if cfg.wrap_style.as_deref() == Some("gutter") {
+            app.diff_state.wrap_style = app::WrapStyle::Gutter;
+        }
         app.relative_line_numbers = cfg.relative_line_numbers.unwrap_or(false);
         // Open in single-file view when the user opts in. Pristine
         // `--all-files` already turned it on inside `App::new`, so we

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -979,6 +979,10 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
     } else {
         (vec![1; visible_lines_unscrolled_for_overlay.len()], None)
     };
+    // SBS wraps per side with blank continuation prefixes, so the uniform
+    // packing model applies; drop any ranges a previous unified gutter
+    // render published.
+    app.gutter_sel_ranges.clear();
     app.diff_state.visible_line_count = populate_row_to_annotation(
         &mut app.diff_row_to_annotation,
         &row_heights,
@@ -1030,6 +1034,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         &visible_lines_unscrolled_for_overlay,
         &row_heights,
         app,
+        app.diff_state.scroll_offset,
     );
 
     // Painted last so the cell overlay wins over cursor-line bg on overlap.

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -1215,11 +1215,49 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
     let wrap = app.diff_state.wrap_lines;
     let viewport_width = inner.width as usize;
     let visible_lines_unscrolled_for_bg = visible_lines_unscrolled.clone();
+    let gutter_wrap = app.gutter_wrap_active();
+    // In gutter mode the expansion itself produces both the rendered rows and
+    // the row counts, so renderer and geometry come from the same pass.
+    let gutter_expansion = (gutter_wrap && viewport_width > 0).then(|| {
+        let gutter_width = crate::app::unified_gutter(app.lineno_width()) as usize;
+        let plans = crate::ui::word_wrap::unified_wrap_plans(
+            app,
+            scroll_offset,
+            visible_lines_unscrolled.len(),
+            gutter_width,
+        );
+        crate::ui::word_wrap::expand_gutter_wrap(
+            visible_lines_unscrolled.clone(),
+            &plans,
+            viewport_width,
+            inner.height as usize,
+            &app.theme,
+        )
+    });
+    // Publish the expansion's per-row content char ranges for selection
+    // geometry (word-boundary rows hold fewer chars than the content
+    // column). Each render clears the map, so flow mode and stale
+    // windows use the uniform packing model. Keys use the same raw
+    // rendered-index space that `populate_row_to_annotation` stores
+    // (scroll_offset + rendered line). Producer and consumers therefore
+    // agree when the comment input box shifts indices.
+    app.gutter_sel_ranges.clear();
+    if let Some(expansion) = &gutter_expansion {
+        let pairs: Vec<(usize, Vec<(usize, usize)>)> = expansion
+            .row_char_ranges
+            .iter()
+            .enumerate()
+            .filter(|(_, ranges)| !ranges.is_empty())
+            .map(|(i, ranges)| (scroll_offset + i, ranges.clone()))
+            .collect();
+        app.gutter_sel_ranges.extend(pairs);
+    }
     // Single pass: wrap each logical line once, producing both the visual
     // rows to render and the per-line height used by every row-mapping
     // consumer below, so the two can't disagree.
-    let (row_heights, wrapped_lines): (Vec<usize>, Option<Vec<Line>>) =
-        if wrap && viewport_width > 0 {
+    let (row_heights, wrapped_lines): (Vec<usize>, Option<Vec<Line>>) = match gutter_expansion {
+        Some(expansion) => (expansion.row_heights, Some(expansion.rows)),
+        None if wrap && viewport_width > 0 => {
             let mut heights = Vec::with_capacity(visible_lines_unscrolled_for_bg.len());
             let mut out: Vec<Line> = Vec::new();
             for line in &visible_lines_unscrolled_for_bg {
@@ -1228,9 +1266,9 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
                 out.extend(rows.into_iter().map(Line::from));
             }
             (heights, Some(out))
-        } else {
-            (vec![1; visible_lines_unscrolled_for_bg.len()], None)
-        };
+        }
+        None => (vec![1; visible_lines_unscrolled_for_bg.len()], None),
+    };
     app.diff_state.visible_line_count = populate_row_to_annotation(
         &mut app.diff_row_to_annotation,
         &row_heights,
@@ -1239,6 +1277,28 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         wrap,
         scroll_offset,
     );
+    // Stale-geometry catch-up: ensure_cursor_visible ran at keypress time
+    // with the previous frame's visible_line_count. When fresh wrapping
+    // shrinks the window and leaves the cursor below the fold, correct
+    // the scroll for the next frame and for post-frame state. Only
+    // cursor motion arms it, view scrolls never do. Every painter in
+    // this frame uses the local `scroll_offset`, so the frame stays
+    // consistent and the lag is at most one frame.
+    if wrap
+        && app.input_mode != crate::app::InputMode::Comment
+        && std::mem::take(&mut app.diff_state.scroll_catchup_armed)
+    {
+        let visible_now = app.diff_state.effective_visible_lines();
+        if app.diff_state.cursor_line >= scroll_offset + visible_now {
+            app.diff_state.scroll_offset = app.diff_state.cursor_line + 1 - visible_now;
+            // The corrected window can shrink again. Stay armed until a
+            // frame passes with no correction, so convergence completes.
+            // View scrolls disarm explicitly and stop the chain.
+            app.diff_state.scroll_catchup_armed = true;
+        }
+    } else {
+        app.diff_state.scroll_catchup_armed = false;
+    }
 
     let max_scroll_x = max_content_width.saturating_sub(viewport_width);
     if app.diff_state.scroll_x > max_scroll_x {
@@ -1274,7 +1334,9 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         wrap_lines: app.diff_state.wrap_lines,
         viewport_width: inner.width as usize,
         scroll_x,
-        scroll_offset: app.diff_state.scroll_offset,
+        // The frame's own offset, never the possibly caught-up live value:
+        // overlays must match the row list this frame rendered.
+        scroll_offset,
         theme: &app.theme,
         comment_bars: &comment_bars,
     };
@@ -1296,6 +1358,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         &visible_lines_unscrolled_for_bg,
         &row_heights,
         app,
+        scroll_offset,
     );
 
     if let Some(sel) = app.visual_selection {
@@ -1491,8 +1554,8 @@ mod remote_comments_snapshot_tests {
     use ratatui::layout::Rect;
     use std::path::{Path, PathBuf};
 
-    struct SnapshotVcs {
-        info: VcsInfo,
+    pub(super) struct SnapshotVcs {
+        pub(super) info: VcsInfo,
     }
 
     impl VcsBackend for SnapshotVcs {
@@ -1576,7 +1639,7 @@ mod remote_comments_snapshot_tests {
         }
     }
 
-    fn header_only_diff_file_at(path: &str) -> DiffFile {
+    pub(super) fn header_only_diff_file_at(path: &str) -> DiffFile {
         let hunks = Vec::new();
         let content_hash = DiffFile::compute_content_hash(&hunks);
         DiffFile {
@@ -1661,7 +1724,7 @@ mod remote_comments_snapshot_tests {
         .expect("build app")
     }
 
-    fn make_revision_app(diff_files: Vec<DiffFile>) -> App {
+    pub(super) fn make_revision_app(diff_files: Vec<DiffFile>) -> App {
         let vcs_info = VcsInfo {
             root_path: PathBuf::from("/tmp/tuicr"),
             head_commit: "headsha".to_string(),
@@ -1711,7 +1774,7 @@ mod remote_comments_snapshot_tests {
         terminal.backend().buffer().clone()
     }
 
-    fn body_text(buffer: &Buffer) -> String {
+    pub(super) fn body_text(buffer: &Buffer) -> String {
         (0..buffer.area.height)
             .map(|y| {
                 (0..buffer.area.width)
@@ -2264,6 +2327,461 @@ mod remote_comments_snapshot_tests {
             assert_eq!(
                 glyph, "│",
                 "expected │ at ({bar_x},{y}) between cap ({cap_y}) and box top ({box_top_y}), got {glyph:?}"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod gutter_wrap_snapshot_tests {
+    //! Render-snapshot tests for `wrap_style = "gutter"`: continuation rows
+    //! keep the gutter (↪ in the lineno column + origin prefix), headers
+    //! never split, and per-row backgrounds/highlights track the expansion.
+    use super::remote_comments_snapshot_tests::{
+        body_text, header_only_diff_file_at, make_revision_app,
+    };
+    use crate::app::{App, WrapStyle};
+    use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use std::path::PathBuf;
+
+    fn long_line_diff_file(content: &str) -> DiffFile {
+        let lines = vec![
+            DiffLine {
+                origin: LineOrigin::Context,
+                content: "short context".to_string(),
+                old_lineno: Some(1),
+                new_lineno: Some(1),
+                highlighted_spans: None,
+            },
+            DiffLine {
+                origin: LineOrigin::Addition,
+                content: content.to_string(),
+                old_lineno: None,
+                new_lineno: Some(2),
+                highlighted_spans: None,
+            },
+        ];
+        let hunk = DiffHunk {
+            header: "@@ -1,1 +1,2 @@".to_string(),
+            lines,
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 2,
+        };
+        let hunks = vec![hunk];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: Some(PathBuf::from("src/lib.rs")),
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    fn gutter_app(diff_files: Vec<DiffFile>) -> App {
+        let mut app = make_revision_app(diff_files);
+        app.diff_state.wrap_style = WrapStyle::Gutter;
+        app.diff_state.wrap_lines = true;
+        app
+    }
+
+    /// A file of `n` additions, each long enough to wrap several times.
+    fn many_wrapped_additions_file(n: usize) -> DiffFile {
+        let lines: Vec<DiffLine> = (0..n)
+            .map(|i| DiffLine {
+                origin: LineOrigin::Addition,
+                content: format!("line{i:02} {}", "wrapped content ".repeat(8)),
+                old_lineno: None,
+                new_lineno: Some(i as u32 + 1),
+                highlighted_spans: None,
+            })
+            .collect();
+        let hunk = DiffHunk {
+            header: format!("@@ -0,0 +1,{n} @@"),
+            lines,
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: n as u32,
+        };
+        let hunks = vec![hunk];
+        let content_hash = DiffFile::compute_content_hash(&hunks);
+        DiffFile {
+            old_path: Some(PathBuf::from("src/lib.rs")),
+            new_path: Some(PathBuf::from("src/lib.rs")),
+            status: FileStatus::Modified,
+            hunks,
+            is_binary: false,
+            is_too_large: false,
+            is_commit_message: false,
+            content_hash,
+        }
+    }
+
+    fn draw_at(app: &mut App, width: u16, height: u16) -> Buffer {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| super::render_unified_diff(frame, app, Rect::new(0, 0, width, height)))
+            .expect("draw unified diff");
+        terminal.backend().buffer().clone()
+    }
+
+    fn rows(buffer: &Buffer) -> Vec<String> {
+        body_text(buffer).lines().map(str::to_string).collect()
+    }
+
+    #[test]
+    fn should_render_continuation_gutter_for_wrapped_addition() {
+        let mut app = gutter_app(vec![long_line_diff_file(&"a".repeat(120))]);
+        let buffer = draw_at(&mut app, 40, 12);
+        let body = body_text(&buffer);
+        // Continuation row: ↪ in the lineno column, then the carried origin
+        // prefix, then content at the content column — not at column 0.
+        assert!(
+            body.contains("↪▌ a"),
+            "expected gutter-aligned continuation row:\n{body}"
+        );
+        let continuation = rows(&buffer)
+            .into_iter()
+            .find(|row| row.contains('↪'))
+            .expect("a continuation row exists");
+        // First cell inside the panel border is the blank indicator slot.
+        assert_eq!(
+            continuation.chars().nth(1),
+            Some(' '),
+            "continuation keeps the indicator slot blank: {continuation:?}"
+        );
+    }
+
+    #[test]
+    fn should_map_all_visual_rows_of_wrapped_line_to_same_annotation() {
+        let mut app = gutter_app(vec![long_line_diff_file(&"b".repeat(120))]);
+        let buffer = draw_at(&mut app, 40, 12);
+        // The wrapped addition occupies as many consecutive identical
+        // entries in the hit-test map as the buffer shows ↪ rows + 1.
+        let marker_rows = rows(&buffer).iter().filter(|row| row.contains('↪')).count();
+        assert!(marker_rows >= 2, "expected at least 2 continuation rows");
+        let mut counts = std::collections::HashMap::new();
+        for &idx in &app.diff_row_to_annotation {
+            *counts.entry(idx).or_insert(0usize) += 1;
+        }
+        let max_duplicates = counts.values().copied().max().unwrap_or(0);
+        assert_eq!(
+            max_duplicates,
+            marker_rows + 1,
+            "hit-test rows must match rendered rows (marker rows {marker_rows} + first row)"
+        );
+    }
+
+    #[test]
+    fn should_never_split_file_header_in_gutter_mode() {
+        // Narrow viewport, long path: the header would wrap under flow mode.
+        let mut app = gutter_app(vec![header_only_diff_file_at(
+            "src/some/deeply/nested/path/with_a_rather_long_name.rs",
+        )]);
+        let buffer = draw_at(&mut app, 30, 12);
+        let body = body_text(&buffer);
+        // The path appears on exactly one row (clipped at the panel edge),
+        // never spilling onto a second row the way the wrapped header did.
+        let header_rows = rows(&buffer)
+            .iter()
+            .filter(|row| row.contains("src/some"))
+            .count();
+        assert_eq!(
+            header_rows, 1,
+            "header must occupy exactly one row:\n{body}"
+        );
+        assert!(
+            !body.contains("long_name"),
+            "clipped header tail must not spill onto another row:\n{body}"
+        );
+        assert!(
+            !body.contains('↪'),
+            "decoration lines must never grow continuation rows:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_keep_short_file_header_intact_in_gutter_mode() {
+        let mut app = gutter_app(vec![header_only_diff_file_at("README.md")]);
+        let buffer = draw_at(&mut app, 60, 12);
+        let body = body_text(&buffer);
+        assert!(
+            body.contains("═══ README.md [M] "),
+            "expected full README.md file header in:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_keep_flow_continuations_at_column_zero_when_wrap_style_flow() {
+        let mut app = make_revision_app(vec![long_line_diff_file(&"c".repeat(120))]);
+        app.diff_state.wrap_lines = true; // default Flow style
+        let buffer = draw_at(&mut app, 40, 12);
+        let body = body_text(&buffer);
+        assert!(
+            !body.contains('↪'),
+            "flow mode must not grow gutter markers:\n{body}"
+        );
+        // Flow continuations start at the panel's first inner column (right
+        // after the border), under the gutter.
+        assert!(
+            rows(&buffer).iter().any(|row| row.starts_with("│c")),
+            "flow continuation rows start at the inner left edge:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_paint_add_background_across_continuation_rows() {
+        let mut app = gutter_app(vec![long_line_diff_file(&"d".repeat(120))]);
+        let add_bg = app.theme.diff_add_bg;
+        let buffer = draw_at(&mut app, 40, 12);
+        let continuation_y = rows(&buffer)
+            .iter()
+            .position(|row| row.contains('↪'))
+            .expect("a continuation row exists") as u16;
+        // Last column inside the panel border carries the add background even
+        // though the wrapped content ends earlier.
+        assert_eq!(
+            buffer[(buffer.area.width - 2, continuation_y)].style().bg,
+            Some(add_bg),
+            "continuation row right edge must carry the add background"
+        );
+    }
+
+    #[test]
+    fn should_highlight_all_visual_rows_of_cursor_line_in_gutter_mode() {
+        let mut app = gutter_app(vec![long_line_diff_file(&"e".repeat(120))]);
+        let cursor_bg = app.theme.cursor_line_bg;
+        // Move the cursor onto the wrapped addition (last navigable line).
+        app.diff_state.cursor_line = app.max_cursor_line();
+        let buffer = draw_at(&mut app, 40, 12);
+        let continuation_y = rows(&buffer)
+            .iter()
+            .position(|row| row.contains('↪'))
+            .expect("a continuation row exists");
+        // The wrapped line's first visual row sits directly above its first
+        // continuation row; both must carry the cursor background on the
+        // first inner column.
+        for y in [continuation_y - 1, continuation_y] {
+            assert_eq!(
+                buffer[(1, y as u16)].style().bg,
+                Some(cursor_bg),
+                "row {y} of the cursor line must carry the cursor background"
+            );
+        }
+    }
+
+    #[test]
+    fn should_render_cjk_diff_line_in_gutter_mode_without_panic() {
+        let mut app = gutter_app(vec![long_line_diff_file(&"漢字テスト".repeat(12))]);
+        let buffer = draw_at(&mut app, 40, 12);
+        let body = body_text(&buffer);
+        assert!(
+            body.contains('↪'),
+            "CJK content must wrap with gutter continuations:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_keep_catchup_frame_consistent_after_cursor_walk() {
+        // A j-walk into heavy wrap arms the catch-up. The first frame
+        // after the walk paints with the old offset. In that frame, each
+        // row that carries the cursor background must map to the cursor
+        // line: the catch-up must not shift overlays mid-render. The
+        // second frame shows the corrected viewport.
+        let mut app = gutter_app(vec![long_line_diff_file(&"g".repeat(200))]);
+        let cursor_bg = app.theme.cursor_line_bg;
+        draw_at(&mut app, 40, 10);
+        let max = app.max_cursor_line();
+        for _ in 0..max {
+            app.cursor_down(1);
+        }
+        let buffer = draw_at(&mut app, 40, 10);
+        // Inner rows start below the top border, so buffer row y maps to
+        // hit-map index y - 1.
+        for y in 1..buffer.area.height - 1 {
+            if buffer[(1, y)].style().bg == Some(cursor_bg) {
+                let ann = app.diff_row_to_annotation.get(y as usize - 1).copied();
+                assert_eq!(
+                    ann,
+                    Some(app.diff_state.cursor_line),
+                    "row {y} carries the cursor background but maps elsewhere"
+                );
+            }
+        }
+        draw_at(&mut app, 40, 10);
+        assert!(app.is_cursor_visible(), "second frame shows the cursor");
+    }
+
+    #[test]
+    fn should_keep_gutter_wrap_correct_while_comment_input_box_is_open() {
+        // The wrap planner maps rendered rows to annotations through the
+        // comment-input-box offset. With the box open on the context line
+        // (above the wrapped addition), the addition must still expand with
+        // gutter continuations and decoration rows must stay exempt.
+        let mut app = gutter_app(vec![long_line_diff_file(&"f".repeat(120))]);
+        app.enter_comment_mode(false, Some((1, crate::model::LineSide::New)));
+        let buffer = draw_at(&mut app, 40, 16);
+        let body = body_text(&buffer);
+        assert!(
+            body.contains("↪▌ f"),
+            "wrapped addition keeps gutter continuations below the open box:\n{body}"
+        );
+        // Match the decoration form only: since v0.24 the panel border title
+        // also carries the file name, which is not a rendered header row.
+        let header_rows = rows(&buffer)
+            .iter()
+            .filter(|row| row.contains("═══ src/lib.rs"))
+            .count();
+        assert_eq!(
+            header_rows, 1,
+            "file header stays a single row with the box open:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_swap_render_modes_when_wrap_toggles_at_runtime() {
+        let mut app = gutter_app(vec![long_line_diff_file(&"g".repeat(120))]);
+        // Gutter wrap on: continuation markers present.
+        let body_on = body_text(&draw_at(&mut app, 40, 12));
+        assert!(
+            body_on.contains('↪'),
+            "expected markers while on:\n{body_on}"
+        );
+
+        // :set wrap! off — clipped single rows, no markers, no flow wrap.
+        app.set_diff_wrap(false);
+        let body_off = body_text(&draw_at(&mut app, 40, 12));
+        assert!(
+            !body_off.contains('↪'),
+            "no markers with wrap off:\n{body_off}"
+        );
+
+        // Back on: gutter expansion resumes.
+        app.set_diff_wrap(true);
+        let body_back = body_text(&draw_at(&mut app, 40, 12));
+        assert!(
+            body_back.contains('↪'),
+            "markers return after toggling wrap back on:\n{body_back}"
+        );
+    }
+
+    #[test]
+    fn should_show_last_line_after_jump_to_bottom_with_heavy_wrapping() {
+        // Regression (test campaign, probe 1): jump_to_bottom positioned the
+        // scroll using the raw viewport height in logical-line units, so
+        // with wrapped lines the cursor and the last line landed far below
+        // the fold.
+        let mut app = gutter_app(vec![many_wrapped_additions_file(14)]);
+        // First draw establishes the wrap-aware visible_line_count.
+        let _ = draw_at(&mut app, 40, 12);
+        app.jump_to_bottom();
+        // Geometry is computed lazily during render, so the first frame
+        // after a jump may still under-scroll; the render's catch-up clamp
+        // corrects the scroll for the following frame — same cadence as
+        // the event loop's next redraw.
+        let _ = draw_at(&mut app, 40, 12);
+        let buffer = draw_at(&mut app, 40, 12);
+        let body = body_text(&buffer);
+        assert!(
+            body.contains("line13"),
+            "last line must be on screen after G:\n{body}"
+        );
+        assert!(
+            app.is_cursor_visible(),
+            "cursor must be visible after G (scroll {}, cursor {}, visible {})",
+            app.diff_state.scroll_offset,
+            app.diff_state.cursor_line,
+            app.diff_state.visible_line_count
+        );
+    }
+
+    #[test]
+    fn should_keep_cursor_on_screen_walking_j_across_wrapped_lines() {
+        // Regression (test campaign, probe 2): the scroll-catch-up cap in
+        // cursor_down assumed one visual row per logical line, accumulating
+        // a scroll deficit on wrapped lines until the cursor walked off
+        // screen.
+        let mut app = gutter_app(vec![many_wrapped_additions_file(14)]);
+        let _ = draw_at(&mut app, 40, 12);
+        let max = app.max_cursor_line();
+        for step in 0..max {
+            app.cursor_down(1);
+            // One frame of catch-up is allowed (lazy geometry; the render's
+            // clamp corrects the scroll for the next frame). What must
+            // never happen is the old unbounded deficit that walked the
+            // cursor permanently off screen.
+            let _ = draw_at(&mut app, 40, 12);
+            let _ = draw_at(&mut app, 40, 12);
+            assert!(
+                app.is_cursor_visible(),
+                "cursor off screen at step {step}: scroll {}, cursor {}, visible {}",
+                app.diff_state.scroll_offset,
+                app.diff_state.cursor_line,
+                app.diff_state.visible_line_count
+            );
+        }
+    }
+
+    #[test]
+    fn should_paint_visual_selection_on_every_row_of_word_wrapped_line() {
+        // Regression (test campaign, probe 4b): word-boundary rows hold
+        // fewer chars than the content column, so the uniform
+        // `which_row * content_width` model exhausted the selection's char
+        // range before the last visual row — the row rendered with no
+        // selection background. The expansion's recorded per-row char
+        // ranges fix the mapping.
+        use crate::app::{SelPoint, VisualSelection};
+        use crate::model::LineSide;
+
+        // Four words that word-wrap into several short rows.
+        let content = "alphaword betaword gammaword deltaword";
+        let mut app = gutter_app(vec![long_line_diff_file(content)]);
+        let buffer = draw_at(&mut app, 24, 12); // content_width 24-2(border)-8(gutter)
+        let marker_rows: Vec<usize> = rows(&buffer)
+            .iter()
+            .enumerate()
+            .filter(|(_, row)| row.contains('↪'))
+            .map(|(y, _)| y)
+            .collect();
+        assert!(marker_rows.len() >= 2, "need a multi-row wrapped line");
+
+        // Select the whole wrapped line.
+        let ann_idx = app.diff_row_to_annotation[marker_rows[0]];
+        let sel_bg = app.theme.bg_highlight; // visual_selection_style's bg
+        app.visual_selection = Some(VisualSelection {
+            anchor: SelPoint {
+                annotation_idx: ann_idx,
+                char_offset: 0,
+                side: LineSide::New,
+            },
+            head: SelPoint {
+                annotation_idx: ann_idx,
+                char_offset: content.chars().count(),
+                side: LineSide::New,
+            },
+        });
+        let buffer = draw_at(&mut app, 24, 12);
+
+        // Every visual row of the line (first row + each continuation row)
+        // must carry the selection background at the content column.
+        let content_x = 1 + 8; // border + gutter
+        let first_row_y = marker_rows[0] - 1;
+        for y in std::iter::once(first_row_y).chain(marker_rows.iter().copied()) {
+            assert_eq!(
+                buffer[(content_x as u16, y as u16)].style().bg,
+                Some(sel_bg),
+                "visual row {y} of the selected wrapped line lacks selection bg"
             );
         }
     }

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -404,6 +404,13 @@ pub(super) fn populate_row_to_annotation(
         let mut logical_lines_visible = 0;
         for (i, &rows_for_line) in row_heights.iter().enumerate() {
             if visual_rows_used + rows_for_line > viewport_height {
+                // The boundary line is partially visible: its top rows fill
+                // the rest of the viewport. Map them so clicks there land on
+                // the line instead of a dead zone (it stays excluded from
+                // `logical_lines_visible` so scroll math is unchanged).
+                for _ in visual_rows_used..viewport_height {
+                    out.push(scroll_offset + i);
+                }
                 break;
             }
             for _ in 0..rows_for_line {
@@ -513,8 +520,8 @@ fn paint_annotation_group(
     }
 
     for which_row in 0..group_height {
-        let row_char_start = which_row * paint.geom.content_width;
-        let row_char_end = row_char_start + paint.geom.content_width;
+        let (row_char_start, row_char_end) =
+            app.sel_row_char_range(ann_idx, which_row, paint.geom.content_width, total_chars);
         let isect_lo = lo.max(row_char_start);
         let isect_hi = hi.min(row_char_end);
         if isect_hi <= isect_lo {
@@ -541,12 +548,50 @@ fn paint_annotation_group(
     }
 }
 
-pub(super) fn is_line_highlighted(app: &App, viewport_idx: usize) -> bool {
+/// Map an absolute rendered line index to its `line_annotations` index,
+/// adjusting for the inline comment input box, which may occupy more or
+/// fewer rendered rows than the annotation entries it replaces. Returns
+/// `None` for rendered rows inside the box that have no annotation entry.
+pub(super) fn annotation_idx_for_rendered_line(app: &App, abs_idx: usize) -> Option<usize> {
+    map_rendered_to_annotation(abs_idx, app.comment_input_annotation_offset)
+}
+
+/// Core math behind [`annotation_idx_for_rendered_line`]: `box_offset` is
+/// `(box_start, box_len, replaced)` for an open comment input box.
+fn map_rendered_to_annotation(
+    abs_idx: usize,
+    box_offset: Option<(usize, usize, usize)>,
+) -> Option<usize> {
+    let Some((box_start, box_len, replaced)) = box_offset else {
+        return Some(abs_idx);
+    };
+    if abs_idx < box_start {
+        Some(abs_idx)
+    } else if abs_idx < box_start + box_len {
+        // Inside the comment input box - only the portion that maps to
+        // annotation entries being replaced (edited comment lines)
+        let offset_in_box = abs_idx - box_start;
+        if offset_in_box < replaced {
+            Some(box_start + offset_in_box)
+        } else {
+            None
+        }
+    } else {
+        // After the box: shift by the difference between rendered and annotation counts
+        // box_len > replaced: input box added extra lines → shift back
+        // box_len < replaced: input box is shorter → shift forward
+        Some(abs_idx + replaced - box_len)
+    }
+}
+
+pub(super) fn is_line_highlighted(app: &App, viewport_idx: usize, scroll_offset: usize) -> bool {
     if !app.cursor_line_highlight {
         return false;
     }
 
-    let abs_idx = viewport_idx + app.diff_state.scroll_offset;
+    // The caller passes the frame's own offset, so a catch-up applied
+    // after the window was built cannot shift the highlight.
+    let abs_idx = viewport_idx + scroll_offset;
 
     // Cursor line
     if abs_idx == app.diff_state.cursor_line {
@@ -559,30 +604,9 @@ pub(super) fn is_line_highlighted(app: &App, viewport_idx: usize) -> bool {
         return false;
     };
 
-    // Adjust the annotation index to account for the comment input box, which
-    // may have a different line count than what line_annotations expects.
-    let annotation_idx =
-        if let Some((box_start, box_len, replaced)) = app.comment_input_annotation_offset {
-            if abs_idx < box_start {
-                abs_idx
-            } else if abs_idx < box_start + box_len {
-                // Inside the comment input box - only highlight the portion that
-                // maps to annotation entries being replaced (edited comment lines)
-                let offset_in_box = abs_idx - box_start;
-                if offset_in_box < replaced {
-                    box_start + offset_in_box
-                } else {
-                    return false;
-                }
-            } else {
-                // After the box: shift by the difference between rendered and annotation counts
-                // box_len > replaced: input box added extra lines → shift back
-                // box_len < replaced: input box is shorter → shift forward
-                abs_idx + replaced - box_len
-            }
-        } else {
-            abs_idx
-        };
+    let Some(annotation_idx) = annotation_idx_for_rendered_line(app, abs_idx) else {
+        return false;
+    };
 
     let Some(annotation) = app.line_annotations.get(annotation_idx) else {
         return false;
@@ -638,6 +662,7 @@ pub(super) fn paint_cursor_line_highlight(
     visible_lines_unscrolled: &[Line],
     row_heights: &[usize],
     app: &App,
+    scroll_offset: usize,
 ) {
     if !app.cursor_line_highlight {
         return;
@@ -651,7 +676,7 @@ pub(super) fn paint_cursor_line_highlight(
         inner,
         visible_lines_unscrolled,
         row_heights,
-        |idx, _line| is_line_highlighted(app, idx).then_some(cursor_style),
+        |idx, _line| is_line_highlighted(app, idx, scroll_offset).then_some(cursor_style),
         |row_rect, row_style| match preserve_bg {
             None => buf.set_style(row_rect, row_style),
             Some(keep) => {
@@ -1134,6 +1159,51 @@ pub(super) fn apply_horizontal_scroll(line: Line, scroll_x: usize) -> Line {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_map_partially_visible_boundary_line_rows() {
+        // Heights [2, 3, 4] at scroll 5, viewport 7 rows: lines 5 and 6
+        // fit (5 rows), line 7 is the boundary line and only its top two
+        // rows fit. Those rows must map to the line, not a dead zone, and
+        // the line stays excluded from the visible-line count.
+        let mut out = Vec::new();
+        let visible = populate_row_to_annotation(&mut out, &[2, 3, 4], 10, 7, true, 5);
+        assert_eq!(out, vec![5, 5, 6, 6, 6, 7, 7]);
+        assert_eq!(visible, 2);
+    }
+
+    #[test]
+    fn should_map_identity_without_comment_box() {
+        assert_eq!(map_rendered_to_annotation(7, None), Some(7));
+    }
+
+    #[test]
+    fn should_map_identity_before_comment_box() {
+        // box at rendered rows 5..9 (len 4), replacing 2 annotation entries
+        assert_eq!(map_rendered_to_annotation(4, Some((5, 4, 2))), Some(4));
+    }
+
+    #[test]
+    fn should_map_replaced_rows_inside_comment_box() {
+        // first `replaced` rows of the box map to the edited annotation entries
+        assert_eq!(map_rendered_to_annotation(5, Some((5, 4, 2))), Some(5));
+        assert_eq!(map_rendered_to_annotation(6, Some((5, 4, 2))), Some(6));
+    }
+
+    #[test]
+    fn should_return_none_for_extra_rows_inside_comment_box() {
+        // rows of the box beyond `replaced` have no annotation entry
+        assert_eq!(map_rendered_to_annotation(7, Some((5, 4, 2))), None);
+        assert_eq!(map_rendered_to_annotation(8, Some((5, 4, 2))), None);
+    }
+
+    #[test]
+    fn should_shift_rows_after_comment_box() {
+        // after the box: rendered idx 9 maps back by (box_len - replaced) = 2
+        assert_eq!(map_rendered_to_annotation(9, Some((5, 4, 2))), Some(7));
+        // box shorter than replaced shifts forward instead
+        assert_eq!(map_rendered_to_annotation(9, Some((5, 1, 3))), Some(11));
+    }
 
     #[test]
     fn should_not_scroll_when_comment_box_already_visible() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,5 +16,6 @@ pub mod styles;
 pub mod submit_modals;
 pub mod summary_popup;
 pub mod text_utils;
+pub mod word_wrap;
 
 pub use app_layout::render;

--- a/src/ui/row_height.rs
+++ b/src/ui/row_height.rs
@@ -17,10 +17,12 @@
 //! the renderers.
 
 use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
-use crate::app::{AnnotatedLine, App, DiffViewMode, sbs_overhead};
+use crate::app::{AnnotatedLine, App, DiffViewMode, sbs_overhead, unified_gutter};
 use crate::ui::text_utils::wrap_spans;
-use crate::ui::{comment_panel, diff_view};
+use crate::ui::{comment_panel, diff_view, word_wrap};
 
 pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
     if !app.diff_state.wrap_lines {
@@ -29,6 +31,13 @@ pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
     let viewport_width = app.diff_state.viewport_width;
     if viewport_width == 0 {
         return 1;
+    }
+    // Gutter wrap pre-expands only unified diff content lines; everything
+    // else renders one row (the no-Wrap Paragraph clips overflow). Mirror
+    // the expansion's packing so jumps sum the same heights the renderer
+    // paints.
+    if app.diff_view_mode == DiffViewMode::Unified && app.gutter_wrap_active() {
+        return gutter_row_height(app, idx, viewport_width);
     }
     // SBS parity: the renderer disables the entire wrap pass (including
     // non-content rows) when the per-side content width is 0, falling back
@@ -111,6 +120,52 @@ pub(crate) fn annotation_row_height(app: &App, idx: usize) -> usize {
             wrap_len(&text, viewport_width)
         }
     }
+}
+
+/// Height of `line_annotations[idx]` under gutter wrap: the row count of
+/// `word_wrap::gutter_row_byte_ranges` over the same text the renderer
+/// expands, or 1 for exempt (non diff-content) lines.
+fn gutter_row_height(app: &App, idx: usize, viewport_width: usize) -> usize {
+    let Some(annotation) = app.line_annotations.get(idx) else {
+        return 1;
+    };
+    if !matches!(
+        annotation,
+        AnnotatedLine::DiffLine { .. } | AnnotatedLine::ExpandedContext { .. }
+    ) {
+        return 1;
+    }
+    let text = full_row_text(app, annotation);
+    if text.width() <= viewport_width {
+        return 1;
+    }
+    let gutter_width = unified_gutter(app.lineno_width()) as usize;
+    let content_width = viewport_width.saturating_sub(gutter_width);
+    if content_width == 0 {
+        return 1;
+    }
+    let content = strip_gutter_cells(&text, gutter_width);
+    if content.width() <= content_width {
+        return 1;
+    }
+    word_wrap::gutter_row_byte_ranges(content, content_width)
+        .len()
+        .max(1)
+}
+
+/// Drop the first `gutter_width` display cells (grapheme-aligned), mirroring
+/// the expansion's span split at the same boundary.
+fn strip_gutter_cells(text: &str, gutter_width: usize) -> &str {
+    let mut width = 0;
+    let mut byte_offset = 0;
+    for grapheme in text.graphemes(true) {
+        if width >= gutter_width {
+            break;
+        }
+        width += grapheme.width();
+        byte_offset += grapheme.len();
+    }
+    &text[byte_offset..]
 }
 
 fn repeated_annotation_row(app: &App, idx: usize, annotation: &AnnotatedLine) -> usize {
@@ -813,6 +868,23 @@ mod tests {
     }
 
     #[test]
+    fn parity_unified_with_gutter_wrap() {
+        let mut app = make_app();
+        app.set_diff_wrap(true);
+        app.diff_state.wrap_style = crate::app::WrapStyle::Gutter;
+        render_diff(&mut app, DiffViewMode::Unified, 40, 200);
+        let expanded = observed_heights(&app).into_iter().any(|(idx, height)| {
+            height > 1
+                && matches!(
+                    app.line_annotations.get(idx),
+                    Some(AnnotatedLine::DiffLine { .. })
+                )
+        });
+        assert!(expanded, "expected at least one diff line to gutter-expand");
+        assert_parity(&app);
+    }
+
+    #[test]
     fn parity_side_by_side_with_wrap() {
         let mut app = make_app();
         app.set_diff_wrap(true);
@@ -820,6 +892,23 @@ mod tests {
         assert_coverage(&app, DiffViewMode::SideBySide);
         assert_remote_rows_wrap(&app);
         assert_parity(&app);
+    }
+
+    #[test]
+    fn parity_side_by_side_gutter_style_stays_flow() {
+        // Gutter wrap must not leak into side-by-side. SBS keeps its flow
+        // layout: annotation_row_height gates the gutter branch on Unified.
+        // The render publishes no gutter selection ranges, and parity holds.
+        let mut app = make_app();
+        app.set_diff_wrap(true);
+        app.diff_state.wrap_style = crate::app::WrapStyle::Gutter;
+        render_diff(&mut app, DiffViewMode::SideBySide, 60, 200);
+        assert_coverage(&app, DiffViewMode::SideBySide);
+        assert_parity(&app);
+        assert!(
+            app.gutter_sel_ranges.is_empty(),
+            "SBS render must not publish gutter selection ranges"
+        );
     }
 
     #[test]

--- a/src/ui/word_wrap.rs
+++ b/src/ui/word_wrap.rs
@@ -1,0 +1,716 @@
+//! Gutter-aligned wrap expansion for `wrap_style = "gutter"`.
+//!
+//! Pre-expands long diff lines into visual rows before the `Paragraph`, so
+//! continuation rows keep the line-number gutter (a `↪` marker in the lineno
+//! column plus the diff origin prefix) instead of flowing under it the way
+//! ratatui's `Wrap` does. Rows break at word boundaries when possible
+//! (matching flow wrap's feel); a single token longer than the content
+//! column hard-cuts at the display-width limit so code identifiers and
+//! URLs still wrap instead of overflowing.
+//!
+//! The expansion also returns rows-per-logical-line, which becomes the
+//! geometry source for scroll math, hit-testing, and overlay painting —
+//! renderer and geometry come from the same pass and cannot diverge.
+
+use ratatui::text::{Line, Span};
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+use crate::app::{AnnotatedLine, App};
+use crate::theme::Theme;
+use crate::ui::styles;
+
+/// Whitespace the word-boundary backtrack may break at. Excludes the
+/// non-breaking family (NBSP, narrow NBSP, figure space), whose entire
+/// purpose is to forbid a break.
+fn is_breakable_space(c: char) -> bool {
+    c.is_whitespace() && !matches!(c, '\u{a0}' | '\u{202f}' | '\u{2007}')
+}
+
+/// How one logical line participates in gutter-mode expansion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WrapPlan {
+    /// Never split. Rendered as one row; the no-`Wrap` `Paragraph` clips
+    /// overflow. This is the safe default for decoration lines (file
+    /// headers, spacing) — the bug class that sank the first wrap attempt
+    /// was headers splitting mid-box.
+    Exempt,
+    /// The first `gutter_width` columns are gutter (indicator + lineno +
+    /// origin prefix); content wraps into rows of
+    /// `viewport_width - gutter_width`. Must be at least 4: continuation
+    /// rows always rebuild indicator(1) + `↪` column(1+) + prefix(2).
+    /// Production passes `unified_gutter(lineno_width()) >= 8`.
+    Gutter { gutter_width: usize },
+}
+
+/// Expansion result. Invariants: `row_heights.len()` and
+/// `row_char_ranges.len()` equal the logical input length, and
+/// `rows.len() == row_heights.iter().sum()`.
+pub(super) struct GutterWrapped<'a> {
+    pub rows: Vec<Line<'a>>,
+    pub row_heights: Vec<usize>,
+    /// Per logical line: the content char range each visual row holds.
+    /// Empty for unexpanded lines (uniform packing model applies).
+    /// Word-boundary rows hold fewer chars than the content column, so
+    /// selection geometry must consult these instead of assuming
+    /// `which_row * content_width`.
+    pub row_char_ranges: Vec<Vec<(usize, usize)>>,
+}
+
+/// Derive per-line wrap plans for the unified renderer's visible window.
+/// Lines are looked up through `annotation_idx_for_rendered_line` (comment
+/// input box aware); anything unmapped defaults to `Exempt`.
+pub(super) fn unified_wrap_plans(
+    app: &App,
+    scroll_offset: usize,
+    window_len: usize,
+    gutter_width: usize,
+) -> Vec<WrapPlan> {
+    (0..window_len)
+        .map(|i| {
+            let annotation =
+                super::diff_view::annotation_idx_for_rendered_line(app, scroll_offset + i)
+                    .and_then(|idx| app.line_annotations.get(idx));
+            match annotation {
+                Some(AnnotatedLine::DiffLine { .. } | AnnotatedLine::ExpandedContext { .. }) => {
+                    WrapPlan::Gutter { gutter_width }
+                }
+                _ => WrapPlan::Exempt,
+            }
+        })
+        .collect()
+}
+
+/// Expand the visible logical-line window into gutter-aligned visual rows.
+/// `max_rows` bounds the output (the viewport height); once reached, the
+/// remaining logical lines pass through unexpanded with height 1 — they are
+/// below the fold and never painted.
+pub(super) fn expand_gutter_wrap<'a>(
+    logical_lines: Vec<Line<'a>>,
+    plans: &[WrapPlan],
+    viewport_width: usize,
+    max_rows: usize,
+    theme: &Theme,
+) -> GutterWrapped<'a> {
+    let mut rows = Vec::with_capacity(logical_lines.len());
+    let mut row_heights = Vec::with_capacity(logical_lines.len());
+    let mut row_char_ranges = Vec::with_capacity(logical_lines.len());
+
+    for (idx, line) in logical_lines.into_iter().enumerate() {
+        let plan = plans.get(idx).copied().unwrap_or(WrapPlan::Exempt);
+        let over_fold = rows.len() >= max_rows;
+
+        let gutter_width = match plan {
+            WrapPlan::Gutter { gutter_width } if !over_fold => {
+                debug_assert!(
+                    gutter_width >= 4,
+                    "continuation gutter needs >= 4 cells (got {gutter_width})"
+                );
+                gutter_width
+            }
+            _ => {
+                rows.push(line);
+                row_heights.push(1);
+                row_char_ranges.push(Vec::new());
+                continue;
+            }
+        };
+
+        let content_width = viewport_width.saturating_sub(gutter_width);
+        let total_width: usize = line.spans.iter().map(|s| s.content.width()).sum();
+        if content_width == 0 || total_width <= viewport_width {
+            rows.push(line);
+            row_heights.push(1);
+            row_char_ranges.push(Vec::new());
+            continue;
+        }
+
+        let (gutter_spans, content_spans) = split_spans_at_width(&line.spans, gutter_width);
+        let content_text: String = content_spans.iter().map(|s| s.content.as_ref()).collect();
+        if content_text.width() <= content_width {
+            rows.push(line);
+            row_heights.push(1);
+            row_char_ranges.push(Vec::new());
+            continue;
+        }
+
+        let mut char_cursor = 0;
+        let mut line_ranges = Vec::new();
+        let byte_ranges = gutter_row_byte_ranges(&content_text, content_width);
+        for (line_rows, &(row_start_byte, row_end_byte)) in byte_ranges.iter().enumerate() {
+            let row_spans = slice_spans_by_bytes(&content_spans, row_start_byte, row_end_byte);
+            rows.push(if line_rows == 0 {
+                let mut spans = gutter_spans.clone();
+                spans.extend(row_spans);
+                Line::from(spans)
+            } else {
+                continuation_row(&gutter_spans, gutter_width, row_spans, theme)
+            });
+            let row_chars = content_text[row_start_byte..row_end_byte].chars().count();
+            line_ranges.push((char_cursor, char_cursor + row_chars));
+            char_cursor += row_chars;
+        }
+
+        row_heights.push(byte_ranges.len().max(1));
+        row_char_ranges.push(line_ranges);
+    }
+
+    GutterWrapped {
+        rows,
+        row_heights,
+        row_char_ranges,
+    }
+}
+
+/// Byte ranges of the visual rows `content_text` packs into at
+/// `content_width`. This is the single packing routine behind gutter wrap:
+/// the expansion slices spans along these ranges and the row-height helper
+/// counts them, so navigation geometry and rendered rows cannot disagree.
+pub(super) fn gutter_row_byte_ranges(
+    content_text: &str,
+    content_width: usize,
+) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut byte_offset = 0;
+    while byte_offset < content_text.len() {
+        // Pack by grapheme clusters measured with str-width — the same
+        // sequence-aware measure ratatui's renderer uses. Per-char
+        // widths under-count emoji presentation sequences (U+FE0F makes
+        // "❤️" 2 cells while its chars sum to 1), which produced rows
+        // wider than the viewport whose tails the no-Wrap Paragraph
+        // clipped invisibly. Grapheme packing also keeps ZWJ families
+        // and flag pairs whole instead of tearing them at cut points.
+        let mut row_end_byte = byte_offset;
+        let mut row_width = 0;
+        for grapheme in content_text[byte_offset..].graphemes(true) {
+            let grapheme_width = grapheme.width();
+            if row_width + grapheme_width > content_width {
+                break;
+            }
+            row_width += grapheme_width;
+            row_end_byte += grapheme.len();
+        }
+        // Word-boundary preference: when the cut lands mid-token,
+        // backtrack to the last breakable whitespace in the row so the
+        // token moves to the next row whole instead of orphaning a few
+        // letters. Non-breaking spaces (NBSP, narrow NBSP, figure
+        // space) are not break candidates — that is their whole point.
+        // A token longer than the whole row has no whitespace to back
+        // up to and hard-cuts at the column limit.
+        if row_end_byte < content_text.len() {
+            let cuts_mid_token = content_text[row_end_byte..]
+                .chars()
+                .next()
+                .is_some_and(|c| !is_breakable_space(c))
+                && content_text[byte_offset..row_end_byte]
+                    .chars()
+                    .next_back()
+                    .is_some_and(|c| !is_breakable_space(c));
+            if cuts_mid_token
+                && let Some(ws_pos) =
+                    content_text[byte_offset..row_end_byte].rfind(is_breakable_space)
+            {
+                let ws_start = byte_offset + ws_pos;
+                let ws_len = content_text[ws_start..]
+                    .chars()
+                    .next()
+                    .map_or(1, char::len_utf8);
+                row_end_byte = ws_start + ws_len;
+            }
+        }
+        // Forced progress: a single grapheme wider than the content
+        // column still consumes one row instead of looping forever.
+        if row_end_byte == byte_offset {
+            if let Some(grapheme) = content_text[byte_offset..].graphemes(true).next() {
+                row_end_byte += grapheme.len();
+            } else {
+                break;
+            }
+        }
+
+        ranges.push((byte_offset, row_end_byte));
+        byte_offset = row_end_byte;
+    }
+    ranges
+}
+
+/// Continuation rows reconstruct the gutter: blank indicator slot, a `↪`
+/// right-aligned in the line-number column, and the origin prefix (`▌ `/
+/// `  ` with its add/del/context style) copied from the logical line so
+/// coloring stays consistent across visual rows.
+fn continuation_row<'a>(
+    gutter_spans: &[Span<'a>],
+    gutter_width: usize,
+    row_spans: Vec<Span<'a>>,
+    theme: &Theme,
+) -> Line<'a> {
+    let indicator_span = Span::styled(" ", styles::current_line_indicator_style(theme));
+    let linenum_width = gutter_width.saturating_sub(4);
+    let linenum_span = Span::styled(
+        format!("{:>w$}↪", "", w = linenum_width),
+        styles::dim_style(theme),
+    );
+    let prefix_span = gutter_spans
+        .get(2)
+        .cloned()
+        .unwrap_or_else(|| Span::raw("  "));
+    let mut spans = vec![indicator_span, linenum_span, prefix_span];
+    spans.extend(row_spans);
+    Line::from(spans)
+}
+
+/// Split styled spans at a display-width boundary, preserving styles on
+/// both sides. A span straddling the boundary is split mid-span.
+fn split_spans_at_width<'a>(
+    spans: &[Span<'a>],
+    split_width: usize,
+) -> (Vec<Span<'a>>, Vec<Span<'a>>) {
+    let mut left = Vec::new();
+    let mut right = Vec::new();
+    let mut consumed = 0;
+
+    for span in spans {
+        let span_width = span.content.width();
+        if consumed >= split_width {
+            right.push(span.clone());
+        } else if consumed + span_width <= split_width {
+            left.push(span.clone());
+            consumed += span_width;
+        } else {
+            let cells_needed = split_width - consumed;
+            let mut left_content = String::new();
+            let mut right_content = String::new();
+            let mut taken_width = 0;
+            for grapheme in span.content.graphemes(true) {
+                let gw = grapheme.width();
+                if taken_width + gw <= cells_needed && right_content.is_empty() {
+                    left_content.push_str(grapheme);
+                    taken_width += gw;
+                } else {
+                    right_content.push_str(grapheme);
+                }
+            }
+            if !left_content.is_empty() {
+                left.push(Span::styled(left_content, span.style));
+            }
+            if !right_content.is_empty() {
+                right.push(Span::styled(right_content, span.style));
+            }
+            consumed = split_width;
+        }
+    }
+
+    (left, right)
+}
+
+/// Slice styled spans by byte range over their concatenated content,
+/// preserving per-span styles. Empty slices are dropped.
+fn slice_spans_by_bytes<'a>(spans: &[Span<'a>], start: usize, end: usize) -> Vec<Span<'a>> {
+    let mut result = Vec::new();
+    let mut position = 0;
+
+    for span in spans {
+        let span_start = position;
+        let span_end = position + span.content.len();
+
+        if span_end <= start || span_start >= end {
+            position = span_end;
+            continue;
+        }
+
+        let slice_start = start.saturating_sub(span_start);
+        let slice_end = (end - span_start).min(span.content.len());
+
+        if slice_start < slice_end && slice_start < span.content.len() {
+            let content = &span.content[slice_start..slice_end];
+            if !content.is_empty() {
+                result.push(Span::styled(content.to_string(), span.style));
+            }
+        }
+
+        position = span_end;
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::style::{Color, Style};
+
+    // indicator(1) + lineno(4)+space(1) + prefix(2) — matches unified_gutter(4).
+    const GUTTER: usize = 8;
+
+    fn diff_line_fixture(content: &str) -> Line<'static> {
+        Line::from(vec![
+            Span::raw(" "),                                        // indicator
+            Span::raw("   1 "),                                    // lineno + space
+            Span::styled("▌ ", Style::default().fg(Color::Green)), // origin prefix
+            Span::styled(content.to_string(), Style::default().fg(Color::White)),
+        ])
+    }
+
+    /// Concatenated content of a produced row (spans after the 3 gutter spans).
+    fn row_content(row: &Line) -> String {
+        row.spans[3..].iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn rows_width(line: &Line) -> usize {
+        line.spans.iter().map(|s| s.content.width()).sum()
+    }
+
+    #[test]
+    fn should_hold_invariants_across_viewport_widths() {
+        // Mixed content: ASCII, CJK, and a one-cell line. For every viewport
+        // width, rows == sum(row_heights) and no produced row exceeds the
+        // viewport.
+        let contents = ["q".repeat(75), "漢字テスト".repeat(9), "x".to_string()];
+        for viewport_width in 9..=60 {
+            let lines: Vec<Line> = contents
+                .iter()
+                .map(|content| diff_line_fixture(content))
+                .collect();
+            let plans = vec![
+                WrapPlan::Gutter {
+                    gutter_width: GUTTER,
+                };
+                lines.len()
+            ];
+            let result = expand_gutter_wrap(lines, &plans, viewport_width, 200, &Theme::dark());
+            assert_eq!(result.row_heights.len(), contents.len());
+            assert_eq!(
+                result.rows.len(),
+                result.row_heights.iter().sum::<usize>(),
+                "rows/heights diverged at viewport width {viewport_width}"
+            );
+            for row in &result.rows {
+                assert!(
+                    rows_width(row) <= viewport_width.max(GUTTER + 2),
+                    "row exceeds viewport at width {viewport_width}: {} cells",
+                    rows_width(row)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_pass_through_exempt_lines_unsplit() {
+        let long_header = Line::from(format!("═══ {} [M] ═══", "a/very/long/path".repeat(8)));
+        let original_width = rows_width(&long_header);
+        let result = expand_gutter_wrap(
+            vec![long_header],
+            &[WrapPlan::Exempt],
+            20,
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![1]);
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(rows_width(&result.rows[0]), original_width);
+    }
+
+    #[test]
+    fn should_expand_long_diff_line_and_match_row_heights_sum() {
+        let line = diff_line_fixture(&"x".repeat(40));
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20, // content_width = 12 → 40 cells = 4 rows (12+12+12+4)
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![4]);
+        assert_eq!(
+            result.rows.len(),
+            result.row_heights.iter().sum::<usize>(),
+            "rows must equal the sum of row_heights"
+        );
+        // No produced row exceeds the viewport width.
+        for row in &result.rows {
+            assert!(rows_width(row) <= 20, "row wider than viewport");
+        }
+    }
+
+    #[test]
+    fn should_place_wrap_marker_and_origin_prefix_on_continuation_rows() {
+        let line = diff_line_fixture(&"y".repeat(30));
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20,
+            50,
+            &Theme::dark(),
+        );
+        assert!(result.rows.len() >= 2);
+        let continuation = &result.rows[1];
+        // span 1 is the lineno column ending in the wrap marker, width lineno+1
+        let marker_span = &continuation.spans[1];
+        assert!(
+            marker_span.content.ends_with('↪'),
+            "expected ↪ at end of lineno column, got {:?}",
+            marker_span.content
+        );
+        assert_eq!(marker_span.content.width(), GUTTER - 4 + 1);
+        // span 2 carries the origin prefix with its original style
+        let prefix_span = &continuation.spans[2];
+        assert_eq!(prefix_span.content.as_ref(), "▌ ");
+        assert_eq!(prefix_span.style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn should_keep_vs16_emoji_rows_within_viewport() {
+        // Regression (fuzz campaign): "❤️" is U+2764 U+FE0F — per-char widths
+        // sum to 1 but the rendered grapheme is 2 cells. Char-based packing
+        // produced rows wider than the viewport whose tails the no-Wrap
+        // Paragraph clipped invisibly.
+        let line = diff_line_fixture(
+            &"fix: works \u{2714}\u{fe0f} now and \u{2764}\u{fe0f} forever ok".repeat(2),
+        );
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            24,
+            50,
+            &Theme::dark(),
+        );
+        for row in &result.rows {
+            assert!(
+                rows_width(row) <= 24,
+                "VS16 row overflows viewport: {} cells",
+                rows_width(row)
+            );
+        }
+        // Lossless: every input character reappears across the rows.
+        let rejoined: String = result.rows.iter().map(row_content).collect();
+        assert_eq!(
+            rejoined,
+            "fix: works \u{2714}\u{fe0f} now and \u{2764}\u{fe0f} forever ok".repeat(2)
+        );
+    }
+
+    #[test]
+    fn should_not_tear_zwj_emoji_families_at_cut_points() {
+        // A ZWJ family is one grapheme; tearing it at a row boundary mutates
+        // which emoji the user sees. Grapheme packing moves it whole.
+        let family = "\u{1f468}\u{200d}\u{1f469}\u{200d}\u{1f467}\u{200d}\u{1f466}";
+        let content = format!("{}{family}{}", "x".repeat(11), "y".repeat(8));
+        let line = diff_line_fixture(&content);
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20, // content_width 12: family (2 cells) would straddle the cut
+            50,
+            &Theme::dark(),
+        );
+        for row in &result.rows {
+            let text = row_content(row);
+            let has_zwj = text.contains('\u{200d}');
+            if has_zwj {
+                assert!(
+                    text.contains(family),
+                    "ZWJ family torn across rows: {text:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn should_not_break_at_non_breaking_spaces() {
+        // NBSP exists to forbid a break; the backtrack must skip it and
+        // hard-cut instead of "honoring" it as a boundary.
+        let content = format!("alpha\u{a0}beta\u{a0}gamma {}", "d".repeat(12));
+        let line = diff_line_fixture(&content);
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20, // content_width 12 cuts inside the NBSP-glued token
+            50,
+            &Theme::dark(),
+        );
+        // First row must hard-cut the NBSP-glued token (12 cells), not
+        // backtrack to an NBSP.
+        assert_eq!(row_content(&result.rows[0]).width(), 12);
+        assert!(
+            !row_content(&result.rows[0]).ends_with('\u{a0}'),
+            "row breaks at a non-breaking space"
+        );
+    }
+
+    #[test]
+    fn should_break_at_word_boundaries() {
+        let line = diff_line_fixture("alpha beta gamma delta epsilon");
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20, // content_width = 12
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![3]);
+        assert_eq!(row_content(&result.rows[0]), "alpha beta ");
+        assert_eq!(row_content(&result.rows[1]), "gamma delta ");
+        assert_eq!(row_content(&result.rows[2]), "epsilon");
+    }
+
+    #[test]
+    fn should_not_orphan_word_tail_on_next_row() {
+        // Regression: with hard cuts, "efghi" lost its tail letter to the
+        // next row ("abcd efgh" / "i"). Word-boundary backtrack moves the
+        // whole token instead.
+        let line = diff_line_fixture("abcd efghi");
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            GUTTER + 9, // content_width = 9: one cell short of the full text
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![2]);
+        assert_eq!(row_content(&result.rows[0]), "abcd ");
+        assert_eq!(row_content(&result.rows[1]), "efghi");
+    }
+
+    #[test]
+    fn should_hard_cut_token_longer_than_content_column() {
+        let line = diff_line_fixture("https://example.com/very/long/path/segment");
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20, // content_width = 12, no whitespace anywhere
+            50,
+            &Theme::dark(),
+        );
+        assert!(result.row_heights[0] >= 3);
+        assert_eq!(row_content(&result.rows[0]).len(), 12);
+        let rejoined: String = result.rows.iter().map(|row| row_content(row)).collect();
+        assert_eq!(rejoined, "https://example.com/very/long/path/segment");
+    }
+
+    #[test]
+    fn should_keep_position_on_short_diff_line() {
+        let line = diff_line_fixture("short");
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            80,
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![1]);
+        assert_eq!(result.rows.len(), 1);
+    }
+
+    #[test]
+    fn should_not_split_wide_chars_across_rows() {
+        // CJK chars are 2 cells; content_width 12 fits 6 per row.
+        let line = diff_line_fixture(&"漢".repeat(10));
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            }],
+            20,
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![2]); // 6 + 4 chars
+        for row in &result.rows {
+            assert!(rows_width(row) <= 20);
+            // every row's content is valid UTF-8 by construction; widths even
+            let content: String = row.spans[3..].iter().map(|s| s.content.as_ref()).collect();
+            assert_eq!(content.width() % 2, 0, "wide char split across rows");
+        }
+    }
+
+    #[test]
+    fn should_make_progress_when_char_wider_than_content_width() {
+        // gutter 8 + viewport 9 → content_width 1; CJK char needs 2 cells.
+        let line = diff_line_fixture("漢字");
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter { gutter_width: 8 }],
+            9,
+            50,
+            &Theme::dark(),
+        );
+        // Forced progress: one char per row, no infinite loop, no panic.
+        assert_eq!(result.row_heights, vec![2]);
+    }
+
+    #[test]
+    fn should_pass_through_when_content_width_is_zero() {
+        let line = diff_line_fixture(&"z".repeat(30));
+        let result = expand_gutter_wrap(
+            vec![line],
+            &[WrapPlan::Gutter { gutter_width: 30 }],
+            20, // gutter wider than viewport → content_width 0
+            50,
+            &Theme::dark(),
+        );
+        assert_eq!(result.row_heights, vec![1]);
+        assert_eq!(result.rows.len(), 1);
+    }
+
+    #[test]
+    fn should_stop_expanding_below_the_fold() {
+        let lines: Vec<Line> = (0..5).map(|_| diff_line_fixture(&"w".repeat(40))).collect();
+        let plans = vec![
+            WrapPlan::Gutter {
+                gutter_width: GUTTER,
+            };
+            5
+        ];
+        // max_rows 4: the first line alone produces 4 rows; the rest pass through.
+        let result = expand_gutter_wrap(lines, &plans, 20, 4, &Theme::dark());
+        assert_eq!(result.row_heights, vec![4, 1, 1, 1, 1]);
+        assert_eq!(result.rows.len(), 8);
+    }
+
+    #[test]
+    fn should_split_spans_at_width_preserving_styles() {
+        let spans = vec![
+            Span::styled("abc", Style::default().fg(Color::Red)),
+            Span::styled("defg", Style::default().fg(Color::Blue)),
+        ];
+        let (left, right) = split_spans_at_width(&spans, 5);
+        let left_text: String = left.iter().map(|s| s.content.as_ref()).collect();
+        let right_text: String = right.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(left_text, "abcde");
+        assert_eq!(right_text, "fg");
+        assert_eq!(left[0].style.fg, Some(Color::Red));
+        assert_eq!(left[1].style.fg, Some(Color::Blue));
+        assert_eq!(right[0].style.fg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn should_slice_spans_by_bytes_preserving_styles() {
+        let spans = vec![
+            Span::styled("hello", Style::default().fg(Color::Red)),
+            Span::styled("world", Style::default().fg(Color::Blue)),
+        ];
+        let sliced = slice_spans_by_bytes(&spans, 3, 8);
+        let text: String = sliced.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "lowor");
+        assert_eq!(sliced[0].style.fg, Some(Color::Red));
+        assert_eq!(sliced[1].style.fg, Some(Color::Blue));
+    }
+}


### PR DESCRIPTION
Redo of the word wrap from #382. I promised in #385 I'd come back: `wrap_style = "gutter"` is opt-in, `"flow"` stays the default and behaves the same as before. 

With gutter on, wrapped lines keep the line number gutter and continuation rows get a ↪ marker, so wrapped code reads like the source instead of flowing under the gutter at column 0. Long lines are just nicer to review this way, at least imho.

The stuff that got #382 reverted is fenced off this time: file headers and separators never wrap (the broken header you screenshotted is a snapshot test now), and the renderer and the scroll math read the same row heights, so line counts can't drift apart.

That's also why the diff looks scary. About two thirds of it is tests: 
- ~340 lines in the new word_wrap.rs, 
- ~80 lines of wiring 
- ~950 lines are tests

Full disclosure Fable did most of this. I'm daily driving it now, will flip off draft when confident.