### PR TITLE
Add q_quits config option

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -33,6 +33,7 @@ show_reviewed = true
 mouse = true
 leader = ","
 comment_vim = false
+q_quits = false
 comment_tab_width = 4
 wrap = false
 relative_line_numbers = false
@@ -88,6 +89,7 @@ legend = true
 | `mouse`                    | `true`       | Wheel scrolling, clicks, and drag-to-select.                                                                                                               |
 | `leader`                   | `;`          | Single-character prefix for panel focus, sidebar toggles, and review-comment shortcuts. Invalid multi-character values are ignored with a startup warning. |
 | `comment_vim`              | `false`      | Vim modal editing in the comment box; toggle at runtime with `:vim`. When off, default emacs/readline bindings.                                            |
+| `q_quits`                  | `false`      | Restore bare `q` as a quit key in review modes. `:q`, `ZZ`, and `ZQ` work regardless of this setting.                                                     |
 | `comment_tab_width`        | `4`          | Spaces inserted by Tab while typing in the vim comment box (Insert mode).                                                                                  |
 | `wrap`                     | `false`      | Line wrap in the diff view. Toggle with `:set wrap!`.                                                                                                      |
 | `relative_line_numbers`    | `false`      | Show gutter numbers as rendered-row distances from the cursor. Toggle with `:set relativenumber!`.                                                         |

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -226,8 +226,8 @@ In command mode,
 | `ZQ` | Quit without saving |
 | `?` | Toggle help |
 
-Pressing bare `q` no longer quits; it prints a reminder to use `:q` instead — a transitional
-affordance that will be removed in a future release.
+Pressing bare `q` no longer quits by default; it prints a reminder to use `:q` instead. Set
+`q_quits = true` to restore `q` as a quit key in review modes.
 
 The summary replaces the diff while leaving the file sidebar visible when it is open. The first
 pending comment is selected when the summary opens. Use `j`/`k` to select the next

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -509,6 +509,7 @@ impl App {
             comment_buffer: String::new(),
             comment_cursor: 0,
             comment_vim_enabled: false,
+            q_quits: false,
             comment_tab_width: 4,
             comment_vim_editor: None,
             comment_vim_command: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1150,6 +1150,8 @@ pub struct App {
     pub comment_cursor: usize,
     /// Config `comment_vim`: vim modal editing in the comment box.
     pub comment_vim_enabled: bool,
+    /// Config `q_quits`: restore bare `q` as a quit key in review modes.
+    pub q_quits: bool,
     /// Spaces inserted by Tab while typing in the vim comment box (config
     /// `comment_tab_width`, default 4).
     pub comment_tab_width: usize,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -136,6 +136,9 @@ pub struct AppConfig {
     /// Enable vim-style modal editing in the review comment text box. When
     /// unset/false the comment box uses the default emacs/readline bindings.
     pub comment_vim: Option<bool>,
+    /// Restore the legacy bare `q` quit binding in review modes.
+    /// Defaults to false.
+    pub q_quits: Option<bool>,
     /// Number of spaces inserted by Tab while typing in the vim comment box.
     /// Defaults to 4 (matching diff tab expansion).
     pub comment_tab_width: Option<usize>,
@@ -203,6 +206,7 @@ const KNOWN_KEYS: &[&str] = &[
     "search_highlight",
     "mouse",
     "comment_vim",
+    "q_quits",
     "comment_tab_width",
     "leader",
     "transparent_background",
@@ -443,6 +447,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
         search_highlight: read_bool(table, "search_highlight", &mut warnings),
         mouse: read_bool(table, "mouse", &mut warnings),
         comment_vim: read_bool(table, "comment_vim", &mut warnings),
+        q_quits: read_bool(table, "q_quits", &mut warnings),
         comment_tab_width: read_usize(table, "comment_tab_width", &mut warnings),
         leader: read_leader(table, &mut warnings),
         transparent_background: read_bool(table, "transparent_background", &mut warnings),
@@ -1348,6 +1353,35 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'mouse' must be a boolean; ignoring value"
+        );
+    }
+
+    // q_quits
+
+    #[test]
+    fn should_parse_q_quits_true() {
+        let outcome = parse_config("q_quits = true\n");
+        assert_eq!(
+            outcome.config.as_ref().and_then(|cfg| cfg.q_quits),
+            Some(true)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_default_q_quits_to_none() {
+        let outcome = parse_config("\n");
+        assert_eq!(outcome.config.as_ref().and_then(|cfg| cfg.q_quits), None);
+    }
+
+    #[test]
+    fn should_warn_and_ignore_q_quits_with_invalid_type() {
+        let outcome = parse_config("q_quits = \"yes\"\n");
+        assert_eq!(outcome.config.as_ref().and_then(|cfg| cfg.q_quits), None);
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'q_quits' must be a boolean; ignoring value"
         );
     }
 

--- a/src/input/keybindings.rs
+++ b/src/input/keybindings.rs
@@ -160,8 +160,17 @@ pub enum Action {
 }
 
 pub fn map_key_to_action(key: KeyEvent, mode: InputMode, leader_key: char) -> Action {
+    map_key_to_action_with_q_quits(key, mode, leader_key, false)
+}
+
+pub fn map_key_to_action_with_q_quits(
+    key: KeyEvent,
+    mode: InputMode,
+    leader_key: char,
+    q_quits: bool,
+) -> Action {
     match mode {
-        InputMode::Normal => map_normal_mode(key, leader_key),
+        InputMode::Normal => map_normal_mode_with_q_quits(key, leader_key, q_quits),
         InputMode::Command => map_command_mode(key),
         InputMode::Search => map_search_mode(key),
         InputMode::Comment => map_comment_mode(key),
@@ -172,15 +181,28 @@ pub fn map_key_to_action(key: KeyEvent, mode: InputMode, leader_key: char) -> Ac
         },
         InputMode::Summary => map_summary_mode(key),
         InputMode::Confirm => map_confirm_mode(key),
-        InputMode::CommitSelect => map_commit_select_mode(key),
-        InputMode::VisualSelect => map_visual_mode(key),
+        InputMode::CommitSelect => map_commit_select_mode_with_q_quits(key, q_quits),
+        InputMode::VisualSelect => map_visual_mode_with_q_quits(key, q_quits),
         InputMode::SubmitResolver => map_submit_resolver_mode(key),
         InputMode::SubmitConfirm => map_submit_confirm_mode(key),
-        InputMode::SubmitActionPicker => map_submit_action_picker_mode(key),
+        InputMode::SubmitActionPicker => map_submit_action_picker_mode_with_q_quits(key, q_quits),
     }
 }
 
+#[cfg(test)]
 fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
+    map_normal_mode_with_q_quits(key, leader_key, false)
+}
+
+fn q_action(q_quits: bool) -> Action {
+    if q_quits {
+        Action::Quit
+    } else {
+        Action::QuitHint
+    }
+}
+
+fn map_normal_mode_with_q_quits(key: KeyEvent, leader_key: char, q_quits: bool) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Char(key), KeyModifiers::NONE) if key == leader_key => {
             Action::PendingLeaderCommand
@@ -244,7 +266,7 @@ fn map_normal_mode(key: KeyEvent, leader_key: char) -> Action {
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ClearSearchHighlight,
 
         // Transitional hint: q used to quit; now it just points at :q.
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => q_action(q_quits),
 
         (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleExpand,
         (KeyCode::Char('o'), KeyModifiers::NONE) => Action::ExpandAll,
@@ -431,25 +453,35 @@ fn map_submit_confirm_mode(key: KeyEvent) -> Action {
     }
 }
 
+#[cfg(test)]
 fn map_submit_action_picker_mode(key: KeyEvent) -> Action {
+    map_submit_action_picker_mode_with_q_quits(key, false)
+}
+
+fn map_submit_action_picker_mode_with_q_quits(key: KeyEvent, q_quits: bool) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::SubmitPickerDown,
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::SubmitPickerUp,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::SubmitPickerConfirm,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => q_action(q_quits),
         _ => Action::None,
     }
 }
 
+#[cfg(test)]
 fn map_commit_select_mode(key: KeyEvent) -> Action {
+    map_commit_select_mode_with_q_quits(key, false)
+}
+
+fn map_commit_select_mode_with_q_quits(key: KeyEvent, q_quits: bool) -> Action {
     match (key.code, key.modifiers) {
         (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::CommitSelectDown,
         (KeyCode::Char('k') | KeyCode::Up, KeyModifiers::NONE) => Action::CommitSelectUp,
         (KeyCode::Char(' '), KeyModifiers::NONE) => Action::ToggleCommitSelect,
         (KeyCode::Enter, KeyModifiers::NONE) => Action::ConfirmCommitSelect,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => q_action(q_quits),
         (KeyCode::Char(':'), _) => Action::EnterCommandMode,
         (KeyCode::Tab, KeyModifiers::NONE) => Action::TargetSelectorTabNext,
         (KeyCode::BackTab, _) => Action::TargetSelectorTabPrev,
@@ -466,10 +498,14 @@ fn map_commit_select_mode(key: KeyEvent) -> Action {
 /// notable override — in the diff it edits the comment at the cursor, in the
 /// tree it opens the include filter.
 pub fn map_file_tree_mode(key: KeyEvent, leader_key: char) -> Action {
+    map_file_tree_mode_with_q_quits(key, leader_key, false)
+}
+
+pub fn map_file_tree_mode_with_q_quits(key: KeyEvent, leader_key: char, q_quits: bool) -> Action {
     // The leader key wins: `;e` (toggle file list) must not be swallowed by
     // the exclude-filter binding.
     if key.code == KeyCode::Char(leader_key) && key.modifiers == KeyModifiers::NONE {
-        return map_normal_mode(key, leader_key);
+        return map_normal_mode_with_q_quits(key, leader_key, q_quits);
     }
     match (key.code, key.modifiers) {
         (KeyCode::Char('i'), KeyModifiers::NONE) => Action::FileTreeFilterInclude,
@@ -477,7 +513,7 @@ pub fn map_file_tree_mode(key: KeyEvent, leader_key: char) -> Action {
         (KeyCode::Char('I'), _) => Action::FileTreeClearInclude,
         (KeyCode::Char('E'), _) => Action::FileTreeClearExclude,
         (KeyCode::Char('/'), _) => Action::FileTreeSearch,
-        _ => map_normal_mode(key, leader_key),
+        _ => map_normal_mode_with_q_quits(key, leader_key, q_quits),
     }
 }
 
@@ -513,7 +549,12 @@ pub fn map_target_filter_mode(key: KeyEvent) -> Action {
     }
 }
 
+#[cfg(test)]
 fn map_visual_mode(key: KeyEvent) -> Action {
+    map_visual_mode_with_q_quits(key, false)
+}
+
+fn map_visual_mode_with_q_quits(key: KeyEvent, q_quits: bool) -> Action {
     match (key.code, key.modifiers) {
         // Extend selection
         (KeyCode::Char('j') | KeyCode::Down, KeyModifiers::NONE) => Action::CursorDown(1),
@@ -523,7 +564,7 @@ fn map_visual_mode(key: KeyEvent) -> Action {
         (KeyCode::Char('y'), KeyModifiers::NONE) => Action::ExportToClipboard,
         (KeyCode::Esc, KeyModifiers::NONE) => Action::ExitMode,
         (KeyCode::Char('v') | KeyCode::Char('V'), _) => Action::ExitMode,
-        (KeyCode::Char('q'), KeyModifiers::NONE) => Action::QuitHint,
+        (KeyCode::Char('q'), KeyModifiers::NONE) => q_action(q_quits),
         _ => Action::None,
     }
 }
@@ -1040,5 +1081,29 @@ mod tests {
         // The overlays keep their own `q`, which closes them rather than tuicr.
         assert_eq!(map_help_mode(key(KeyCode::Char('q'))), Action::ToggleHelp);
         assert_eq!(map_summary_mode(key(KeyCode::Char('q'))), Action::ExitMode);
+    }
+
+    #[test]
+    fn should_map_q_to_quit_when_q_quits_is_enabled() {
+        assert_eq!(
+            map_normal_mode_with_q_quits(key(KeyCode::Char('q')), DEFAULT_LEADER_KEY, true),
+            Action::Quit
+        );
+        assert_eq!(
+            map_file_tree_mode_with_q_quits(key(KeyCode::Char('q')), DEFAULT_LEADER_KEY, true),
+            Action::Quit
+        );
+        assert_eq!(
+            map_visual_mode_with_q_quits(key(KeyCode::Char('q')), true),
+            Action::Quit
+        );
+        assert_eq!(
+            map_commit_select_mode_with_q_quits(key(KeyCode::Char('q')), true),
+            Action::Quit
+        );
+        assert_eq!(
+            map_submit_action_picker_mode_with_q_quits(key(KeyCode::Char('q')), true),
+            Action::Quit
+        );
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3,6 +3,6 @@ pub mod keybindings;
 pub mod mode;
 
 pub use keybindings::{
-    Action, map_file_tree_mode, map_file_tree_prompt_mode, map_key_to_action,
-    map_target_filter_mode,
+    Action, map_file_tree_mode, map_file_tree_mode_with_q_quits, map_file_tree_prompt_mode,
+    map_key_to_action, map_key_to_action_with_q_quits, map_target_filter_mode,
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ use tuicr::handler::{
     handle_submit_resolver_action, handle_summary_action, handle_visual_action,
 };
 use tuicr::input::{
-    Action, map_file_tree_mode, map_file_tree_prompt_mode, map_key_to_action,
-    map_target_filter_mode,
+    Action, map_file_tree_mode_with_q_quits, map_file_tree_prompt_mode,
+    map_key_to_action_with_q_quits, map_target_filter_mode,
 };
 use tuicr::terminal_state::{TerminalFeatures, TerminalSession};
 use tuicr::theme::resolve_theme_with_config;
@@ -234,6 +234,7 @@ fn main() -> anyhow::Result<()> {
                     app.leader_key = leader;
                 }
                 app.comment_vim_enabled = cfg.comment_vim.unwrap_or(false);
+                app.q_quits = cfg.q_quits.unwrap_or(false);
                 if let Some(w) = cfg.comment_tab_width {
                     app.comment_tab_width = w;
                 }
@@ -656,9 +657,14 @@ fn main() -> anyhow::Result<()> {
                     {
                         // The tree claims i/e/I/E and `/` for filtering; the
                         // diff keeps its own meanings for those keys.
-                        map_file_tree_mode(key, app.leader_key)
+                        map_file_tree_mode_with_q_quits(key, app.leader_key, app.q_quits)
                     } else {
-                        map_key_to_action(key, app.input_mode, app.leader_key)
+                        map_key_to_action_with_q_quits(
+                            key,
+                            app.input_mode,
+                            app.leader_key,
+                            app.q_quits,
+                        )
                     };
 
                     // Handle pending command setters (these work in any mode)


### PR DESCRIPTION
Fixes #686

## Summary
- add the `q_quits` config option, defaulting to the current hint behavior
- make bare `q` quit only when enabled in normal, visual, commit-select, submit-action-picker, and file-tree modes
- document the option and keybinding behavior

## Testing
- `cargo fmt -- --check`
- `git diff --check`
- `cargo test --no-run`
- `cargo test q_quits`
- `cargo test should_map_q_to_quit_hint_instead_of_quitting`
- `cargo build`
- `cargo test --quiet -- --skip should_discover_worktree_with_relativeworktrees_extension`
- manual TUI smoke test with `cargo run --quiet -- --no-update-check`

The full suite passed except that the libgit2 worktree test `should_discover_worktree_with_relativeworktrees_extension` hangs locally, so it was skipped in the final complete run.