### PR TITLE
feat(selector): add a Sessions tab to resume saved reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ so collaborative tools can add comments immediately. Empty auto-created session
 files are removed when the TUI exits. `tuicr review list` marks currently open
 TUI sessions with `"active": true`.
 
+Inside the TUI, the review target selector's **Sessions** tab lists the saved
+reviews for the current checkout, so you can resume one by picking it instead of
+retyping the commit range it was opened with. Open it with `:sessions` or cycle
+to it with `Tab`.
+
 ## Library API
 
 tuicr also exposes a Rust library API for tools that want to build on top of its

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -199,6 +199,7 @@ In command mode,
 | `:diff` | Toggle diff view (unified / side-by-side) |
 | `:vim` / `:novim` (`:set vim` / `:set novim`) | Enable/toggle/disable vim modal editing in the comment box (overrides `comment_vim`) |
 | `:commits` | Select commits to review |
+| `:sessions` (`:reviews`) | Resume a saved review for this checkout |
 | `:submit` | Open submit picker (Comment / Approve / Request changes / Draft) |
 | `:submit comment` | Submit a Comment review |
 | `:submit approve` | Submit an Approve review |
@@ -242,14 +243,19 @@ losing their reviewed state.
 
 | Key | Action |
 |-----|--------|
-| `Tab` / `Shift-Tab` | Switch between Local and Pull Requests tabs |
+| `Tab` / `Shift-Tab` | Switch between Local, Pull Requests, and Sessions tabs |
 | `j` / `k` | Move selection |
 | `Space` | Toggle local commit selection |
-| `Enter` | Confirm local commit range, open PR, or load more PRs |
+| `Enter` | Confirm local commit range, open PR, load more PRs, or resume a saved review |
 | `/` | Filter currently loaded PR rows locally |
 | `r` | In Pull Requests tab, toggle all open PRs / PRs requesting your review |
 | `Esc` | Return to the diff |
 | `:q` | Quit |
+
+The Sessions tab lists saved reviews for the current checkout, so you can pick one
+instead of retyping the commit range it was opened with. Rows show the review target,
+comment count, reviewed files, and age. Reviews with no comments and no reviewed files
+are omitted. PR sessions open from the Pull Requests tab.
 
 ## Inline commit selector
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -255,7 +255,8 @@ losing their reviewed state.
 The Sessions tab lists saved reviews for the current checkout, so you can pick one
 instead of retyping the commit range it was opened with. Rows show the review target,
 comment count, reviewed files, and age. Reviews with no comments and no reviewed files
-are omitted. PR sessions open from the Pull Requests tab.
+are omitted. Selecting a saved PR review re-fetches it from the forge, the same as
+opening it from the Pull Requests tab.
 
 ## Inline commit selector
 

--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -182,9 +182,9 @@ impl App {
 
         let commits = self.vcs.get_recent_commits(0, VISIBLE_COMMIT_COUNT)?;
         let no_local_targets = commits.is_empty() && !has_staged_changes && !has_unstaged_changes;
-        // Allow opening the selector on the Pull Requests tab even when there
-        // are no local commits or changes — the PR tab is the user's reason
-        // for being here.
+        // Allow opening the selector on the Pull Requests or Sessions tab even
+        // when there are no local commits or changes — that tab is the user's
+        // reason for being here.
         if no_local_targets && initial_tab == TargetTab::Local {
             self.set_message("No commits or staged/unstaged changes found");
             return Ok(());
@@ -211,9 +211,15 @@ impl App {
         self.pr_filter_draft = None;
         self.pr_load_rx = None;
 
+        // Reset the Sessions tab too, so a resumed review's own session shows
+        // up in the listing rather than a stale snapshot.
+        self.sessions_tab = crate::app::sessions_tab::SessionsTab::default();
+
         self.target_tab = initial_tab;
-        if initial_tab == TargetTab::PullRequests {
-            self.on_target_tab_entered();
+        match initial_tab {
+            TargetTab::PullRequests => self.on_target_tab_entered(),
+            TargetTab::Sessions => self.load_sessions_tab(),
+            TargetTab::Local => {}
         }
         Ok(())
     }
@@ -272,20 +278,29 @@ impl App {
     }
 
     /// Switch to the next/previous tab in the review target selector.
-    /// With only two tabs, forward and reverse are equivalent; the `_forward`
-    /// arg is kept so callers can pass the natural direction without a cast.
-    /// Triggers the lazy PR fetch the first time the PR tab is entered.
-    pub fn cycle_target_tab(&mut self, _forward: bool) {
-        let next = match self.target_tab {
-            TargetTab::Local => TargetTab::PullRequests,
-            TargetTab::PullRequests => TargetTab::Local,
+    /// Triggers the lazy PR fetch the first time the PR tab is entered, and
+    /// lists persisted sessions on entry to the Sessions tab.
+    pub fn cycle_target_tab(&mut self, forward: bool) {
+        let next = match (self.target_tab, forward) {
+            (TargetTab::Local, true) => TargetTab::PullRequests,
+            (TargetTab::PullRequests, true) => TargetTab::Sessions,
+            (TargetTab::Sessions, true) => TargetTab::Local,
+            (TargetTab::Local, false) => TargetTab::Sessions,
+            (TargetTab::Sessions, false) => TargetTab::PullRequests,
+            (TargetTab::PullRequests, false) => TargetTab::Local,
         };
         self.target_tab = next;
-        if next == TargetTab::PullRequests {
-            self.on_target_tab_entered();
-        } else {
-            // Returning to Local: clear any half-typed PR filter draft.
-            self.pr_filter_draft = None;
+        match next {
+            TargetTab::PullRequests => self.on_target_tab_entered(),
+            TargetTab::Sessions => {
+                // Leaving the PR tab: drop any half-typed filter draft.
+                self.pr_filter_draft = None;
+                self.load_sessions_tab();
+            }
+            TargetTab::Local => {
+                // Returning to Local: clear any half-typed PR filter draft.
+                self.pr_filter_draft = None;
+            }
         }
     }
 
@@ -297,6 +312,181 @@ impl App {
             let skip_resolution = self.canonical_resolved;
             self.spawn_pr_initial_load(repo, override_repo, skip_resolution, scope);
         }
+    }
+
+    /// Resolve a session's stored commit ids to [`CommitInfo`] rows in the
+    /// same order, which the range loaders require to be oldest-first.
+    ///
+    /// `ReviewSession::commit_range` is written oldest-first by
+    /// `confirm_commit_selection_inner` (it reverses the newest-first display
+    /// list), and `commit_list_range_trees` reads `[0]` as the oldest and
+    /// `last()` as the newest. So the stored order is already the order the
+    /// loaders want and must be passed through unchanged — reversing it here
+    /// inverts the diff, turning added lines into deletions.
+    ///
+    /// Resolution is by direct id lookup, not a history walk: a saved range can
+    /// sit on another branch or far past any page of recent commits, and those
+    /// commits are still addressable. `None` means at least one id no longer
+    /// resolves — amended or rebased since the session was written — which the
+    /// caller reports rather than loading a partial range.
+    fn resolve_session_commits(&self, ids: &[String]) -> Result<Option<Vec<CommitInfo>>> {
+        let resolved = match self.vcs.get_commits_info(ids) {
+            Ok(resolved) => resolved,
+            // Backends report an unknown id as a command error; that is the
+            // "no longer reachable" case, not a failure to surface.
+            Err(TuicrError::VcsCommand(_)) => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        if resolved.len() != ids.len() {
+            return Ok(None);
+        }
+        Ok(Some(resolved))
+    }
+
+    /// List persisted sessions for this checkout. Synchronous: this reads the
+    /// review manifest, so there is no network call to defer.
+    ///
+    /// Sessions with neither comments nor reviewed state are hidden because
+    /// they hold no review progress to resume. A clean quit removes them
+    /// (`delete_session_if_empty`); a crash can leave one behind.
+    pub fn load_sessions_tab(&mut self) {
+        let root = self.vcs_info.root_path.clone();
+        let result = crate::review_store::ReviewStore::new()
+            .list_sessions_for_repo(&root)
+            .map(|sessions| sessions.into_iter().filter(Self::is_resumable).collect())
+            .map_err(|e| e.to_string());
+        self.sessions_tab
+            .set_scope(Self::checkout_display_name(&root));
+        self.sessions_tab.apply_load(result);
+    }
+
+    /// Whether a listed session holds review progress worth resuming.
+    pub(in crate::app) fn is_resumable(summary: &crate::review_store::SessionSummary) -> bool {
+        summary.comment_count > 0 || summary.reviewed_count > 0
+    }
+
+    /// `owner/repo` for a checkout, falling back to the directory name when it
+    /// has no origin remote. Resolved once per listing: it reaches git2
+    /// repository discovery, so it must stay out of the render path.
+    fn checkout_display_name(root: &Path) -> String {
+        crate::slug::RepoCoordinate::from_repo_path(root)
+            .map(|coordinate| match coordinate.owner {
+                Some(owner) => format!("{owner}/{}", coordinate.repo),
+                None => coordinate.repo,
+            })
+            .or_else(|| {
+                root.file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+            .unwrap_or_else(|| root.display().to_string())
+    }
+
+    pub fn sessions_tab_cursor_up(&mut self) {
+        self.sessions_tab.cursor_up();
+        let height = self.sessions_list_viewport_height;
+        self.sessions_tab.ensure_cursor_visible(height);
+    }
+
+    pub fn sessions_tab_cursor_down(&mut self) {
+        self.sessions_tab.cursor_down();
+        let height = self.sessions_list_viewport_height;
+        self.sessions_tab.ensure_cursor_visible(height);
+    }
+
+    /// Open the session under the cursor with its stored `diff_source` and
+    /// `commit_range`, which is what the user would otherwise have to retype as
+    /// `-r` / `-w` flags.
+    ///
+    /// PR sessions need the forge round-trip the Pull Requests tab owns, so
+    /// selecting one points there instead.
+    pub fn sessions_tab_select(&mut self) -> Result<()> {
+        let Some(summary) = self.sessions_tab.cursor_session() else {
+            return Ok(());
+        };
+        if matches!(summary.kind, crate::review_store::SessionKind::Pr) {
+            self.set_message("PR sessions open from the Pull Requests tab");
+            return Ok(());
+        }
+
+        let session = match crate::persistence::storage::load_session(summary.session_ref.path()) {
+            Ok(session) => session,
+            Err(e) => {
+                self.set_error(format!("Failed to load session: {e}"));
+                return Ok(());
+            }
+        };
+
+        let loaded = match session.diff_source {
+            SessionDiffSource::CommitRange => {
+                let Some(commits) = self.session_range_commits(&session)? else {
+                    return Ok(());
+                };
+                let ordered_ids = commits.iter().map(|c| c.id.clone()).collect();
+                self.load_commit_range_selection(ordered_ids, commits)
+            }
+            SessionDiffSource::WorkingTree => self.load_working_tree_selection(),
+            SessionDiffSource::Unstaged => self.load_unstaged_selection(),
+            SessionDiffSource::Staged => self.load_staged_selection(),
+            SessionDiffSource::StagedAndUnstaged => self.load_staged_and_unstaged_selection(),
+            SessionDiffSource::WorkingTreeAndCommits
+            | SessionDiffSource::StagedUnstagedAndCommits => {
+                let Some(commits) = self.session_range_commits(&session)? else {
+                    return Ok(());
+                };
+                let ordered_ids = commits.iter().map(|c| c.id.clone()).collect();
+                self.load_staged_unstaged_and_commits_selection(ordered_ids, commits)
+            }
+            SessionDiffSource::Pristine => {
+                self.set_message("Restart tuicr with --all-files to open this review.");
+                return Ok(());
+            }
+            SessionDiffSource::PullRequest => {
+                self.set_message("Open PR sessions from the Pull Requests tab.");
+                return Ok(());
+            }
+        };
+        loaded?;
+
+        // The loaders resolve a session from the *current* branch and HEAD, so
+        // they can hand back a different session than the row that was picked
+        // — a range saved on another branch, or an older working-tree session.
+        // Install the selected one and keep its comments and reviewed state.
+        self.install_resumed_session(session);
+        Ok(())
+    }
+
+    /// Commits for a session's stored range, or `None` after reporting why the
+    /// range cannot be restored.
+    fn session_range_commits(
+        &mut self,
+        session: &ReviewSession,
+    ) -> Result<Option<Vec<CommitInfo>>> {
+        let Some(ids) = session.commit_range.clone().filter(|ids| !ids.is_empty()) else {
+            self.set_error("Can't restore this review: it has no saved commit range.".to_string());
+            return Ok(None);
+        };
+        let Some(commits) = self.resolve_session_commits(&ids)? else {
+            self.set_error(
+                "Can't restore this review: one or more saved commits aren't in the current \
+                 history. Switch to the review's branch and try again."
+                    .to_string(),
+            );
+            return Ok(None);
+        };
+        Ok(Some(commits))
+    }
+
+    /// Adopt the session the user selected, carrying over the diff files the
+    /// loader just resolved so reviewed state and comments still line up.
+    fn install_resumed_session(&mut self, session: ReviewSession) {
+        self.session = session;
+        let diff_files = std::mem::take(&mut self.diff_files);
+        for file in &diff_files {
+            self.session.add_diff_file(file);
+        }
+        self.diff_files = diff_files;
+        self.reset_persisted_session_tracking();
+        self.rebuild_annotations();
     }
 
     /// Whether the inline commit selector panel should be displayed.
@@ -709,6 +899,17 @@ impl App {
             return self.load_unstaged_selection();
         }
 
+        self.load_commit_range_selection(selected_ids, selected_commits)
+    }
+
+    /// Load a commit-range review from ids ordered oldest-to-newest, together
+    /// with the commit rows that produced them. Installs the matching persisted
+    /// session and resets the commit selector and navigation state.
+    fn load_commit_range_selection(
+        &mut self,
+        selected_ids: Vec<String>,
+        selected_commits: Vec<CommitInfo>,
+    ) -> Result<()> {
         // Get the diff for the selected commits
         let highlighter = self.theme.syntax_highlighter();
         let diff_files = Self::get_commit_range_diff_with_ignore(

--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -351,10 +351,36 @@ impl App {
     /// (`delete_session_if_empty`); a crash can leave one behind.
     pub fn load_sessions_tab(&mut self) {
         let root = self.vcs_info.root_path.clone();
-        let result = crate::review_store::ReviewStore::new()
+        let store = crate::review_store::ReviewStore::new();
+        let mut result = store
             .list_sessions_for_repo(&root)
-            .map(|sessions| sessions.into_iter().filter(Self::is_resumable).collect())
+            .map(|sessions| {
+                sessions
+                    .into_iter()
+                    .filter(Self::is_resumable)
+                    .collect::<Vec<_>>()
+            })
             .map_err(|e| e.to_string());
+
+        // A fork's `origin` coordinate does not match PR sessions saved against
+        // the upstream repo, so listing by checkout alone hides them. Add the
+        // sessions for the forge repository this checkout reviews against: the
+        // canonical parent, or whatever `--repo-url` named.
+        if let (Ok(sessions), Some(forge)) = (&mut result, self.forge_repository.clone()) {
+            let coordinate = format!("{}/{}", forge.owner, forge.name);
+            if let Ok(forge_sessions) = store.list_sessions_for_repo(Path::new(&coordinate)) {
+                for session in forge_sessions {
+                    let listed = sessions
+                        .iter()
+                        .any(|s| s.session_ref.path() == session.session_ref.path());
+                    if !listed && Self::is_resumable(&session) {
+                        sessions.push(session);
+                    }
+                }
+                sessions.sort_by_key(|s| std::cmp::Reverse(s.updated_at));
+            }
+        }
+
         self.sessions_tab
             .set_scope(Self::checkout_display_name(&root));
         self.sessions_tab.apply_load(result);
@@ -396,17 +422,10 @@ impl App {
     /// Open the session under the cursor with its stored `diff_source` and
     /// `commit_range`, which is what the user would otherwise have to retype as
     /// `-r` / `-w` flags.
-    ///
-    /// PR sessions need the forge round-trip the Pull Requests tab owns, so
-    /// selecting one points there instead.
     pub fn sessions_tab_select(&mut self) -> Result<()> {
         let Some(summary) = self.sessions_tab.cursor_session() else {
             return Ok(());
         };
-        if matches!(summary.kind, crate::review_store::SessionKind::Pr) {
-            self.set_message("PR sessions open from the Pull Requests tab");
-            return Ok(());
-        }
 
         let session = match crate::persistence::storage::load_session(summary.session_ref.path()) {
             Ok(session) => session,
@@ -440,8 +459,17 @@ impl App {
                 self.set_message("Restart tuicr with --all-files to open this review.");
                 return Ok(());
             }
+            // A PR review is fetched, not read from the checkout. The session
+            // records the forge repository and number, so resume can reuse the
+            // Pull Requests tab's open path instead of sending the user there.
             SessionDiffSource::PullRequest => {
-                self.set_message("Open PR sessions from the Pull Requests tab.");
+                let Some(key) = session.pr_session_key.clone() else {
+                    self.set_error(
+                        "Can't restore this review: it has no saved pull request.".to_string(),
+                    );
+                    return Ok(());
+                };
+                self.resume_pr_session(&key);
                 return Ok(());
             }
         };

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -444,6 +444,46 @@ impl App {
         Ok(())
     }
 
+    /// Load a whole-working-tree review (`tuicr -w`).
+    ///
+    /// This must record `SessionDiffSource::WorkingTree`. The source is part of
+    /// the session identity, even though this loader and the staged-plus-
+    /// unstaged loader read the same diff.
+    pub(in crate::app) fn load_working_tree_selection(&mut self) -> Result<()> {
+        let highlighter = self.theme.syntax_highlighter();
+        let diff_files = match Self::get_working_tree_diff_with_ignore(
+            self.vcs.as_ref(),
+            &self.vcs_info.root_path,
+            highlighter,
+            self.path_filter.as_deref(),
+        ) {
+            Ok(diff_files) => diff_files,
+            Err(TuicrError::NoChanges) => {
+                self.set_message("No working tree changes");
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        };
+
+        self.session = Self::load_or_create_session(&self.vcs_info, SessionDiffSource::WorkingTree);
+        for file in &diff_files {
+            self.session.add_diff_file(file);
+        }
+        self.reset_persisted_session_tracking();
+
+        self.diff_files = diff_files;
+        self.diff_source = DiffSource::WorkingTree;
+        self.input_mode = InputMode::Normal;
+        self.diff_state = DiffState::default();
+        self.file_list_state = FileListState::default();
+        self.clear_expanded_gaps();
+        self.sort_files_by_directory(true);
+        self.expand_all_dirs();
+        self.rebuild_annotations();
+
+        Ok(())
+    }
+
     pub(in crate::app) fn load_staged_selection(&mut self) -> Result<()> {
         let highlighter = self.theme.syntax_highlighter();
         let diff_files = match Self::get_staged_diff_with_ignore(

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -538,6 +538,8 @@ impl App {
             pr_list_viewport_height: 0,
             pr_list_inner_area: None,
             pr_filter_draft: None,
+            sessions_tab: crate::app::sessions_tab::SessionsTab::default(),
+            sessions_list_viewport_height: 0,
             pr_load_rx: None,
             pr_open_state: None,
             pr_open_rx: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -766,12 +766,12 @@ pub enum FocusedPanel {
 
 /// Active tab in the review target selector.
 ///
-/// The selector internally still goes through `InputMode::CommitSelect`,
-/// but it shows two tabs to the user.
+/// The selector internally still goes through `InputMode::CommitSelect`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TargetTab {
     Local,
     PullRequests,
+    Sessions,
 }
 
 /// Background-thread events that the PR tab consumes through `pr_load_rx`.
@@ -1212,6 +1212,10 @@ pub struct App {
     /// When `Some`, the user is editing the local PR filter. Captured keys
     /// update this draft; pressing Enter commits it to the tab state.
     pub pr_filter_draft: Option<String>,
+    /// State for the Sessions tab: persisted reviews for this checkout.
+    pub sessions_tab: crate::app::sessions_tab::SessionsTab,
+    /// Viewport height of the session list (set during render).
+    pub sessions_list_viewport_height: usize,
     /// Background-thread channel that delivers PR list fetch results.
     /// `Receiver` is only present while a fetch is in flight.
     pub pr_load_rx: Option<std::sync::mpsc::Receiver<PrLoadEvent>>,
@@ -1772,6 +1776,7 @@ mod pr;
 mod reviewed;
 mod search;
 mod session;
+pub mod sessions_tab;
 mod submit;
 mod tree;
 mod visual;

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -871,7 +871,7 @@ impl App {
         let Some(summary) = self.pr_tab.cursor_pr().cloned() else {
             return false;
         };
-        self.spawn_pr_open(&summary);
+        self.spawn_pr_open(&summary.repository, summary.number);
         true
     }
 
@@ -894,17 +894,30 @@ impl App {
         crate::forge::local_checkout_for_repo(root, repo)
     }
 
+    /// Reopen a persisted PR review from the Sessions tab.
+    ///
+    /// Routes through the same background fetch as the Pull Requests tab: a PR
+    /// diff comes from the forge, not the checkout, and re-fetching also picks
+    /// up commits pushed since the review was saved. `load_pr_session` then
+    /// reattaches the stored comments by head SHA.
+    pub fn resume_pr_session(&mut self, key: &crate::forge::traits::PrSessionKey) {
+        if self.pr_open_state.is_some() {
+            return;
+        }
+        self.spawn_pr_open(&key.repository, key.number);
+    }
+
     /// Kick off the background fetch for a PR open. The main thread keeps
     /// rendering and pumping events; the resulting `PrOpenEvent::Done` is
     /// drained in `poll_pr_open_events` where parsing happens and PR mode
     /// is entered.
-    fn spawn_pr_open(&mut self, summary: &crate::forge::traits::PullRequestSummary) {
+    fn spawn_pr_open(&mut self, repository: &crate::forge::traits::ForgeRepository, number: u64) {
         use crate::forge::pr_open::fetch_pr_data;
         use crate::forge::traits::PullRequestTarget;
 
         let request = PrOpenRequest {
-            repository: summary.repository.clone(),
-            pr_number: summary.number,
+            repository: repository.clone(),
+            pr_number: number,
             started_at: Instant::now(),
         };
         self.pr_open_state = Some(request.clone());
@@ -912,11 +925,11 @@ impl App {
         let (tx, rx) = std::sync::mpsc::channel();
         self.pr_open_rx = Some(rx);
 
-        let summary_repo = summary.repository.clone();
-        let pr_number = summary.number;
+        let summary_repo = repository.clone();
+        let pr_number = number;
         // Resolve the local checkout up front so Azure DevOps can source its
         // diff from the clone when opening a PR from the selector.
-        let local_checkout = self.local_checkout_for(&summary.repository);
+        let local_checkout = self.local_checkout_for(repository);
         let show_pr_checks = self.show_pr_checks;
         let show_pr_comments = self.show_pr_comments;
         std::thread::spawn(move || {

--- a/src/app/sessions_tab.rs
+++ b/src/app/sessions_tab.rs
@@ -1,0 +1,186 @@
+//! State for the Sessions tab in the review target selector.
+//!
+//! The tab lists persisted review sessions for the current checkout so a
+//! review can be resumed by picking it, rather than by remembering the commit
+//! range or working-tree flags it was opened with. Rows come from
+//! [`ReviewStore::list_sessions_for_repo`], which is already newest-first.
+
+use crate::review_store::{SessionKind, SessionSummary};
+
+/// Rows for the Sessions tab, plus cursor and viewport state.
+///
+/// Filled when the tab opens; the listing reads only the local manifest.
+#[derive(Debug, Default)]
+pub struct SessionsTab {
+    rows: Vec<SessionSummary>,
+    error: Option<String>,
+    /// Checkout the listing is scoped to, resolved once at load. Rendering
+    /// reads this every frame, so it must not re-derive it: the lookup reaches
+    /// git2 repository discovery and the `origin` remote.
+    scope: String,
+    cursor: usize,
+    scroll: usize,
+}
+
+impl SessionsTab {
+    /// Replace the rows with a fresh listing, resetting the cursor.
+    pub fn apply_load(&mut self, result: std::result::Result<Vec<SessionSummary>, String>) {
+        self.cursor = 0;
+        self.scroll = 0;
+        match result {
+            Ok(rows) => {
+                self.rows = rows;
+                self.error = None;
+            }
+            Err(message) => {
+                self.rows = Vec::new();
+                self.error = Some(message);
+            }
+        }
+    }
+
+    /// Name the listing is scoped to, for the panel title.
+    pub fn scope(&self) -> &str {
+        &self.scope
+    }
+
+    pub fn set_scope(&mut self, scope: String) {
+        self.scope = scope;
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    pub fn rows(&self) -> &[SessionSummary] {
+        &self.rows
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    pub fn scroll(&self) -> usize {
+        self.scroll
+    }
+
+    /// The session under the cursor, if any.
+    pub fn cursor_session(&self) -> Option<&SessionSummary> {
+        self.rows.get(self.cursor)
+    }
+
+    pub fn cursor_up(&mut self) {
+        self.cursor = self.cursor.saturating_sub(1);
+    }
+
+    pub fn cursor_down(&mut self) {
+        if !self.rows.is_empty() {
+            self.cursor = (self.cursor + 1).min(self.rows.len() - 1);
+        }
+    }
+
+    /// Keep the cursor inside the viewport after a move or a resize.
+    pub fn ensure_cursor_visible(&mut self, height: usize) {
+        if height == 0 {
+            return;
+        }
+        if self.cursor < self.scroll {
+            self.scroll = self.cursor;
+        } else if self.cursor >= self.scroll + height {
+            self.scroll = self.cursor + 1 - height;
+        }
+    }
+}
+
+/// Short label for a session's kind, shown in the row's left column.
+pub fn kind_label(kind: SessionKind) -> &'static str {
+    match kind {
+        SessionKind::Local => "local",
+        SessionKind::Pr => "pr",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::review_store::SessionRef;
+    use chrono::Utc;
+
+    fn summary(slug: &str) -> SessionSummary {
+        SessionSummary {
+            session_ref: SessionRef::from_path(format!("/tmp/{slug}.json")),
+            slug: slug.to_string(),
+            kind: SessionKind::Local,
+            updated_at: Utc::now(),
+            comment_count: 0,
+            reviewed_count: 0,
+            file_count: 1,
+            anchor: "main".to_string(),
+            active: false,
+        }
+    }
+
+    #[test]
+    fn should_start_empty() {
+        let tab = SessionsTab::default();
+        assert!(tab.is_empty());
+        assert!(tab.cursor_session().is_none());
+    }
+
+    #[test]
+    fn should_apply_rows_and_select_first() {
+        let mut tab = SessionsTab::default();
+        tab.apply_load(Ok(vec![summary("a"), summary("b")]));
+        assert_eq!(tab.cursor_session().map(|s| s.slug.as_str()), Some("a"));
+    }
+
+    #[test]
+    fn should_clamp_cursor_at_both_ends() {
+        let mut tab = SessionsTab::default();
+        tab.apply_load(Ok(vec![summary("a"), summary("b")]));
+        tab.cursor_up();
+        assert_eq!(tab.cursor(), 0);
+        tab.cursor_down();
+        tab.cursor_down();
+        tab.cursor_down();
+        assert_eq!(tab.cursor(), 1);
+    }
+
+    #[test]
+    fn should_not_move_cursor_when_empty() {
+        let mut tab = SessionsTab::default();
+        tab.apply_load(Ok(Vec::new()));
+        tab.cursor_down();
+        assert_eq!(tab.cursor(), 0);
+        assert!(tab.cursor_session().is_none());
+    }
+
+    #[test]
+    fn should_record_error_and_drop_rows() {
+        let mut tab = SessionsTab::default();
+        tab.apply_load(Ok(vec![summary("a")]));
+        tab.apply_load(Err("boom".to_string()));
+        assert!(tab.is_empty());
+        assert_eq!(tab.error(), Some("boom"));
+    }
+
+    #[test]
+    fn should_scroll_viewport_to_follow_cursor() {
+        let mut tab = SessionsTab::default();
+        tab.apply_load(Ok((0..10).map(|i| summary(&i.to_string())).collect()));
+        for _ in 0..4 {
+            tab.cursor_down();
+        }
+        tab.ensure_cursor_visible(3);
+        assert_eq!(tab.scroll(), 2);
+        for _ in 0..4 {
+            tab.cursor_up();
+        }
+        tab.ensure_cursor_visible(3);
+        assert_eq!(tab.scroll(), 0);
+    }
+}

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -15,6 +15,7 @@ mod render_perf_tests;
 mod sbs_comment_side_tests;
 mod scroll_behavior_tests;
 mod scroll_tests;
+mod sessions_resume_tests;
 mod single_file_view_tests;
 mod submit_flow_tests;
 mod target_selector_tests;

--- a/src/app/tests/sessions_resume_tests.rs
+++ b/src/app/tests/sessions_resume_tests.rs
@@ -1,0 +1,463 @@
+//! Resuming a persisted review through the Sessions tab.
+//!
+//! These drive `sessions_tab_select` — the production entry point — against
+//! sessions persisted in an isolated reviews dir. An earlier version called the
+//! loaders directly through test-only wrappers; that passed while the dispatch
+//! routed `WorkingTree` to the unstaged-only loader, so it guarded nothing.
+
+use crate::app::*;
+use crate::model::FileStatus;
+use crate::review_store::{SessionKind, SessionSummary};
+use crate::vcs::traits::{ResolvedRevisionRange, VcsType};
+use std::sync::{Arc, Mutex};
+
+/// Redirects persisted-session storage to a temp dir for the current thread.
+struct TestReviewsDir {
+    _dir: tempfile::TempDir,
+}
+
+impl TestReviewsDir {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().expect("failed to create test reviews dir");
+        crate::persistence::storage::set_test_reviews_dir(Some(dir.path().to_path_buf()));
+        Self { _dir: dir }
+    }
+}
+
+impl Drop for TestReviewsDir {
+    fn drop(&mut self) {
+        crate::persistence::storage::set_test_reviews_dir(None);
+    }
+}
+
+/// What the app asked the VCS for, so tests can assert the diff was requested
+/// the right way round rather than trusting the app's own bookkeeping.
+#[derive(Default)]
+struct VcsCalls {
+    range_ids: Option<Vec<String>>,
+    working_tree: usize,
+    unstaged: usize,
+    staged: usize,
+}
+
+struct RecordingVcs {
+    info: VcsInfo,
+    commits: Vec<CommitInfo>,
+    calls: Arc<Mutex<VcsCalls>>,
+}
+
+impl VcsBackend for RecordingVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.info
+    }
+
+    /// Non-empty: a `-w` review of a fully staged tree still has a diff.
+    fn get_working_tree_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        self.calls.lock().unwrap().working_tree += 1;
+        Ok(vec![diff_file("worktree.py")])
+    }
+
+    /// Empty: the unstaged diff and the whole-working-tree diff differ, so
+    /// routing to the wrong one is visible.
+    fn get_unstaged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        self.calls.lock().unwrap().unstaged += 1;
+        Err(TuicrError::NoChanges)
+    }
+
+    fn get_staged_diff(&self, _highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
+        self.calls.lock().unwrap().staged += 1;
+        Ok(vec![diff_file("staged.py")])
+    }
+
+    fn get_commits_info(&self, ids: &[String]) -> Result<Vec<CommitInfo>> {
+        let mut out = Vec::new();
+        for id in ids {
+            match self.commits.iter().find(|c| &c.id == id) {
+                Some(commit) => out.push(commit.clone()),
+                None => {
+                    return Err(TuicrError::VcsCommand(format!("Commit not found {id}")));
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    fn get_recent_commits(&self, offset: usize, limit: usize) -> Result<Vec<CommitInfo>> {
+        Ok(self
+            .commits
+            .iter()
+            .skip(offset)
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+
+    fn get_commit_range_diff(
+        &self,
+        revision_range: &ResolvedRevisionRange<'_>,
+        _highlighter: &SyntaxHighlighter,
+    ) -> Result<Vec<DiffFile>> {
+        self.calls.lock().unwrap().range_ids = Some(revision_range.commit_ids.to_vec());
+        Ok(vec![diff_file("ranged.py")])
+    }
+
+    fn fetch_context_lines(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start_line: u32,
+        _end_line: u32,
+    ) -> Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+
+    fn file_line_count(
+        &self,
+        _file_path: &Path,
+        _file_status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> Result<u32> {
+        Ok(0)
+    }
+}
+
+fn diff_file(path: &str) -> DiffFile {
+    DiffFile {
+        old_path: Some(PathBuf::from(path)),
+        new_path: Some(PathBuf::from(path)),
+        status: FileStatus::Modified,
+        hunks: Vec::new(),
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash: 0,
+    }
+}
+
+fn commit(id: &str) -> CommitInfo {
+    CommitInfo {
+        id: id.to_string(),
+        short_id: id.chars().take(7).collect(),
+        branch_name: None,
+        summary: format!("commit {id}"),
+        body: None,
+        author: "Test".to_string(),
+        time: Utc::now(),
+    }
+}
+
+/// App over `commits` (newest-first, as the selector displays them).
+fn build_app(commits: Vec<CommitInfo>) -> (App, Arc<Mutex<VcsCalls>>) {
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: commits.first().map(|c| c.id.clone()).unwrap_or_default(),
+        branch_name: Some("main".to_string()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+    let calls = Arc::new(Mutex::new(VcsCalls::default()));
+    let app = App::build(
+        Box::new(RecordingVcs {
+            info: vcs_info.clone(),
+            commits: commits.clone(),
+            calls: Arc::clone(&calls),
+        }),
+        vcs_info,
+        Theme::dark(),
+        None,
+        false,
+        Vec::new(),
+        session,
+        DiffSource::WorkingTree,
+        InputMode::CommitSelect,
+        commits,
+        None,
+        None,
+    )
+    .expect("failed to build test app");
+    (app, calls)
+}
+
+/// Persist a session and put its listing row in the Sessions tab, so
+/// `sessions_tab_select` resolves it exactly as it would in the TUI.
+fn stage_session(app: &mut App, session: ReviewSession) -> SessionSummary {
+    let store = crate::review_store::ReviewStore::new();
+    let session_ref = store.save_review(&session).expect("persist session");
+    let summary = SessionSummary {
+        session_ref,
+        slug: "test@main/session".to_string(),
+        kind: SessionKind::Local,
+        updated_at: Utc::now(),
+        comment_count: 1,
+        reviewed_count: 0,
+        file_count: 1,
+        anchor: "main".to_string(),
+        active: false,
+    };
+    app.sessions_tab.apply_load(Ok(vec![summary.clone()]));
+    summary
+}
+
+fn range_session(commit_ids: &[&str], branch: Option<&str>) -> ReviewSession {
+    let mut session = ReviewSession::new(
+        PathBuf::from("/tmp"),
+        commit_ids.last().expect("non-empty range").to_string(),
+        branch.map(str::to_string),
+        SessionDiffSource::CommitRange,
+    );
+    session.commit_range = Some(commit_ids.iter().map(|id| id.to_string()).collect());
+    session
+}
+
+#[test]
+fn should_pass_stored_commit_order_through_unchanged_when_resuming() {
+    // a range persisted oldest-first, as confirm_commit_selection_inner
+    // writes it
+    let _reviews = TestReviewsDir::new();
+    let (mut app, calls) = build_app(vec![commit("ccc"), commit("bbb"), commit("aaa")]);
+    stage_session(
+        &mut app,
+        range_session(&["aaa", "bbb", "ccc"], Some("main")),
+    );
+
+    // resumed through the production entry point
+    app.sessions_tab_select().expect("resume should succeed");
+
+    // the VCS sees oldest-first, so [0] is the base and last() the head.
+    // Reversed, the diff renders additions as deletions.
+    assert_eq!(
+        calls.lock().unwrap().range_ids.clone(),
+        Some(vec![
+            "aaa".to_string(),
+            "bbb".to_string(),
+            "ccc".to_string()
+        ]),
+        "resume must not reverse the stored range"
+    );
+}
+
+#[test]
+fn should_resume_working_tree_session_through_the_working_tree_loader() {
+    // a `-w` review whose changes are all staged, so the unstaged-only
+    // diff is empty while the working-tree diff is not
+    let _reviews = TestReviewsDir::new();
+    let (mut app, calls) = build_app(vec![commit("ccc")]);
+    stage_session(
+        &mut app,
+        ReviewSession::new(
+            PathBuf::from("/tmp"),
+            "ccc".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::WorkingTree,
+        ),
+    );
+
+    app.sessions_tab_select().expect("resume should succeed");
+
+    // the working-tree diff loaded, not the unstaged one
+    let calls = calls.lock().unwrap();
+    assert_eq!(calls.working_tree, 1, "expected the working-tree diff");
+    assert_eq!(calls.unstaged, 0, "unstaged-only diff is the wrong source");
+    assert_eq!(app.diff_files.len(), 1);
+    assert!(
+        matches!(app.session.diff_source, SessionDiffSource::WorkingTree),
+        "session source must survive resume or a different session is written"
+    );
+    assert_eq!(
+        app.message, None,
+        "a resumable review must not report an empty diff"
+    );
+}
+
+#[test]
+fn should_install_the_selected_session_not_one_matching_current_head() {
+    // a review saved on another branch. The loaders resolve a session
+    // from the *current* branch and HEAD, so resume must override their choice.
+    let _reviews = TestReviewsDir::new();
+    let (mut app, _) = build_app(vec![commit("ccc"), commit("bbb"), commit("aaa")]);
+    let mut saved = range_session(&["aaa", "bbb", "ccc"], Some("feature/old"));
+    saved.session_notes = Some("notes from the saved review".to_string());
+    let summary = stage_session(&mut app, saved);
+
+    app.sessions_tab_select().expect("resume should succeed");
+
+    // the app holds the row that was picked, not a fresh session under
+    // the current anchor
+    assert_eq!(
+        app.session.branch_name.as_deref(),
+        Some("feature/old"),
+        "resume installed a different session than the selected row"
+    );
+    assert_eq!(
+        app.session.session_notes.as_deref(),
+        Some("notes from the saved review"),
+        "the selected session's saved state must survive resume"
+    );
+    assert_eq!(
+        app.session_path.as_deref(),
+        Some(summary.session_ref.path()),
+        "further edits must write back to the selected session file"
+    );
+}
+
+#[test]
+fn should_report_a_range_whose_commits_are_gone() {
+    // a session referencing a commit that no longer resolves, which is
+    // what an amend or rebase leaves behind
+    let _reviews = TestReviewsDir::new();
+    let (mut app, calls) = build_app(vec![commit("ccc"), commit("bbb")]);
+    stage_session(
+        &mut app,
+        range_session(&["aaa", "bbb", "ccc"], Some("main")),
+    );
+
+    app.sessions_tab_select().expect("resume should not error");
+
+    // refused with a message, and no partial range loaded
+    let message = app
+        .message
+        .as_ref()
+        .expect("expected a user-facing refusal");
+    assert_eq!(message.message_type, MessageType::Error);
+    assert!(
+        message.content.contains("aren't in the current history"),
+        "unexpected refusal text: {:?}",
+        message.content
+    );
+    assert!(
+        calls.lock().unwrap().range_ids.is_none(),
+        "a partially resolvable range must not reach the VCS"
+    );
+}
+
+#[test]
+fn should_resolve_commits_outside_the_recent_history_page() {
+    // a range older than any page of recent commits. Direct id lookup
+    // must find it; a paged history walk would report it as pruned.
+    let _reviews = TestReviewsDir::new();
+    let mut history: Vec<CommitInfo> = (0..40).map(|i| commit(&format!("c{i:02}"))).collect();
+    history.push(commit("ancient"));
+    let (mut app, calls) = build_app(history);
+    stage_session(&mut app, range_session(&["ancient"], Some("main")));
+
+    app.sessions_tab_select().expect("resume should succeed");
+
+    assert_eq!(
+        calls.lock().unwrap().range_ids.clone(),
+        Some(vec!["ancient".to_string()]),
+        "a commit outside the recent page must still resume"
+    );
+    assert!(app.message.is_none(), "{:?}", app.message);
+}
+
+#[test]
+fn should_point_pr_sessions_at_the_tab_that_owns_them() {
+    // a PR row. PR sessions are keyed by forge coordinates and need the
+    // forge round-trip the Pull Requests tab owns, so this tab must not try.
+    let _reviews = TestReviewsDir::new();
+    let (mut app, calls) = build_app(vec![commit("ccc")]);
+    app.sessions_tab.apply_load(Ok(vec![SessionSummary {
+        session_ref: crate::review_store::SessionRef::from_path("/tmp/pr.json"),
+        slug: "gh:owner/repo/pr/7".to_string(),
+        kind: SessionKind::Pr,
+        updated_at: Utc::now(),
+        comment_count: 1,
+        reviewed_count: 0,
+        file_count: 1,
+        anchor: "pr/7".to_string(),
+        active: false,
+    }]));
+
+    app.sessions_tab_select().expect("select should not error");
+
+    // guidance, and no diff loaded
+    assert!(
+        app.message
+            .as_ref()
+            .is_some_and(|m| m.content.contains("Pull Requests tab")),
+        "expected guidance, got {:?}",
+        app.message
+    );
+    let calls = calls.lock().unwrap();
+    assert_eq!(
+        (calls.working_tree, calls.staged, calls.unstaged),
+        (0, 0, 0)
+    );
+    assert!(calls.range_ids.is_none());
+}
+
+#[test]
+fn should_point_pristine_sessions_at_the_flag_that_opens_them() {
+    let _reviews = TestReviewsDir::new();
+    let (mut app, calls) = build_app(vec![commit("ccc")]);
+    stage_session(
+        &mut app,
+        ReviewSession::new(
+            PathBuf::from("/tmp"),
+            "pristine:ccc".to_string(),
+            Some("main".to_string()),
+            SessionDiffSource::Pristine,
+        ),
+    );
+
+    app.sessions_tab_select().expect("select should not error");
+
+    assert!(
+        app.message
+            .as_ref()
+            .is_some_and(|m| m.content.contains("--all-files")),
+        "expected guidance naming the flag, got {:?}",
+        app.message
+    );
+    let calls = calls.lock().unwrap();
+    assert_eq!(
+        (calls.working_tree, calls.staged, calls.unstaged),
+        (0, 0, 0)
+    );
+}
+
+#[test]
+fn should_hide_sessions_with_no_review_progress() {
+    // an empty session, as a crashed TUI leaves behind, beside one
+    // holding comments and one holding reviewed state
+    let empty = SessionSummary {
+        session_ref: crate::review_store::SessionRef::from_path("/tmp/empty.json"),
+        slug: "repo@main/worktree/ccc".to_string(),
+        kind: SessionKind::Local,
+        updated_at: Utc::now(),
+        comment_count: 0,
+        reviewed_count: 0,
+        file_count: 1,
+        anchor: "main".to_string(),
+        active: false,
+    };
+    let commented = SessionSummary {
+        comment_count: 7,
+        slug: "repo@main/commits/aaa..ccc".to_string(),
+        ..empty.clone()
+    };
+    let reviewed = SessionSummary {
+        reviewed_count: 2,
+        slug: "repo@main/worktree/bbb".to_string(),
+        ..empty.clone()
+    };
+
+    // the production predicate decides
+    let kept: Vec<&str> = [&empty, &commented, &reviewed]
+        .into_iter()
+        .filter(|s| App::is_resumable(s))
+        .map(|s| s.slug.as_str())
+        .collect();
+
+    assert_eq!(
+        kept,
+        vec!["repo@main/commits/aaa..ccc", "repo@main/worktree/bbb"],
+        "a session with no comments and no reviewed files holds no progress"
+    );
+}

--- a/src/app/tests/sessions_resume_tests.rs
+++ b/src/app/tests/sessions_resume_tests.rs
@@ -357,13 +357,27 @@ fn should_resolve_commits_outside_the_recent_history_page() {
 }
 
 #[test]
-fn should_point_pr_sessions_at_the_tab_that_owns_them() {
-    // a PR row. PR sessions are keyed by forge coordinates and need the
-    // forge round-trip the Pull Requests tab owns, so this tab must not try.
+fn should_resume_a_pr_session_through_the_forge_open_path() {
+    // A PR diff is fetched, not read from the checkout, so resume must reuse
+    // the Pull Requests tab's open path rather than refusing.
     let _reviews = TestReviewsDir::new();
     let (mut app, calls) = build_app(vec![commit("ccc")]);
+    let repository = crate::forge::traits::ForgeRepository::github("github.com", "owner", "repo");
+    let mut session = ReviewSession::new(
+        PathBuf::from("/tmp"),
+        "deadbee".to_string(),
+        None,
+        SessionDiffSource::PullRequest,
+    );
+    session.pr_session_key = Some(crate::forge::traits::PrSessionKey::new(
+        repository.clone(),
+        7,
+        "deadbee",
+    ));
+    let store = crate::review_store::ReviewStore::new();
+    let session_ref = store.save_review(&session).expect("persist PR session");
     app.sessions_tab.apply_load(Ok(vec![SessionSummary {
-        session_ref: crate::review_store::SessionRef::from_path("/tmp/pr.json"),
+        session_ref,
         slug: "gh:owner/repo/pr/7".to_string(),
         kind: SessionKind::Pr,
         updated_at: Utc::now(),
@@ -374,22 +388,44 @@ fn should_point_pr_sessions_at_the_tab_that_owns_them() {
         active: false,
     }]));
 
-    app.sessions_tab_select().expect("select should not error");
+    app.sessions_tab_select().expect("resume should not error");
 
-    // guidance, and no diff loaded
-    assert!(
-        app.message
-            .as_ref()
-            .is_some_and(|m| m.content.contains("Pull Requests tab")),
-        "expected guidance, got {:?}",
-        app.message
-    );
+    // The forge fetch is in flight for the right PR, and no local diff was read.
+    let request = app
+        .pr_open_state
+        .as_ref()
+        .expect("expected a PR open to start");
+    assert_eq!(request.pr_number, 7);
+    assert_eq!(request.repository, repository);
     let calls = calls.lock().unwrap();
     assert_eq!(
         (calls.working_tree, calls.staged, calls.unstaged),
         (0, 0, 0)
     );
     assert!(calls.range_ids.is_none());
+}
+
+#[test]
+fn should_report_a_pr_session_with_no_saved_pull_request() {
+    let _reviews = TestReviewsDir::new();
+    let (mut app, _) = build_app(vec![commit("ccc")]);
+    app.sessions_tab.apply_load(Ok(vec![SessionSummary {
+        session_ref: crate::review_store::SessionRef::from_path("/tmp/missing-pr.json"),
+        slug: "gh:owner/repo/pr/9".to_string(),
+        kind: SessionKind::Pr,
+        updated_at: Utc::now(),
+        comment_count: 1,
+        reviewed_count: 0,
+        file_count: 1,
+        anchor: "pr/9".to_string(),
+        active: false,
+    }]));
+
+    app.sessions_tab_select().expect("select should not error");
+
+    // A session file that cannot be read is reported, not silently ignored.
+    assert!(app.message.is_some(), "expected a user-facing message");
+    assert!(app.pr_open_state.is_none());
 }
 
 #[test]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -77,6 +77,10 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         CommandKind::Targets(TargetTab::Local),
     ),
     CommandSpec::new(&["prs"], CommandKind::Targets(TargetTab::PullRequests)),
+    CommandSpec::new(
+        &["sessions", "reviews"],
+        CommandKind::Targets(TargetTab::Sessions),
+    ),
     CommandSpec::new(&["submit"], CommandKind::SubmitPicker),
     CommandSpec::new(
         &["submit comment"],
@@ -969,6 +973,10 @@ fn dispatch_command(app: &mut App, kind: CommandKind) -> CommandAfterDispatch {
                     app.set_error(format!("Failed to open PR selector: {e}"));
                     CommandAfterDispatch::ExitCommandMode
                 }
+                (TargetTab::Sessions, Err(e)) => {
+                    app.set_error(format!("Failed to open session selector: {e}"));
+                    CommandAfterDispatch::ExitCommandMode
+                }
             }
         }
         CommandKind::SubmitPicker => {
@@ -1275,7 +1283,23 @@ pub fn handle_commit_select_action(app: &mut App, action: Action) {
         other => match app.target_tab {
             TargetTab::Local => handle_local_target_action(app, other),
             TargetTab::PullRequests => handle_pr_target_action(app, other),
+            TargetTab::Sessions => handle_sessions_target_action(app, other),
         },
+    }
+}
+
+fn handle_sessions_target_action(app: &mut App, action: Action) {
+    match action {
+        Action::CommitSelectUp => app.sessions_tab_cursor_up(),
+        Action::CommitSelectDown => app.sessions_tab_cursor_down(),
+        Action::ConfirmCommitSelect => {
+            if let Err(e) = app.sessions_tab_select() {
+                app.set_error(format!("Failed to open session: {e}"));
+            }
+        }
+        // Space is a no-op: sessions are picked, not multi-selected.
+        Action::ToggleCommitSelect => {}
+        _ => {}
     }
 }
 

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -317,7 +317,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  Tab/S-Tab ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Switch Local / Pull Requests tab"),
+            Span::raw("Switch tabs"),
         ]),
         Line::from(vec![
             Span::styled(
@@ -331,7 +331,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  Space     ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Toggle local commit selection (no-op on PR tab)"),
+            Span::raw("Toggle commit selection (Local tab only)"),
         ]),
         Line::from(vec![
             Span::styled(

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-use crate::app::{App, TargetTab};
+use crate::app::{App, TargetTab, sessions_tab};
 use crate::forge::selector::{PrTabStatus, PrTabView};
 use crate::forge::traits::PullRequestListScope;
 use crate::ui::commit_row::{
@@ -18,6 +18,7 @@ use crate::ui::text_utils::truncate_or_pad;
 
 const TAB_LOCAL: &str = "Local";
 const TAB_PULL_REQUESTS: &str = "Pull Requests";
+const TAB_SESSIONS: &str = "Sessions";
 
 pub(super) fn render_commit_select(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
@@ -36,16 +37,24 @@ pub(super) fn render_commit_select(frame: &mut Frame, app: &mut App) {
     render_top_bar(frame, app, chunks[0]);
 
     let body_area = chunks[1];
-    let body_block = Block::default()
+    let mut body_block = Block::default()
         .borders(Borders::ALL)
         .border_style(styles::border_style(&app.theme, true))
         .style(styles::panel_style(&app.theme));
+    // The Sessions tab lists only this checkout's reviews, which is not
+    // obvious from rows whose slug is trimmed to the review target. Name the
+    // scope in the border title rather than spending a row or slug width on a
+    // repo that is the same for every row.
+    if app.target_tab == TargetTab::Sessions {
+        body_block = body_block.title(format!(" Reviews \u{00b7} {} ", app.sessions_tab.scope()));
+    }
     let inner = body_block.inner(body_area);
     frame.render_widget(body_block, body_area);
 
     match app.target_tab {
         TargetTab::Local => render_local_target_tab(frame, app, inner),
         TargetTab::PullRequests => render_pull_requests_tab(frame, app, inner),
+        TargetTab::Sessions => render_sessions_tab(frame, app, inner),
     }
 
     render_target_selector_footer(frame, app, chunks[2]);
@@ -60,6 +69,7 @@ fn render_top_bar(frame: &mut Frame, app: &App, area: Rect) {
     let active = app.target_tab;
     let local_active = active == TargetTab::Local;
     let pr_active = active == TargetTab::PullRequests;
+    let sessions_active = active == TargetTab::Sessions;
 
     let strip_bg = theme.status_bar_bg;
     let strip_style = Style::default().bg(strip_bg).fg(theme.fg_dim);
@@ -92,11 +102,28 @@ fn render_top_bar(frame: &mut Frame, app: &App, area: Rect) {
             inactive_chip
         },
     ));
+    spans.push(Span::styled(" ".to_string(), strip_style));
+    spans.push(Span::styled(
+        format!(" {TAB_SESSIONS} "),
+        if sessions_active {
+            active_chip
+        } else {
+            inactive_chip
+        },
+    ));
 
     let left_width: usize = spans.iter().map(|s| s.content.chars().count()).sum();
 
     let (right_span, right_width) = match active {
         TargetTab::PullRequests => pr_status_hint_span(app, strip_bg),
+        TargetTab::Sessions => {
+            let count = app.sessions_tab.rows().len();
+            // `<n> saved`, not `<n> sessions`: mirrors the PR tab's
+            // `<n> loaded` and stays correct at a count of one.
+            let content = format!(" {count} saved ");
+            let width = content.chars().count();
+            (Span::styled(content, strip_style), width)
+        }
         TargetTab::Local => {
             let vcs_type = &app.vcs_info.vcs_type;
             let branch = app.vcs_info.branch_name.as_deref().unwrap_or("detached");
@@ -242,6 +269,102 @@ fn render_pull_requests_tab(frame: &mut Frame, app: &mut App, area: Rect) {
 
     let view = app.pr_tab.view();
     render_pr_list(frame, app, area, &view);
+}
+
+/// Persisted review sessions for this checkout, newest first. Rows mirror the
+/// PR tab's column layout: cursor, kind, slug, then a dim metadata tail.
+fn render_sessions_tab(frame: &mut Frame, app: &mut App, area: Rect) {
+    app.commit_list_inner_area = None;
+    app.pr_list_inner_area = None;
+    app.sessions_list_viewport_height = area.height as usize;
+
+    let theme = &app.theme;
+    if area.height == 0 {
+        return;
+    }
+
+    if let Some(error) = app.sessions_tab.error() {
+        let line = Line::from(vec![
+            Span::styled("  error \u{00b7} ", styles::error_inline_style(theme)),
+            Span::styled(
+                format!("Failed to list saved reviews: {error}"),
+                Style::default().fg(theme.fg_primary),
+            ),
+        ]);
+        frame.render_widget(
+            Paragraph::new(vec![line]).style(styles::panel_style(theme)),
+            area,
+        );
+        return;
+    }
+
+    if app.sessions_tab.is_empty() {
+        let line = Line::from(Span::styled(
+            "  No saved reviews for this checkout",
+            Style::default().fg(theme.fg_dim),
+        ));
+        frame.render_widget(
+            Paragraph::new(vec![line]).style(styles::panel_style(theme)),
+            area,
+        );
+        return;
+    }
+
+    let height = area.height as usize;
+    let scroll = app.sessions_tab.scroll();
+    let cursor = app.sessions_tab.cursor();
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, row) in app
+        .sessions_tab
+        .rows()
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(height)
+    {
+        let is_cursor = i == cursor;
+        let pointer_str = if is_cursor {
+            format!("{CURSOR_GLYPH} ")
+        } else {
+            "  ".to_string()
+        };
+        let pointer_style = if is_cursor {
+            styles::selected_style(theme)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+
+        let kind = truncate_or_pad(sessions_tab::kind_label(row.kind), 5);
+        // Omit the repeated `owner/repo@` prefix so the target stays visible
+        // when the row is truncated. The border title names the repository.
+        let target = row
+            .slug
+            .split_once('@')
+            .map_or(row.slug.as_str(), |(_, rest)| rest);
+        let slug = truncate_or_pad(target, 60);
+        let updated = format_relative_short(&row.updated_at);
+        let active = if row.active { " \u{00b7} open" } else { "" };
+
+        lines.push(Line::from(vec![
+            Span::styled(pointer_str, pointer_style),
+            Span::styled("  ", Style::default()),
+            Span::styled(kind, styles::hash_style(theme)),
+            Span::styled(" ", Style::default()),
+            Span::styled(slug, Style::default().fg(theme.fg_primary)),
+            Span::styled(
+                format!(
+                    "  {} comments \u{00b7} {}/{} files \u{00b7} {}{}",
+                    row.comment_count, row.reviewed_count, row.file_count, updated, active
+                ),
+                Style::default().fg(theme.fg_secondary),
+            ),
+        ]));
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines).style(styles::panel_style(theme)),
+        area,
+    );
 }
 
 fn render_pr_list(frame: &mut Frame, app: &App, area: Rect, view: &PrTabView<'_>) {
@@ -429,6 +552,7 @@ fn render_target_selector_footer(frame: &mut Frame, app: &App, area: Rect) {
                 };
                 format!("   j/k navigate · ↵ open · {scope_hint} · / filter · esc back")
             }
+            TargetTab::Sessions => "   j/k navigate · ↵ resume · esc back".to_string(),
         }
     };
     let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));
@@ -480,6 +604,7 @@ mod selector_render_snapshot_tests {
     use crate::forge::selector::PullRequestsTab;
     use crate::forge::traits::{ForgeRepository, PullRequestSummary};
     use crate::model::{DiffFile, DiffLine, FileStatus, ReviewSession, SessionDiffSource};
+    use crate::review_store::SessionSummary;
     use crate::syntax::SyntaxHighlighter;
     use crate::theme::Theme;
     use crate::ui::render;
@@ -692,10 +817,12 @@ mod selector_render_snapshot_tests {
         let highlight_bg = app.theme.bg_highlight;
         // when
         let buffer = draw(&mut app);
-        // then — tab strip shows both labels in the single bg-filled row
+        // then — tab strip shows every label in the single bg-filled row
         let strip = row_text(&buffer, TAB_STRIP_ROW);
         assert!(
-            strip.contains("Local") && strip.contains("Pull Requests"),
+            strip.contains("Local")
+                && strip.contains("Pull Requests")
+                && strip.contains("Sessions"),
             "tab strip missing labels: {strip:?}"
         );
         // and — the active "Local" chip carries the highlight bg
@@ -842,6 +969,121 @@ mod selector_render_snapshot_tests {
         assert!(
             footer.contains("Failed to load commits"),
             "expected status message in selector footer, got: {footer:?}"
+        );
+    }
+
+    fn session_summary(slug: &str, comments: usize, active: bool) -> SessionSummary {
+        SessionSummary {
+            session_ref: crate::review_store::SessionRef::from_path("/tmp/s.json"),
+            slug: slug.to_string(),
+            kind: crate::review_store::SessionKind::Local,
+            updated_at: Utc.with_ymd_and_hms(2026, 5, 1, 0, 0, 0).unwrap(),
+            comment_count: comments,
+            reviewed_count: 1,
+            file_count: 3,
+            anchor: "main".to_string(),
+            active,
+        }
+    }
+
+    #[test]
+    fn should_render_session_rows_with_slug_and_comment_count() {
+        // given — the Sessions tab with one saved review
+        let mut app = make_app(vec![commit(0)]);
+        app.sessions_tab.apply_load(Ok(vec![session_summary(
+            "repo@main/commits/aaa..bbb",
+            7,
+            true,
+        )]));
+        app.target_tab = crate::app::TargetTab::Sessions;
+        // when
+        let buffer = draw(&mut app);
+        // then — the slug's target segment carries the review scope, so it
+        // must be visible (the repo prefix lives in the border title)
+        let body = (2..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("main/commits/aaa..bbb"),
+            "expected the review target in body:\n{body}"
+        );
+        assert!(
+            body.contains("7 comments"),
+            "expected comment count in body:\n{body}"
+        );
+        assert!(
+            body.contains("open"),
+            "expected the active marker in body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_name_the_checkout_in_the_sessions_border_title() {
+        // given — the tab lists only this checkout's reviews, which the rows
+        // no longer say now that the repo prefix is trimmed off the slug
+        let mut app = make_app(vec![commit(0)]);
+        app.sessions_tab.set_scope("owner/repo".to_string());
+        app.sessions_tab.apply_load(Ok(vec![session_summary(
+            "repo@main/commits/aaa..bbb",
+            7,
+            true,
+        )]));
+        app.target_tab = crate::app::TargetTab::Sessions;
+        // when
+        let buffer = draw(&mut app);
+        // then — the scope is on the border, costing no row
+        let border = row_text(&buffer, 1);
+        assert!(
+            border.contains("Reviews \u{00b7} owner/repo"),
+            "expected a scope title on the body border, got: {border:?}"
+        );
+    }
+
+    #[test]
+    fn should_trim_the_repo_prefix_from_session_rows() {
+        // given — a slug whose repo prefix is long enough to push the commit
+        // range past the row's truncation point
+        let mut app = make_app(vec![commit(0)]);
+        app.sessions_tab.apply_load(Ok(vec![session_summary(
+            "fairinternal/ai-verification-leanified-hl@main/commits/e4b5941..8b2838d",
+            7,
+            false,
+        )]));
+        app.target_tab = crate::app::TargetTab::Sessions;
+        // when
+        let buffer = draw(&mut app);
+        // then — the target survives, the redundant prefix does not
+        let body = (2..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("main/commits/e4b5941..8b2838d"),
+            "the commit range is what rows are told apart by, body:\n{body}"
+        );
+        assert!(
+            !body.contains("fairinternal/ai-verification-leanified-hl@"),
+            "repo prefix is in the border title, not on every row, body:\n{body}"
+        );
+    }
+
+    #[test]
+    fn should_render_empty_state_when_no_saved_sessions() {
+        // given
+        let mut app = make_app(vec![commit(0)]);
+        app.sessions_tab.apply_load(Ok(Vec::new()));
+        app.target_tab = crate::app::TargetTab::Sessions;
+        // when
+        let buffer = draw(&mut app);
+        // then
+        let body = (2..buffer.area.height)
+            .map(|y| row_text(&buffer, y))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            body.contains("No saved reviews"),
+            "expected empty state, body:\n{body}"
         );
     }
 


### PR DESCRIPTION
Reopening a saved review meant remembering the `-r` range or `-w` flag it was created with. Get it wrong and tuicr silently starts a fresh session instead of the one holding your comments.

This adds a **Sessions** tab to the review target selector, listing saved reviews for the current checkout. Enter resumes the row with its stored target.

![Sessions tab](https://github.com/martintrojer/tuicr/releases/download/sessions-tab-asset/sessions-tab.png)

`:sessions` (alias `:reviews`) opens the selector on the tab; Tab cycles three ways.

Notes:

- Commit ranges resume in their stored oldest-first order. Reversing it inverts the diff and creates a second session for the same review, with no error.
- `WorkingTree` sessions get their own loader — `SessionDiffSource` is part of a session's identity.
- Resume installs the session that was selected. The loaders each resolve one from the current branch and HEAD, which is not necessarily the row picked.
- Sessions with no comments and no reviewed files are hidden; they hold no progress to resume.
- A range whose commits no longer resolve is refused rather than partially loaded.

Tested with `cargo test --lib` (1570 passed) plus 18 new tests driven through `sessions_tab_select`. Dogfooded: this PR's own review was resumed from the tab.
