### PR TITLE
fix(forge): return GitLab MR commits oldest-first

### DIFF
--- a/src/forge/gitlab/glab.rs
+++ b/src/forge/gitlab/glab.rs
@@ -429,6 +429,9 @@ where
                 break;
             }
         }
+        // GitLab lists MR commits newest-first; the trait contract is
+        // oldest-first.
+        commits.reverse();
         Ok(commits)
     }
 
@@ -1350,6 +1353,28 @@ mod tests {
             !calls[0].0.iter().any(|arg| arg == "--output"),
             "glab 1.36 does not support `mr view --output`"
         );
+    }
+
+    #[test]
+    fn should_return_commits_oldest_first() {
+        // given — GitLab lists MR commits newest-first
+        let repo = ForgeRepository::gitlab("gitlab.com", "owner", "repo");
+        let pr = make_pr_details(repo.clone());
+        let runner = RecordingRunner::new_with_responses(vec![
+            r#"[
+              {"id":"64ad53963568726a9ed23fd96b6d73203176775d","short_id":"64ad5396","title":"fixup!","author_name":"Radek","committed_date":"2026-08-27T13:49:53Z"},
+              {"id":"e52022cd3bb22302b9775c7281ad27bddcf04f03","short_id":"e52022cd","title":"Edit README.md","author_name":"Radek","committed_date":"2026-08-27T13:48:53Z"}
+            ]"#
+                .to_string(),
+        ]);
+        let backend = GitLabGlabBackend::with_runner(Some(repo), runner);
+
+        // when
+        let commits = backend.list_pull_request_commits(&pr).unwrap();
+
+        // then — the trait contract is chronological
+        let summaries: Vec<&str> = commits.iter().map(|c| c.summary.as_str()).collect();
+        assert_eq!(summaries, vec!["Edit README.md", "fixup!"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

GitLab MR commits now load oldest-first, matching what the inline commit selector expects.

GitLab's `merge_requests/:id/commits` endpoint returns newest-first while the other forge backends return oldest-first (the `ForgeBackend` contract — Bitbucket already reverses its newest-first rows in its backend). The GitLab backend passed the rows through, so every commit index was mirrored: selecting the first commit of the sample MR in #660 showed the second commit's diff instead. One `commits.reverse()` in the GitLab backend, same as the Bitbucket one.

This also fixes the commits order in the "Commits" section being reversed compared to `git log` — same root cause.

## Verification

- before, on current `main`: `cargo test forge::gitlab::glab::tests::should_return_commits_oldest_first` — failed, commits came back newest-first
- after: same command passes
- `cargo test` — all green
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- also checked live that `gitlab.com/api/v4/.../merge_requests/1/commits` returns newest-first rows (the reporter's sample MR) and GitHub's `pulls/:n/commits` returns oldest-first, so the other backends are unaffected

Fixes #660
