### PR TITLE
fix: stage deleted files with libgit2

### DIFF
--- a/src/vcs/git/staging.rs
+++ b/src/vcs/git/staging.rs
@@ -5,7 +5,14 @@ use crate::error::Result;
 
 pub fn stage_file(repo: &Repository, path: &Path) -> Result<()> {
     let mut index = repo.index()?;
-    index.add_path(path)?;
+    if repo
+        .workdir()
+        .is_some_and(|workdir| workdir.join(path).exists())
+    {
+        index.add_path(path)?;
+    } else {
+        index.remove_path(path)?;
+    }
     index.write()?;
     Ok(())
 }
@@ -14,6 +21,25 @@ pub fn stage_file(repo: &Repository, path: &Path) -> Result<()> {
 mod tests {
     use super::*;
     use std::fs;
+
+    fn create_initial_commit(repo: &Repository, file_name: &str, content: &str) {
+        fs::write(repo.workdir().unwrap().join(file_name), content)
+            .expect("failed to write initial file");
+
+        let mut index = repo.index().expect("failed to open index");
+        index
+            .add_path(Path::new(file_name))
+            .expect("failed to add file to index");
+        index.write().expect("failed to write index");
+
+        let tree_id = index.write_tree().expect("failed to write tree");
+        let tree = repo.find_tree(tree_id).expect("failed to find tree");
+        let sig = git2::Signature::now("Test User", "test@example.com")
+            .expect("failed to create signature");
+
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .expect("failed to create commit");
+    }
 
     #[test]
     fn stage_file_adds_to_index() {
@@ -27,5 +53,31 @@ mod tests {
 
         let index = repo.index().unwrap();
         assert!(index.get_path(Path::new("test.txt"), 0).is_some());
+    }
+
+    #[test]
+    fn stage_file_removes_deleted_file_from_index() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+        create_initial_commit(&repo, "deleted.txt", "goodbye\n");
+
+        fs::remove_file(temp_dir.path().join("deleted.txt")).expect("failed to delete file");
+
+        stage_file(&repo, Path::new("deleted.txt")).unwrap();
+
+        let reopened_repo = Repository::open(temp_dir.path()).expect("failed to reopen repo");
+        let index = reopened_repo.index().expect("failed to reopen index");
+        assert!(index.get_path(Path::new("deleted.txt"), 0).is_none());
+
+        let head_tree = reopened_repo
+            .head()
+            .expect("failed to find HEAD")
+            .peel_to_tree()
+            .expect("failed to find HEAD tree");
+        let diff = reopened_repo
+            .diff_tree_to_index(Some(&head_tree), Some(&index), None)
+            .expect("failed to diff HEAD against index");
+        let delta = diff.deltas().next().expect("expected staged deletion");
+        assert_eq!(delta.status(), git2::Delta::Deleted);
     }
 }


### PR DESCRIPTION
Update the existing `stage_file` primitive to distinguish a path that still exists in the repository worktree from a tracked path that has been removed. Continue using the current index add operation for present files, but remove an absent tracked path from the index before performing the existing index write so the deletion becomes staged. When a reviewed, tracked file has been removed from the working tree, `:stage` reaches the libgit2 staging adapter and fails because that adapter unconditionally asks the index to add the missing path. The Git CLI backend already handles this case through `git add -- <path>`, so the defect is specific to the default libgit2 backend.

A tracked and committed file is deleted from the worktree, then staged through the libgit2 primitive: the call succeeds and the file is absent from the index relative to `HEAD`, representing a staged deletion; An existing new or modified file is staged: the current add-to-index behavior continues to succeed and the path remains present in the index.

Fixes #638

AI was used for assistance.
