### PR TITLE
fix: update naersk lock for static.crates.io crate downloads

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`nix build` / `nix run github:agavra/tuicr` currently fails for anyone without a
warm Nix store: every crate in the dependency tree 403s.

## Cause

crates.io now rejects requests whose `User-Agent` starts with `curl/`:

```
$ curl -so /dev/null -w '%{http_code}\n' -A 'curl/8.16.0' \
    https://crates.io/api/v1/crates/serde/1.0.200/download
403
$ curl -so /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0' \
    https://crates.io/api/v1/crates/serde/1.0.200/download
302
```

`curl/...` is exactly the User-Agent nixpkgs' `fetchurl` sends, and the naersk
revision pinned in `flake.lock` (`9d4ed44`, 2026-01-30) fetches every crate from
`https://crates.io/api/v1/crates/<name>/<version>/download`. So the download
derivation for all 394 crates in this tree fails:

```
trying https://crates.io/api/v1/crates/ratatui/0.30.2/download
curl: (22) The requested URL returned error: 403
error: cannot download download-ratatui-0.30.2 from any mirror
```

## Fix

naersk `0e8c8c2` ("Use static.crates.io to download crates", 2026-05-27) changed
the default `cratesDownloadUrl` to `https://static.crates.io/crates`, which has
no User-Agent filtering. `flake.nix` already tracks `naersk/master`, so nothing
in the flake itself is wrong -- only the lock was stale.

This bumps naersk `9d4ed44` (2026-01-30) -> `9aa07bb` (2026-06-23), which
contains `0e8c8c2`. The diff is three lines in `flake.lock`; `nixpkgs`, `utils`,
`systems`, `fenix` and `rust-analyzer-src` are untouched, and `flake.nix` is
unchanged.

## Verification

All 394 crate fetch derivations move from `crates.io/api/v1` to
`static.crates.io/crates`:

```
$ nix derivation show -r .#default | grep -o 'https://[a-z.]*crates\.io[^"]*' ...
# before: 420 x https://crates.io/api/v1/crates/<n>/<v>/download
# after:  394 x https://static.crates.io/crates/<n>/<v>/download
#          26 x https://crates.io/api/v1/... (nixpkgs' own fetchCrate)
```

The 26 leftovers belong to nixpkgs' `fetchCrate` for unrelated packages in the
build-time closure (a `libimagequant` -> `pillow` chain), not to naersk. They
403 too if you force them, but they are never realised on a cold store because
cache.nixos.org substitutes those packages' built outputs -- so they don't block
`nix run`. Fixing them is a separate nixpkgs issue.

Because these are fixed-output derivations, a warm store or a substituter hides
the failure, so I forced real downloads of the same crate under both revisions
(`nix-store --realise --check --no-substitute`):

```
# old lock  -> trying https://crates.io/api/v1/crates/ratatui/0.30.2/download
#              curl: (22) ... 403 (x4 retries), build fails
# new lock  -> trying https://static.crates.io/crates/ratatui/0.30.2/download
#              100  72412 ... OK, hash matches
```

Same result for `clap`, `libc`, `regex`, `regex-automata` and `regex-syntax`.
`nix build .#default -L` succeeds and `./result/bin/tuicr --version` prints
`tuicr 0.24.0`.
