### PR TITLE
fix(cli): include comment author in review output

### DIFF
--- a/docs/REVIEW_CLI.md
+++ b/docs/REVIEW_CLI.md
@@ -90,6 +90,8 @@ Target flags:
 - add `--line <n>` for a line comment
 - add `--end-line <n>` for a range comment
 - use `--side old|new` for inline comments
+- use `--username <name>` to identify the comment author; otherwise tuicr uses
+  the configured `username` or `"user"`
 
 ## JSON Input
 
@@ -116,6 +118,8 @@ Flat JSON fields:
 - `line`: line number for a line comment
 - `start_line` and `end_line`: range bounds
 - `side`: `old` or `new`, defaults to `new`
+- `username` or `author`: comment author; uses the same fallback as
+  `--username`
 
 Nested targets are also accepted:
 
@@ -191,9 +195,13 @@ PR slug:
     "end_line": 42,
     "side": "new",
     "comment_type": "issue",
+    "author": "alice",
     "lifecycle_state": "local_draft",
     "created_at": "2026-05-22T17:20:00Z",
     "content": "Handle the empty case here."
   }
 ]
 ```
+
+The `author` field is the username stored with the comment. It is present in
+the JSON emitted by both `review add` and `review comments`.

--- a/src/review_cli.rs
+++ b/src/review_cli.rs
@@ -1014,6 +1014,5 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(value["author"], "review-agent");
-        assert_eq!(value["author"], "review-agent");
     }
 }

--- a/src/review_cli.rs
+++ b/src/review_cli.rs
@@ -587,6 +587,7 @@ struct CommentOutput {
     end_line: Option<u32>,
     side: Option<&'static str>,
     comment_type: String,
+    author: String,
     lifecycle_state: &'static str,
     created_at: String,
     content: String,
@@ -636,6 +637,7 @@ impl CommentOutput {
             end_line,
             side: side_id(side),
             comment_type: comment.comment_type.id().to_string(),
+            author: comment.author.clone(),
             lifecycle_state: lifecycle_id(comment.lifecycle_state),
             created_at: comment.created_at.to_rfc3339(),
             content: comment.content.clone(),
@@ -883,7 +885,7 @@ mod tests {
                     },
                     content: "check this".to_string(),
                     comment_type: CommentType::from_id("issue"),
-                    author: crate::model::comment::DEFAULT_AUTHOR.to_string(),
+                    author: "review-agent".to_string(),
                     commit_id: None,
                 },
             )
@@ -895,11 +897,13 @@ mod tests {
         assert_eq!(comments[0].id, comment.id);
         assert_eq!(comments[0].location, "src/main.rs:42");
         assert_eq!(comments[0].comment_type, "issue");
+        assert_eq!(comments[0].author, "review-agent");
 
         show_comments(&session_ref.path().display().to_string(), &repo, &mut out).unwrap();
         let text = String::from_utf8(out).unwrap();
         let value: serde_json::Value = serde_json::from_str(&text).unwrap();
         assert_eq!(value[0]["comment_type"], "issue");
+        assert_eq!(value[0]["author"], "review-agent");
         assert_eq!(value[0]["location"], "src/main.rs:42");
         assert_eq!(value[0]["content"], "check this");
     }
@@ -990,5 +994,26 @@ mod tests {
 
         // then the warning is advisory only — the comment is still stored
         assert_eq!(comment.comment_type.id(), "isue");
+    }
+
+    #[test]
+    fn should_include_author_in_add_comment_output() {
+        let comment = Comment::new(
+            "check this".to_string(),
+            CommentType::from_id("issue"),
+            Some(LineSide::New),
+        )
+        .with_author("review-agent");
+        let value = serde_json::to_value(CommentOutput::from_target(
+            &CommentTarget::Line {
+                path: PathBuf::from("src/main.rs"),
+                line: 42,
+                side: LineSide::New,
+            },
+            &comment,
+        ))
+        .unwrap();
+        assert_eq!(value["author"], "review-agent");
+        assert_eq!(value["author"], "review-agent");
     }
 }


### PR DESCRIPTION
# fix(cli): include comment author in review output

## Summary

This PR includes each persisted comment's `author` in the JSON emitted by
`tuicr review add` and `tuicr review comments`. Callers can distinguish comment
authors after reading a session instead of retaining the IDs returned when each
comment was added.

Comments added through the CLI use a nonblank `--username` or JSON
`username`/`author`, then a nonblank configured `username`, then `"user"`.
Comments written in the TUI use the configured `username`, or `"user"` when it
is unset. Agents should pass an explicit username when attribution must
distinguish their comments from the user's.

Open PR #680 currently says `review comments` reports no author. This PR adds
that missing field, so the statement in #680 will need updating.
