### PR TITLE
Add export.session_header to drop the session slug

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -272,6 +272,7 @@ comments_header = "## Comments"
 | `comments_header`        | `## Local tuicr Comments`                                                    | Heading above comments you wrote in the TUI. Set to `""` to omit it.                                                                        |
 | `remote_comments_header` | `## Existing GitHub Comments`                                                | Heading above unresolved forge threads. Appears only in pull request mode. Set to `""` to omit it.                                          |
 | `legend`                 | `true`                                                                       | Emit the `Comment types:` legend. Takes precedence over the top-level `export_legend` key when set.                                         |
+| `session_header`         | `true`                                                                       | Emit the `## Session: <slug>` header naming the session. Set to `false` for agents that treat it as noise.                                  |
 
 The example above produces an export that opens directly on the comment list:
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,6 +62,8 @@ pub struct ExportConfig {
     pub remote_comments_header: Option<String>,
     /// Whether to emit the `Comment types:` legend.
     pub legend: Option<bool>,
+    /// Whether to emit the `## Session: <slug>` header.
+    pub session_header: Option<bool>,
 }
 
 impl ExportConfig {
@@ -91,6 +93,10 @@ impl ExportConfig {
 
     pub fn legend(&self) -> bool {
         self.legend.unwrap_or(true)
+    }
+
+    pub fn session_header(&self) -> bool {
+        self.session_header.unwrap_or(true)
     }
 }
 
@@ -225,6 +231,7 @@ const EXPORT_KNOWN_KEYS: &[&str] = &[
     "comments_header",
     "remote_comments_header",
     "legend",
+    "session_header",
 ];
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -530,6 +537,7 @@ fn parse_export(value: &Value, warnings: &mut Vec<String>) -> Option<ExportConfi
             warnings,
         ),
         legend: read_section_bool(table, "export", "legend", warnings),
+        session_header: read_section_bool(table, "export", "session_header", warnings),
     };
 
     if cfg == ExportConfig::default() {
@@ -1698,6 +1706,7 @@ pr_metadata = false
 comments_header = "## Comments"
 remote_comments_header = "## Upstream"
 legend = false
+session_header = false
 "###,
         );
         let export = outcome
@@ -1711,6 +1720,7 @@ legend = false
         assert_eq!(export.comments_header(), "## Comments");
         assert_eq!(export.remote_comments_header(), "## Upstream");
         assert!(!export.legend());
+        assert!(!export.session_header());
         assert!(outcome.warnings.is_empty());
     }
 

--- a/src/output/markdown.rs
+++ b/src/output/markdown.rs
@@ -266,7 +266,9 @@ fn generate_markdown(
 ) -> String {
     let mut md = String::new();
 
-    if let Some(slug) = session_slug {
+    // The slug names the session an agent should write comments back into.
+    // `session_header = false` drops it for agents that read it as noise.
+    if let Some(slug) = session_slug.filter(|_| export.session_header()) {
         let _ = writeln!(md, "## Session: {slug}");
         let _ = writeln!(md);
     }
@@ -864,6 +866,30 @@ mod tests {
         assert!(
             markdown.contains("## Session: agavra/tuicr@main/worktree"),
             "expected slug header in:\n{markdown}"
+        );
+    }
+
+    #[test]
+    fn should_omit_session_slug_header_when_disabled_by_config() {
+        let session = create_test_session();
+        let diff_source = DiffSource::WorkingTree;
+        let export = ExportConfig {
+            session_header: Some(false),
+            ..ExportConfig::default()
+        };
+
+        let markdown = generate_markdown(
+            &session,
+            &diff_source,
+            &comment_types(),
+            &export,
+            &[],
+            Some("agavra/tuicr@main/worktree"),
+        );
+
+        assert!(
+            !markdown.contains("## Session:"),
+            "expected no slug header in:\n{markdown}"
         );
     }
 


### PR DESCRIPTION
Closes #664.

`## Session: <slug>` was the only export line without a config key, so there was no way to trim it for agents that read it as noise. Adds `session_header` to the `[export]` block, defaulting to `true` — exports stay byte-identical until it is set.

```toml
[export]
session_header = false
```

Documented in `docs/CONFIG.md` next to the other export keys.

Verified end to end: with a draft comment in a local session and `--stdout`, the default export still opens with `## Session: nfvelten/tuicr@…`, and with `session_header = false` it opens directly on `I reviewed your code…`. Unit tests cover both the markdown gating and the config parse.