### PR TITLE
fix: scroll side-by-side diffs horizontally

### DIFF
--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -921,9 +921,9 @@ impl App {
 
     pub fn enter_comment_mode(&mut self, file_level: bool, line: Option<(u32, LineSide)>) {
         self.input_mode = InputMode::Comment;
-        // Snap horizontal scroll back to the left edge so the inline input
-        // box renders inside the viewport on long lines.
-        self.diff_state.scroll_x = 0;
+        if self.diff_view_mode != DiffViewMode::SideBySide {
+            self.diff_state.scroll_x = 0;
+        }
         self.comment_buffer.clear();
         self.comment_cursor = 0;
         self.comment_type = self.default_comment_type();

--- a/src/app/navigation.rs
+++ b/src/app/navigation.rs
@@ -286,10 +286,18 @@ impl App {
         if self.diff_state.wrap_lines {
             return;
         }
+        let viewport_width = if self.diff_view_mode == DiffViewMode::SideBySide {
+            self.diff_state
+                .viewport_width
+                .saturating_sub(crate::app::sbs_overhead(self.lineno_width()) as usize)
+                / 2
+        } else {
+            self.diff_state.viewport_width
+        };
         let max_scroll_x = self
             .diff_state
             .max_content_width
-            .saturating_sub(self.diff_state.viewport_width);
+            .saturating_sub(viewport_width);
         self.diff_state.scroll_x =
             (self.diff_state.scroll_x.saturating_add(cols)).min(max_scroll_x);
     }

--- a/src/app/tests/sbs_comment_side_tests.rs
+++ b/src/app/tests/sbs_comment_side_tests.rs
@@ -151,6 +151,36 @@ fn horizontal_keys_scroll_in_side_by_side_and_leave_side_unchanged() {
 }
 
 #[test]
+fn line_comment_preserves_horizontal_scroll() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.diff_state.scroll_x = 12;
+
+    app.enter_comment_mode(false, Some((20, LineSide::New)));
+
+    assert_eq!(app.diff_state.scroll_x, 12);
+}
+
+#[test]
+fn range_comment_preserves_horizontal_scroll() {
+    let mut app = build_app();
+    app.diff_view_mode = DiffViewMode::SideBySide;
+    app.diff_state.scroll_x = 12;
+    app.input_mode = InputMode::VisualSelect;
+    app.line_annotations = vec![sbs_line(Some(10), Some(20))];
+    app.visual_selection = Some(VisualSelection::collapsed(SelPoint {
+        annotation_idx: 0,
+        char_offset: 0,
+        side: LineSide::New,
+    }));
+
+    app.enter_comment_from_visual();
+
+    assert_eq!(app.diff_state.scroll_x, 12);
+    assert_eq!(app.input_mode, InputMode::Comment);
+}
+
+#[test]
 fn leader_walk_steps_through_the_side_by_side_panes() {
     let mut app = build_app();
     app.diff_view_mode = DiffViewMode::SideBySide;

--- a/src/app/visual.rs
+++ b/src/app/visual.rs
@@ -135,7 +135,9 @@ impl App {
             self.comment_line_range = Some((range, side));
             self.comment_line = Some((range.end, side));
             self.input_mode = InputMode::Comment;
-            self.diff_state.scroll_x = 0;
+            if self.diff_view_mode != DiffViewMode::SideBySide {
+                self.diff_state.scroll_x = 0;
+            }
             self.comment_buffer.clear();
             self.comment_cursor = 0;
             self.comment_type = self.default_comment_type();

--- a/src/ui/diff_side_by_side.rs
+++ b/src/ui/diff_side_by_side.rs
@@ -5,7 +5,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
-use unicode_width::UnicodeWidthStr;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{
     App, DiffSource, ExpandDirection, FocusedPanel, GAP_EXPAND_BATCH, GapId, InputMode,
@@ -14,10 +14,10 @@ use crate::model::{DiffLine, FileStatus, LineOrigin, LineRange, LineSide};
 use crate::theme::Theme;
 use crate::ui::comment_panel;
 use crate::ui::diff_view::{
-    apply_horizontal_scroll, comment_type_presentation, cursor_indicator, cursor_indicator_spaced,
-    diff_stat_title, hunk_header_text_and_style, paint_cursor_line_highlight,
-    paint_visual_selection_overlay, populate_row_to_annotation, render_expander_line,
-    render_hidden_lines, scroll_comment_input_into_view, skip_comment_box,
+    apply_horizontal_scroll, comment_box_row, comment_type_presentation, cursor_indicator,
+    cursor_indicator_spaced, diff_stat_title, hunk_header_text_and_style,
+    paint_cursor_line_highlight, paint_visual_selection_overlay, populate_row_to_annotation,
+    render_expander_line, render_hidden_lines, scroll_comment_input_into_view, skip_comment_box,
 };
 use crate::ui::styles;
 use crate::ui::text_utils::{
@@ -116,6 +116,59 @@ fn pad_spans_to_width(
         spans.push(Span::styled(" ".repeat(width - cur), pad_style));
     }
     spans
+}
+
+fn pan_spans(
+    spans: &[Span<'static>],
+    scroll_x: usize,
+    width: usize,
+    pad_style: Style,
+) -> Vec<Span<'static>> {
+    let mut skipped = 0;
+    let mut visible_width = 0;
+    let mut visible = Vec::new();
+    for span in spans {
+        let mut text = String::new();
+        for ch in span.content.chars() {
+            let ch_width = ch.width().unwrap_or(if ch == '\t' { 1 } else { 0 });
+            if skipped < scroll_x {
+                skipped += ch_width;
+            } else if visible_width + ch_width <= width {
+                text.push(ch);
+                visible_width += ch_width;
+            } else {
+                if !text.is_empty() {
+                    visible.push(Span::styled(text, span.style));
+                }
+                return pad_spans_to_width(visible, width, pad_style);
+            }
+        }
+        if !text.is_empty() {
+            visible.push(Span::styled(text, span.style));
+        }
+        if visible_width == width {
+            break;
+        }
+    }
+    pad_spans_to_width(visible, width, pad_style)
+}
+
+fn pan_sbs_row(meta: &SbsRowMeta, scroll_x: usize, content_width: usize) -> Line<'static> {
+    let mut spans = meta.left_prefix.clone();
+    spans.extend(pan_spans(
+        &meta.left_content,
+        scroll_x,
+        content_width,
+        meta.left_pad_style,
+    ));
+    spans.extend(meta.right_prefix.clone());
+    spans.extend(pan_spans(
+        &meta.right_content,
+        scroll_x,
+        content_width,
+        meta.right_pad_style,
+    ));
+    Line::from(spans)
 }
 
 struct SideSpec {
@@ -972,7 +1025,12 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         })
         .collect();
 
-    let max_content_width = line_widths.iter().copied().max().unwrap_or(0);
+    let max_content_width = sbs_meta
+        .values()
+        .flat_map(|meta| [&meta.left_content, &meta.right_content])
+        .map(|spans| spans.iter().map(|span| span.content.width()).sum::<usize>())
+        .max()
+        .unwrap_or(0);
 
     app.sync_viewport_width(inner.width as usize);
     app.diff_state.max_content_width = max_content_width;
@@ -1045,7 +1103,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         scroll_offset,
     );
 
-    let max_scroll_x = max_content_width.saturating_sub(viewport_width);
+    let max_scroll_x = max_content_width.saturating_sub(content_width);
     if app.diff_state.scroll_x > max_scroll_x {
         app.diff_state.scroll_x = max_scroll_x;
     }
@@ -1058,7 +1116,17 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         Some(out) => out,
         None => visible_lines_unscrolled
             .into_iter()
-            .map(|line| apply_horizontal_scroll(line, scroll_x))
+            .enumerate()
+            .map(|(i, line)| {
+                if scroll_x == 0 || comment_box_row(&line).is_some() {
+                    line
+                } else {
+                    sbs_meta
+                        .get(&(scroll_offset + i))
+                        .map(|meta| pan_sbs_row(meta, scroll_x, content_width))
+                        .unwrap_or_else(|| apply_horizontal_scroll(line, scroll_x))
+                }
+            })
             .collect(),
     };
 
@@ -1073,6 +1141,7 @@ pub(super) fn render_side_by_side_diff(frame: &mut Frame, app: &mut App, area: R
         scroll_offset: app.diff_state.scroll_offset,
         theme: &app.theme,
         comment_bars: &comment_bars,
+        fixed_gutters: true,
     };
 
     // Section-marker row tint (hunk headers + expand/hidden stubs).
@@ -2108,7 +2177,8 @@ mod remote_comments_side_by_side_snapshot_tests {
     };
     use crate::forge::traits::{ForgeRepository, PrSessionKey};
     use crate::model::{
-        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, ReviewSession, SessionDiffSource,
+        DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin, LineSide, ReviewSession,
+        SessionDiffSource,
     };
     use crate::syntax::SyntaxHighlighter;
     use crate::theme::Theme;
@@ -2520,6 +2590,60 @@ mod remote_comments_side_by_side_snapshot_tests {
             rows_with_l, 1,
             "wrap-off should produce exactly one row of L, got {rows_with_l}"
         );
+    }
+
+    #[test]
+    fn should_pan_both_columns_when_wrap_is_disabled() {
+        let mut app = make_pr_app();
+        app.diff_files = vec![diff_file_with_pair(
+            &format!("0000LEFT{}", "L".repeat(100)),
+            &format!("0000RIGHT{}", "R".repeat(100)),
+        )];
+        app.set_diff_wrap(false);
+        app.rebuild_annotations();
+
+        let _ = draw_sbs(&mut app, 80, 20);
+        app.scroll_right(4);
+        let buf = draw_sbs(&mut app, 80, 20);
+
+        assert_eq!(app.diff_state.scroll_x, 4);
+        let body = body_text(&buf);
+        assert!(body.contains("LEFT"), "left column did not pan:\n{body}");
+        assert!(body.contains("RIGHT"), "right column did not pan:\n{body}");
+        assert!(
+            !body.contains("0000LEFT"),
+            "left column stayed put:\n{body}"
+        );
+        assert!(
+            !body.contains("0000RIGHT"),
+            "right column stayed put:\n{body}"
+        );
+
+        let row = (0..buf.area.height)
+            .find(|&y| {
+                (0..buf.area.width)
+                    .map(|x| char_at(&buf, x, y))
+                    .collect::<String>()
+                    .contains("LEFT")
+            })
+            .expect("panned diff row");
+        let lw = app.lineno_width();
+        let content_width = (78 - crate::app::sbs_overhead(lw) as usize) / 2;
+        let left_start = 1 + crate::app::sbs_left_gutter(lw);
+        let divider = left_start + content_width as u16 + 1;
+        let right_start = left_start + content_width as u16 + lw as u16 + 5;
+        assert_eq!(char_at(&buf, left_start, row), "L");
+        assert_eq!(char_at(&buf, divider, row), "│");
+        assert_eq!(char_at(&buf, right_start, row), "R");
+
+        app.enter_comment_mode(false, Some((1, LineSide::New)));
+        app.comment_buffer = "COMMENT".to_string();
+        app.comment_cursor = app.comment_buffer.len();
+        let buf = draw_sbs(&mut app, 80, 20);
+        let (cursor_x, cursor_y) = app.comment_cursor_screen_pos.expect("comment cursor");
+        assert_eq!(app.diff_state.scroll_x, 4);
+        assert!(body_text(&buf).contains("COMMENT"));
+        assert_eq!(char_at(&buf, cursor_x - 1, cursor_y), "T");
     }
 
     #[test]

--- a/src/ui/diff_unified.rs
+++ b/src/ui/diff_unified.rs
@@ -1277,6 +1277,7 @@ pub(super) fn render_unified_diff(frame: &mut Frame, app: &mut App, area: Rect) 
         scroll_offset: app.diff_state.scroll_offset,
         theme: &app.theme,
         comment_bars: &comment_bars,
+        fixed_gutters: false,
     };
 
     // Section-marker row tint (hunk headers + expand/hidden stubs). Painted

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -776,6 +776,8 @@ pub(super) struct DiffOverlayPaint<'a> {
     pub scroll_offset: usize,
     pub theme: &'a Theme,
     pub comment_bars: &'a [CommentBarAnchor],
+    /// Side-by-side scrolls within each content cell, leaving its gutters fixed.
+    pub fixed_gutters: bool,
 }
 
 /// Records that an inline comment box at `box_top_row` (logical line index
@@ -917,10 +919,14 @@ pub(super) fn paint_comment_box_bar(frame: &mut Frame, ctx: &DiffOverlayPaint) {
     if ctx.inner.width == 0 || ctx.viewport_width == 0 || ctx.comment_bars.is_empty() {
         return;
     }
-    if ctx.scroll_x > 4 {
+    if !ctx.fixed_gutters && ctx.scroll_x > 4 {
         return;
     }
-    let bar_screen_col = ctx.inner.x + 5 - ctx.scroll_x as u16;
+    let bar_screen_col = if ctx.fixed_gutters {
+        ctx.inner.x + 5
+    } else {
+        ctx.inner.x + 5 - ctx.scroll_x as u16
+    };
     if bar_screen_col >= ctx.inner.x + ctx.inner.width {
         return;
     }


### PR DESCRIPTION
# Motivation

Side-by-side diff mode mapped `h` and `l` to horizontal scrolling, but each column truncated its content before calculating the offset. The view could not move when wrapping was off.

Closes #404 - i haven't been able to use side by side diff because of horizontal scrolling not working

# Summary of changes

- Calculate horizontal bounds per side-by-side content pane and pan both code columns while keeping gutters and the divider fixed.
- Keep the scroll position when opening line and range comments, with the editor fixed to the viewport.
- Add state and render-level regression tests for scrolling and comment entry.

# Testing

- Open a change with lines wider than each side-by-side column.
- Run `:diff`, then turn wrapping off with `:set wrap!`.
- Press `l` and `h`. Confirm that both code columns move while their gutters and center divider stay fixed.
- While scrolled right, open a line comment with `c`. Cancel it, select a range with visual mode, and open another comment. Confirm that both editors stay visible and the code remains scrolled.


https://github.com/user-attachments/assets/9a005593-85bf-4aee-b1d5-8938b4f44cb5



# Dependencies/Special Considerations

None.