### PR TITLE
feat(config): add editor key to override $EDITOR for e/:edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ ignore_whitespace = false    # ignore all whitespace in local VCS diffs
 appearance = "system"        # or "dark" / "light"
 mouse = true
 leader = ";"                  # configurable prefix for leader shortcuts
+editor = "nvim"               # editor for `e` / `:edit`; overrides $EDITOR
 comment_vim = false           # vim modal editing in the review comment box
 relative_line_numbers = false # show rendered-row distances in the diff gutter
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -32,6 +32,7 @@ show_pr_comments = true
 show_reviewed = true
 mouse = true
 leader = ","
+editor = "nvim"
 comment_vim = false
 comment_tab_width = 4
 wrap = false
@@ -87,6 +88,7 @@ legend = true
 | `show_reviewed`            | `true`       | Whether files already marked reviewed appear in the file tree and the diff. Set `false` to start a session showing only what is left. Toggle with `:set reviewed!`. |
 | `mouse`                    | `true`       | Wheel scrolling, clicks, and drag-to-select.                                                                                                               |
 | `leader`                   | `;`          | Single-character prefix for panel focus, sidebar toggles, and review-comment shortcuts. Invalid multi-character values are ignored with a startup warning. |
+| `editor`                   | `$EDITOR`    | Editor command for the `e` / `:edit` handoff, split with shell-like quoting rules (e.g. `"code -w"`). Falls back to `$EDITOR`, then `vi`. |
 | `comment_vim`              | `false`      | Vim modal editing in the comment box; toggle at runtime with `:vim`. When off, default emacs/readline bindings.                                            |
 | `comment_tab_width`        | `4`          | Spaces inserted by Tab while typing in the vim comment box (Insert mode).                                                                                  |
 | `wrap`                     | `false`      | Line wrap in the diff view. Toggle with `:set wrap!`.                                                                                                      |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -147,8 +147,9 @@ Shown below the file tree when local comments or visible remote PR threads exist
 `e` opens the file at the cursor's line. Terminal editors (`vim`, `nvim`, `nano`, …)
 take over the screen and tuicr reloads the diff once they exit. Windowed editors
 (`code`, `cursor`, `zed`, `subl`, …) open in their own window while tuicr stays on
-screen; reload with `:e` after editing. Adding `--wait` to `$EDITOR` opts a windowed
-editor back into the blocking behaviour.
+screen; reload with `:e` after editing. Adding `--wait` to the editor command opts a
+windowed editor back into the blocking behaviour. Set the `editor` config key to
+override `$EDITOR`.
 
 ## Visual mode
 

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -482,6 +482,7 @@ impl App {
             diff_files,
             diff_source,
             pending_editor_target: None,
+            editor_override: None,
             editor_launches: Vec::new(),
             input_mode,
             focused_panel: FocusedPanel::Diff,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1114,6 +1114,7 @@ pub struct App {
     pub diff_files: Vec<DiffFile>,
     pub diff_source: DiffSource,
     pub pending_editor_target: Option<EditorTarget>,
+    pub editor_override: Option<String>,
     /// Windowed editors that have not exited yet; polled by
     /// `poll_editor_launches`.
     pub(crate) editor_launches: Vec<EditorLaunch>,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1403,7 +1403,10 @@ mod tests {
     #[test]
     fn should_warn_and_ignore_editor_with_invalid_type() {
         let outcome = parse_config("editor = 42\n");
-        assert_eq!(outcome.config.as_ref().and_then(|cfg| cfg.editor.clone()), None);
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.editor.clone()),
+            None
+        );
         assert_eq!(outcome.warnings.len(), 1);
         assert_eq!(
             outcome.warnings[0],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -140,6 +140,7 @@ pub struct AppConfig {
     /// Defaults to 4 (matching diff tab expansion).
     pub comment_tab_width: Option<usize>,
     pub leader: Option<char>,
+    pub editor: Option<String>,
     pub transparent_background: Option<bool>,
     pub scroll_offset: Option<usize>,
     pub review_watch_interval_ms: Option<usize>,
@@ -205,6 +206,7 @@ const KNOWN_KEYS: &[&str] = &[
     "comment_vim",
     "comment_tab_width",
     "leader",
+    "editor",
     "transparent_background",
     "scroll_offset",
     "review_watch_interval_ms",
@@ -445,6 +447,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         comment_vim: read_bool(table, "comment_vim", &mut warnings),
         comment_tab_width: read_usize(table, "comment_tab_width", &mut warnings),
         leader: read_leader(table, &mut warnings),
+        editor: read_string(table, "editor", &mut warnings),
         transparent_background: read_bool(table, "transparent_background", &mut warnings),
         scroll_offset: read_usize(table, "scroll_offset", &mut warnings),
         review_watch_interval_ms: read_usize(table, "review_watch_interval_ms", &mut warnings),
@@ -1382,6 +1385,29 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'leader' must be a string; ignoring value"
+        );
+    }
+
+    // editor
+
+    #[test]
+    fn should_parse_editor_command_with_args() {
+        let outcome = parse_config("editor = \"code -w\"\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.editor.clone()),
+            Some("code -w".to_string())
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_editor_with_invalid_type() {
+        let outcome = parse_config("editor = 42\n");
+        assert_eq!(outcome.config.as_ref().and_then(|cfg| cfg.editor.clone()), None);
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'editor' must be a string; ignoring value"
         );
     }
 

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -423,7 +423,10 @@ mod tests {
 
     #[test]
     fn config_override_wins_over_env() {
-        assert_eq!(resolve_editor(Some("from-config"), "from-env"), "from-config");
+        assert_eq!(
+            resolve_editor(Some("from-config"), "from-env"),
+            "from-config"
+        );
     }
 
     #[test]

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -36,13 +36,14 @@ pub struct EditorCommand {
 }
 
 impl EditorCommand {
-    /// Builds an invocation from `$EDITOR`.
+    /// Builds an invocation from the configured editor.
+    /// Builds an invocation from `$EDITOR` or the config `editor` override.
     ///
     /// An unset, empty, or unparsable value falls back to `vi` so the caller
     /// always gets a concrete command to run.
-    pub fn from_env(target: &EditorTarget) -> Self {
-        let editor = std::env::var("EDITOR").unwrap_or_default();
-        Self::from_editor(&editor, target)
+    pub fn from_env(editor_override: Option<&str>, target: &EditorTarget) -> Self {
+        let env_editor = std::env::var("EDITOR").unwrap_or_default();
+        Self::from_editor(&resolve_editor(editor_override, &env_editor), target)
     }
 
     /// Builds an invocation from an editor command string.
@@ -205,6 +206,13 @@ enum EditorFamily {
     GotoLine,
     /// Has no known line syntax; opens with `$editor $file`.
     Plain,
+}
+
+fn resolve_editor(editor_override: Option<&str>, env_editor: &str) -> String {
+    editor_override
+        .filter(|editor| !editor.trim().is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| env_editor.to_string())
 }
 
 fn editor_family(program: &str) -> EditorFamily {
@@ -411,5 +419,26 @@ mod tests {
         let command = EditorCommand::from_editor("", &target(None));
         assert_eq!(command.program, "vi");
         assert_eq!(args(&command), vec!["/repo/src/main.rs"]);
+    }
+
+    #[test]
+    fn config_override_wins_over_env() {
+        assert_eq!(resolve_editor(Some("from-config"), "from-env"), "from-config");
+    }
+
+    #[test]
+    fn env_is_used_without_config_override() {
+        assert_eq!(resolve_editor(None, "from-env"), "from-env");
+    }
+
+    #[test]
+    fn blank_config_override_falls_back_to_env() {
+        assert_eq!(resolve_editor(Some("  "), "from-env"), "from-env");
+    }
+
+    #[test]
+    fn missing_env_and_config_fall_back_to_vi() {
+        let command = EditorCommand::from_editor(&resolve_editor(None, ""), &target(None));
+        assert_eq!(command.program, "vi");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,7 +741,11 @@ fn main() -> anyhow::Result<()> {
 
                     dispatch_action(&mut app, action);
                     if let Some(target) = app.take_pending_editor_target() {
-                        match run_editor_from_tui(&mut terminal, &target, app.editor_override.as_deref()) {
+                        match run_editor_from_tui(
+                            &mut terminal,
+                            &target,
+                            app.editor_override.as_deref(),
+                        ) {
                             // The editor is still open, so there is nothing to
                             // pick up yet; the user reloads once they are done.
                             Ok(Ok(EditorOutcome::Detached(launch))) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,7 @@ fn main() -> anyhow::Result<()> {
                     app.leader_key = leader;
                 }
                 app.comment_vim_enabled = cfg.comment_vim.unwrap_or(false);
+                app.editor_override = cfg.editor.clone();
                 if let Some(w) = cfg.comment_tab_width {
                     app.comment_tab_width = w;
                 }
@@ -740,7 +741,7 @@ fn main() -> anyhow::Result<()> {
 
                     dispatch_action(&mut app, action);
                     if let Some(target) = app.take_pending_editor_target() {
-                        match run_editor_from_tui(&mut terminal, &target) {
+                        match run_editor_from_tui(&mut terminal, &target, app.editor_override.as_deref()) {
                             // The editor is still open, so there is nothing to
                             // pick up yet; the user reloads once they are done.
                             Ok(Ok(EditorOutcome::Detached(launch))) => {
@@ -939,8 +940,9 @@ enum EditorOutcome {
 fn run_editor_from_tui<W: Write>(
     terminal: &mut TerminalSession<W>,
     target: &EditorTarget,
+    editor_override: Option<&str>,
 ) -> anyhow::Result<Result<EditorOutcome, EditorError>> {
-    let command = EditorCommand::from_env(target);
+    let command = EditorCommand::from_env(editor_override, target);
     // Windowed editors never draw on our terminal, so suspending would only
     // blank the TUI for as long as the editor takes to come up.
     if command.surface() == EditorSurface::Gui {

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -571,7 +571,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  e         ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Open focused file in $EDITOR"),
+            Span::raw("Open focused file in editor config / $EDITOR"),
         ]),
         Line::from(vec![
             Span::styled(
@@ -677,7 +677,7 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
                 "  :edit     ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),
-            Span::raw("Open focused file in $EDITOR"),
+            Span::raw("Open focused file in editor config / $EDITOR"),
         ]),
         Line::from(vec![
             Span::styled(


### PR DESCRIPTION
## Problem

Coming from tools like lazygit, I expected to configure the editor in `config.toml`.

Tuicr only reads `$EDITOR`, which means stuffing the environment variable through wrappers or aliases just to control which editor the `e` / `:edit` handoff opens.

## Proposal

Add a top-level `editor` config key:

```toml
editor = "nvim"
editor = "code -w"   # args allowed; -w keeps tuicr blocking on windowed editors
```

When set, it overrides $EDITOR.

## Implementation

- EditorCommand::from_env takes the override as a parameter and resolves editor config key → $EDITOR → vi in a small resolve_editor helper
- App carries editor_override from config into the editor handoff
- docs updated: docs/CONFIG.md, docs/KEYBINDINGS.md, README.md, help popup