### PR TITLE
docs(skill): guide agents through seeding comments correctly

### DIFF
--- a/skills/tuicr/SKILL.md
+++ b/skills/tuicr/SKILL.md
@@ -49,11 +49,15 @@ If the user's intent is ambiguous, ask which workflow they want.
    local and PR sessions by owner/repo. Each row carries a `kind` (`local` or
    `pr`) and a usable `slug`. Use `--all` when you don't know the repo.
 
+   `[]` with exit 0 also means "not a repo root" — a subdirectory returns it
+   too. Pass the root, then `--all`, before concluding nothing is open.
+
 3. Choose the session:
    - If the CLI clearly reports exactly one relevant active session with
      `"active": true`, attach to it.
    - If multiple sessions are active, or the correct session is not clear, ask
-     the user which slug to use.
+     the user which slug to use. One repo can hold a worktree and a
+     commit-range session at once, and adding to the wrong one exits 0.
    - If the user provided a slug or session JSON path, use it directly.
    - For a PR review, pass the PR slug from the listing (e.g.
      `gh:owner/repo/pr/N`) to `--session`; it is self-contained and needs no
@@ -118,6 +122,24 @@ Once the TUI creates its active session, use
 `tuicr review list --repo /path/to/repo` to capture the slug. If your
 environment cannot run another command while a blocking wrapper is waiting,
 read the comments after the user exits tuicr.
+
+## Reconstruct The Diff
+
+To review a patch yourself, rebuild the diff the user sees. The slug's source
+segment says which:
+
+| Slug segment | Diff |
+|--------------|------|
+| `worktree/<head>`, `staged-and-unstaged/<head>` | `git diff HEAD` |
+| `staged/<head>` | `git diff --cached` |
+| `unstaged/<head>` | `git diff` |
+| `commits/<base>..<head>` | `git diff <base>~1..<head>` |
+| `pr/<n>` | `gh pr diff <n>` |
+| `pristine` | none; every tracked file shown in full |
+
+Range endpoints are inclusive and printed oldest-first, so `<base>` without
+`~1` drops the first commit. Check the file count against the listing row's
+`file_count`; a mismatch means every line number you derive will be wrong.
 
 ## Read User Comments
 
@@ -200,7 +222,20 @@ unchanged lines in the new file.
 
 For structured input, use `--input` with literal JSON, `@path/to/file.json`, or
 `-` for stdin. Supported target types are `review`, `file`, `line`, and
-`line_range`.
+`line_range`. One object per call — an array is a parse error. The file key is
+`file`, not `path`. `target.type` is inferred from the fields present:
+
+```bash
+tuicr review add --session <slug> --username "Codex" --input \
+  '{"file":"src/main.rs","line":42,"side":"new","comment_type":"issue","content":"Handle the empty case."}'
+```
+
+Then verify. A line outside the diff stores, prints back, and exits 0, but
+never renders — invisible to the user, successful-looking to you. Re-read
+`tuicr review comments` and check each `start_line` exists on the side you gave
+(`new` for added or unchanged, `old` for removed). Keep the returned `id`s:
+`review comments` reports no author, so they are the only way to tell your
+comments from the user's.
 
 ## Legacy Export Output
 


### PR DESCRIPTION
This targets the second workflow the skill already names — agent review of a patch — where the agent files its findings into tuicr with `review add` and the human then opens the TUI to read them. The review lands on the diff, anchored to the lines it is about, instead of arriving as a wall of chat text the human has to map back onto the code themselves. They page through it with `j`/`k`, mark hunks reviewed, reply, delete the findings they disagree with, and export what survives. The human is reviewing the review, in the tool they already use for reviewing. That flow only works if the agent anchors comments to the right lines, and today nothing in the skill tells it how.

Three failure modes on that path. Each succeeds silently, so nothing steers away from it.

**Reconstruct The Diff** (new section). An agent needs the same diff the user sees before it can pick line numbers, and the slug says which one. Adds the scope-per-slug-segment table and the `<base>~1` detail: range endpoints are inclusive, so diffing from `<base>` silently drops the first commit. Get this wrong and every line number is off, which is exactly how findings end up anchored to unrelated code.

**`--repo` caveat** (into Attach To A Session). `[]` with exit 0 also means "not a repo root" — a subdirectory returns it too. Read as "nothing open", an agent gives up while a session is running.

**Verify seeded comments** (into Add Agent Comments, next to the `--input` shape it depends on). A line past the end of the diff stores, prints back, and exits 0, but never renders — so the agent reports success on a review the human cannot see. Also: `review comments` reports no author, so the ids from `add` are the only way to tell agent comments from the user's later.

## Test plan

- Field shapes read off `src/review_cli.rs` and exercised against the built binary: the documented flat `--input` form round-trips, an array is a parse error, `path` is not an alias for `file`
- Range recipe measured here. For `commits/82e9508..b55e218`, `<base>~1..<head>` gives 15 files / 306 insertions; `<base>..<head>` gives 9 / 155 — short by exactly commit `82e9508` (6 files / 151)
- `[]` exit 0 reproduced for repo root, subdirectory, and nonexistent path
- Out-of-range line reproduced: line 9999 in a 3-line file returns the stored comment, exit 0