### PR TITLE
diff: drop the frame and fold the header when the diff is the sole pane

### DIFF
--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -324,6 +324,13 @@ impl App {
         self.set_message(format!("Commit selector: {status}"));
     }
 
+    /// Whether the diff is the only visible pane — no file list (which also
+    /// carries the comment navigator) and no inline commit selector. Used to
+    /// drop the diff's frame for a cleaner full-width view.
+    pub fn is_diff_sole_pane(&self) -> bool {
+        !self.show_file_list && !self.has_inline_commit_selector()
+    }
+
     // Commit selection methods
 
     pub fn commit_select_up(&mut self) {

--- a/src/app/tests/commit_selection_tests.rs
+++ b/src/app/tests/commit_selection_tests.rs
@@ -449,6 +449,28 @@ fn should_comment_on_a_commit_only_file_after_narrowing_the_commit_pane() {
 }
 
 #[test]
+fn is_diff_sole_pane_only_when_no_other_panes_visible() {
+    let mut app = build_app(vec![normal_commit("a"), normal_commit("b")]);
+    app.review_commits = app.commit_list.clone();
+    app.diff_source = DiffSource::CommitRange(vec!["a".to_string(), "b".to_string()]);
+
+    // File list visible -> not sole.
+    app.show_file_list = true;
+    app.show_commit_selector = false;
+    assert!(!app.is_diff_sole_pane());
+
+    // File list hidden but commit selector visible -> not sole.
+    app.show_file_list = false;
+    app.show_commit_selector = true;
+    assert!(app.has_inline_commit_selector());
+    assert!(!app.is_diff_sole_pane());
+
+    // Both hidden -> diff is the sole pane.
+    app.show_commit_selector = false;
+    assert!(app.is_diff_sole_pane());
+}
+
+#[test]
 fn review_comments_header_hidden_while_empty() {
     let mut app = build_app(vec![normal_commit("a")]);
     app.is_single_file_view = false;

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -287,10 +287,17 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
 
     let title = crate::ui::diff_view::diff_title(app, area.width);
 
+    // Drop the frame when the diff is the only pane; the title still renders
+    // on the reserved top row (ratatui keeps it without a top border).
+    let borders = if app.is_diff_sole_pane() {
+        Borders::NONE
+    } else {
+        Borders::ALL
+    };
     let block = Block::default()
         .title(title)
         .title_top(diff_stat_title(app).right_aligned())
-        .borders(Borders::ALL)
+        .borders(borders)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
 

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -285,21 +285,19 @@ impl SideBySideContext<'_> {
 pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
-    let title = crate::ui::diff_view::diff_title(app, area.width);
-
-    // Drop the frame when the diff is the only pane; the title still renders
-    // on the reserved top row (ratatui keeps it without a top border).
-    let borders = if app.is_diff_sole_pane() {
-        Borders::NONE
-    } else {
-        Borders::ALL
-    };
-    let block = Block::default()
-        .title(title)
-        .title_top(diff_stat_title(app).right_aligned())
-        .borders(borders)
+    // When the diff is the only pane, drop the frame entirely — including its
+    // title row. The file name and stats are folded into the top header line
+    // instead (see status_bar::render_header) so there's a single header line.
+    let sole = app.is_diff_sole_pane();
+    let mut block = Block::default()
+        .borders(if sole { Borders::NONE } else { Borders::ALL })
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
+    if !sole {
+        block = block
+            .title(crate::ui::diff_view::diff_title(app, area.width))
+            .title_top(diff_stat_title(app).right_aligned());
+    }
 
     let inner = block.inner(area);
     frame.render_widget(block, area);

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -29,10 +29,17 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
 
     let title = crate::ui::diff_view::diff_title(app, area.width);
 
+    // Drop the frame when the diff is the only pane; the title still renders
+    // on the reserved top row (ratatui keeps it without a top border).
+    let borders = if app.is_diff_sole_pane() {
+        Borders::NONE
+    } else {
+        Borders::ALL
+    };
     let block = Block::default()
         .title(title)
         .title_top(diff_stat_title(app).right_aligned())
-        .borders(Borders::ALL)
+        .borders(borders)
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
 

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -27,21 +27,19 @@ use crate::vcs::git::calculate_gap;
 pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.focused_panel == FocusedPanel::Diff;
 
-    let title = crate::ui::diff_view::diff_title(app, area.width);
-
-    // Drop the frame when the diff is the only pane; the title still renders
-    // on the reserved top row (ratatui keeps it without a top border).
-    let borders = if app.is_diff_sole_pane() {
-        Borders::NONE
-    } else {
-        Borders::ALL
-    };
-    let block = Block::default()
-        .title(title)
-        .title_top(diff_stat_title(app).right_aligned())
-        .borders(borders)
+    // When the diff is the only pane, drop the frame entirely — including its
+    // title row. The file name and stats are folded into the top header line
+    // instead (see status_bar::render_header) so there's a single header line.
+    let sole = app.is_diff_sole_pane();
+    let mut block = Block::default()
+        .borders(if sole { Borders::NONE } else { Borders::ALL })
         .style(styles::panel_style(&app.theme))
         .border_style(styles::border_style(&app.theme, focused));
+    if !sole {
+        block = block
+            .title(crate::ui::diff_view::diff_title(app, area.width))
+            .title_top(diff_stat_title(app).right_aligned());
+    }
 
     let inner = block.inner(area);
     let comment_width = inner.width.saturating_sub(1) as usize;

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -150,10 +150,61 @@ pub fn render_header(frame: &mut Frame, app: &App, area: Rect) {
 
     let total_width = area.width as usize;
     let brand_width = brand.content.chars().count();
-    let right_width = source_width + update_width;
-    let pad_width = total_width.saturating_sub(brand_width + right_width);
 
-    let mut spans = vec![brand, Span::raw(" ".repeat(pad_width)), source_span];
+    // When the diff is the only pane it has no frame/title row, so fold the
+    // current file name (left, after the brand) and its diff stats (right,
+    // after the source cluster) into this single header line.
+    let sole = app.is_diff_sole_pane();
+    let (stat_spans, stat_width): (Vec<Span>, usize) = if sole {
+        let line = crate::ui::diff_view::diff_stat_title(app);
+        let w = line
+            .spans
+            .iter()
+            .map(|s| s.content.chars().count())
+            .sum::<usize>();
+        (line.spans, w)
+    } else {
+        (Vec::new(), 0)
+    };
+
+    let right_width = source_width + stat_width + update_width;
+
+    let (file_span, file_width) = if sole {
+        let label = if app.is_cursor_in_overview() || app.current_file_path().is_none() {
+            "Overview".to_string()
+        } else {
+            app.current_file_path()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default()
+        };
+        // Leave a two-column minimum gap between the file name and the right
+        // cluster; truncate the path (keeping the basename) to whatever fits.
+        let avail = total_width.saturating_sub(brand_width + right_width + 2);
+        let label = crate::ui::diff_view::truncate_path_smart(&label, avail);
+        let text = format!(" {label} ");
+        let width = text.chars().count();
+        (
+            Some(Span::styled(
+                text,
+                Style::default()
+                    .fg(theme.fg_secondary)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            width,
+        )
+    } else {
+        (None, 0)
+    };
+
+    let pad_width = total_width.saturating_sub(brand_width + file_width + right_width);
+
+    let mut spans = vec![brand];
+    if let Some(file_span) = file_span {
+        spans.push(file_span);
+    }
+    spans.push(Span::raw(" ".repeat(pad_width)));
+    spans.push(source_span);
+    spans.extend(stat_spans);
     if update_width > 0 {
         spans.push(update_span);
     }
@@ -888,6 +939,35 @@ mod header_snapshot_tests {
         let line = row_text(&buffer, 0);
         assert!(line.contains("PR Mode"), "got: {line:?}");
         assert!(!line.contains("read only"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_fold_file_and_stats_into_header_when_diff_is_sole_pane() {
+        // given a PR app with no other panes (file list hidden, no commit pane)
+        let mut app = build_pr_app(pr_source(false, false));
+        app.show_file_list = false;
+        assert!(app.is_diff_sole_pane());
+        // when
+        let buffer = draw_header(&app);
+        // then: the diff title row is gone; its file label + stats fold into
+        // this header line (no diff files -> "Overview" and +0/-0).
+        let line = row_text(&buffer, 0);
+        assert!(line.contains("PR Mode"), "got: {line:?}");
+        assert!(line.contains("Overview"), "got: {line:?}");
+        assert!(line.contains("+0") && line.contains("-0"), "got: {line:?}");
+    }
+
+    #[test]
+    fn should_not_fold_file_into_header_when_other_panes_visible() {
+        // given the file list is visible -> diff keeps its own framed title
+        let mut app = build_pr_app(pr_source(false, false));
+        app.show_file_list = true;
+        assert!(!app.is_diff_sole_pane());
+        // when
+        let buffer = draw_header(&app);
+        // then the header does not carry the file label
+        let line = row_text(&buffer, 0);
+        assert!(!line.contains("Overview"), "got: {line:?}");
     }
 
     #[test]


### PR DESCRIPTION
When neither the file list nor the inline commit selector is shown, the diff's
border box is redundant chrome. Render it borderless so the diff uses the full
width, and fold the file name (after the brand) and the diff stats (after the
source cluster) into the single top header line — the reserved title row read
as a second header under the global one.

<img width="1939" height="2226" alt="sole-pane-before-after" src="https://github.com/user-attachments/assets/096341c8-1a6a-4a06-b50b-25f7a8250957" />

Framed layouts (any other pane visible) keep the file name in the frame title
as before. No new config key or keybinding: `App::is_diff_sole_pane()` derives
it from `show_file_list` and the inline commit selector.

`cargo fmt --all --check`, `cargo check`, `cargo clippy -- -D warnings` and
`cargo test` (1555 passed) are green locally.
