### PR TITLE
feat: add opt-in compact folders to the file tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - GitHub-style continuous diff in the terminal. Scroll through every changed file in one stream.
 - PR-style comments at the line, range, file, and review level. 
 - Review tracking at file or hunk granularity, persisted across sessions.
+- Optional [compact folders](./docs/CONFIG.md#compact-folders) for deeply nested file trees.
 - Three export targets: push a real review to GitHub, GitLab, or Bitbucket, copy structured
   markdown to your clipboard, or pipe to stdout.
 - Works with git, jj, and mercurial. Reviews uncommitted changes, commit ranges, or any GitHub PR,

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,6 +27,7 @@ theme_light = "gruvbox-light"
 diff_view = "side-by-side"
 ignore_whitespace = false
 show_file_list = true
+compact_folders = false
 show_pr_checks = false
 show_pr_comments = true
 show_reviewed = true
@@ -82,6 +83,7 @@ legend = true
 | `initial_commit_selection` | `all`        | Which commits are selected when a multi-commit review first opens: `all`, or `oldest` to start on just the oldest commit and walk forward with `(` / `)`.  |
 | `ignore_whitespace`        | `false`      | Ignore all whitespace in local Git, jj, and hg diffs. PR diffs are unchanged.                                                                              |
 | `show_file_list`           | `true`       | Whether the file list panel is visible on startup. Toggle with `<leader>e`.                                                                                |
+| `compact_folders` | `false` | Join single-child directory chains into one file-tree row. Restart tuicr after changing this setting. |
 | `show_pr_checks`           | `false`      | Whether PR CI checks are fetched and shown. Set to `true` to include GitHub check rollups.                                                           |
 | `show_pr_comments`         | `true`       | Whether PR conversation comments are fetched and shown. Set to `false` to skip PR comments.                                                         |
 | `show_commits`             | `true`       | Whether the inline commit selector pane is visible on startup for multi-commit reviews. Toggle with `<leader>s` or `:set commits!`.                        |
@@ -309,3 +311,16 @@ dist/
 *.lock
 !Cargo.lock
 ```
+
+## Compact folders
+
+Set `compact_folders = true` to reduce nesting in the file tree. For example,
+`app/src/main/kotlin/Editor.kt` appears as one `app/src/main/kotlin/` directory
+row with `Editor.kt` one level below it.
+
+A chain stops at a directory containing a review file directly or more than one
+child directory. Chains follow the active file filters, so hiding a sibling can
+join more directories. Opening or closing a joined row affects the whole chain;
+expand-all, collapse-all, and full-path search continue to work. Long labels use
+the existing horizontal scrolling. The default is `false`; there is no runtime
+toggle.

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -568,6 +568,7 @@ impl App {
             pending_confirm: None,
             supports_keyboard_enhancement: false,
             show_file_list: true,
+            compact_folders: false,
             is_pristine_mode: false,
             is_single_file_view: false,
             revealed_reviewed_file: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -138,6 +138,7 @@ fn profile_unit_result(result: &Result<()>) -> String {
 pub enum FileTreeItem {
     Directory {
         path: String,
+        label: String,
         depth: usize,
         expanded: bool,
     },
@@ -1295,6 +1296,7 @@ pub struct App {
     pub pending_confirm: Option<ConfirmAction>,
     pub supports_keyboard_enhancement: bool,
     pub show_file_list: bool,
+    pub compact_folders: bool,
     /// `true` when the session was opened via `--all-files`. Drives the
     /// `PRISTINE · N files` chip in the status bar and prevents that chip
     /// from showing in the regular `--file <dir>` directory mode.

--- a/src/app/tests/tree_tests.rs
+++ b/src/app/tests/tree_tests.rs
@@ -78,6 +78,11 @@ impl TreeTestHarness {
                     let expanded = self.expanded_dirs.contains(dir);
                     items.push(FileTreeItem::Directory {
                         path: dir.clone(),
+                        label: Path::new(dir)
+                            .file_name()
+                            .unwrap()
+                            .to_string_lossy()
+                            .into_owned(),
                         depth,
                         expanded,
                     });
@@ -292,5 +297,106 @@ fn test_interleaved_paths_stay_under_own_directory() {
             ("ChronoStream.BuildTests/".to_string(), 0),
             ("ChronoStream.BuildTests/test.cs".to_string(), 1),
         ]
+    );
+}
+
+#[test]
+fn compact_folders_join_deep_chains_and_toggle_as_one_row() {
+    let mut app = app_with(&["app/src/main/kotlin/Editor.kt"]);
+    app.compact_folders = true;
+    app.expand_all_dirs();
+    assert_eq!(
+        rendered_tree(&app),
+        vec![
+            ("app/src/main/kotlin/".into(), 0),
+            ("app/src/main/kotlin/Editor.kt".into(), 1),
+        ]
+    );
+    app.collapse_all_dirs();
+    assert_eq!(app.build_visible_items().len(), 1);
+    app.toggle_directory("app/src/main/kotlin");
+    assert_eq!(app.build_visible_items().len(), 2);
+    app.toggle_directory("app/src/main/kotlin");
+    assert_eq!(app.build_visible_items().len(), 1);
+    assert_eq!(app.file_list_state.selected(), 0);
+}
+
+#[test]
+fn compact_folders_stop_at_files_and_branches() {
+    let mut app = app_with(&[
+        "README.md",
+        "a/b/direct.kt",
+        "a/b/c/d/one.kt",
+        "a/b/e/two.kt",
+    ]);
+    app.compact_folders = true;
+    assert_eq!(
+        rendered_tree(&app),
+        vec![
+            ("README.md".into(), 0),
+            ("a/b/".into(), 0),
+            ("a/b/direct.kt".into(), 1),
+            ("a/b/c/d/".into(), 1),
+            ("a/b/c/d/one.kt".into(), 2),
+            ("a/b/e/".into(), 1),
+            ("a/b/e/two.kt".into(), 2),
+        ]
+    );
+    app.collapse_all_dirs();
+    assert_eq!(
+        rendered_tree(&app),
+        vec![("README.md".into(), 0), ("a/b/".into(), 0)]
+    );
+    app.expand_all_dirs();
+    assert_eq!(app.build_visible_items().len(), 7);
+}
+
+#[test]
+fn compact_folders_recompute_after_filter_and_search_reveals_full_path() {
+    let mut app = app_with(&["a/b/c/one.kt", "a/b/d/two.kt"]);
+    app.compact_folders = true;
+    assert_eq!(app.build_visible_items().len(), 5);
+    app.begin_file_tree_prompt(FileTreePrompt::Include);
+    for ch in "one".chars() {
+        app.file_tree_prompt_insert_char(ch);
+    }
+    app.commit_file_tree_prompt();
+    assert_eq!(
+        rendered_tree(&app),
+        vec![("a/b/c/".into(), 0), ("a/b/c/one.kt".into(), 1)]
+    );
+    app.collapse_all_dirs();
+    app.begin_file_tree_prompt(FileTreePrompt::Search);
+    for ch in "a/b/c/one".chars() {
+        app.file_tree_prompt_insert_char(ch);
+    }
+    app.commit_file_tree_prompt();
+    assert!(matches!(
+        app.get_selected_tree_item(),
+        Some(FileTreeItem::File {
+            file_idx: 0,
+            depth: 1
+        })
+    ));
+    app.clear_include_filter();
+    assert_eq!(app.build_visible_items().len(), 4);
+    app.expand_all_dirs();
+    assert_eq!(app.build_visible_items().len(), 5);
+}
+
+#[test]
+fn compact_folders_are_disabled_by_default() {
+    let app = app_with(&["a/b/c/one.kt"]);
+    assert!(!app.compact_folders);
+    assert_eq!(app.build_visible_items().len(), 4);
+}
+
+#[test]
+fn compact_folders_startup_keeps_selection_on_current_file() {
+    let mut app = app_with(&["a/b/c/one.kt", "z/two.kt"]);
+    let current_file_idx = app.diff_state.current_file_idx;
+    app.set_compact_folders(true);
+    assert!(
+        matches!(app.get_selected_tree_item(), Some(FileTreeItem::File { file_idx, .. }) if file_idx == current_file_idx)
     );
 }

--- a/src/app/tree.rs
+++ b/src/app/tree.rs
@@ -1,6 +1,11 @@
 use super::*;
 
 impl App {
+    pub fn set_compact_folders(&mut self, enabled: bool) {
+        self.compact_folders = enabled;
+        self.ensure_valid_tree_selection();
+    }
+
     pub fn file_list_down(&mut self, n: usize) {
         let visible_items = self.build_visible_items();
         let max_idx = visible_items.len().saturating_sub(1);
@@ -219,7 +224,17 @@ impl App {
     }
 
     pub fn toggle_directory(&mut self, dir_path: &str) {
-        if self.expanded_dirs.contains(dir_path) {
+        let expanded = self
+            .build_visible_items()
+            .iter()
+            .find_map(|item| match item {
+                FileTreeItem::Directory { path, expanded, .. } if path == dir_path => {
+                    Some(*expanded)
+                }
+                _ => None,
+            })
+            .unwrap_or_else(|| self.expanded_dirs.contains(dir_path));
+        if expanded {
             self.expanded_dirs.remove(dir_path);
             if let Some(tree_idx) = self
                 .build_visible_items()
@@ -234,7 +249,18 @@ impl App {
                 self.ensure_valid_tree_selection();
             }
         } else {
-            self.expanded_dirs.insert(dir_path.to_string());
+            if self.compact_folders {
+                // A compact row can contain closed intermediate directories,
+                // notably after collapse-all. Open the whole represented chain.
+                for ancestor in std::path::Path::new(dir_path).ancestors() {
+                    if !ancestor.as_os_str().is_empty() {
+                        self.expanded_dirs
+                            .insert(ancestor.to_string_lossy().into_owned());
+                    }
+                }
+            } else {
+                self.expanded_dirs.insert(dir_path.to_string());
+            }
         }
     }
 
@@ -282,6 +308,11 @@ impl App {
     pub fn build_visible_items(&self) -> Vec<FileTreeItem> {
         use std::path::Path;
 
+        let single_children = if self.compact_folders {
+            self.single_child_directories()
+        } else {
+            HashMap::new()
+        };
         let mut items = Vec::new();
         let mut seen_dirs: HashSet<String> = HashSet::new();
 
@@ -305,31 +336,83 @@ impl App {
             ancestors.reverse();
 
             let mut visible = true;
-            for (depth, dir) in ancestors.iter().enumerate() {
-                if !seen_dirs.contains(dir) && visible {
-                    let expanded = self.expanded_dirs.contains(dir);
+            let mut start = 0;
+            let mut depth = 0;
+            while start < ancestors.len() && visible {
+                let mut end = start;
+                while end + 1 < ancestors.len()
+                    && single_children
+                        .get(&ancestors[end])
+                        .and_then(Option::as_ref)
+                        == Some(&ancestors[end + 1])
+                {
+                    end += 1;
+                }
+                let dir = &ancestors[end];
+                let expanded = ancestors[start..=end]
+                    .iter()
+                    .all(|path| self.expanded_dirs.contains(path));
+                if seen_dirs.insert(dir.clone()) {
+                    let parent = Path::new(&ancestors[start])
+                        .parent()
+                        .unwrap_or(Path::new(""));
+                    let label = Path::new(dir)
+                        .strip_prefix(parent)
+                        .unwrap_or(Path::new(dir))
+                        .to_string_lossy()
+                        .into_owned();
                     items.push(FileTreeItem::Directory {
                         path: dir.clone(),
+                        label,
                         depth,
                         expanded,
                     });
-                    seen_dirs.insert(dir.clone());
                 }
-
-                if !self.expanded_dirs.contains(dir) {
-                    visible = false;
-                }
+                visible = expanded;
+                depth += 1;
+                start = end + 1;
             }
 
             if visible {
-                items.push(FileTreeItem::File {
-                    file_idx,
-                    depth: ancestors.len(),
-                });
+                items.push(FileTreeItem::File { file_idx, depth });
             }
         }
 
         items
+    }
+
+    /// `Some(child)` identifies a mergeable directory; `None` marks a
+    /// branch point or a directory containing a direct file. Expansion state
+    /// does not affect chain shape, so collapsed rows keep their full label.
+    fn single_child_directories(&self) -> HashMap<String, Option<String>> {
+        let mut children: HashMap<String, Option<String>> = HashMap::new();
+        for file in self
+            .diff_files
+            .iter()
+            .filter(|file| self.file_passes_filter(file))
+        {
+            let Some(directory) = file.display_path().parent() else {
+                continue;
+            };
+            children.insert(directory.to_string_lossy().into_owned(), None);
+            let mut child = directory;
+            while let Some(parent) = child.parent() {
+                if parent.as_os_str().is_empty() {
+                    break;
+                }
+                let child_path = child.to_string_lossy().into_owned();
+                children
+                    .entry(parent.to_string_lossy().into_owned())
+                    .and_modify(|existing| {
+                        if existing.as_ref() != Some(&child_path) {
+                            *existing = None;
+                        }
+                    })
+                    .or_insert(Some(child_path));
+                child = parent;
+            }
+        }
+        children
     }
 
     pub fn get_selected_tree_item(&self) -> Option<FileTreeItem> {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -110,6 +110,8 @@ pub struct AppConfig {
     pub backend: Option<String>,
     pub comment_types: Option<Vec<CommentTypeConfig>>,
     pub show_file_list: Option<bool>,
+    /// Join single-child directory chains in the file tree. Defaults to false.
+    pub compact_folders: Option<bool>,
     /// Whether pull-request CI checks are fetched and shown.
     /// Defaults to false.
     pub show_pr_checks: Option<bool>,
@@ -195,6 +197,7 @@ const KNOWN_KEYS: &[&str] = &[
     "backend",
     "comment_types",
     "show_file_list",
+    "compact_folders",
     "show_pr_checks",
     "show_pr_comments",
     "show_commits",
@@ -422,6 +425,7 @@ fn load_config_from_path(path: &Path) -> Result<ConfigLoadOutcome> {
             .get("comment_types")
             .and_then(|v| parse_comment_types(v, &mut warnings)),
         show_file_list: read_bool(table, "show_file_list", &mut warnings),
+        compact_folders: read_bool(table, "compact_folders", &mut warnings),
         show_pr_checks: read_bool(table, "show_pr_checks", &mut warnings),
         show_pr_comments: read_bool(table, "show_pr_comments", &mut warnings),
         show_commits: read_bool(table, "show_commits", &mut warnings),
@@ -908,6 +912,18 @@ mod tests {
             outcome.warnings[0],
             "Warning: Config key 'theme_dark' must be a string; ignoring value"
         );
+    }
+
+    #[test]
+    fn should_parse_compact_folders_and_reject_invalid_types() {
+        for value in [true, false] {
+            let outcome = parse_config(&format!("compact_folders = {value}\n"));
+            assert_eq!(outcome.config.unwrap().compact_folders, Some(value));
+            assert!(outcome.warnings.is_empty());
+        }
+        let outcome = parse_config("compact_folders = \"yes\"\n");
+        assert_eq!(outcome.config.unwrap().compact_folders, None);
+        assert_eq!(outcome.warnings.len(), 1);
     }
 
     // show_file_list

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,6 +315,7 @@ fn main() -> anyhow::Result<()> {
     if let Some(ref cfg) = config_outcome.config {
         app.show_pr_checks = cfg.show_pr_checks.unwrap_or(false);
         app.show_pr_comments = cfg.show_pr_comments.unwrap_or(true);
+        app.set_compact_folders(cfg.compact_folders.unwrap_or(false));
         if cfg.show_file_list == Some(false) {
             app.show_file_list = false;
             app.focused_panel = FocusedPanel::Diff;

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -5,7 +5,6 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem},
 };
-use std::path::Path;
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, FileTreeItem, FocusedPanel};
@@ -53,13 +52,7 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
     let max_content_width = visible_items
         .iter()
         .map(|item| match item {
-            FileTreeItem::Directory { path, depth, .. } => {
-                let dir_name = Path::new(path)
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or(path);
-                depth * 2 + 2 + dir_name.width() + 1
-            }
+            FileTreeItem::Directory { label, depth, .. } => depth * 2 + 2 + label.width() + 1,
             FileTreeItem::File { file_idx, depth } => {
                 let file = &app.diff_files[*file_idx];
                 let filename = file
@@ -108,9 +101,10 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
         .map(|item| {
             let line = match item {
                 FileTreeItem::Directory {
-                    path,
+                    label,
                     depth,
                     expanded,
+                    ..
                 } => {
                     let indent = "  ".repeat(*depth);
                     let icon = if *expanded {
@@ -118,14 +112,10 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                     } else {
                         COLLAPSED_GLYPH
                     };
-                    let dir_name = Path::new(path)
-                        .file_name()
-                        .and_then(|n| n.to_str())
-                        .unwrap_or(path);
                     Line::from(vec![
                         Span::raw(indent),
                         Span::styled(format!("{icon} "), styles::dir_icon_style(&app.theme)),
-                        Span::raw(format!("{dir_name}/")),
+                        Span::raw(format!("{label}/")),
                     ])
                 }
                 FileTreeItem::File { file_idx, depth } => {
@@ -170,7 +160,11 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
             };
 
-            ListItem::new(apply_horizontal_scroll(line, scroll_x))
+            ListItem::new(if app.compact_folders {
+                scroll_compact_row(line, scroll_x)
+            } else {
+                apply_horizontal_scroll(line, scroll_x)
+            })
         })
         .collect();
 
@@ -193,6 +187,34 @@ pub(super) fn render_file_list(frame: &mut Frame, app: &mut App, area: Rect) {
             y: area.y + area.height.saturating_sub(1),
         });
     }
+}
+
+/// Compact paths are measured in terminal columns; pan by the same unit,
+/// preserving grapheme clusters and padding a partially clipped wide glyph.
+fn scroll_compact_row(line: Line<'_>, mut columns: usize) -> Line<'_> {
+    if columns == 0 {
+        return line;
+    }
+    let spans = line
+        .spans
+        .into_iter()
+        .map(|span| {
+            let mut text = String::new();
+            for grapheme in span.styled_graphemes(Style::default()) {
+                let width = grapheme.symbol.width();
+                if columns == 0 {
+                    text.push_str(grapheme.symbol);
+                } else if columns >= width {
+                    columns -= width;
+                } else {
+                    text.push_str(&" ".repeat(width - columns));
+                    columns = 0;
+                }
+            }
+            Span::styled(text, span.style)
+        })
+        .collect::<Vec<_>>();
+    Line::from(spans)
 }
 
 /// Leading `│` border plus one space before the prompt sigil.
@@ -373,6 +395,62 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn compact_folders_scroll_preserves_partial_wide_and_combining_graphemes() {
+        use ratatui::text::Line;
+        let line = Line::from("界e\u{301}/next");
+        assert_eq!(
+            super::scroll_compact_row(line.clone(), 1).to_string(),
+            " e\u{301}/next"
+        );
+        assert_eq!(super::scroll_compact_row(line, 3).to_string(), "/next");
+    }
+
+    #[test]
+    fn compact_folders_render_joined_labels_and_shallow_filenames() {
+        let mut app = app_with(&["app/src/main/kotlin/Editor.kt"]);
+        app.compact_folders = true;
+        let mut terminal = Terminal::new(TestBackend::new(60, 8)).unwrap();
+        terminal
+            .draw(|frame| super::render_file_list(frame, &mut app, frame.area()))
+            .unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("▼ app/src/main/kotlin/"), "{text}");
+        assert!(text.contains("│  ▢ M Editor.kt"), "{text}");
+        app.collapse_all_dirs();
+        terminal
+            .draw(|frame| super::render_file_list(frame, &mut app, frame.area()))
+            .unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("▶ app/src/main/kotlin/"), "{text}");
+        assert!(!text.contains("Editor.kt"), "{text}");
+    }
+
+    #[test]
+    fn compact_folders_measure_and_scroll_unicode_labels() {
+        use unicode_width::UnicodeWidthStr;
+        let mut app = app_with(&["模块/éditeur/long_directory/file.kt"]);
+        app.compact_folders = true;
+        let mut terminal = Terminal::new(TestBackend::new(18, 8)).unwrap();
+        terminal
+            .draw(|frame| super::render_file_list(frame, &mut app, frame.area()))
+            .unwrap();
+        assert_eq!(
+            app.file_list_state.max_content_width,
+            "模块/éditeur/long_directory".width() + 3
+        );
+        app.file_list_state.scroll_x = usize::MAX;
+        terminal
+            .draw(|frame| super::render_file_list(frame, &mut app, frame.area()))
+            .unwrap();
+        assert_eq!(
+            app.file_list_state.scroll_x,
+            app.file_list_state.max_content_width - 16
+        );
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("long_directory/"), "{text}");
     }
 
     #[test]


### PR DESCRIPTION
Deep package hierarchies consume file-tree rows and push filenames far to the right. This adds `compact_folders = true` to join single-child directory chains into one row, with existing behavior preserved by default.

For a review containing `app/src/main/kotlin/EditorScreen.kt`:

```text
Before                         With compact_folders = true
app/                           app/src/main/kotlin/
  src/                           EditorScreen.kt
    main/
      kotlin/
        EditorScreen.kt
```

Chains stop at directories containing direct review files or multiple child directories, using the active filtered file set. Each joined row expands or collapses as one unit. Full-path search, file identity, and diff navigation are preserved. Compact rows scroll by terminal columns, including wide and combining Unicode characters.

Addresses the compact-folder portion of #476. Flat mode, label ellipses, sidebar resizing, and runtime mode switching are outside this PR.

### Validation

- `cargo test`: 1,618 passed, 4 ignored.
- `cargo build`, `cargo check`, and `cargo fmt --check`: passed.
- Dogfooded with `cargo run -- -w` against this diff. A live Kotlin fixture verified compact rendering, Enter collapse/reopen, and full-path search from a collapsed tree.
- Strict `cargo clippy --all-targets -- -D warnings` reports a pre-existing `clippy::useless_format` in `src/forge/bitbucket/bkt.rs:1155`, also present in base commit `58eb8e1`. With that lint suppressed, all-target Clippy passes. That file is unchanged.

### Related work

#370 proposes optional arrow navigation and scrolling changes; #556 changes file-tree scrolling and adds flat mode/resizing. Neither implements compact chains, but both touch related tree behavior and rendering.
