### PR TITLE
feat(selector): delete and unhide saved reviews from the Sessions tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ Repository-managed agent integrations:
 **ReviewStore** (`src/review_store.rs`):
 
 - Public library facade for persisted review sessions
-- Methods: `list_sessions_for_repo()`, `get_review()`, `add_comment()`, `save_review()`
+- Methods: `list_sessions_for_repo()`, `get_review()`, `add_comment()`, `save_review()`, `delete_review()`
 - Shared primitive: `add_comment_to_session()` is used by both the library facade and `App::save_comment()`
 
 **Action** (`src/input/keybindings.rs`):

--- a/README.md
+++ b/README.md
@@ -201,7 +201,9 @@ TUI sessions with `"active": true`.
 Inside the TUI, the review target selector's **Sessions** tab lists the saved
 reviews for the current checkout, so you can resume one by picking it instead of
 retyping the commit range it was opened with. Open it with `:sessions` or cycle
-to it with `Tab`.
+to it with `Tab`. Press `dd` to delete the review under the cursor after a
+confirmation prompt, and `a` to reveal reviews holding no comments and no
+reviewed files, which are hidden by default.
 
 ## Library API
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -249,14 +249,21 @@ losing their reviewed state.
 | `Enter` | Confirm local commit range, open PR, load more PRs, or resume a saved review |
 | `/` | Filter currently loaded PR rows locally |
 | `r` | In Pull Requests tab, toggle all open PRs / PRs requesting your review |
+| `a` | In Sessions tab, show or hide saved reviews holding no progress |
+| `dd` | In Sessions tab, delete the saved review under the cursor (asks to confirm) |
 | `Esc` | Return to the diff |
 | `:q` | Quit |
 
 The Sessions tab lists saved reviews for the current checkout, so you can pick one
 instead of retyping the commit range it was opened with. Rows show the review target,
 comment count, reviewed files, and age. Reviews with no comments and no reviewed files
-are omitted. Selecting a saved PR review re-fetches it from the forge, the same as
-opening it from the Pull Requests tab.
+are omitted; press `a` to show them. Selecting a saved PR review re-fetches it from the
+forge, the same as opening it from the Pull Requests tab.
+
+Press `dd` to delete the saved review under the cursor. tuicr asks to confirm first, and
+refuses to delete a review that is open in another tuicr, since that process would write
+it straight back. Combine `a` with `dd` to clear out empty sessions left behind by a
+crash.
 
 ## Inline commit selector
 

--- a/src/app/commits.rs
+++ b/src/app/commits.rs
@@ -348,16 +348,18 @@ impl App {
     ///
     /// Sessions with neither comments nor reviewed state are hidden because
     /// they hold no review progress to resume. A clean quit removes them
-    /// (`delete_session_if_empty`); a crash can leave one behind.
+    /// (`delete_session_if_empty`); a crash can leave one behind. `a` on the
+    /// tab unhides them so they can be cleaned up with `dd`.
     pub fn load_sessions_tab(&mut self) {
         let root = self.vcs_info.root_path.clone();
         let store = crate::review_store::ReviewStore::new();
+        let show_empty = self.sessions_tab.show_empty();
         let mut result = store
             .list_sessions_for_repo(&root)
             .map(|sessions| {
                 sessions
                     .into_iter()
-                    .filter(Self::is_resumable)
+                    .filter(|s| show_empty || Self::is_resumable(s))
                     .collect::<Vec<_>>()
             })
             .map_err(|e| e.to_string());
@@ -373,7 +375,7 @@ impl App {
                     let listed = sessions
                         .iter()
                         .any(|s| s.session_ref.path() == session.session_ref.path());
-                    if !listed && Self::is_resumable(&session) {
+                    if !listed && (show_empty || Self::is_resumable(&session)) {
                         sessions.push(session);
                     }
                 }
@@ -405,6 +407,49 @@ impl App {
                     .map(|name| name.to_string_lossy().into_owned())
             })
             .unwrap_or_else(|| root.display().to_string())
+    }
+
+    /// Toggle whether empty sessions are listed, then reload.
+    ///
+    /// The filter is applied while rows are gathered rather than at render
+    /// time, so revealing them needs a fresh listing.
+    pub fn sessions_tab_toggle_show_empty(&mut self) {
+        self.sessions_tab.toggle_show_empty();
+        self.load_sessions_tab();
+    }
+
+    /// Delete the session under the cursor. Called after the confirm dialog,
+    /// never straight from the keypress.
+    pub fn sessions_tab_delete_selected(&mut self) {
+        let index = self.sessions_tab.cursor();
+        let Some(summary) = self.sessions_tab.cursor_session() else {
+            return;
+        };
+        // An open session would be rewritten by the TUI holding it, so the
+        // file would come back moments after being deleted.
+        if summary.active {
+            self.set_message("That review is open in another tuicr — close it first");
+            return;
+        }
+
+        let session_ref = summary.session_ref.clone();
+        let slug = summary.slug.clone();
+        match crate::review_store::ReviewStore::new().delete_review(&session_ref) {
+            Ok(true) => {
+                self.sessions_tab.remove_row(index);
+                self.sessions_tab
+                    .ensure_cursor_visible(self.sessions_list_viewport_height);
+                self.set_message(format!("Deleted review {slug}"));
+            }
+            // Already gone on disk: drop the stale row rather than report an
+            // error the user can do nothing about.
+            Ok(false) => {
+                self.sessions_tab.remove_row(index);
+                self.sessions_tab
+                    .ensure_cursor_visible(self.sessions_list_viewport_height);
+            }
+            Err(e) => self.set_error(format!("Failed to delete review: {e}")),
+        }
     }
 
     pub fn sessions_tab_cursor_up(&mut self) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -697,6 +697,27 @@ impl PullRequestDiffSource {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfirmAction {
     CopyAndQuit,
+    /// Delete the session under the cursor on the Sessions tab. Unlike
+    /// `CopyAndQuit` this returns to the selector instead of quitting.
+    DeleteSession,
+}
+
+impl ConfirmAction {
+    /// Mode to return to once the prompt is answered either way.
+    pub fn return_mode(self) -> InputMode {
+        match self {
+            ConfirmAction::CopyAndQuit => InputMode::Normal,
+            ConfirmAction::DeleteSession => InputMode::CommitSelect,
+        }
+    }
+
+    /// Prompt shown in the dialog.
+    pub fn prompt(self) -> &'static str {
+        match self {
+            ConfirmAction::CopyAndQuit => "Copy review to clipboard?",
+            ConfirmAction::DeleteSession => "Delete this saved review?",
+        }
+    }
 }
 
 /// Push a `MappedComment` onto the appropriate bucket. Free function so the

--- a/src/app/modes.rs
+++ b/src/app/modes.rs
@@ -344,7 +344,11 @@ impl App {
     }
 
     pub fn exit_confirm_mode(&mut self) {
-        self.input_mode = InputMode::Normal;
+        // Not every prompt is a quit prompt: a Sessions-tab delete has to drop
+        // the user back on the selector, not into an empty diff behind it.
+        self.input_mode = self
+            .pending_confirm
+            .map_or(InputMode::Normal, ConfirmAction::return_mode);
         self.pending_confirm = None;
     }
 }

--- a/src/app/sessions_tab.rs
+++ b/src/app/sessions_tab.rs
@@ -14,6 +14,10 @@ use crate::review_store::{SessionKind, SessionSummary};
 pub struct SessionsTab {
     rows: Vec<SessionSummary>,
     error: Option<String>,
+    /// When true the listing also shows sessions with no comments and no
+    /// reviewed files. They hold nothing to resume, so they are hidden by
+    /// default; revealing them is what makes them reachable for `dd`.
+    show_empty: bool,
     /// Checkout the listing is scoped to, resolved once at load. Rendering
     /// reads this every frame, so it must not re-derive it: the lookup reaches
     /// git2 repository discovery and the `origin` remote.
@@ -23,6 +27,29 @@ pub struct SessionsTab {
 }
 
 impl SessionsTab {
+    /// Whether empty sessions are currently listed.
+    pub fn show_empty(&self) -> bool {
+        self.show_empty
+    }
+
+    /// Flip the empty-session filter. The caller reloads the listing, since
+    /// the filter is applied while rows are gathered, not while they render.
+    pub fn toggle_show_empty(&mut self) {
+        self.show_empty = !self.show_empty;
+    }
+
+    /// Drop the row at `index`, keeping the cursor on a valid neighbour.
+    ///
+    /// Used after a session file is deleted so the list reflects the removal
+    /// without a full reload, which would reset the cursor to the top.
+    pub fn remove_row(&mut self, index: usize) {
+        if index >= self.rows.len() {
+            return;
+        }
+        self.rows.remove(index);
+        self.cursor = self.cursor.min(self.rows.len().saturating_sub(1));
+    }
+
     /// Replace the rows with a fresh listing, resetting the cursor.
     pub fn apply_load(&mut self, result: std::result::Result<Vec<SessionSummary>, String>) {
         self.cursor = 0;

--- a/src/app/tests/sessions_resume_tests.rs
+++ b/src/app/tests/sessions_resume_tests.rs
@@ -6,6 +6,7 @@
 //! routed `WorkingTree` to the unstaged-only loader, so it guarded nothing.
 
 use crate::app::*;
+use crate::input::keybindings::Action;
 use crate::model::FileStatus;
 use crate::review_store::{SessionKind, SessionSummary};
 use crate::vcs::traits::{ResolvedRevisionRange, VcsType};
@@ -496,4 +497,128 @@ fn should_hide_sessions_with_no_review_progress() {
         vec!["repo@main/commits/aaa..ccc", "repo@main/worktree/bbb"],
         "a session with no comments and no reviewed files holds no progress"
     );
+}
+
+#[test]
+fn should_delete_the_selected_session_file_and_row() {
+    // given — one persisted session, listed on the tab
+    let _reviews = TestReviewsDir::new();
+    let (mut app, _calls) = build_app(vec![commit("aaa")]);
+    let summary = stage_session(&mut app, range_session(&["aaa"], Some("main")));
+    let path = summary.session_ref.path().to_path_buf();
+    assert!(
+        path.exists(),
+        "fixture should have persisted a session file"
+    );
+
+    // when
+    app.sessions_tab_delete_selected();
+
+    // then — gone from disk and from the listing, no reload needed
+    assert!(!path.exists(), "delete should remove the session file");
+    assert!(app.sessions_tab.is_empty());
+    assert!(
+        crate::review_store::ReviewStore::new()
+            .list_all_sessions()
+            .expect("list")
+            .is_empty(),
+        "delete should prune the manifest entry too"
+    );
+}
+
+#[test]
+fn should_refuse_to_delete_a_session_open_in_another_tuicr() {
+    // given — the listing row is marked active, as a running TUI records
+    let _reviews = TestReviewsDir::new();
+    let (mut app, _calls) = build_app(vec![commit("aaa")]);
+    let mut summary = stage_session(&mut app, range_session(&["aaa"], Some("main")));
+    summary.active = true;
+    let path = summary.session_ref.path().to_path_buf();
+    app.sessions_tab.apply_load(Ok(vec![summary]));
+
+    // when
+    app.sessions_tab_delete_selected();
+
+    // then — the owning process would just write it back, so refuse
+    assert!(path.exists(), "an open session must survive");
+    assert_eq!(app.sessions_tab.rows().len(), 1);
+    assert!(
+        app.message
+            .as_ref()
+            .is_some_and(|m| m.content.contains("close it first")),
+        "expected guidance, got {:?}",
+        app.message
+    );
+}
+
+#[test]
+fn should_confirm_before_deleting_and_return_to_the_selector() {
+    // given — the cursor is on a session
+    let _reviews = TestReviewsDir::new();
+    let (mut app, _calls) = build_app(vec![commit("aaa")]);
+    let summary = stage_session(&mut app, range_session(&["aaa"], Some("main")));
+    let path = summary.session_ref.path().to_path_buf();
+    app.target_tab = TargetTab::Sessions;
+
+    // when — dd raises the prompt rather than deleting outright
+    crate::handler::handle_commit_select_action(&mut app, Action::SessionsTabDelete);
+    assert_eq!(app.input_mode, InputMode::Confirm);
+    assert_eq!(app.pending_confirm, Some(ConfirmAction::DeleteSession));
+    assert!(path.exists(), "the prompt must not delete anything yet");
+
+    // and — declining keeps the session and stays in the selector
+    crate::handler::handle_confirm_action(&mut app, Action::ConfirmNo);
+    assert!(path.exists());
+    assert_eq!(app.input_mode, InputMode::CommitSelect);
+    assert!(!app.should_quit, "a delete prompt must not quit tuicr");
+
+    // and — confirming deletes, still without quitting
+    crate::handler::handle_commit_select_action(&mut app, Action::SessionsTabDelete);
+    crate::handler::handle_confirm_action(&mut app, Action::ConfirmYes);
+    assert!(!path.exists());
+    assert_eq!(app.input_mode, InputMode::CommitSelect);
+    assert!(!app.should_quit);
+}
+
+#[test]
+fn should_keep_quit_prompts_quitting() {
+    // given — the clipboard prompt, which shares the confirm plumbing
+    let (mut app, _calls) = build_app(vec![commit("aaa")]);
+    app.enter_confirm_mode(ConfirmAction::CopyAndQuit);
+
+    // when
+    crate::handler::handle_confirm_action(&mut app, Action::ConfirmNo);
+
+    // then — routing delete through Confirm must not have broken this
+    assert!(app.should_quit);
+    assert_eq!(app.input_mode, InputMode::Normal);
+}
+
+#[test]
+fn should_reveal_empty_sessions_only_when_toggled_on() {
+    // given — one session with no comments and no reviewed files
+    let _reviews = TestReviewsDir::new();
+    let (mut app, _calls) = build_app(vec![commit("aaa")]);
+    let store = crate::review_store::ReviewStore::new();
+    store
+        .save_review(&range_session(&["aaa"], Some("main")))
+        .expect("persist session");
+
+    // when — the default listing
+    app.load_sessions_tab();
+
+    // then — hidden, since there is no progress to resume
+    assert!(app.sessions_tab.is_empty());
+    assert!(!app.sessions_tab.show_empty());
+
+    // when — `a` unhides so it can be cleaned up
+    app.sessions_tab_toggle_show_empty();
+
+    // then
+    assert!(app.sessions_tab.show_empty());
+    assert_eq!(app.sessions_tab.rows().len(), 1);
+
+    // and — toggling back re-hides it
+    app.sessions_tab_toggle_show_empty();
+    assert!(app.sessions_tab.is_empty());
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1205,8 +1205,14 @@ pub fn handle_comment_action(app: &mut App, action: Action) {
 
 /// Handle actions in Confirm mode (Y/N prompts)
 pub fn handle_confirm_action(app: &mut App, action: Action) {
+    // Only the quit prompts end the session. A Sessions-tab delete answers
+    // in place and returns to the selector.
+    let quits = app.pending_confirm != Some(app::ConfirmAction::DeleteSession);
     match action {
         Action::ConfirmYes => {
+            if let Some(app::ConfirmAction::DeleteSession) = app.pending_confirm {
+                app.sessions_tab_delete_selected();
+            }
             if let Some(app::ConfirmAction::CopyAndQuit) = app.pending_confirm {
                 let slug = app.session_slug();
                 if app.output_to_stdout {
@@ -1236,11 +1242,11 @@ pub fn handle_confirm_action(app: &mut App, action: Action) {
                 }
             }
             app.exit_confirm_mode();
-            app.should_quit = true;
+            app.should_quit = quits;
         }
         Action::ConfirmNo => {
             app.exit_confirm_mode();
-            app.should_quit = true;
+            app.should_quit = quits;
         }
         Action::Quit => app.should_quit = true,
         _ => {}
@@ -1297,6 +1303,12 @@ fn handle_sessions_target_action(app: &mut App, action: Action) {
         Action::ConfirmCommitSelect => {
             if let Err(e) = app.sessions_tab_select() {
                 app.set_error(format!("Failed to open session: {e}"));
+            }
+        }
+        Action::SessionsTabToggleShowEmpty => app.sessions_tab_toggle_show_empty(),
+        Action::SessionsTabDelete => {
+            if app.sessions_tab.cursor_session().is_some() {
+                app.enter_confirm_mode(app::ConfirmAction::DeleteSession);
             }
         }
         // Space is a no-op: sessions are picked, not multi-selected.

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -115,6 +115,10 @@ pub enum Action {
     BeginTargetFilter,
     /// Toggle PR tab between all open PRs and PRs awaiting your review (`r`).
     TogglePrReviewRequestedFilter,
+    /// Sessions tab: show or hide sessions holding no review progress.
+    SessionsTabToggleShowEmpty,
+    /// Sessions tab: delete the session under the cursor, after a confirm.
+    SessionsTabDelete,
 
     // Submit resolver
     /// Move resolver cursor down (`j` / Down).
@@ -455,6 +459,9 @@ fn map_commit_select_mode(key: KeyEvent) -> Action {
         (KeyCode::BackTab, _) => Action::TargetSelectorTabPrev,
         (KeyCode::Char('/'), _) => Action::BeginTargetFilter,
         (KeyCode::Char('r'), KeyModifiers::NONE) => Action::TogglePrReviewRequestedFilter,
+        // Sessions-tab only; the other tabs ignore these in their dispatch.
+        (KeyCode::Char('a'), KeyModifiers::NONE) => Action::SessionsTabToggleShowEmpty,
+        (KeyCode::Char('d'), KeyModifiers::NONE) => Action::PendingDCommand,
         _ => Action::None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -557,6 +557,15 @@ fn main() -> anyhow::Result<()> {
                     if pending_d {
                         pending_d = false;
                         if key.code == crossterm::event::KeyCode::Char('d') {
+                            // In the target selector `dd` deletes the saved
+                            // review under the cursor, not a comment.
+                            if app.input_mode == InputMode::CommitSelect {
+                                handler::handle_commit_select_action(
+                                    &mut app,
+                                    Action::SessionsTabDelete,
+                                );
+                                continue;
+                            }
                             if app.cursor_on_locked_comment() {
                                 let forge = app.forge_display_name();
                                 app.set_message(format!(

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -83,6 +83,16 @@ impl ReviewStore {
         Ok(comment)
     }
 
+    /// Delete a persisted session and prune its manifest entry. Returns
+    /// `false` when there was no file to remove.
+    ///
+    /// Unconditional: unlike quit-time cleanup this also discards sessions
+    /// that carry comments, so callers are expected to confirm first.
+    pub fn delete_review(&self, session_ref: &SessionRef) -> Result<bool> {
+        let reviews_dir = self.reviews_dir()?;
+        storage::delete_session_in_dir(session_ref.path(), &reviews_dir)
+    }
+
     /// Save a session through this store's storage root.
     pub fn save_review(&self, session: &ReviewSession) -> Result<SessionRef> {
         let reviews_dir = self.reviews_dir()?;

--- a/src/ui/app_layout.rs
+++ b/src/ui/app_layout.rs
@@ -4,7 +4,7 @@ use ratatui::{
     widgets::Block,
 };
 
-use crate::app::{App, InputMode};
+use crate::app::{App, ConfirmAction, InputMode};
 use crate::ui::comment_navigator::render_comment_navigator;
 use crate::ui::diff_view::render_diff_view;
 use crate::ui::file_list::render_file_list;
@@ -28,6 +28,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     let selector_background = app.input_mode == InputMode::CommitSelect
+        || (app.input_mode == InputMode::Confirm
+            && app.pending_confirm.map(ConfirmAction::return_mode)
+                == Some(InputMode::CommitSelect))
         || (app.input_mode == InputMode::Command
             && app.command_return_mode == InputMode::CommitSelect)
         || (app.input_mode == InputMode::Help
@@ -48,6 +51,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         }
         if app.input_mode == InputMode::Help || app.searching_help() {
             help_popup::render_help(frame, app);
+        }
+        if let Some(confirm) = app.pending_confirm {
+            comment_panel::render_confirm_dialog(frame, app, confirm.prompt());
         }
         return;
     }
@@ -77,8 +83,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // Comment input is now rendered inline in the diff view
 
     // Render confirm dialog if in confirm mode
-    if app.input_mode == InputMode::Confirm {
-        comment_panel::render_confirm_dialog(frame, app, "Copy review to clipboard?");
+    if let Some(confirm) = app.pending_confirm {
+        comment_panel::render_confirm_dialog(frame, app, confirm.prompt());
     }
 
     // Submit-flow modals.

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -370,6 +370,20 @@ pub fn render_help(frame: &mut Frame, app: &mut App) {
         ]),
         Line::from(vec![
             Span::styled(
+                "  a         ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Show/hide empty saved reviews (Sessions tab)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                "  dd        ",
+                Style::default().add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("Delete saved review, with confirm (Sessions tab)"),
+        ]),
+        Line::from(vec![
+            Span::styled(
                 "  Esc       ",
                 Style::default().add_modifier(Modifier::BOLD),
             ),

--- a/src/ui/selector.rs
+++ b/src/ui/selector.rs
@@ -299,10 +299,12 @@ fn render_sessions_tab(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 
     if app.sessions_tab.is_empty() {
-        let line = Line::from(Span::styled(
-            "  No saved reviews for this checkout",
-            Style::default().fg(theme.fg_dim),
-        ));
+        let hint = if app.sessions_tab.show_empty() {
+            "  No saved reviews for this checkout"
+        } else {
+            "  No saved reviews for this checkout — press a to show empty ones"
+        };
+        let line = Line::from(Span::styled(hint, Style::default().fg(theme.fg_dim)));
         frame.render_widget(
             Paragraph::new(vec![line]).style(styles::panel_style(theme)),
             area,
@@ -552,7 +554,14 @@ fn render_target_selector_footer(frame: &mut Frame, app: &App, area: Rect) {
                 };
                 format!("   j/k navigate · ↵ open · {scope_hint} · / filter · esc back")
             }
-            TargetTab::Sessions => "   j/k navigate · ↵ resume · esc back".to_string(),
+            TargetTab::Sessions => {
+                let empty_hint = if app.sessions_tab.show_empty() {
+                    "a hide empty"
+                } else {
+                    "a show empty"
+                };
+                format!("   j/k navigate · ↵ resume · dd delete · {empty_hint} · esc back")
+            }
         }
     };
     let hints_span = Span::styled(hints, Style::default().fg(theme.fg_secondary));


### PR DESCRIPTION
Follow-up to the review on #669.

`dd` on the Sessions tab deletes the review under the cursor, behind a Y/N confirm. `a` toggles whether reviews holding no comments and no reviewed files are listed — hidden by default, since they hold nothing to resume, but a crashed TUI leaves them behind and there was no way to clear them out.

Two things worth calling out:

- `ConfirmAction` now carries a return mode and a prompt. Confirm mode assumed every prompt was a quit prompt: hardcoded clipboard message, `should_quit` on both answers. A delete answers in place and lands back on the selector.
- Deleting a session another tuicr has open is refused — the owning process would write it straight back.

The empty filter is applied while rows are gathered, not at render time, so toggling reloads. Keeps `is_resumable` as the single predicate.

## Test plan

- `cargo test`: 1585 passed, 0 failed
- `cargo fmt --check`, `cargo clippy --all-targets` clean (one pre-existing warning in `bitbucket/bkt.rs`, present on main)
- New tests: delete removes file + manifest entry + row, active-session refusal, confirm round trip both answers, reveal toggle, and a guard that quit prompts still quit