### PR TITLE
fix: apply .tuicrignore before parsing PR diffs

### DIFF
--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -413,22 +413,23 @@ impl App {
         use crate::vcs::diff_parser::parse_file_patches;
 
         let highlighter = self.theme.syntax_highlighter();
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|b| b.local_checkout_path());
+        // Filter before parsing so an ignored large file is never
+        // highlighted, exactly as in `prepare_open_pr`.
+        let patches = match local_checkout.as_deref() {
+            Some(root) => crate::tuicrignore::filter_file_patches(root, patches),
+            None => patches,
+        };
         let parsed = match parse_file_patches(patches, highlighter) {
             Ok(files) => files,
             Err(TuicrError::NoChanges) => Vec::new(),
             Err(e) => return Err(e),
         };
 
-        let local_checkout = self
-            .forge_backend
-            .as_deref()
-            .and_then(|b| b.local_checkout_path());
-        let files = match local_checkout.as_deref() {
-            Some(root) => crate::tuicrignore::filter_diff_files(root, parsed),
-            None => parsed,
-        };
-
-        self.diff_files = files;
+        self.diff_files = parsed;
         self.clear_expanded_gaps();
         // Range diffs can hide hunks that are still reviewed in the broader
         // PR session, so registration must not prune them.

--- a/src/forge/pr_open.rs
+++ b/src/forge/pr_open.rs
@@ -94,9 +94,11 @@ pub fn fetch_pr_data(backend: &dyn ForgeBackend, target: PullRequestTarget) -> R
     Ok((details, patches, commits, review_metadata, pr_info))
 }
 
-/// CPU-only half of the PR open path: parse the hunks, apply
-/// `.tuicrignore`, and build the session. Runs on the main thread because
-/// `SyntaxHighlighter` is not trivially `Send`-cloneable.
+/// CPU-only half of the PR open path: apply `.tuicrignore` to the raw
+/// patches, then parse the hunks and build the session. Filtering before the
+/// parse keeps an ignored large file from being highlighted at all. Runs on
+/// the main thread because `SyntaxHighlighter` is not trivially
+/// `Send`-cloneable.
 pub fn prepare_open_pr(
     details: PullRequestDetails,
     patches: Vec<FilePatch>,
@@ -106,20 +108,25 @@ pub fn prepare_open_pr(
     local_checkout: Option<&Path>,
     highlighter: &SyntaxHighlighter,
 ) -> Result<OpenedPullRequest> {
-    let parsed = match parse_file_patches(patches, highlighter) {
-        Ok(files) => files,
-        Err(TuicrError::NoChanges) => {
-            return Err(TuicrError::Forge(format!(
-                "Pull request #{} has no file changes",
-                details.number
-            )));
-        }
-        Err(e) => return Err(e),
+    let had_patches = !patches.is_empty();
+    let patches = match local_checkout {
+        Some(root) => tuicrignore::filter_file_patches(root, patches),
+        None => patches,
     };
 
-    let diff_files = match local_checkout {
-        Some(root) => tuicrignore::filter_diff_files(root, parsed),
-        None => parsed,
+    let diff_files = if had_patches && patches.is_empty() {
+        Vec::new()
+    } else {
+        match parse_file_patches(patches, highlighter) {
+            Ok(files) => files,
+            Err(TuicrError::NoChanges) => {
+                return Err(TuicrError::Forge(format!(
+                    "Pull request #{} has no file changes",
+                    details.number
+                )));
+            }
+            Err(e) => return Err(e),
+        }
     };
 
     let key = PrSessionKey::from_details(&details);
@@ -398,5 +405,74 @@ rename to new_name.rs
             msg.contains("Pull request #125 has no file changes"),
             "unexpected error message: {msg}"
         );
+    }
+
+    #[test]
+    fn should_drop_ignored_patches_before_parsing_them() {
+        // given a checkout whose .tuicrignore excludes dist/, and a PR diff
+        // whose ignored patch body is malformed (a hunk header the parser
+        // rejects)
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        std::fs::write(dir.path().join(".tuicrignore"), "dist/\n")
+            .expect("failed to write .tuicrignore");
+        let patches = vec![
+            FilePatch::new(
+                None,
+                Some(std::path::PathBuf::from("src/main.rs")),
+                crate::model::FileStatus::Modified,
+                "@@ -1,3 +1,3 @@\n pub fn answer() -> u32 {\n-    41\n+    42\n }\n",
+            ),
+            FilePatch::new(
+                None,
+                Some(std::path::PathBuf::from("dist/bundle.js")),
+                crate::model::FileStatus::Modified,
+                "@@not-a-hunk\n+minified one-liner\n",
+            ),
+        ];
+        let highlighter = SyntaxHighlighter::default();
+        // when
+        let opened = prepare_open_pr(
+            details(),
+            patches,
+            Vec::new(),
+            crate::forge::traits::PullRequestReviewMetadata::default(),
+            crate::forge::traits::PullRequestInfo::from_details(details()),
+            Some(dir.path()),
+            &highlighter,
+        )
+        .expect("ignored patch must never reach the parser");
+        // then only the kept file was parsed into the review
+        let kept: Vec<String> = opened
+            .diff_files
+            .iter()
+            .map(|f| f.display_path().display().to_string())
+            .collect();
+        assert_eq!(kept, vec!["src/main.rs"]);
+    }
+
+    #[test]
+    fn should_open_an_empty_review_when_every_pr_patch_is_ignored() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        std::fs::write(dir.path().join(".tuicrignore"), "dist/\n")
+            .expect("failed to write .tuicrignore");
+        let highlighter = SyntaxHighlighter::default();
+
+        let opened = prepare_open_pr(
+            details(),
+            vec![FilePatch::new(
+                None,
+                Some(std::path::PathBuf::from("dist/bundle.js")),
+                crate::model::FileStatus::Modified,
+                "@@ -1 +1 @@\n-old\n+new\n",
+            )],
+            Vec::new(),
+            crate::forge::traits::PullRequestReviewMetadata::default(),
+            crate::forge::traits::PullRequestInfo::from_details(details()),
+            Some(dir.path()),
+            &highlighter,
+        )
+        .expect("an ignored-only PR should open as an empty review");
+
+        assert!(opened.diff_files.is_empty());
     }
 }

--- a/src/tuicrignore.rs
+++ b/src/tuicrignore.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use ignore::gitignore::GitignoreBuilder;
 
-use crate::model::DiffFile;
+use crate::model::{DiffFile, FilePatch};
 
 /// Apply `.tuicrignore` rules from the repository root to a diff file set.
 pub fn filter_diff_files(repo_root: &Path, diff_files: Vec<DiffFile>) -> Vec<DiffFile> {
@@ -16,6 +16,25 @@ pub fn filter_diff_files(repo_root: &Path, diff_files: Vec<DiffFile>) -> Vec<Dif
             !matcher
                 .matched_path_or_any_parents(file.display_path(), false)
                 .is_ignore()
+        })
+        .collect()
+}
+
+/// Apply `.tuicrignore` rules from the repository root to raw file patches,
+/// before hunks are parsed and highlighted, so an ignored file never pays
+/// the syntax-highlighting cost (a large minified bundle otherwise stalls
+/// PR open even though it is excluded from the review).
+pub fn filter_file_patches(repo_root: &Path, patches: Vec<FilePatch>) -> Vec<FilePatch> {
+    let Some(matcher) = load_matcher(repo_root) else {
+        return patches;
+    };
+
+    patches
+        .into_iter()
+        .filter(|patch| {
+            patch
+                .display_path()
+                .is_none_or(|path| !matcher.matched_path_or_any_parents(path, false).is_ignore())
         })
         .collect()
 }


### PR DESCRIPTION
PR mode applied `.tuicrignore` after `parse_file_patches`, so a diff that was configured to be excluded was still fully parsed and syntax-highlighted first — on a PR touching a large minified bundle, `tuicr pr <n>` spent its whole startup in the highlighter (the `startup.syntax_highlighter` span) and then dropped the file anyway. The filter now runs on the raw `FilePatch` list before the parser (`tuicrignore::filter_file_patches`, mirroring the existing `filter_diff_files`), so an ignored file never reaches the parser or the highlighter at all. Both PR-mode parse sites get the reorder: the initial open/reload path (`prepare_open_pr`) and the commit-subrange reload (`finish_pr_range_reload`).

Two consequences worth naming:

- An ignored patch can no longer fail the PR open on content the parser would reject — there's a test pinning exactly that (`should_drop_ignored_patches_before_parsing_them`, which fails on the old ordering).
- A PR whose every file is ignored now opens as an empty review instead of colliding with the "no file changes" error path (a PR that genuinely has zero patches from the forge still errors).

Behavior outside a checkout is unchanged: with no `local_checkout` there is still no filtering, matching the module's documented invariant.

Local mode was already fine — the libgit2 backend builds diffs from structured deltas rather than reparsing patch text, which is why `-r main..HEAD` was instant for the same `.tuicrignore`.

Fixes #650
