### PR TITLE
fix(pr): render Markdown in description panel

### DIFF
--- a/src/ui/comment_panel.rs
+++ b/src/ui/comment_panel.rs
@@ -432,21 +432,12 @@ fn forge_badge_label(kind: Option<ForgeKind>) -> &'static str {
     }
 }
 
-/// Format a comment as multiple lines with a box border (themed version).
-///
-/// `author` advertises the comment's author in the top-row badge and tints
-/// the box border. Callers pass `Some(name)` for non-self comments — the
-/// resulting badge reads `[TYPE @name]`, mirroring the remote forge badge
-/// format used for remote PR threads. `None` keeps the existing neutral
-/// `[TYPE]` badge and theme border.
-/// Render `content` as markdown-highlighted, border-prefixed, pre-wrapped lines
-/// (no cursor). Colors come from the active syntect theme. Used for displayed
-/// comment bodies; the editor box does its own variant with cursor handling.
-fn markdown_body_lines(
+/// Render `content` as markdown-highlighted, pre-wrapped lines. Colors come
+/// from the active syntect theme.
+pub(crate) fn markdown_body_lines(
     theme: &Theme,
     content: &str,
     content_area: usize,
-    border_style: Style,
 ) -> Vec<Line<'static>> {
     let lines: Vec<&str> = content.split('\n').collect();
     // Highlight the body as a whole so multi-line constructs (e.g. fenced code)
@@ -459,15 +450,22 @@ fn markdown_body_lines(
         let mut seg_start = 0usize;
         for seg in wrap_segments(text, content_area) {
             let seg_end = seg_start + seg.len();
-            let mut spans = vec![Span::styled(BORDER_PREFIX, border_style)];
-            spans.extend(highlighted_window_spans(runs, text, seg_start, seg_end));
-            out.push(Line::from(spans));
+            out.push(Line::from(highlighted_window_spans(
+                runs, text, seg_start, seg_end,
+            )));
             seg_start = seg_end;
         }
     }
     out
 }
 
+/// Format a comment as multiple lines with a box border (themed version).
+///
+/// `author` advertises the comment's author in the top-row badge and tints
+/// the box border. Callers pass `Some(name)` for non-self comments — the
+/// resulting badge reads `[TYPE @name]`, mirroring the remote forge badge
+/// format used for remote PR threads. `None` keeps the existing neutral
+/// `[TYPE]` badge and theme border.
 pub fn format_comment_lines(
     theme: &Theme,
     comment_type: CommentTypePresentation,
@@ -522,12 +520,12 @@ pub fn format_comment_lines(
     ]));
 
     // Content lines — markdown-highlighted, pre-wrapped at content_area.
-    result.extend(markdown_body_lines(
-        theme,
-        content,
-        content_area,
-        border_style,
-    ));
+    let mut body_lines = markdown_body_lines(theme, content, content_area);
+    for line in &mut body_lines {
+        line.spans
+            .insert(0, Span::styled(BORDER_PREFIX, border_style));
+    }
+    result.extend(body_lines);
 
     // Bottom border — "    ╰" = 5 chars, fill to width
     result.push(Line::from(vec![Span::styled(

--- a/src/ui/pr_info_panel.rs
+++ b/src/ui/pr_info_panel.rs
@@ -170,9 +170,11 @@ pub fn build_pr_info_lines(
     } else {
         details.body.clone()
     };
-    for paragraph in body.lines() {
-        push_wrapped_line(&mut lines, paragraph.to_string(), content_width);
-    }
+    lines.extend(comment_panel::markdown_body_lines(
+        theme,
+        &body,
+        content_width,
+    ));
 
     push_blank(&mut lines);
     push_section_header(
@@ -498,5 +500,40 @@ mod tests {
                 .iter()
                 .any(|line| { line.contains("https://github.com/owner/repo/actions/runs/1") })
         );
+    }
+
+    #[test]
+    fn should_render_pr_description_markdown() {
+        let mut info = sample_info();
+        info.details.body = "plain `code` plain".to_string();
+        let lines = build_pr_info_lines(&info, 80, &Theme::dark());
+        let description = &lines[1];
+
+        assert_eq!(
+            description
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>(),
+            info.details.body
+        );
+        assert!(
+            description.spans.len() > 1,
+            "expected markdown description to be highlighted into multiple spans"
+        );
+
+        info.details.body = "plain description".to_string();
+        let lines = build_pr_info_lines(&info, 80, &Theme::dark());
+        let description = &lines[1];
+
+        assert_eq!(
+            description
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect::<String>(),
+            info.details.body
+        );
+        assert_eq!(description.spans.len(), 1);
     }
 }


### PR DESCRIPTION
## Summary

PR descriptions now use the existing Markdown renderer used for review comments, so formatted descriptions are styled consistently in the TUI.

## Verification

- before: `cargo test ui::pr_info_panel::tests::should_render_pr_description_markdown -- --exact` failed because the description was one raw span
- after: `cargo test ui::pr_info_panel::tests::should_render_pr_description_markdown -- --exact`
- `cargo test`
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build`

Fixes #670
