### PR TITLE
chore: bump nix flake input (naersk) due to changes to crate API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -30,11 +30,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
crates.io started returning 403 for crates.io/api/v1/crates/<name>/<version>/download when the request carries curl's default User-Agent — which is what Nix's fetchurl sends. Browser UA gets 200, so it's UA-based blocking.

naersk fetched crates from that endpoint. It was fixed in nix-community/naersk#391 (merged 2026-06-08) by switching to static.crates.io, see https://github.com/nix-community/naersk/issues/390 for the issue.
