### PR TITLE
Print a review-exit summary line to stderr

### DIFF
--- a/skills/tuicr/SKILL.md
+++ b/skills/tuicr/SKILL.md
@@ -155,10 +155,17 @@ seconds and compare comment IDs with the previous result. Read immediately when
 the user says comments are ready. Stop polling once the user says the review is
 done or your tooling would block other work.
 
-If the result is empty, ask whether the user saved comments in the intended
-session or whether another active session should be selected. If the review may
-have continued while you were working, rerun `tuicr review comments` before
-claiming completion.
+An empty result does not by itself mean the review didn't happen. On exit,
+tuicr always prints a line like `tuicr-summary: reviewed 3/3 files, 0 comments
+added` to stderr (visible in the pane's scrollback), and `tuicr review list`
+reports the same `reviewed_count`/`file_count` for the session. If
+`reviewed_count` equals `file_count`, zero comments is a legitimate "nothing to
+flag" outcome — treat the review as complete, don't ask the user to confirm.
+Only ask whether the user saved comments in the intended session, or whether
+another active session should be selected, when `reviewed_count` is less than
+`file_count` (the user quit before reviewing everything) or you can't find a
+`tuicr-summary:` line at all. If the review may have continued while you were
+working, rerun `tuicr review comments` before claiming completion.
 
 ## Add Agent Comments
 
@@ -256,7 +263,8 @@ Herdr:
 | cmux wrapper printed no surface ref | Run `cmux list-panes` to find the pane, or ask the user to start `tuicr` themselves |
 | `tuicr` not installed | Tell the user to install tuicr |
 | Not a repository | Ask for the correct repo directory |
-| Comments are empty | Confirm the selected session or ask the user to save/add comments |
+| Comments are empty, but `reviewed_count` == `file_count` | Treat as a completed review with nothing to flag — don't ask |
+| Comments are empty and `reviewed_count` < `file_count` | Confirm the selected session or ask the user to save/add comments |
 
 ## When Not To Use
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -820,6 +820,15 @@ fn main() -> anyhow::Result<()> {
         eprintln!("Warning: failed to clear active review session marker: {e}");
     }
 
+    // Always report how the review ended, even with zero comments, so a
+    // human or agent watching the pane can tell "reviewed everything, had
+    // nothing to flag" apart from "quit without looking".
+    let reviewed = app.session.reviewed_count();
+    let total = app.session.files.len();
+    let comments = app.session.comment_count();
+    let comment_word = if comments == 1 { "comment" } else { "comments" };
+    eprintln!("tuicr-summary: reviewed {reviewed}/{total} files, {comments} {comment_word} added");
+
     // Print pending stdout output if --stdout was used
     if let Some(output) = app.pending_stdout_output {
         print!("{output}");

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -204,7 +204,11 @@ impl ReviewSession {
 
     pub fn comment_count(&self) -> usize {
         self.review_comments.len()
-            + self.files.values().map(|f| f.comment_count()).sum::<usize>()
+            + self
+                .files
+                .values()
+                .map(|f| f.comment_count())
+                .sum::<usize>()
     }
 
     pub fn clear_comments(&mut self, scope: ClearScope) -> (usize, usize) {

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -202,6 +202,11 @@ impl ReviewSession {
         !self.review_comments.is_empty() || self.files.values().any(|f| f.comment_count() > 0)
     }
 
+    pub fn comment_count(&self) -> usize {
+        self.review_comments.len()
+            + self.files.values().map(|f| f.comment_count()).sum::<usize>()
+    }
+
     pub fn clear_comments(&mut self, scope: ClearScope) -> (usize, usize) {
         let mut cleared = self.review_comments.len();
         let mut unreviewed = 0;
@@ -331,6 +336,33 @@ mod tests {
         let file = session.files.get(&path).unwrap();
         assert!(file.file_comments.is_empty());
         assert!(file.line_comments.is_empty());
+    }
+
+    #[test]
+    fn should_count_review_level_and_file_and_line_comments() {
+        let mut session = test_session();
+        assert_eq!(session.comment_count(), 0);
+
+        session.review_comments.push(Comment::new(
+            "note".to_string(),
+            CommentType::from_id("note"),
+            None,
+        ));
+
+        let path = PathBuf::from("src/main.rs");
+        session.add_file(path.clone(), FileStatus::Modified, SOME_HASH);
+        let file = session.get_file_mut(&path).unwrap();
+        file.add_file_comment(Comment::new(
+            "comment".to_string(),
+            CommentType::from_id("note"),
+            None,
+        ));
+        file.add_line_comment(
+            10,
+            Comment::new("line".to_string(), CommentType::from_id("note"), None),
+        );
+
+        assert_eq!(session.comment_count(), 3);
     }
 
     #[test]

--- a/src/persistence/manifest.rs
+++ b/src/persistence/manifest.rs
@@ -191,12 +191,7 @@ pub fn entry_from_session(
         None
     };
 
-    let comment_count = session.review_comments.len()
-        + session
-            .files
-            .values()
-            .map(|f| f.comment_count())
-            .sum::<usize>();
+    let comment_count = session.comment_count();
     let reviewed_count = session.reviewed_count();
     let file_count = session.files.len();
 


### PR DESCRIPTION
## Summary

An agent driving `tuicr` from a pane can't currently tell "reviewed
everything, had nothing to flag" apart from "quit without looking" — both
show up as an empty `tuicr review comments` result. This adds a
`ReviewSession::comment_count()` helper (deduping the count logic that
previously lived only in `persistence/manifest.rs`) and prints one line to
stderr whenever the TUI exits:

```
tuicr-summary: reviewed <reviewed>/<total> files, <n> comment(s) added
```

`skills/tuicr/SKILL.md` is updated so an agent checks `reviewed_count` against
`file_count` before treating a zero-comment result as inconclusive: equal
counts means "reviewed, nothing to flag" and should be accepted; a shortfall
still triggers the "confirm with the user" fallback.

## Sample output

Real output from a `tuicr -r <revset>` run reviewing this PR's own 4 changed
files, exited with `ZZ`:

```
$ tuicr -r upstream/main..print-review-summary
tuicr-session: joshgummersall/tuicr@print-review-summary/commits/5e793fe..29345a6
tuicr-summary: reviewed 4/4 files, 0 comments added
```

## Test plan
- [x] `cargo test` — 1581 passed, 4 ignored, 0 failed
- [x] `cargo build --release`, manually ran the built binary against this
      branch's own diff and confirmed the `tuicr-summary:` line above