### PR TITLE
feat(config): add include_untracked option for local diffs

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -26,6 +26,7 @@ theme_light = "gruvbox-light"
 
 diff_view = "side-by-side"
 ignore_whitespace = false
+include_untracked = true
 show_file_list = true
 show_pr_checks = false
 show_pr_comments = true
@@ -80,6 +81,7 @@ legend = true
 | `commit_order`             | `descending` | Inline commit selector order: `descending` (newest on top, the default) or `ascending` (oldest on top).                                                    |
 | `initial_commit_selection` | `all`        | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`.  |
 | `ignore_whitespace`        | `false`      | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged.                                                                              |
+| `include_untracked`        | `true`       | Include untracked files in local Git working-tree / unstaged diffs. Set `false` to review only tracked changes; scanning many untracked files can be slow, and turning this off skips that scan. |
 | `show_file_list`           | `true`       | Whether the file list panel is visible on startup. Toggle with `<leader>e`.                                                                                |
 | `show_pr_checks`           | `false`      | Whether PR CI checks are fetched and shown. Set to `true` to include GitHub check rollups.                                                           |
 | `show_pr_comments`         | `true`       | Whether PR conversation comments are fetched and shown. Set to `false` to skip PR comments.                                                         |

--- a/src/app/diff_load.rs
+++ b/src/app/diff_load.rs
@@ -1118,6 +1118,7 @@ impl App {
         let vcs = detect_vcs(
             vcs_open_options.git_backend_preference,
             vcs_open_options.diff_whitespace_mode,
+            vcs_open_options.include_untracked,
         )?;
         let root_path = &vcs.info().root_path;
         let fetch_source = Self::narrowed_fetch_source(

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -133,7 +133,11 @@ impl App {
         }
 
         let vcs = crate::profile::time("startup.detect_vcs", || {
-            detect_vcs(options.git_backend_preference, options.diff_whitespace_mode)
+            detect_vcs(
+                options.git_backend_preference,
+                options.diff_whitespace_mode,
+                options.include_untracked,
+            )
         })?;
         let vcs_info = vcs.info().clone();
         let highlighter =

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1733,6 +1733,7 @@ enum CommentLocation {
 struct VcsOpenOptions {
     git_backend_preference: GitBackendPreference,
     diff_whitespace_mode: DiffWhitespaceMode,
+    include_untracked: bool,
 }
 
 impl Default for VcsOpenOptions {
@@ -1742,6 +1743,7 @@ impl Default for VcsOpenOptions {
         Self {
             git_backend_preference: GitBackendPreference::Libgit2,
             diff_whitespace_mode: DiffWhitespaceMode::default(),
+            include_untracked: true,
         }
     }
 }
@@ -1760,6 +1762,8 @@ pub struct AppStartupOptions<'a> {
     pub show_pr_comments: bool,
     pub git_backend_preference: GitBackendPreference,
     pub diff_whitespace_mode: DiffWhitespaceMode,
+    /// Whether untracked files are included in working-tree / unstaged diffs.
+    pub include_untracked: bool,
     /// Which commits are selected when a multi-commit review first opens.
     pub commit_selection: CommitSelectionStart,
     /// Direct PR target (`tuicr pr <target>`). Mutually exclusive with the
@@ -1778,6 +1782,7 @@ impl AppStartupOptions<'_> {
         VcsOpenOptions {
             git_backend_preference: self.git_backend_preference,
             diff_whitespace_mode: self.diff_whitespace_mode,
+            include_untracked: self.include_untracked,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -127,6 +127,7 @@ pub struct AppConfig {
     /// walk-forward per-commit review).
     pub initial_commit_selection: Option<String>,
     pub ignore_whitespace: Option<bool>,
+    pub include_untracked: Option<bool>,
     pub wrap: Option<bool>,
     pub relative_line_numbers: Option<bool>,
     pub export_legend: Option<bool>,
@@ -196,6 +197,7 @@ const KNOWN_KEYS: &[&str] = &[
     "commit_order",
     "initial_commit_selection",
     "ignore_whitespace",
+    "include_untracked",
     "wrap",
     "relative_line_numbers",
     "export_legend",
@@ -437,6 +439,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             &mut warnings,
         ),
         ignore_whitespace: read_bool(table, "ignore_whitespace", &mut warnings),
+        include_untracked: read_bool(table, "include_untracked", &mut warnings),
         wrap: read_bool(table, "wrap", &mut warnings),
         export_legend: read_bool(table, "export_legend", &mut warnings),
         cursor_line: read_bool(table, "cursor_line", &mut warnings),
@@ -1185,6 +1188,51 @@ mod tests {
         assert_eq!(
             outcome.warnings[0],
             "Warning: Config key 'ignore_whitespace' must be a boolean; ignoring value"
+        );
+    }
+
+    // include_untracked
+
+    #[test]
+    fn should_parse_include_untracked_true() {
+        let outcome = parse_config("include_untracked = true\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.include_untracked),
+            Some(true)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_include_untracked_false() {
+        let outcome = parse_config("include_untracked = false\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.include_untracked),
+            Some(false)
+        );
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_warn_and_ignore_include_untracked_with_invalid_type() {
+        let outcome = parse_config("include_untracked = \"yes\"\n");
+        assert_eq!(
+            outcome
+                .config
+                .as_ref()
+                .and_then(|cfg| cfg.include_untracked),
+            None
+        );
+        assert_eq!(outcome.warnings.len(), 1);
+        assert_eq!(
+            outcome.warnings[0],
+            "Warning: Config key 'include_untracked' must be a boolean; ignoring value"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,12 @@ fn main() -> anyhow::Result<()> {
         DiffWhitespaceMode::Normal
     };
 
+    let include_untracked = config_outcome
+        .config
+        .as_ref()
+        .and_then(|cfg| cfg.include_untracked)
+        .unwrap_or(true);
+
     let commit_order = match config_outcome
         .config
         .as_ref()
@@ -214,6 +220,7 @@ fn main() -> anyhow::Result<()> {
                     .unwrap_or(true),
                 git_backend_preference,
                 diff_whitespace_mode,
+                include_untracked,
                 commit_selection,
                 pr_target: cli_args.pr_target.as_deref(),
                 repo_url_override: cli_args

--- a/src/vcs/git/cli.rs
+++ b/src/vcs/git/cli.rs
@@ -42,6 +42,7 @@ pub struct GitCliBackend {
     untracked_cache: bool,
     fsmonitor: bool,
     whitespace_mode: DiffWhitespaceMode,
+    include_untracked: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -53,7 +54,11 @@ enum GitContentSource<'a> {
 }
 
 impl GitCliBackend {
-    pub(super) fn discover_from(cwd: &Path, whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
+    pub(super) fn discover_from(
+        cwd: &Path,
+        whitespace_mode: DiffWhitespaceMode,
+        include_untracked: bool,
+    ) -> Result<Self> {
         let root_path =
             PathBuf::from(run_git_command(cwd, &["rev-parse", "--show-toplevel"])?.trim());
         let repo_mode = GitRepoMode::detect(&root_path)?;
@@ -81,6 +86,7 @@ impl GitCliBackend {
             untracked_cache,
             fsmonitor,
             whitespace_mode,
+            include_untracked,
         })
     }
 
@@ -206,7 +212,7 @@ impl VcsBackend for GitCliBackend {
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         self.get_cli_diff(
             strings(["diff", "--no-ext-diff", "--binary", "HEAD", "--"]),
-            true,
+            self.include_untracked,
             GitContentSource::Revision("HEAD"),
             GitContentSource::Workdir,
             highlighter,
@@ -232,7 +238,7 @@ impl VcsBackend for GitCliBackend {
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
         self.get_cli_diff(
             strings(["diff", "--no-ext-diff", "--binary", "--"]),
-            true,
+            self.include_untracked,
             GitContentSource::Index,
             GitContentSource::Workdir,
             highlighter,
@@ -241,20 +247,24 @@ impl VcsBackend for GitCliBackend {
 
     fn get_change_status(&self) -> Result<VcsChangeStatus> {
         if self.repo_mode == GitRepoMode::Standard {
-            return get_cli_change_status(&self.root_path);
+            if self.include_untracked {
+                return get_cli_change_status(&self.root_path);
+            }
+            return get_cli_change_status_tracked_only(&self.root_path);
         }
 
         // Keep sparse probes pathspec-scoped. Plain `git status` reports
         // out-of-cone untracked files and would show an empty Unstaged row.
         let staged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--cached", "--"])?;
         let tracked_unstaged = has_diff_changes(&self.root_path, &["diff", "--quiet", "--"])?;
-        let untracked_pathspecs = if tracked_unstaged {
+        let untracked_pathspecs = if tracked_unstaged || !self.include_untracked {
             Vec::new()
         } else {
             sparse_checkout_untracked_pathspecs(&self.root_path)?
         };
-        let unstaged =
-            tracked_unstaged || has_untracked_changes(&self.root_path, &untracked_pathspecs)?;
+        let unstaged = tracked_unstaged
+            || (self.include_untracked
+                && has_untracked_changes(&self.root_path, &untracked_pathspecs)?);
 
         Ok(VcsChangeStatus { staged, unstaged })
     }
@@ -268,8 +278,10 @@ impl VcsBackend for GitCliBackend {
             ChangeKind::Unstaged => {
                 let mut paths =
                     list_diff_paths(&self.root_path, &["diff", "--name-only", "-z", "--"])?;
-                let untracked_pathspecs = sparse_checkout_untracked_pathspecs(&self.root_path)?;
-                paths.extend(list_untracked_paths(&self.root_path, &untracked_pathspecs)?);
+                if self.include_untracked {
+                    let untracked_pathspecs = sparse_checkout_untracked_pathspecs(&self.root_path)?;
+                    paths.extend(list_untracked_paths(&self.root_path, &untracked_pathspecs)?);
+                }
                 Ok(paths)
             }
         }
@@ -470,6 +482,27 @@ fn get_cli_change_status(workdir: &Path) -> Result<VcsChangeStatus> {
     let output = Command::new("git")
         .current_dir(workdir)
         .args(["status", "--porcelain=v1", "-z", "--untracked-files=normal"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| TuicrError::VcsCommand(format!("Failed to run git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(TuicrError::VcsCommand(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
+
+    Ok(parse_porcelain_status(&output.stdout))
+}
+
+/// Same probe as [`get_cli_change_status`], but with untracked files excluded
+/// at the Git level so `include_untracked = false` never pays the untracked
+/// scan that can hang large working trees.
+fn get_cli_change_status_tracked_only(workdir: &Path) -> Result<VcsChangeStatus> {
+    let output = Command::new("git")
+        .current_dir(workdir)
+        .args(["status", "--porcelain=v1", "-z", "--untracked-files=no"])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
@@ -1362,7 +1395,7 @@ mod tests {
         git(workdir, &["sparse-checkout", "reapply", "--sparse-index"]);
         git(workdir, &["config", "advice.sparseIndexExpanded", "false"]);
 
-        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal, true)
             .expect("failed to discover backend");
         (temp_dir, backend, vec![first_id, second_id])
     }
@@ -1404,7 +1437,7 @@ mod tests {
         git(workdir, &["add", "staged.txt"]);
         write_file(workdir, "untracked.txt", "untracked\n");
 
-        let cli_backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+        let cli_backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal, true)
             .expect("failed to discover cli backend");
         let repo = git2::Repository::open(workdir).expect("failed to open git2 repo");
         (temp_dir, cli_backend, repo, vec![first_id, second_id])
@@ -1452,7 +1485,7 @@ mod tests {
             .trim()
             .to_string();
 
-        let cli_backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+        let cli_backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal, true)
             .expect("failed to discover cli backend");
         let repo = git2::Repository::open(workdir).expect("failed to open git2 repo");
         (temp_dir, cli_backend, repo, left_id, right_id)
@@ -1589,7 +1622,7 @@ mod tests {
         );
         fs::write(&binary_path, [0, 1, 9, 3]).unwrap();
 
-        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal, true)
             .expect("failed to discover CLI backend");
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())
@@ -1662,7 +1695,7 @@ mod tests {
         git(workdir, &["init"]);
         git(workdir, &["config", "status.showUntrackedFiles", "no"]);
         write_file(workdir, "untracked.txt", "untracked\n");
-        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal)
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::Normal, true)
             .expect("failed to discover cli backend");
 
         let status = backend
@@ -1716,7 +1749,7 @@ mod tests {
         assert_eq!(
             summarize_files(cli_backend.get_working_tree_diff(&highlighter).unwrap()),
             summarize_files(
-                diff::get_working_tree_diff(&repo, DiffWhitespaceMode::Normal, &highlighter)
+                diff::get_working_tree_diff(&repo, DiffWhitespaceMode::Normal, true, &highlighter)
                     .unwrap()
             )
         );
@@ -1729,7 +1762,8 @@ mod tests {
         assert_eq!(
             summarize_files(cli_backend.get_unstaged_diff(&highlighter).unwrap()),
             summarize_files(
-                diff::get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter).unwrap()
+                diff::get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, true, &highlighter)
+                    .unwrap()
             )
         );
         assert_eq!(
@@ -1878,7 +1912,7 @@ mod tests {
         git(workdir, &["add", "."]);
         git(workdir, &["commit", "-m", "initial"]);
 
-        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::IgnoreAll)
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::IgnoreAll, true)
             .expect("failed to discover cli backend");
 
         write_file(workdir, "file.txt", " alpha \n beta\n");
@@ -1912,7 +1946,7 @@ mod tests {
         write_file(workdir, "whitespace.txt", " alpha \n beta\n");
         write_file(workdir, substantive_path, "after\n");
 
-        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::IgnoreAll)
+        let backend = GitCliBackend::discover_from(workdir, DiffWhitespaceMode::IgnoreAll, true)
             .expect("failed to discover cli backend");
         let files = backend
             .get_working_tree_diff(&SyntaxHighlighter::default())

--- a/src/vcs/git/diff.rs
+++ b/src/vcs/git/diff.rs
@@ -12,6 +12,7 @@ use crate::vcs::{enhance_with_full_file_highlight, tabify};
 pub fn get_working_tree_diff(
     repo: &Repository,
     whitespace_mode: DiffWhitespaceMode,
+    include_untracked: bool,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     // Unborn HEAD (fresh `git init` / `git clone` of an empty remote) has no
@@ -20,9 +21,11 @@ pub fn get_working_tree_diff(
     let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
 
     let mut opts = diff_options(whitespace_mode);
-    opts.include_untracked(true);
-    opts.show_untracked_content(true);
-    opts.recurse_untracked_dirs(true);
+    if include_untracked {
+        opts.include_untracked(true);
+        opts.show_untracked_content(true);
+        opts.recurse_untracked_dirs(true);
+    }
 
     let diff = repo.diff_tree_to_workdir_with_index(head.as_ref(), Some(&mut opts))?;
     let mut files = parse_diff(&diff, highlighter)?;
@@ -68,7 +71,11 @@ pub fn get_staged_diff(
 /// materializing hunks or running the syntax highlighter. Lets callers verify
 /// `get_change_status` against ignore rules cheaply — full diff parsing only
 /// happens once the user actually selects the staged/unstaged view.
-pub fn list_changed_paths(repo: &Repository, kind: ChangeKind) -> Result<Vec<PathBuf>> {
+pub fn list_changed_paths(
+    repo: &Repository,
+    kind: ChangeKind,
+    include_untracked: bool,
+) -> Result<Vec<PathBuf>> {
     let diff = match kind {
         ChangeKind::Staged => {
             let head = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
@@ -79,11 +86,13 @@ pub fn list_changed_paths(repo: &Repository, kind: ChangeKind) -> Result<Vec<Pat
         ChangeKind::Unstaged => {
             let index = repo.index()?;
             let mut opts = diff_options(DiffWhitespaceMode::Normal);
-            opts.include_untracked(true);
-            // `show_untracked_content(false)` keeps libgit2 from reading each
-            // untracked file's bytes — only the paths are needed here.
-            opts.show_untracked_content(false);
-            opts.recurse_untracked_dirs(true);
+            if include_untracked {
+                opts.include_untracked(true);
+                // `show_untracked_content(false)` keeps libgit2 from reading each
+                // untracked file's bytes — only the paths are needed here.
+                opts.show_untracked_content(false);
+                opts.recurse_untracked_dirs(true);
+            }
             opts.skip_binary_check(true);
             repo.diff_index_to_workdir(Some(&index), Some(&mut opts))?
         }
@@ -106,13 +115,16 @@ pub fn list_changed_paths(repo: &Repository, kind: ChangeKind) -> Result<Vec<Pat
 pub fn get_unstaged_diff(
     repo: &Repository,
     whitespace_mode: DiffWhitespaceMode,
+    include_untracked: bool,
     highlighter: &SyntaxHighlighter,
 ) -> Result<Vec<DiffFile>> {
     let index = repo.index()?;
     let mut opts = diff_options(whitespace_mode);
-    opts.include_untracked(true);
-    opts.show_untracked_content(true);
-    opts.recurse_untracked_dirs(true);
+    if include_untracked {
+        opts.include_untracked(true);
+        opts.show_untracked_content(true);
+        opts.recurse_untracked_dirs(true);
+    }
 
     let diff = repo.diff_index_to_workdir(Some(&index), Some(&mut opts))?;
     let mut files = parse_diff(&diff, highlighter)?;
@@ -472,6 +484,7 @@ mod tests {
         let files = get_working_tree_diff(
             &repo,
             DiffWhitespaceMode::Normal,
+            true,
             &SyntaxHighlighter::default(),
         )
         .expect("failed to get diff");
@@ -500,6 +513,7 @@ mod tests {
         let files = get_working_tree_diff(
             &repo,
             DiffWhitespaceMode::Normal,
+            true,
             &SyntaxHighlighter::default(),
         )
         .expect("failed to get diff");
@@ -537,7 +551,7 @@ mod tests {
 
         let highlighter = SyntaxHighlighter::default();
 
-        let unstaged = get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter)
+        let unstaged = get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, true, &highlighter)
             .expect("unstaged diff failed");
         assert_eq!(unstaged.len(), 1);
         assert!(matches!(
@@ -555,9 +569,76 @@ mod tests {
             .expect("staged diff failed");
         assert_eq!(staged.len(), 1);
         assert!(matches!(
-            get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, &highlighter),
+            get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, true, &highlighter),
             Err(TuicrError::NoChanges)
         ));
+    }
+
+    #[test]
+    fn should_exclude_untracked_files_from_unstaged_diff_when_disabled() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit(&repo, "file.txt", "base\n");
+        fs::write(temp_dir.path().join("file.txt"), "changed\n")
+            .expect("failed to update tracked file");
+        fs::write(temp_dir.path().join("untracked.txt"), "new\n")
+            .expect("failed to write untracked file");
+
+        let highlighter = SyntaxHighlighter::default();
+
+        // Untracked files are excluded when include_untracked is false; the
+        // tracked modification still surfaces.
+        let unstaged = get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, false, &highlighter)
+            .expect("unstaged diff failed");
+        assert_eq!(unstaged.len(), 1);
+        assert_eq!(unstaged[0].display_path(), Path::new("file.txt"));
+
+        // The default keeps surfacing untracked files as additions.
+        let unstaged = get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, true, &highlighter)
+            .expect("unstaged diff failed");
+        assert_eq!(unstaged.len(), 2);
+    }
+
+    #[test]
+    fn should_report_no_changes_for_untracked_only_repo_when_untracked_disabled() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit(&repo, "file.txt", "base\n");
+        fs::write(temp_dir.path().join("untracked.txt"), "new\n")
+            .expect("failed to write untracked file");
+
+        let highlighter = SyntaxHighlighter::default();
+
+        assert!(matches!(
+            get_unstaged_diff(&repo, DiffWhitespaceMode::Normal, false, &highlighter),
+            Err(TuicrError::NoChanges)
+        ));
+        assert!(matches!(
+            get_working_tree_diff(&repo, DiffWhitespaceMode::Normal, false, &highlighter),
+            Err(TuicrError::NoChanges)
+        ));
+    }
+
+    #[test]
+    fn should_list_changed_paths_without_untracked_when_disabled() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let repo = Repository::init(temp_dir.path()).expect("failed to init repo");
+
+        create_initial_commit(&repo, "file.txt", "base\n");
+        fs::write(temp_dir.path().join("file.txt"), "changed\n")
+            .expect("failed to update tracked file");
+        fs::write(temp_dir.path().join("untracked.txt"), "new\n")
+            .expect("failed to write untracked file");
+
+        let paths = list_changed_paths(&repo, ChangeKind::Unstaged, false)
+            .expect("failed to list changed paths");
+        assert_eq!(paths, vec![PathBuf::from("file.txt")]);
+
+        let paths = list_changed_paths(&repo, ChangeKind::Unstaged, true)
+            .expect("failed to list changed paths");
+        assert_eq!(paths.len(), 2);
     }
 
     #[test]
@@ -575,6 +656,7 @@ mod tests {
         let files = get_working_tree_diff(
             &repo,
             DiffWhitespaceMode::Normal,
+            true,
             &SyntaxHighlighter::default(),
         )
         .expect("unborn HEAD should produce a diff against an empty tree");
@@ -598,6 +680,7 @@ mod tests {
         let files = get_working_tree_diff(
             &repo,
             DiffWhitespaceMode::IgnoreAll,
+            true,
             &SyntaxHighlighter::default(),
         )
         .expect("whitespace-only edit may surface as a no-op diff file");
@@ -610,6 +693,7 @@ mod tests {
         let files = get_working_tree_diff(
             &repo,
             DiffWhitespaceMode::IgnoreAll,
+            true,
             &SyntaxHighlighter::default(),
         )
         .expect("non-whitespace edit should still produce a diff");
@@ -635,6 +719,7 @@ mod tests {
         let files = get_working_tree_diff(
             &repo,
             DiffWhitespaceMode::IgnoreAll,
+            true,
             &SyntaxHighlighter::default(),
         )
         .expect("mode-only edit should still produce a diff");
@@ -763,14 +848,14 @@ mod tests {
             (
                 "libgit2",
                 Box::new(
-                    Libgit2Backend::discover_from(repo.path(), DiffWhitespaceMode::Normal)
+                    Libgit2Backend::discover_from(repo.path(), DiffWhitespaceMode::Normal, true)
                         .expect("failed to open libgit2 backend"),
                 ),
             ),
             (
                 "git cli",
                 Box::new(
-                    GitCliBackend::discover_from(repo.path(), DiffWhitespaceMode::Normal)
+                    GitCliBackend::discover_from(repo.path(), DiffWhitespaceMode::Normal, true)
                         .expect("failed to open git cli backend"),
                 ),
             ),

--- a/src/vcs/git/libgit2.rs
+++ b/src/vcs/git/libgit2.rs
@@ -16,6 +16,7 @@ pub struct Libgit2Backend {
     repo: Repository,
     info: VcsInfo,
     whitespace_mode: DiffWhitespaceMode,
+    include_untracked: bool,
 }
 
 /// Declare libgit2 extensions tuicr understands so discovery doesn't refuse
@@ -38,7 +39,11 @@ fn register_supported_extensions() {
 }
 
 impl Libgit2Backend {
-    pub(super) fn discover_from(cwd: &Path, whitespace_mode: DiffWhitespaceMode) -> Result<Self> {
+    pub(super) fn discover_from(
+        cwd: &Path,
+        whitespace_mode: DiffWhitespaceMode,
+        include_untracked: bool,
+    ) -> Result<Self> {
         register_supported_extensions();
         let repo = Repository::discover(cwd).map_err(|_| TuicrError::NotARepository)?;
 
@@ -86,6 +91,7 @@ impl Libgit2Backend {
             repo,
             info,
             whitespace_mode,
+            include_untracked,
         })
     }
 }
@@ -100,7 +106,12 @@ impl VcsBackend for Libgit2Backend {
     }
 
     fn get_working_tree_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        diff::get_working_tree_diff(&self.repo, self.whitespace_mode, highlighter)
+        diff::get_working_tree_diff(
+            &self.repo,
+            self.whitespace_mode,
+            self.include_untracked,
+            highlighter,
+        )
     }
 
     fn get_staged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
@@ -108,11 +119,16 @@ impl VcsBackend for Libgit2Backend {
     }
 
     fn get_unstaged_diff(&self, highlighter: &SyntaxHighlighter) -> Result<Vec<DiffFile>> {
-        diff::get_unstaged_diff(&self.repo, self.whitespace_mode, highlighter)
+        diff::get_unstaged_diff(
+            &self.repo,
+            self.whitespace_mode,
+            self.include_untracked,
+            highlighter,
+        )
     }
 
     fn list_changed_paths(&self, kind: ChangeKind) -> Result<Vec<PathBuf>> {
-        diff::list_changed_paths(&self.repo, kind)
+        diff::list_changed_paths(&self.repo, kind, self.include_untracked)
     }
 
     fn fetch_context_lines(
@@ -285,7 +301,7 @@ mod tests {
         );
 
         // when
-        let backend = Libgit2Backend::discover_from(&worktree, DiffWhitespaceMode::Normal)
+        let backend = Libgit2Backend::discover_from(&worktree, DiffWhitespaceMode::Normal, true)
             .expect("worktree with relativeworktrees extension should open");
 
         // then

--- a/src/vcs/git/mod.rs
+++ b/src/vcs/git/mod.rs
@@ -155,15 +155,17 @@ impl GitBackend {
     pub fn discover(
         preference: GitBackendPreference,
         whitespace_mode: DiffWhitespaceMode,
+        include_untracked: bool,
     ) -> Result<Self> {
         let cwd = std::env::current_dir().map_err(|_| TuicrError::NotARepository)?;
-        Self::discover_from(&cwd, preference, whitespace_mode)
+        Self::discover_from(&cwd, preference, whitespace_mode, include_untracked)
     }
 
     fn discover_from(
         cwd: &Path,
         preference: GitBackendPreference,
         whitespace_mode: DiffWhitespaceMode,
+        include_untracked: bool,
     ) -> Result<Self> {
         // libgit2 doesn't support reftable or split index repositories, so we fallback to cli
         // TODO: remove reftable fallback logic when libgit2 supports it as part of https://github.com/libgit2/libgit2/issues/5352
@@ -175,15 +177,21 @@ impl GitBackend {
             return Ok(Self::Cli(GitCliBackend::discover_from(
                 cwd,
                 whitespace_mode,
+                include_untracked,
             )?));
         }
 
-        let backend = Self::Libgit2(Libgit2Backend::discover_from(cwd, whitespace_mode)?);
+        let backend = Self::Libgit2(Libgit2Backend::discover_from(
+            cwd,
+            whitespace_mode,
+            include_untracked,
+        )?);
         let repo_mode = GitRepoMode::detect(&backend.info().root_path)?;
         if repo_mode.is_sparse_checkout() && !backend.supports_sparse_checkout() {
             return Ok(Self::Cli(GitCliBackend::discover_from(
                 cwd,
                 whitespace_mode,
+                include_untracked,
             )?));
         }
 
@@ -448,6 +456,7 @@ mod tests {
             root,
             GitBackendPreference::Libgit2,
             DiffWhitespaceMode::Normal,
+            true,
         )
         .expect("failed to discover backend");
 
@@ -473,6 +482,7 @@ mod tests {
             root,
             GitBackendPreference::Libgit2,
             DiffWhitespaceMode::Normal,
+            true,
         )
         .expect("failed to discover backend");
 
@@ -496,6 +506,7 @@ mod tests {
             root,
             GitBackendPreference::Libgit2,
             DiffWhitespaceMode::Normal,
+            true,
         )
         .expect("reftable repo should open via CLI fallback");
 
@@ -517,6 +528,7 @@ mod tests {
             root,
             GitBackendPreference::Libgit2,
             DiffWhitespaceMode::Normal,
+            true,
         )
         .expect("split-index repo should open via CLI fallback");
 

--- a/src/vcs/mod.rs
+++ b/src/vcs/mod.rs
@@ -328,6 +328,7 @@ fn apply_full_file_spans(
 pub fn detect_vcs(
     git_backend_preference: GitBackendPreference,
     whitespace_mode: DiffWhitespaceMode,
+    include_untracked: bool,
 ) -> Result<Box<dyn VcsBackend>> {
     // Try jj first since jj repos are Git-backed
     if let Ok(backend) = JjBackend::discover(whitespace_mode) {
@@ -335,7 +336,9 @@ pub fn detect_vcs(
     }
 
     // Try git
-    if let Ok(backend) = GitBackend::discover(git_backend_preference, whitespace_mode) {
+    if let Ok(backend) =
+        GitBackend::discover(git_backend_preference, whitespace_mode, include_untracked)
+    {
         return Ok(Box::new(backend));
     }
 
@@ -356,7 +359,7 @@ mod tests {
     #[test]
     fn exports_are_accessible() {
         // Verify that public types are properly exported
-        let _: fn(GitBackendPreference, DiffWhitespaceMode) -> Result<Box<dyn VcsBackend>> =
+        let _: fn(GitBackendPreference, DiffWhitespaceMode, bool) -> Result<Box<dyn VcsBackend>> =
             detect_vcs;
 
         // VcsInfo can be constructed
@@ -387,7 +390,11 @@ mod tests {
         // Note: This test may pass or fail depending on where tests are run
         // In CI or outside a repo, it should fail with NotARepository
         // Inside the tuicr repo (which is git), it will succeed
-        let result = detect_vcs(GitBackendPreference::Libgit2, DiffWhitespaceMode::Normal);
+        let result = detect_vcs(
+            GitBackendPreference::Libgit2,
+            DiffWhitespaceMode::Normal,
+            true,
+        );
 
         // We just verify the function runs without panic
         // The actual result depends on the environment


### PR DESCRIPTION
## Summary

I added `include_untracked`, a Git local-diff config option that defaults to `true` and keeps the current behavior.

When it is `false`, working-tree and unstaged diffs, including the selector's status probes, skip untracked files in both the libgit2 and CLI backends. Jujutsu and Mercurial are unchanged.

Fixes #431

## Why

Large working trees with many untracked files can make the local Git scan slow. Users who only want tracked changes can now opt out of that scan without changing the default workflow of reviewing files before they are tracked.

## Verification

- `cargo test` (1586 passed, 0 failed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- the regression cases fail with the old hardcoded inclusion and pass with the option wired through: disabled mode keeps tracked modifications, hides untracked-only changes from the selector, and the default still shows untracked additions
