### PR TITLE
Pass through scope args to all wrappers

### DIFF
--- a/skills/tuicr/SKILL.md
+++ b/skills/tuicr/SKILL.md
@@ -72,11 +72,15 @@ When the user needs an interactive tuicr pane and no active session exists:
 
 | Environment | Action |
 |-------------|--------|
-| `$CMUX_WORKSPACE_ID` is set | Run `tuicr-wrapper-cmux.sh /path/to/repo` |
-| `$TMUX` is set | Run `tuicr-wrapper.sh /path/to/repo` |
-| `$ZELLIJ` is set | Run `tuicr-wrapper-zellij.sh /path/to/repo` |
-| `$HERDR_ENV` is `1` | Run `tuicr-wrapper-herdr.sh /path/to/repo` |
+| `$CMUX_WORKSPACE_ID` is set | Run `tuicr-wrapper-cmux.sh /path/to/repo -- <scope>` |
+| `$TMUX` is set | Run `tuicr-wrapper.sh /path/to/repo -- <scope>` |
+| `$ZELLIJ` is set | Run `tuicr-wrapper-zellij.sh /path/to/repo -- <scope>` |
+| `$HERDR_ENV` is `1` | Run `tuicr-wrapper-herdr.sh /path/to/repo -- <scope>` |
 | None is set | Tell the user you are waiting for them to start `tuicr` in the repo, then attach with `tuicr review list` after they say it is ready |
+
+`<scope>` is `-w` for uncommitted working-tree changes or `-r <revset>` for a
+commit range — always pass one explicitly so the user is never left to pick
+staged/unstaged/commit-range manually in the TUI.
 
 If more than one multiplexer marker is set, prefer the innermost multiplexer if
 that is clear; otherwise ask. cmux hosts a Ghostty terminal, so `$TERM_PROGRAM`
@@ -90,18 +94,20 @@ run the wrapper and let it validate the repository.
 Wrapper paths are relative to this skill directory:
 
 ```bash
-<skill-directory>/tuicr-wrapper-cmux.sh /path/to/repo
-<skill-directory>/tuicr-wrapper.sh /path/to/repo
-<skill-directory>/tuicr-wrapper-zellij.sh /path/to/repo
-<skill-directory>/tuicr-wrapper-herdr.sh /path/to/repo
+<skill-directory>/tuicr-wrapper-cmux.sh /path/to/repo -- -w
+<skill-directory>/tuicr-wrapper.sh /path/to/repo -- -w
+<skill-directory>/tuicr-wrapper-zellij.sh /path/to/repo -- -w
+<skill-directory>/tuicr-wrapper-herdr.sh /path/to/repo -- -w
 ```
 
 The Herdr wrapper requires `jq` to read pane IDs and completion results from
 Herdr's JSON responses.
 
-The cmux wrapper accepts pass-through tuicr arguments after `--`, which is how
-you scope the review — for example `-- -w` for uncommitted working-tree changes
-or `-- -r <revset>` for a commit range.
+Every wrapper accepts pass-through tuicr arguments after `--`, which is how
+you scope the review instead of leaving the scope selector for the user to
+fill in — for example `-- -w` for uncommitted working-tree changes or
+`-- -r <revset>` for a commit range. Always pass one of these explicitly when
+launching a review pane.
 
 If your tool supports command timeouts, use a long timeout, such as 10 minutes,
 because the tmux, Zellij, and Herdr wrappers wait for the TUI to exit. The cmux

--- a/skills/tuicr/_tuicr-common.sh
+++ b/skills/tuicr/_tuicr-common.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Sourced by the tuicr-wrapper-*.sh scripts. Not an entry point on its own.
+
+# Splits "$@" on the `[directory] [-- tuicr-args...]` convention every
+# wrapper shares. Sets TUICR_TARGET_DIR and the TUICR_PASSTHROUGH_ARGS array
+# instead of returning them, since a sourced function's positional
+# parameters are its own and can't shift the caller's.
+tuicr_parse_args() {
+  TUICR_TARGET_DIR="."
+  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+    TUICR_TARGET_DIR="$1"
+    shift
+  fi
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
+  TUICR_PASSTHROUGH_ARGS=("$@")
+}
+
+# Prints each argument bash-%q-quoted with a leading space, e.g.
+# `tuicr_quote_args -w` prints " -w", so the caller can append the result
+# straight onto a command string: cmd="tuicr$(tuicr_quote_args "${args[@]}")"
+tuicr_quote_args() {
+  local arg quoted
+  for arg in "$@"; do
+    printf -v quoted ' %q' "$arg"
+    printf '%s' "$quoted"
+  done
+}

--- a/skills/tuicr/_tuicr-common.sh
+++ b/skills/tuicr/_tuicr-common.sh
@@ -27,3 +27,32 @@ tuicr_quote_args() {
     printf '%s' "$quoted"
   done
 }
+
+# True if the installed tuicr accepts --stdout, which exports the review
+# straight to a file instead of prompting the human to save & copy on exit.
+tuicr_stdout_supported() {
+  tuicr --help 2>&1 | grep -q -- '--stdout'
+}
+
+# Prints the review exported via --stdout, or points the caller at the
+# clipboard when --stdout capture wasn't used. Cleans up output_file either
+# way. Callers must define log_info before invoking this.
+tuicr_report_stdout_output() {
+  local use_stdout="$1"
+  local output_file="$2"
+
+  if [[ "$use_stdout" == true ]] && [[ -f "$output_file" ]]; then
+    if [[ -s "$output_file" ]]; then
+      echo ""
+      echo "=== TUICR INSTRUCTIONS ==="
+      cat "$output_file"
+      echo "=== END TUICR INSTRUCTIONS ==="
+    else
+      log_info "No instructions exported from tuicr"
+      log_info "If you exported to clipboard, paste the instructions here"
+    fi
+    rm -f "$output_file"
+  else
+    log_info "If you exported instructions, they are in your clipboard - paste them here"
+  fi
+}

--- a/skills/tuicr/tuicr-wrapper-cmux.sh
+++ b/skills/tuicr/tuicr-wrapper-cmux.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_tuicr-common.sh"
+
 # Configuration - override via environment variables
 TUICR_PANE_DIRECTION="${TUICR_PANE_DIRECTION:-right}"  # left, right, up or down
 CMUX_BIN="${CMUX_BIN:-cmux}"
@@ -124,10 +126,7 @@ launch_tuicr_pane() {
   local command_line
   # exec: no shell survives tuicr, so cmux closes the pane when the TUI exits
   printf -v command_line 'cd %q && exec tuicr' "$target_dir"
-  local arg
-  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
-    printf -v command_line '%s %q' "$command_line" "$arg"
-  done
+  command_line="$command_line$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
 
   "$CMUX_BIN" send --surface "$surface_ref" "$command_line"$'\n' > /dev/null
 
@@ -157,14 +156,8 @@ main() {
   fi
 
   # Determine target directory, then split off any pass-through tuicr args
-  local target_dir="."
-  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
-    target_dir="$1"
-    shift
-  fi
-  if [[ "${1:-}" == "--" ]]; then
-    shift
-  fi
+  tuicr_parse_args "$@"
+  local target_dir="$TUICR_TARGET_DIR"
   target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
 
   # Verify it's a git or jj repo
@@ -186,7 +179,7 @@ main() {
     exit 1
   fi
 
-  launch_tuicr_pane "$target_dir" "$@"
+  launch_tuicr_pane "$target_dir" "${TUICR_PASSTHROUGH_ARGS[@]+"${TUICR_PASSTHROUGH_ARGS[@]}"}"
 }
 
 main "$@"

--- a/skills/tuicr/tuicr-wrapper-herdr.sh
+++ b/skills/tuicr/tuicr-wrapper-herdr.sh
@@ -24,12 +24,13 @@ log_error() {
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [directory]
+Usage: $(basename "$0") [directory] [-- tuicr-args...]
 
 Launch tuicr in a Herdr split pane.
 
 Arguments:
   directory    Repository directory to review (default: current directory)
+  tuicr-args   Extra arguments passed through to tuicr (e.g. -w, -r <revset>)
 
 Environment variables:
   TUICR_PANE_DIRECTION  Split direction: right or down (default: right)
@@ -39,6 +40,7 @@ Environment variables:
 Examples:
   $(basename "$0")
   $(basename "$0") ~/project
+  $(basename "$0") . -- -w
   TUICR_PANE_DIRECTION=down $(basename "$0")
 EOF
 }
@@ -67,6 +69,8 @@ cleanup() {
 
 launch_tuicr_pane() {
   local target_dir="$1"
+  shift
+  local tuicr_args=("$@")
 
   case "$TUICR_PANE_DIRECTION" in
     right|down) ;;
@@ -94,6 +98,12 @@ launch_tuicr_pane() {
   local quoted_tuicr
   printf -v quoted_tuicr '%q' "$tuicr_bin"
 
+  local arg quoted_arg
+  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
+    printf -v quoted_arg '%q' "$arg"
+    quoted_tuicr="$quoted_tuicr $quoted_arg"
+  done
+
   local completion_suffix="_DONE_$$_${RANDOM}__"
   local completion_token="__TUICR${completion_suffix}"
   # `herdr pane run` injects this string into the pane's *interactive* shell,
@@ -104,8 +114,18 @@ launch_tuicr_pane() {
   # printf %q quoting, which can emit non-POSIX $'...' forms.
   # $completion_suffix needs no quoting: it is built from $$ and $RANDOM, so it
   # is digits and underscores by construction.
+  local inner_script
+  inner_script="$quoted_tuicr; printf \"\\n__TUICR%s:%s\\n\" $completion_suffix \$?"
+
+  # $quoted_tuicr may itself contain a `'` (e.g. a -r revset with an
+  # apostrophe, %q-escaped as \' for bash's own parsing). Embedding that raw
+  # into the outer single-quoted argument below would close it early. Escape
+  # every `'` as '\'' (close, escaped literal quote, reopen) so the pane's
+  # shell reproduces $inner_script byte-for-byte as bash -c's one argument.
+  local escaped_inner_script="${inner_script//\'/\'\\\'\'}"
+
   local pane_command
-  pane_command="bash -c '$quoted_tuicr; printf \"\\n__TUICR%s:%s\\n\" $completion_suffix \$?'"
+  pane_command="bash -c '$escaped_inner_script'"
 
   "$HERDR_BIN" pane run "$new_pane_id" "$pane_command" >/dev/null
 
@@ -155,7 +175,14 @@ main() {
   require_command "$JQ_BIN" "jq"
   require_command "tuicr" "tuicr"
 
-  local target_dir="${1:-.}"
+  local target_dir="."
+  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+    target_dir="$1"
+    shift
+  fi
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
   if [[ ! -d "$target_dir" ]]; then
     log_error "Directory not found: $target_dir"
     exit 1
@@ -166,7 +193,7 @@ main() {
   trap 'exit 130' INT
   trap 'exit 143' TERM
 
-  launch_tuicr_pane "$target_dir"
+  launch_tuicr_pane "$target_dir" "$@"
 }
 
 main "$@"

--- a/skills/tuicr/tuicr-wrapper-herdr.sh
+++ b/skills/tuicr/tuicr-wrapper-herdr.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_tuicr-common.sh"
+
 TUICR_PANE_DIRECTION="${TUICR_PANE_DIRECTION:-right}"
 HERDR_BIN="${HERDR_BIN:-herdr}"
 JQ_BIN="${JQ_BIN:-jq}"
@@ -97,12 +99,7 @@ launch_tuicr_pane() {
 
   local quoted_tuicr
   printf -v quoted_tuicr '%q' "$tuicr_bin"
-
-  local arg quoted_arg
-  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
-    printf -v quoted_arg '%q' "$arg"
-    quoted_tuicr="$quoted_tuicr $quoted_arg"
-  done
+  quoted_tuicr="$quoted_tuicr$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
 
   local completion_suffix="_DONE_$$_${RANDOM}__"
   local completion_token="__TUICR${completion_suffix}"
@@ -175,14 +172,8 @@ main() {
   require_command "$JQ_BIN" "jq"
   require_command "tuicr" "tuicr"
 
-  local target_dir="."
-  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
-    target_dir="$1"
-    shift
-  fi
-  if [[ "${1:-}" == "--" ]]; then
-    shift
-  fi
+  tuicr_parse_args "$@"
+  local target_dir="$TUICR_TARGET_DIR"
   if [[ ! -d "$target_dir" ]]; then
     log_error "Directory not found: $target_dir"
     exit 1
@@ -193,7 +184,7 @@ main() {
   trap 'exit 130' INT
   trap 'exit 143' TERM
 
-  launch_tuicr_pane "$target_dir" "$@"
+  launch_tuicr_pane "$target_dir" "${TUICR_PASSTHROUGH_ARGS[@]+"${TUICR_PASSTHROUGH_ARGS[@]}"}"
 }
 
 main "$@"

--- a/skills/tuicr/tuicr-wrapper-herdr.sh
+++ b/skills/tuicr/tuicr-wrapper-herdr.sh
@@ -101,6 +101,19 @@ launch_tuicr_pane() {
   printf -v quoted_tuicr '%q' "$tuicr_bin"
   quoted_tuicr="$quoted_tuicr$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
 
+  # Optional --stdout capture: skips tuicr's save & copy confirm dialog on
+  # exit and writes the exported review straight to a file we print below.
+  local output_file=""
+  local use_stdout=false
+  if tuicr_stdout_supported; then
+    output_file=$(mktemp /tmp/tuicr-output.XXXXXX)
+    quoted_tuicr="$quoted_tuicr --stdout > '$output_file'"
+    use_stdout=true
+    log_info "Using --stdout mode (output will be captured)"
+  else
+    log_warn "tuicr --stdout not supported, output will be copied to clipboard"
+  fi
+
   local completion_suffix="_DONE_$$_${RANDOM}__"
   local completion_token="__TUICR${completion_suffix}"
   # `herdr pane run` injects this string into the pane's *interactive* shell,
@@ -152,6 +165,8 @@ launch_tuicr_pane() {
   else
     log_error "tuicr exited with status $tuicr_status"
   fi
+
+  tuicr_report_stdout_output "$use_stdout" "$output_file"
 
   return "$tuicr_status"
 }

--- a/skills/tuicr/tuicr-wrapper-zellij.sh
+++ b/skills/tuicr/tuicr-wrapper-zellij.sh
@@ -70,11 +70,6 @@ check_tuicr() {
   return 0
 }
 
-check_tuicr_stdout_support() {
-  # Check if tuicr supports --stdout flag
-  tuicr --help 2>&1 | grep -q -- '--stdout'
-}
-
 check_repo() {
   local dir="$1"
   if git -C "$dir" rev-parse --git-dir &> /dev/null; then
@@ -123,7 +118,7 @@ launch_tuicr_pane() {
   local tuicr_cmd="$(command -v tuicr)$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
   local use_stdout=false
 
-  if check_tuicr_stdout_support; then
+  if tuicr_stdout_supported; then
     output_file=$(mktemp /tmp/tuicr-output.XXXXXX)
     tuicr_cmd="$tuicr_cmd --stdout > '$output_file'"
     use_stdout=true
@@ -160,21 +155,7 @@ launch_tuicr_pane() {
 
   log_info "tuicr finished"
 
-  # Output captured instructions if --stdout was used
-  if [[ "$use_stdout" == true ]] && [[ -f "$output_file" ]]; then
-    if [[ -s "$output_file" ]]; then
-      echo ""
-      echo "=== TUICR INSTRUCTIONS ==="
-      cat "$output_file"
-      echo "=== END TUICR INSTRUCTIONS ==="
-    else
-      log_info "No instructions exported from tuicr"
-      log_info "If you exported to clipboard, paste the instructions here"
-    fi
-    rm -f "$output_file"
-  else
-    log_info "If you exported instructions, they are in your clipboard - paste them here"
-  fi
+  tuicr_report_stdout_output "$use_stdout" "$output_file"
 }
 
 main() {

--- a/skills/tuicr/tuicr-wrapper-zellij.sh
+++ b/skills/tuicr/tuicr-wrapper-zellij.sh
@@ -32,12 +32,13 @@ log_error() {
 
 usage() {
   cat << EOF
-Usage: $(basename "$0") [directory]
+Usage: $(basename "$0") [directory] [-- tuicr-args...]
 
 Launch tuicr in a zellij split pane to review changes.
 
 Arguments:
   directory    Git or jj repository directory to review (default: current directory)
+  tuicr-args   Extra arguments passed through to tuicr (e.g. -w, -r <revset>)
 
 Environment variables:
   TUICR_PANE_DIRECTION  Split direction: down or right or stacked (default: stacked)
@@ -46,6 +47,7 @@ Environment variables:
 Examples:
   $(basename "$0")                            # Review changes in current directory
   $(basename "$0") ~/project                  # Review changes in ~/project
+  $(basename "$0") . -- -w                    # Review uncommitted working-tree changes
   TUICR_PANE_DIRECTION=right $(basename "$0") # Split to the right instead of below
 EOF
 }
@@ -94,6 +96,8 @@ check_tuicr_running() {
 
 launch_tuicr_pane() {
   local target_dir="$1"
+  shift
+  local tuicr_args=("$@")
 
   # Validate direction
   case "$TUICR_PANE_DIRECTION" in
@@ -115,6 +119,10 @@ launch_tuicr_pane() {
   # Optional --stdout capture
   local output_file=""
   local tuicr_cmd="$(command -v tuicr)"
+  local arg
+  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
+    tuicr_cmd="$tuicr_cmd $(printf '%q' "$arg")"
+  done
   local use_stdout=false
 
   if check_tuicr_stdout_support; then
@@ -180,8 +188,15 @@ main() {
     exit 1
   fi
 
-  # Determine target directory
-  local target_dir="${1:-.}"
+  # Determine target directory, then split off any pass-through tuicr args
+  local target_dir="."
+  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+    target_dir="$1"
+    shift
+  fi
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
   target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
 
   # Verify it's a git or jj repo
@@ -211,7 +226,7 @@ main() {
   fi
 
   # Launch tuicr in a split pane
-  launch_tuicr_pane "$target_dir"
+  launch_tuicr_pane "$target_dir" "$@"
 }
 
 main "$@"

--- a/skills/tuicr/tuicr-wrapper-zellij.sh
+++ b/skills/tuicr/tuicr-wrapper-zellij.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_tuicr-common.sh"
+
 # Configuration - override via environment variables
 TUICR_PANE_DIRECTION="${TUICR_PANE_DIRECTION:-stacked}"  # down or right or stacked
 ZELLIJ_BIN="${ZELLIJ_BIN:-zellij}"
@@ -118,11 +120,7 @@ launch_tuicr_pane() {
 
   # Optional --stdout capture
   local output_file=""
-  local tuicr_cmd="$(command -v tuicr)"
-  local arg
-  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
-    tuicr_cmd="$tuicr_cmd $(printf '%q' "$arg")"
-  done
+  local tuicr_cmd="$(command -v tuicr)$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
   local use_stdout=false
 
   if check_tuicr_stdout_support; then
@@ -144,7 +142,10 @@ launch_tuicr_pane() {
     zellij_args+=("--direction" "$TUICR_PANE_DIRECTION")
   fi
 
-  zellij_args+=(-- sh -c "$tuicr_cmd; echo done > '$fifo'")
+  # bash, not sh: $tuicr_cmd carries bash's printf %q quoting, which can emit
+  # non-POSIX $'...' forms that dash (the default /bin/sh on many Linux
+  # distros) does not understand.
+  zellij_args+=(-- bash -c "$tuicr_cmd; echo done > '$fifo'")
 
   "$ZELLIJ_BIN" run\
     "${zellij_args[@]}"
@@ -189,14 +190,8 @@ main() {
   fi
 
   # Determine target directory, then split off any pass-through tuicr args
-  local target_dir="."
-  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
-    target_dir="$1"
-    shift
-  fi
-  if [[ "${1:-}" == "--" ]]; then
-    shift
-  fi
+  tuicr_parse_args "$@"
+  local target_dir="$TUICR_TARGET_DIR"
   target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
 
   # Verify it's a git or jj repo
@@ -226,7 +221,7 @@ main() {
   fi
 
   # Launch tuicr in a split pane
-  launch_tuicr_pane "$target_dir" "$@"
+  launch_tuicr_pane "$target_dir" "${TUICR_PASSTHROUGH_ARGS[@]+"${TUICR_PASSTHROUGH_ARGS[@]}"}"
 }
 
 main "$@"

--- a/skills/tuicr/tuicr-wrapper.sh
+++ b/skills/tuicr/tuicr-wrapper.sh
@@ -62,11 +62,6 @@ check_tuicr() {
   return 0
 }
 
-check_tuicr_stdout_support() {
-  # Check if tuicr supports --stdout flag
-  tuicr --help 2>&1 | grep -q -- '--stdout'
-}
-
 check_repo() {
   local dir="$1"
   if git -C "$dir" rev-parse --git-dir &> /dev/null; then
@@ -124,7 +119,7 @@ launch_tuicr_pane() {
   local tuicr_cmd="tuicr$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
   local use_stdout=false
 
-  if check_tuicr_stdout_support; then
+  if tuicr_stdout_supported; then
     output_file=$(mktemp /tmp/tuicr-output.XXXXXX)
     tuicr_cmd="$tuicr_cmd --stdout > '$output_file'"
     use_stdout=true
@@ -150,21 +145,7 @@ launch_tuicr_pane() {
 
   log_info "tuicr finished"
 
-  # Output captured instructions if --stdout was used
-  if [[ "$use_stdout" == true ]] && [[ -f "$output_file" ]]; then
-    if [[ -s "$output_file" ]]; then
-      echo ""
-      echo "=== TUICR INSTRUCTIONS ==="
-      cat "$output_file"
-      echo "=== END TUICR INSTRUCTIONS ==="
-    else
-      log_info "No instructions exported from tuicr"
-      log_info "If you exported to clipboard, paste the instructions here"
-    fi
-    rm -f "$output_file"
-  else
-    log_info "If you exported instructions, they are in your clipboard - paste them here"
-  fi
+  tuicr_report_stdout_output "$use_stdout" "$output_file"
 }
 
 main() {

--- a/skills/tuicr/tuicr-wrapper.sh
+++ b/skills/tuicr/tuicr-wrapper.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e -u -o pipefail
 
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_tuicr-common.sh"
+
 # Configuration - override via environment variables
 TUICR_PANE_POSITION="${TUICR_PANE_POSITION:-top}"    # top or bottom
 TUICR_PANE_SIZE="${TUICR_PANE_SIZE:-80}"              # percentage of screen
@@ -119,11 +121,7 @@ launch_tuicr_pane() {
 
   # Check if --stdout is supported and set up output capture
   local output_file=""
-  local tuicr_cmd="tuicr"
-  local arg
-  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
-    tuicr_cmd="$tuicr_cmd $(printf '%q' "$arg")"
-  done
+  local tuicr_cmd="tuicr$(tuicr_quote_args "${tuicr_args[@]+"${tuicr_args[@]}"}")"
   local use_stdout=false
 
   if check_tuicr_stdout_support; then
@@ -182,14 +180,8 @@ main() {
   fi
 
   # Determine target directory, then split off any pass-through tuicr args
-  local target_dir="."
-  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
-    target_dir="$1"
-    shift
-  fi
-  if [[ "${1:-}" == "--" ]]; then
-    shift
-  fi
+  tuicr_parse_args "$@"
+  local target_dir="$TUICR_TARGET_DIR"
   target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
 
   # Verify it's a git or jj repo
@@ -219,7 +211,7 @@ main() {
   fi
 
   # Launch tuicr in a split pane
-  launch_tuicr_pane "$target_dir" "$@"
+  launch_tuicr_pane "$target_dir" "${TUICR_PASSTHROUGH_ARGS[@]+"${TUICR_PASSTHROUGH_ARGS[@]}"}"
 }
 
 main "$@"

--- a/skills/tuicr/tuicr-wrapper.sh
+++ b/skills/tuicr/tuicr-wrapper.sh
@@ -128,7 +128,7 @@ launch_tuicr_pane() {
 
   if check_tuicr_stdout_support; then
     output_file=$(mktemp /tmp/tuicr-output.XXXXXX)
-    tuicr_cmd="tuicr --stdout > '$output_file'"
+    tuicr_cmd="$tuicr_cmd --stdout > '$output_file'"
     use_stdout=true
     log_info "Using --stdout mode (output will be captured)"
   else

--- a/skills/tuicr/tuicr-wrapper.sh
+++ b/skills/tuicr/tuicr-wrapper.sh
@@ -25,12 +25,13 @@ log_error() {
 
 usage() {
   cat << EOF
-Usage: $(basename "$0") [directory]
+Usage: $(basename "$0") [directory] [-- tuicr-args...]
 
 Launch tuicr in a tmux split pane to review changes.
 
 Arguments:
   directory    Git or jj repository directory to review (default: current directory)
+  tuicr-args   Extra arguments passed through to tuicr (e.g. -w, -r <revset>)
 
 Environment variables:
   TUICR_PANE_POSITION   Position of tuicr pane: top or bottom (default: top)
@@ -39,6 +40,7 @@ Environment variables:
 Examples:
   $(basename "$0")                    # Review changes in current directory
   $(basename "$0") ~/project          # Review changes in ~/project
+  $(basename "$0") . -- -w            # Review uncommitted working-tree changes
   TUICR_PANE_SIZE=70 $(basename "$0") # Use 70% of screen
 EOF
 }
@@ -86,6 +88,8 @@ check_tuicr_running() {
 
 launch_tuicr_pane() {
   local target_dir="$1"
+  shift
+  local tuicr_args=("$@")
 
   # Get window height and calculate lines (using -l instead of -p to avoid "size missing" error)
   local window_height
@@ -116,6 +120,10 @@ launch_tuicr_pane() {
   # Check if --stdout is supported and set up output capture
   local output_file=""
   local tuicr_cmd="tuicr"
+  local arg
+  for arg in ${tuicr_args[@]+"${tuicr_args[@]}"}; do
+    tuicr_cmd="$tuicr_cmd $(printf '%q' "$arg")"
+  done
   local use_stdout=false
 
   if check_tuicr_stdout_support; then
@@ -173,8 +181,15 @@ main() {
     exit 1
   fi
 
-  # Determine target directory
-  local target_dir="${1:-.}"
+  # Determine target directory, then split off any pass-through tuicr args
+  local target_dir="."
+  if [[ "${1:-}" != "--" && -n "${1:-}" ]]; then
+    target_dir="$1"
+    shift
+  fi
+  if [[ "${1:-}" == "--" ]]; then
+    shift
+  fi
   target_dir=$(cd "$target_dir" && pwd)  # Get absolute path
 
   # Verify it's a git or jj repo
@@ -204,7 +219,7 @@ main() {
   fi
 
   # Launch tuicr in a split pane
-  launch_tuicr_pane "$target_dir"
+  launch_tuicr_pane "$target_dir" "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Quick one — this extends the `-- <scope>` pass-through pattern from the cmux wrapper to the tmux, Zellij, and Herdr wrappers too. Previously only cmux let you scope a review with `-- -w` or `-- -r <revset>`; the other three only took a directory arg, so the agent had to launch tuicr first and leave the user to pick staged/unstaged/commit-range by hand in the TUI.

What changed:

- Added a shared helper for parsing and formatting tuicr args, fixing up herdr, tmux, and zellij usages
- Updated SKILL.md to say "every wrapper" instead of calling out cmux specifically, and made passing a scope explicit/required instead of optional

Should be no observable changes for existing cmux usage — this just closes the gap for the other three wrappers.

Tested out in cmux, herdr, tmux, and zellij. 