### PR TITLE
feat(forge): allow a template for the comment type prefix

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -57,7 +57,7 @@ comment_types = [
 ]
 
 [forge]
-comment_type_prefix = true
+comment_type_prefix = "**{type}:** "   # or true / false
 
 [export]
 intro = "I reviewed your code and have the following comments. Please address them."
@@ -229,9 +229,9 @@ Settings under the `[forge]` section control how tuicr submits reviews to GitHub
 comment_type_prefix = false
 ```
 
-| Key                   | Default | Description                                                                                                                                                                 |
-| --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `comment_type_prefix` | `true`  | Prepend `[TYPE] ` to comment bodies on submit (e.g. `[ISSUE] Magic number should be a constant`). Set to `false` to send the raw comment body without a classification tag. |
+| Key                   | Default | Description                                                                                                                                                                                                       |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `comment_type_prefix` | `true`  | How to tag comment bodies with their type on submit. `true` prepends `[TYPE] ` (e.g. `[ISSUE] Magic number should be a constant`), `false` sends the raw body, and a template string renders a tag of your own. |
 
 When enabled (the default), submitted comments look like:
 
@@ -248,6 +248,35 @@ Consider adding unit tests
 Magic number should be a named constant
 This module could use a doc comment
 ```
+
+### Prefix templates
+
+`[TYPE] ` reads as shouting on forges that render Markdown, and it does not match the
+review conventions some teams have already standardised on. Set the key to a template
+string to choose the tag yourself:
+
+| Placeholder | Renders                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `{type}`    | The comment type id as configured, which is lowercase      |
+| `{TYPE}`    | The same id uppercased                                     |
+
+```toml
+[forge]
+comment_type_prefix = "**{type}:** "
+```
+
+```
+**suggestion:** Consider adding unit tests
+**issue:** Magic number should be a named constant
+**note:** File-level: This module could use a doc comment
+```
+
+`true` is exactly `"[{TYPE}] "`, and `""` is exactly `false`. A template that contains
+neither placeholder would tag every comment identically — almost always a mistyped
+placeholder — so tuicr warns and falls back to the default.
+
+The template interpolates the comment type **id**, not its `label`; the two are the same
+unless you set `label` explicitly. Untyped (`none`) comments never render a tag.
 
 This applies to inline line comments, file-level comments, and review-level comments pushed via `:submit`. The prefix works the same way on GitLab MR and Bitbucket PR submissions.
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -17,21 +17,79 @@ pub struct CommentTypeConfig {
     pub color: Option<String>,
 }
 
+/// How the comment-type classification tag is rendered onto comment bodies
+/// pushed to a forge.
+///
+/// `true`/`false` keep the original toggle semantics; a string is a template
+/// so the tag can match a team's review convention (for example the bold
+/// lowercase labels of Conventional Comments) rather than being locked to
+/// `[TYPE] `.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(default)]
-pub struct ForgeConfig {
-    /// Prepend `[TYPE] ` to inline review comment bodies on submit so the
-    /// reader can see the comment classification at a glance. Defaults to
-    /// `true`; set to `false` to send the raw comment body.
-    pub comment_type_prefix: bool,
+#[serde(untagged)]
+pub enum CommentTypePrefix {
+    /// `true` renders [`CommentTypePrefix::DEFAULT_TEMPLATE`]; `false` renders
+    /// no tag at all.
+    Toggle(bool),
+    /// A template with `{type}` (the comment type id) and `{TYPE}` (the same
+    /// id uppercased) placeholders.
+    Template(String),
 }
 
-impl Default for ForgeConfig {
+impl Default for CommentTypePrefix {
     fn default() -> Self {
-        Self {
-            comment_type_prefix: true,
+        Self::Toggle(true)
+    }
+}
+
+impl CommentTypePrefix {
+    /// What `true` renders, and what tuicr has always emitted.
+    pub const DEFAULT_TEMPLATE: &'static str = "[{TYPE}] ";
+
+    const LOWER_PLACEHOLDER: &'static str = "{type}";
+    const UPPER_PLACEHOLDER: &'static str = "{TYPE}";
+
+    /// Whether `template` interpolates the comment type at all. A template
+    /// without a placeholder would tag every comment identically, which is
+    /// never what the author meant — usually a mistyped placeholder.
+    pub fn template_has_placeholder(template: &str) -> bool {
+        template.contains(Self::LOWER_PLACEHOLDER) || template.contains(Self::UPPER_PLACEHOLDER)
+    }
+
+    /// The active template, empty when no tag should be rendered.
+    pub fn template(&self) -> &str {
+        match self {
+            Self::Toggle(true) => Self::DEFAULT_TEMPLATE,
+            Self::Toggle(false) => "",
+            Self::Template(template) => template.as_str(),
         }
     }
+
+    /// True when no tag is rendered, whatever the spelling (`false` or `""`).
+    pub fn is_disabled(&self) -> bool {
+        self.template().is_empty()
+    }
+
+    /// Render the tag for `type_id` — a `comment_types` id, already lowercased
+    /// by config parsing. Empty when disabled; callers skip untyped comments.
+    pub fn render(&self, type_id: &str) -> String {
+        let template = self.template();
+        if template.is_empty() {
+            return String::new();
+        }
+        template
+            .replace(Self::UPPER_PLACEHOLDER, &type_id.to_ascii_uppercase())
+            .replace(Self::LOWER_PLACEHOLDER, type_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct ForgeConfig {
+    /// How to tag inline review comment bodies with their comment type on
+    /// submit, so the reader can see the classification at a glance. Defaults
+    /// to `true` (`[TYPE] `); `false` sends the raw comment body, and a
+    /// template string renders the tag that template describes.
+    pub comment_type_prefix: CommentTypePrefix,
 }
 
 const DEFAULT_EXPORT_INTRO: &str =
@@ -493,7 +551,7 @@ fn parse_forge(value: &Value, warnings: &mut Vec<String>) -> Option<ForgeConfig>
     let mut cfg = defaults.clone();
     let mut any_override = false;
 
-    if let Some(v) = read_section_bool(table, "forge", "comment_type_prefix", warnings) {
+    if let Some(v) = read_comment_type_prefix(table, warnings) {
         cfg.comment_type_prefix = v;
         any_override = true;
     }
@@ -541,6 +599,40 @@ fn parse_export(value: &Value, warnings: &mut Vec<String>) -> Option<ExportConfi
 
 /// Like `read_bool`, but emits a `<section>.<key>` qualified warning so the
 /// user can locate the misconfigured field.
+/// Read `forge.comment_type_prefix`, which accepts either the original
+/// boolean toggle or a template string.
+fn read_comment_type_prefix(
+    table: &toml::Table,
+    warnings: &mut Vec<String>,
+) -> Option<CommentTypePrefix> {
+    let val = table.get("comment_type_prefix")?;
+
+    if let Some(toggled) = val.as_bool() {
+        return Some(CommentTypePrefix::Toggle(toggled));
+    }
+
+    if let Some(template) = val.as_str() {
+        if template.is_empty() {
+            // An explicit empty template reads as "no tag", same as `false`.
+            return Some(CommentTypePrefix::Toggle(false));
+        }
+        if !CommentTypePrefix::template_has_placeholder(template) {
+            warnings.push(
+                "Warning: Config key 'forge.comment_type_prefix' template must contain '{type}' or '{TYPE}'; ignoring value"
+                    .to_string(),
+            );
+            return None;
+        }
+        return Some(CommentTypePrefix::Template(template.to_string()));
+    }
+
+    warnings.push(
+        "Warning: Config key 'forge.comment_type_prefix' must be a boolean or a template string; ignoring value"
+            .to_string(),
+    );
+    None
+}
+
 fn read_section_bool(
     table: &toml::Table,
     section: &str,
@@ -1547,7 +1639,7 @@ comment_type_prefix = false
             .as_ref()
             .and_then(|cfg| cfg.forge.clone())
             .expect("forge section should parse");
-        assert!(!forge.comment_type_prefix);
+        assert_eq!(forge.comment_type_prefix, CommentTypePrefix::Toggle(false));
         assert!(outcome.warnings.is_empty());
     }
 
@@ -1576,7 +1668,7 @@ foo = "bar"
             .as_ref()
             .and_then(|cfg| cfg.forge.clone())
             .expect("forge section should parse");
-        assert!(!forge.comment_type_prefix);
+        assert_eq!(forge.comment_type_prefix, CommentTypePrefix::Toggle(false));
         assert_eq!(outcome.warnings.len(), 1);
         assert_eq!(
             outcome.warnings[0],
@@ -1588,7 +1680,7 @@ foo = "bar"
     fn should_warn_and_ignore_forge_value_with_wrong_type() {
         let outcome = parse_config(
             r#"[forge]
-comment_type_prefix = "yes"
+comment_type_prefix = 42
 "#,
         );
         // Wrong-type fields fall back to defaults; with no other overrides
@@ -1606,6 +1698,77 @@ comment_type_prefix = "yes"
             "warning should be qualified, got {:?}",
             outcome.warnings[0]
         );
+    }
+
+    #[test]
+    fn should_parse_comment_type_prefix_template() {
+        let outcome = parse_config(
+            r#"[forge]
+comment_type_prefix = "**{type}:** "
+"#,
+        );
+        let forge = outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.forge.clone())
+            .expect("forge section should parse");
+        assert_eq!(
+            forge.comment_type_prefix,
+            CommentTypePrefix::Template("**{type}:** ".to_string())
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_read_empty_comment_type_prefix_template_as_disabled() {
+        let outcome = parse_config(
+            r#"[forge]
+comment_type_prefix = ""
+"#,
+        );
+        let forge = outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.forge.clone())
+            .expect("forge section should parse");
+        assert!(forge.comment_type_prefix.is_disabled());
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_comment_type_prefix_template_without_placeholder() {
+        // A template that never interpolates the type would tag every comment
+        // identically -- almost always a mistyped placeholder.
+        let outcome = parse_config(
+            r#"[forge]
+comment_type_prefix = "nit: "
+"#,
+        );
+        assert!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.forge.clone())
+                .is_none()
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(
+            outcome.warnings[0].contains("'{type}' or '{TYPE}'"),
+            "warning should name the placeholders, got {:?}",
+            outcome.warnings[0]
+        );
+    }
+
+    #[test]
+    fn comment_type_prefix_renders_both_placeholder_cases() {
+        let prefix = CommentTypePrefix::Template("**{type}** ({TYPE}) ".to_string());
+        assert_eq!(prefix.render("nitpick"), "**nitpick** (NITPICK) ");
+    }
+
+    #[test]
+    fn disabled_comment_type_prefix_renders_nothing() {
+        assert!(CommentTypePrefix::Toggle(false).render("issue").is_empty());
+        assert!(CommentTypePrefix::Template(String::new()).is_disabled());
     }
 
     #[test]
@@ -1627,7 +1790,12 @@ comment_type_prefix = "yes"
     #[test]
     fn forge_defaults_enable_comment_type_prefix() {
         let cfg = ForgeConfig::default();
-        assert!(cfg.comment_type_prefix);
+        assert_eq!(cfg.comment_type_prefix, CommentTypePrefix::Toggle(true));
+        assert_eq!(
+            cfg.comment_type_prefix.render("issue"),
+            "[ISSUE] ",
+            "the default must stay byte-identical to the historical tag"
+        );
     }
 
     #[test]

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -176,7 +176,7 @@ pub enum MappedComment {
 /// Compute the inline body for `comment` honoring the `[TYPE]` prefix toggle.
 /// File-level bodies are prefixed `[TYPE] File-level:`.
 fn build_inline_body(comment: &Comment, file_level: bool, config: &ForgeConfig) -> String {
-    if !config.comment_type_prefix {
+    if config.comment_type_prefix.is_disabled() {
         return comment.content.clone();
     }
     // `None` comments carry no `[TYPE]` tag, but file-level ones keep the
@@ -184,7 +184,7 @@ fn build_inline_body(comment: &Comment, file_level: bool, config: &ForgeConfig) 
     let type_tag = if comment.comment_type.is_none() {
         String::new()
     } else {
-        format!("[{ty}] ", ty = comment.comment_type.as_str())
+        config.comment_type_prefix.render(comment.comment_type.id())
     };
     let prefix = if file_level {
         format!("{type_tag}File-level: ")
@@ -539,8 +539,8 @@ pub fn build_review_body(
             if i > 0 {
                 block.push_str("\n\n");
             }
-            if config.comment_type_prefix && !c.comment_type.is_none() {
-                block.push_str(&format!("[{}] ", c.comment_type.as_str()));
+            if !c.comment_type.is_none() {
+                block.push_str(&config.comment_type_prefix.render(c.comment_type.id()));
             }
             block.push_str(&c.content);
         }
@@ -550,10 +550,12 @@ pub fn build_review_body(
     if !moved_to_summary.is_empty() {
         let mut block = String::from("## Unplaced comments\n");
         for item in moved_to_summary {
-            let prefix = if config.comment_type_prefix && !item.comment.comment_type.is_none() {
-                format!("[{}] ", item.comment.comment_type.as_str())
-            } else {
+            let prefix = if item.comment.comment_type.is_none() {
                 String::new()
+            } else {
+                config
+                    .comment_type_prefix
+                    .render(item.comment.comment_type.id())
             };
             let path = item.file.display();
             block.push_str(&format!(
@@ -574,6 +576,7 @@ pub fn build_review_body(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::CommentTypePrefix;
     use crate::model::comment::{Comment, CommentType, LineContext, LineRange, LineSide};
     use crate::model::diff_types::{DiffHunk, DiffLine, FileStatus, LineOrigin};
     use std::path::PathBuf;
@@ -1023,7 +1026,7 @@ mod tests {
     fn should_omit_type_prefix_when_config_disables_it() {
         let comment = comment_with_line(LineSide::New, Some(11), None);
         let cfg = ForgeConfig {
-            comment_type_prefix: false,
+            comment_type_prefix: CommentTypePrefix::Toggle(false),
         };
         let mapped = map_comment(&comment, anchor_from(&comment), &typical_file(), &cfg);
         match mapped {
@@ -1033,6 +1036,38 @@ mod tests {
             }
             other => panic!("expected Inline, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn should_render_custom_type_prefix_template_on_inline_bodies() {
+        let comment = comment_with_line(LineSide::New, Some(11), None);
+        let cfg = ForgeConfig {
+            comment_type_prefix: CommentTypePrefix::Template("**{type}:** ".to_string()),
+        };
+        let mapped = map_comment(&comment, anchor_from(&comment), &typical_file(), &cfg);
+        match mapped {
+            MappedComment::Inline(inline) => {
+                assert_eq!(inline.body, "**issue:** needs work");
+            }
+            other => panic!("expected Inline, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_render_custom_type_prefix_template_on_file_level_bodies() {
+        let comment = Comment::new(
+            "needs work".to_string(),
+            CommentType::from_id("issue"),
+            None,
+        );
+        let cfg = ForgeConfig {
+            comment_type_prefix: CommentTypePrefix::Template("**{type}:** ".to_string()),
+        };
+        // The `File-level:` marker still follows the tag.
+        assert_eq!(
+            build_inline_body(&comment, true, &cfg),
+            "**issue:** File-level: needs work"
+        );
     }
 
     // build_review_body
@@ -1081,7 +1116,7 @@ mod tests {
     #[test]
     fn should_omit_type_prefix_in_body_when_disabled() {
         let cfg = ForgeConfig {
-            comment_type_prefix: false,
+            comment_type_prefix: CommentTypePrefix::Toggle(false),
         };
         let comments = vec![note("just text")];
         let body = build_review_body(&comments, &[], &cfg);
@@ -1099,6 +1134,24 @@ mod tests {
         assert!(!body.contains('['), "no type tag expected on None: {body}");
         assert!(body.contains("untyped"));
         assert!(body.contains("- a.rs: also untyped"));
+    }
+
+    #[test]
+    fn should_render_custom_type_prefix_template_in_review_body() {
+        let cfg = ForgeConfig {
+            comment_type_prefix: CommentTypePrefix::Template("**{type}:** ".to_string()),
+        };
+        let comments = vec![note("first")];
+        let summary = vec![MovedToSummaryItem {
+            comment: Comment::new("kaboom".to_string(), CommentType::from_id("issue"), None),
+            file: PathBuf::from("src/lib.rs"),
+        }];
+        let body = build_review_body(&comments, &summary, &cfg);
+        assert!(body.contains("**note:** first"), "review level: {body}");
+        assert!(
+            body.contains("- **issue:** src/lib.rs: kaboom"),
+            "unplaced: {body}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`forge.comment_type_prefix` is a bool, and the tag it prepends is hardcoded:

```rust
// src/forge/submit.rs
format!("[{ty}] ", ty = comment.comment_type.as_str())   // as_str() = id.to_ascii_uppercase()
```

So on a Markdown-rendering forge there are only two choices: shout `[ISSUE]` at the author, or set the key to `false` and lose the classification entirely on the way to the PR. I hit this reviewing with types locally and wanting [Conventional Comments](https://conventionalcomments.org) labels (`**issue:**`, `**nit:**`) in the posted bodies — the type is exactly the information the convention wants, it just cannot be spelled that way.

## Change

The key now also accepts a template string:

```toml
[forge]
comment_type_prefix = "**{type}:** "
```

```
**suggestion:** Consider adding unit tests
**issue:** Magic number should be a named constant
**note:** File-level: This module could use a doc comment
```

| Placeholder | Renders |
| --- | --- |
| `{type}` | the comment type id as configured, which is lowercase |
| `{TYPE}` | the same id uppercased |

- `true` is exactly `"[{TYPE}] "`, `""` is exactly `false` — existing configs render byte-identical bodies, asserted in `forge_defaults_enable_comment_type_prefix`.
- A template with neither placeholder would tag every comment identically (almost always a mistyped placeholder), so it warns and falls back to the default instead of silently prefixing literal text.
- Untyped (`none`) comments still render no tag, and the `File-level:` marker still follows the tag.
- Disabling still short-circuits to the raw body, so `false` keeps dropping the `File-level:` marker exactly as before.

Applies to inline, file-level, and review-level bodies on `:submit`, plus the unplaced-comments list — same reach the bool had, so GitLab and Bitbucket get it too. `[export]` markdown is untouched.

## Notes for review

- The template interpolates the type **id**, not its configured `label`, because the submit path only carries `CommentType`. Threading the comment type definitions into `build_inline_body` would touch every caller in the pipeline, so I left it out; happy to follow up with `{label}` if you'd rather have it. (Related: submit uses the id while `output/markdown.rs` uses the `label` for the same tag — I did not touch that inconsistency here.)
- `ForgeConfig.comment_type_prefix` changes type from `bool` to `CommentTypePrefix`, which is a breaking change for library consumers constructing it directly. `Default` still gives the historical behavior.
- `should_warn_and_ignore_forge_value_with_wrong_type` now uses `42`, since a string is valid input.

## Testing

- `cargo fmt --all --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1588 passed) all green.
- 8 new tests across `config` (bool back-compat, template, `""`, placeholder-less warning, both placeholder cases) and `forge::submit` (inline, file-level, and review-body rendering with a custom template).
- Verified end-to-end through `load_config()` against a real `~/.config/tuicr/config.toml`: `true` → `[ISSUE] `, `"**{type}:** "` → `**issue:** `, `"nit: "` → warning plus fallback.

## Docs

`docs/CONFIG.md`: Options row rewritten, a **Prefix templates** section added, and the full example block updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)