### PR TITLE
fix(gitlab): open merge requests through API

### DIFF
--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -378,16 +378,9 @@ where
 
     fn get_pull_request(&self, target: PullRequestTarget) -> Result<PullRequestDetails> {
         let repository = self.resolve_repository(&target)?;
-        let args = vec![
-            "mr".to_string(),
-            "view".to_string(),
-            target.number.to_string(),
-            "--repo".to_string(),
-            Self::repo_arg(&repository),
-            "--output".to_string(),
-            "json".to_string(),
-        ];
-        let output = self.run_glab(args, &repository.host)?;
+        let project = gl_project_path(&repository.owner, &repository.name);
+        let endpoint = format!("projects/{project}/merge_requests/{}", target.number);
+        let output = self.run_api(&repository, endpoint)?;
         let mr: GlabMrDetails = serde_json::from_str(&output)?;
         mr.into_details(&repository)
     }
@@ -1318,6 +1311,44 @@ mod tests {
                 "2",
                 "--reviewer=@me",
             ]
+        );
+    }
+
+    #[test]
+    fn get_pull_request_uses_version_compatible_api_endpoint() {
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let runner = RecordingRunner::new_with_responses(vec![
+            r#"{
+                "iid": 42,
+                "title": "Test MR",
+                "web_url": "https://gitlab.com/owner/repo/-/merge_requests/42",
+                "state": "opened",
+                "source_branch": "feature",
+                "target_branch": "main",
+                "diff_refs": {
+                    "base_sha": "basesha1",
+                    "head_sha": "headsha1",
+                    "start_sha": "startsha1"
+                }
+            }"#
+            .to_string(),
+        ]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        let details = backend
+            .get_pull_request(PullRequestTarget::number(42, "42"))
+            .unwrap();
+
+        assert_eq!(details.number, 42);
+        assert_eq!(details.head_sha, "headsha1");
+        let calls = backend.runner.calls.borrow();
+        assert_eq!(
+            calls[0].0,
+            vec!["api", "projects/owner%2Frepo/merge_requests/42"]
+        );
+        assert!(
+            !calls[0].0.iter().any(|arg| arg == "--output"),
+            "glab 1.36 does not support `mr view --output`"
         );
     }
 


### PR DESCRIPTION
## Summary
- fetch GitLab merge request details through `glab api` instead of `glab mr view --output json`
- preserve project-path encoding and the existing self-hosted hostname handling

## Problem
`glab` 1.36 does not support `--output` on `mr view`, so opening a GitLab merge request fails before tuicr can render it. The GitLab API provides the same fields without depending on that version-specific command flag.

## Testing
- `cargo test forge::gitlab:: -- --nocapture` — 40 passed
- `cargo test -- --skip vcs::pristine::tests::errors_when_not_a_git_repo` — 1,552 library tests and 1 binary test passed; 4 ignored
- `cargo fmt -- --check` — passed
- `cargo clippy --lib --bins -- -D warnings` — passed
- `cargo test` — 1 unrelated pre-existing failure in `vcs::pristine::tests::errors_when_not_a_git_repo`, reproduced on unmodified `1723c9db`

Fixes #644