### PR TITLE
Pan the help popup with h/l

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1650,11 +1650,31 @@ impl Default for FileTreeFilter {
 #[derive(Debug, Default)]
 pub struct HelpState {
     pub scroll_offset: usize,
+    pub horizontal_offset: usize,
     pub viewport_height: usize,
-    pub total_lines: usize, // Set during render
+    pub viewport_width: usize,
+    pub total_lines: usize,    // Set during render
+    pub max_line_width: usize, // Set during render
     pub(crate) searchable_lines: Vec<String>,
     pub(crate) last_search_pattern: Option<String>,
     pub(crate) current_match_line: Option<usize>,
+}
+
+impl HelpState {
+    /// Furthest left column the popup can be panned to, so the widest help
+    /// line's tail can still reach the viewport.
+    pub(crate) fn max_horizontal_offset(&self) -> usize {
+        self.max_line_width.saturating_sub(self.viewport_width)
+    }
+
+    pub(crate) fn scroll_right(&mut self, columns: usize) {
+        self.horizontal_offset =
+            (self.horizontal_offset + columns).min(self.max_horizontal_offset());
+    }
+
+    pub(crate) fn scroll_left(&mut self, columns: usize) {
+        self.horizontal_offset = self.horizontal_offset.saturating_sub(columns);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/app/modes.rs
+++ b/src/app/modes.rs
@@ -104,6 +104,7 @@ impl App {
                 self.overlay_return_mode = self.input_mode;
                 self.input_mode = InputMode::Help;
                 self.help_state.scroll_offset = 0;
+                self.help_state.horizontal_offset = 0;
             }
         }
     }
@@ -118,6 +119,14 @@ impl App {
 
     pub fn help_scroll_up(&mut self, lines: usize) {
         self.help_state.scroll_offset = self.help_state.scroll_offset.saturating_sub(lines);
+    }
+
+    pub fn help_scroll_right(&mut self, columns: usize) {
+        self.help_state.scroll_right(columns);
+    }
+
+    pub fn help_scroll_left(&mut self, columns: usize) {
+        self.help_state.scroll_left(columns);
     }
 
     pub fn help_scroll_to_top(&mut self) {

--- a/src/app/search.rs
+++ b/src/app/search.rs
@@ -473,6 +473,44 @@ mod tests {
     }
 
     #[test]
+    fn should_pan_help_right_only_until_the_widest_line_ends() {
+        let mut state = help_state();
+        state.viewport_width = 20;
+        state.max_line_width = 30;
+
+        state.scroll_right(4);
+        assert_eq!(state.horizontal_offset, 4);
+
+        state.scroll_right(40);
+        assert_eq!(state.horizontal_offset, 10);
+    }
+
+    #[test]
+    fn should_not_pan_help_when_every_line_fits() {
+        let mut state = help_state();
+        state.viewport_width = 40;
+        state.max_line_width = 30;
+
+        state.scroll_right(4);
+
+        assert_eq!(state.horizontal_offset, 0);
+    }
+
+    #[test]
+    fn should_pan_help_back_to_the_left_edge() {
+        let mut state = help_state();
+        state.viewport_width = 20;
+        state.max_line_width = 30;
+        state.horizontal_offset = 8;
+
+        state.scroll_left(4);
+        assert_eq!(state.horizontal_offset, 4);
+
+        state.scroll_left(40);
+        assert_eq!(state.horizontal_offset, 0);
+    }
+
+    #[test]
     fn should_keep_the_current_help_position_when_no_match_exists() {
         let mut state = help_state();
         state.scroll_offset = 2;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -557,6 +557,8 @@ pub fn handle_help_action(app: &mut App, action: Action) {
     match action {
         Action::CursorDown(n) => app.help_scroll_down(n),
         Action::CursorUp(n) => app.help_scroll_up(n),
+        Action::ScrollLeft(n) => app.help_scroll_left(n),
+        Action::ScrollRight(n) => app.help_scroll_right(n),
         Action::HalfPageDown => app.help_scroll_down(app.help_state.viewport_height / 2),
         Action::HalfPageUp => app.help_scroll_up(app.help_state.viewport_height / 2),
         Action::PageDown => app.help_scroll_down(app.help_state.viewport_height),

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -365,6 +365,8 @@ fn map_help_mode(key: KeyEvent) -> Action {
         // Scroll navigation
         (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::CursorDown(1),
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::CursorUp(1),
+        (KeyCode::Char('h') | KeyCode::Left, KeyModifiers::NONE) => Action::ScrollLeft(4),
+        (KeyCode::Char('l') | KeyCode::Right, KeyModifiers::NONE) => Action::ScrollRight(4),
         (KeyCode::Char('d'), KeyModifiers::CONTROL) => Action::HalfPageDown,
         (KeyCode::Char('u'), KeyModifiers::CONTROL) => Action::HalfPageUp,
         (KeyCode::Char('f'), KeyModifiers::CONTROL) => Action::PageDown,
@@ -586,6 +588,22 @@ mod tests {
             map_file_tree_mode(key(KeyCode::Char('h')), DEFAULT_LEADER_KEY),
             Action::ScrollLeft(4)
         );
+    }
+
+    #[test]
+    fn should_pan_the_help_popup_with_h_and_l() {
+        // Long descriptions are cut off on narrow terminals; `h`/`l` pan the
+        // popup the same way they pan the diff and the file tree.
+        assert_eq!(
+            map_help_mode(key(KeyCode::Char('h'))),
+            Action::ScrollLeft(4)
+        );
+        assert_eq!(
+            map_help_mode(key(KeyCode::Char('l'))),
+            Action::ScrollRight(4)
+        );
+        assert_eq!(map_help_mode(key(KeyCode::Left)), Action::ScrollLeft(4));
+        assert_eq!(map_help_mode(key(KeyCode::Right)), Action::ScrollRight(4));
     }
 
     #[test]

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -102,7 +102,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
     frame.render_widget(Clear, area);
 
     let block = Block::default()
-        .title(" Help (j/k scroll, / search) - Press ? or Esc to close ")
+        .title(" Help (j/k scroll, h/l pan, / search) - Press ? or Esc to close ")
         .borders(Borders::ALL)
         .style(styles::popup_style(theme))
         .border_style(styles::border_style(theme, true));
@@ -934,6 +934,10 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
     let viewport_height = inner.height as usize;
     app.help_state.total_lines = total_lines;
     app.help_state.viewport_height = viewport_height;
+    app.help_state.viewport_width = inner.width as usize;
+    app.help_state.max_line_width = help_text.iter().map(Line::width).max().unwrap_or(0);
+    let max_horizontal_offset = app.help_state.max_horizontal_offset();
+    app.help_state.horizontal_offset = app.help_state.horizontal_offset.min(max_horizontal_offset);
     app.help_state.searchable_lines = help_text
         .iter()
         .map(|line| {
@@ -963,7 +967,12 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         })
         .collect();
 
-    let paragraph = Paragraph::new(visible_lines).style(styles::popup_style(theme));
+    let paragraph = Paragraph::new(visible_lines)
+        .style(styles::popup_style(theme))
+        .scroll((
+            0,
+            app.help_state.horizontal_offset.min(u16::MAX as usize) as u16,
+        ));
     frame.render_widget(paragraph, inner);
 
     // Render scroll indicators


### PR DESCRIPTION
Follow-up to #667, closes #672.

The help popup renders unwrapped lines, so on a narrow terminal the descriptions get cut off at the right border with no way to reach them. This adds horizontal scrolling on `h`/`l` (and left/right arrows), matching the diff and file tree.

The render pass records the widest help line and the viewport width, so the offset clamps at the point where the longest description ends and does nothing when everything already fits. Title now reads `Help (j/k scroll, h/l pan, / search)`.

Tested by driving the TUI in a 60-column pty: before, `;h/;l  Move focus left/right (sid` is truncated; after four `l` presses the full `Move focus left/right (side-by-side...)` is visible. Unit tests cover the key mapping and the offset clamping.