### PR TITLE
Add review delete, clearc, and clear commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ tuicr --stdout | pbcopy
 ## Review session CLI
 
 `tuicr review` exposes saved sessions without opening the TUI. It can list
-sessions, add comments, and print stored comments for agent and script
+sessions, add, delete, and clear comments, and print stored comments for
+agent and script
 integrations. See [docs/REVIEW_CLI.md](docs/REVIEW_CLI.md).
 
 The TUI creates a persisted session file when a review target becomes active,

--- a/docs/REVIEW_CLI.md
+++ b/docs/REVIEW_CLI.md
@@ -91,6 +91,32 @@ Target flags:
 - add `--end-line <n>` for a range comment
 - use `--side old|new` for inline comments
 
+## Delete and clear comments
+
+Delete one comment by id:
+
+```bash
+tuicr review delete --session agavra/tuicr@main/worktree --comment-id <id>
+```
+
+The id is the `id` field reported by `tuicr review comments`. Deleting a
+comment that does not exist is an error.
+
+Clear every comment in a session:
+
+```bash
+tuicr review clearc --session agavra/tuicr@main/worktree
+```
+
+`clearc` keeps review marks. `clear` also resets them:
+
+```bash
+tuicr review clear --session agavra/tuicr@main/worktree
+```
+
+All three commands remove the session itself once nothing is left — no
+comments and no review marks — the same cleanup the TUI performs on exit.
+
 ## JSON Input
 
 For machine input, pass a JSON payload with `--input`. The value can be literal

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -672,58 +672,21 @@ impl App {
     /// Delete the comment at the current cursor position, if any
     /// Returns true if a comment was deleted
     pub fn delete_comment_at_cursor(&mut self) -> bool {
-        let location = self.find_comment_at_cursor();
-
-        match location {
-            Some(CommentLocation::Review { index })
-                if index < self.session.review_comments.len() =>
-            {
-                self.session.review_comments.remove(index);
-                self.dirty = true;
-                self.set_message("Review comment deleted");
-                self.rebuild_annotations();
-                return true;
-            }
-            Some(CommentLocation::File { path, index }) => {
-                if let Some(review) = self.session.get_file_mut(&path) {
-                    review.file_comments.remove(index);
-                    self.dirty = true;
-                    self.set_message("Comment deleted");
-                    self.rebuild_annotations();
-                    return true;
-                }
-            }
-            Some(CommentLocation::Line {
-                path,
-                line,
-                side,
-                index,
-            }) => {
-                if let Some(review) = self.session.get_file_mut(&path)
-                    && let Some(comments) = review.line_comments.get_mut(&line)
-                {
-                    // `comment_idx` from the annotation is the absolute index
-                    // into the stored Vec (see `push_comments`), so delete
-                    // directly — no side-filtered re-count.
-                    if index < comments.len() {
-                        let comment_side = comments[index].side.unwrap_or(LineSide::New);
-                        if comment_side == side {
-                            comments.remove(index);
-                            if comments.is_empty() {
-                                review.line_comments.remove(&line);
-                            }
-                            self.dirty = true;
-                            self.set_message(format!("Comment on line {line} deleted"));
-                            self.rebuild_annotations();
-                            return true;
-                        }
-                    }
-                }
-            }
-            Some(CommentLocation::Review { .. }) | None => {}
+        let Some(location) = self.find_comment_at_cursor() else {
+            return false;
+        };
+        if !self.session.remove_comment(&location) {
+            return false;
         }
-
-        false
+        let message = match location {
+            CommentLocation::Review { .. } => "Review comment deleted".to_string(),
+            CommentLocation::File { .. } => "Comment deleted".to_string(),
+            CommentLocation::Line { line, .. } => format!("Comment on line {line} deleted"),
+        };
+        self.dirty = true;
+        self.set_message(message);
+        self.rebuild_annotations();
+        true
     }
 
     pub fn clear_comments(&mut self, scope: ClearScope) {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -12,7 +12,7 @@ use crate::error::{Result, TuicrError};
 use crate::forge::context::{ContextProvider, ForgeContextProvider, VcsContextProvider};
 use crate::forge::selector::PullRequestsTab;
 use crate::forge::traits::{ForgeBackend, ForgeRepository};
-use crate::model::review::FileReview;
+use crate::model::review::{CommentLocation, FileReview};
 use crate::model::{
     ClearScope, Comment, CommentType, DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin,
     LineRange, LineSide, ReviewSession, SessionDiffSource,
@@ -1708,23 +1708,6 @@ pub struct SummaryState {
     /// commit selection, or file-tree filters.
     pub targets: Vec<Option<SummaryCommentTarget>>,
     pub(crate) selection_needs_scroll: bool,
-}
-
-/// Represents a comment location for deletion
-enum CommentLocation {
-    Review {
-        index: usize,
-    },
-    File {
-        path: std::path::PathBuf,
-        index: usize,
-    },
-    Line {
-        path: std::path::PathBuf,
-        line: u32,
-        side: LineSide,
-        index: usize,
-    },
 }
 
 /// What `detect_vcs` needs to open a backend. Bundled because these two

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -265,6 +265,23 @@ pub enum ReviewCommand {
         #[arg(long, value_name = "PATH|OWNER/REPO", default_value = ".")]
         repo: PathBuf,
     },
+
+    /// Delete one local draft comment from a persisted session.
+    Delete {
+        /// Session slug from `tuicr review list` (local or PR), or path to a
+        /// session JSON file.
+        #[arg(long, value_name = "SESSION")]
+        session: String,
+
+        /// Id of the comment to delete, as reported by `tuicr review comments`.
+        #[arg(long = "comment-id", value_name = "ID")]
+        comment_id: String,
+
+        /// Repo selector used to resolve a local session slug (path or
+        /// `owner/repo`). PR slugs and JSON paths resolve without it.
+        #[arg(long, value_name = "PATH|OWNER/REPO", default_value = ".")]
+        repo: PathBuf,
+    },
 }
 
 /// Diff side accepted by `tuicr review add --side`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -282,6 +282,32 @@ pub enum ReviewCommand {
         #[arg(long, value_name = "PATH|OWNER/REPO", default_value = ".")]
         repo: PathBuf,
     },
+
+    /// Clear all comments in a persisted session, keeping review marks.
+    Clearc {
+        /// Session slug from `tuicr review list` (local or PR), or path to a
+        /// session JSON file.
+        #[arg(long, value_name = "SESSION")]
+        session: String,
+
+        /// Repo selector used to resolve a local session slug (path or
+        /// `owner/repo`). PR slugs and JSON paths resolve without it.
+        #[arg(long, value_name = "PATH|OWNER/REPO", default_value = ".")]
+        repo: PathBuf,
+    },
+
+    /// Clear all comments and review marks in a persisted session.
+    Clear {
+        /// Session slug from `tuicr review list` (local or PR), or path to a
+        /// session JSON file.
+        #[arg(long, value_name = "SESSION")]
+        session: String,
+
+        /// Repo selector used to resolve a local session slug (path or
+        /// `owner/repo`). PR slugs and JSON paths resolve without it.
+        #[arg(long, value_name = "PATH|OWNER/REPO", default_value = ".")]
+        repo: PathBuf,
+    },
 }
 
 /// Diff side accepted by `tuicr review add --side`.

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -217,14 +217,21 @@ impl ReviewSession {
     pub(crate) fn remove_comment(&mut self, location: &CommentLocation) -> bool {
         match location {
             CommentLocation::Review { index } => {
-                if *index < self.review_comments.len() {
+                if self
+                    .review_comments
+                    .get(*index)
+                    .is_some_and(|comment| !comment.is_locked())
+                {
                     self.review_comments.remove(*index);
                     return true;
                 }
             }
             CommentLocation::File { path, index } => {
                 if let Some(review) = self.get_file_mut(path)
-                    && *index < review.file_comments.len()
+                    && review
+                        .file_comments
+                        .get(*index)
+                        .is_some_and(|comment| !comment.is_locked())
                 {
                     review.file_comments.remove(*index);
                     return true;
@@ -238,16 +245,15 @@ impl ReviewSession {
             } => {
                 if let Some(review) = self.get_file_mut(path)
                     && let Some(comments) = review.line_comments.get_mut(line)
-                    && *index < comments.len()
+                    && comments.get(*index).is_some_and(|comment| {
+                        !comment.is_locked() && comment.side.unwrap_or(LineSide::New) == *side
+                    })
                 {
-                    let comment_side = comments[*index].side.unwrap_or(LineSide::New);
-                    if comment_side == *side {
-                        comments.remove(*index);
-                        if comments.is_empty() {
-                            review.line_comments.remove(line);
-                        }
-                        return true;
+                    comments.remove(*index);
+                    if comments.is_empty() {
+                        review.line_comments.remove(line);
                     }
+                    return true;
                 }
             }
         }

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -223,11 +223,11 @@ impl ReviewSession {
                 }
             }
             CommentLocation::File { path, index } => {
-                if let Some(review) = self.get_file_mut(path) {
-                    if *index < review.file_comments.len() {
-                        review.file_comments.remove(*index);
-                        return true;
-                    }
+                if let Some(review) = self.get_file_mut(path)
+                    && *index < review.file_comments.len()
+                {
+                    review.file_comments.remove(*index);
+                    return true;
                 }
             }
             CommentLocation::Line {
@@ -238,16 +238,15 @@ impl ReviewSession {
             } => {
                 if let Some(review) = self.get_file_mut(path)
                     && let Some(comments) = review.line_comments.get_mut(line)
+                    && *index < comments.len()
                 {
-                    if *index < comments.len() {
-                        let comment_side = comments[*index].side.unwrap_or(LineSide::New);
-                        if comment_side == *side {
-                            comments.remove(*index);
-                            if comments.is_empty() {
-                                review.line_comments.remove(line);
-                            }
-                            return true;
+                    let comment_side = comments[*index].side.unwrap_or(LineSide::New);
+                    if comment_side == *side {
+                        comments.remove(*index);
+                        if comments.is_empty() {
+                            review.line_comments.remove(line);
                         }
+                        return true;
                     }
                 }
             }

--- a/src/model/review.rs
+++ b/src/model/review.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
 
-use super::comment::Comment;
+use super::comment::{Comment, LineSide};
 use super::diff_types::{DiffFile, FileStatus};
 use crate::forge::remote_comments::PrCommentsVisibility;
 use crate::forge::traits::PrSessionKey;
@@ -12,6 +12,22 @@ use crate::forge::traits::PrSessionKey;
 pub enum ClearScope {
     CommentsOnly,
     CommentsAndReviewed,
+}
+
+pub(crate) enum CommentLocation {
+    Review {
+        index: usize,
+    },
+    File {
+        path: PathBuf,
+        index: usize,
+    },
+    Line {
+        path: PathBuf,
+        line: u32,
+        side: LineSide,
+        index: usize,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -198,6 +214,78 @@ impl ReviewSession {
         self.files.get_mut(path)
     }
 
+    pub(crate) fn remove_comment(&mut self, location: &CommentLocation) -> bool {
+        match location {
+            CommentLocation::Review { index } => {
+                if *index < self.review_comments.len() {
+                    self.review_comments.remove(*index);
+                    return true;
+                }
+            }
+            CommentLocation::File { path, index } => {
+                if let Some(review) = self.get_file_mut(path) {
+                    if *index < review.file_comments.len() {
+                        review.file_comments.remove(*index);
+                        return true;
+                    }
+                }
+            }
+            CommentLocation::Line {
+                path,
+                line,
+                side,
+                index,
+            } => {
+                if let Some(review) = self.get_file_mut(path)
+                    && let Some(comments) = review.line_comments.get_mut(line)
+                {
+                    if *index < comments.len() {
+                        let comment_side = comments[*index].side.unwrap_or(LineSide::New);
+                        if comment_side == *side {
+                            comments.remove(*index);
+                            if comments.is_empty() {
+                                review.line_comments.remove(line);
+                            }
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    pub(crate) fn find_comment_by_id(&self, comment_id: &str) -> Option<CommentLocation> {
+        for (index, comment) in self.review_comments.iter().enumerate() {
+            if comment.id == comment_id {
+                return Some(CommentLocation::Review { index });
+            }
+        }
+        for (path, review) in &self.files {
+            for (index, comment) in review.file_comments.iter().enumerate() {
+                if comment.id == comment_id {
+                    return Some(CommentLocation::File {
+                        path: path.clone(),
+                        index,
+                    });
+                }
+            }
+            for (line, comments) in &review.line_comments {
+                for (index, comment) in comments.iter().enumerate() {
+                    if comment.id == comment_id {
+                        return Some(CommentLocation::Line {
+                            path: path.clone(),
+                            line: *line,
+                            side: comment.side.unwrap_or(LineSide::New),
+                            index,
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+
     pub fn has_comments(&self) -> bool {
         !self.review_comments.is_empty() || self.files.values().any(|f| f.comment_count() > 0)
     }
@@ -340,6 +428,89 @@ mod tests {
         let file = session.files.get(&path).unwrap();
         assert!(file.file_comments.is_empty());
         assert!(file.line_comments.is_empty());
+    }
+
+    #[test]
+    fn should_find_review_level_comment_by_id() {
+        let mut session = test_session();
+        let first = Comment::new("first".to_string(), CommentType::from_id("note"), None);
+        let second = Comment::new("second".to_string(), CommentType::from_id("note"), None);
+        let second_id = second.id.clone();
+        session.review_comments.push(first);
+        session.review_comments.push(second);
+
+        let location = session.find_comment_by_id(&second_id);
+
+        assert!(matches!(
+            location,
+            Some(CommentLocation::Review { index: 1 })
+        ));
+    }
+
+    #[test]
+    fn should_find_file_level_comment_by_id() {
+        let mut session = test_session();
+        let path = PathBuf::from("src/main.rs");
+        session.add_file(path.clone(), FileStatus::Modified, SOME_HASH);
+        let comment = Comment::new("note".to_string(), CommentType::from_id("note"), None);
+        let comment_id = comment.id.clone();
+        let file = session.get_file_mut(&path).unwrap();
+        file.add_file_comment(comment);
+
+        let location = session.find_comment_by_id(&comment_id).unwrap();
+
+        let CommentLocation::File {
+            path: found_path,
+            index,
+        } = location
+        else {
+            panic!("expected file-level comment location");
+        };
+        assert_eq!(found_path, path);
+        assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn should_find_line_level_comment_by_id_with_side() {
+        let mut session = test_session();
+        let path = PathBuf::from("src/main.rs");
+        session.add_file(path.clone(), FileStatus::Modified, SOME_HASH);
+        let comment = Comment::new(
+            "note".to_string(),
+            CommentType::from_id("note"),
+            Some(LineSide::Old),
+        );
+        let comment_id = comment.id.clone();
+        let file = session.get_file_mut(&path).unwrap();
+        file.add_line_comment(42, comment);
+
+        let location = session.find_comment_by_id(&comment_id).unwrap();
+
+        let CommentLocation::Line {
+            path: found_path,
+            line,
+            side,
+            index,
+        } = location
+        else {
+            panic!("expected line-level comment location");
+        };
+        assert_eq!(found_path, path);
+        assert_eq!(line, 42);
+        assert_eq!(side, LineSide::Old);
+        assert_eq!(index, 0);
+    }
+
+    #[test]
+    fn should_return_none_for_unknown_comment_id() {
+        let mut session = test_session();
+        session.review_comments.push(Comment::new(
+            "note".to_string(),
+            CommentType::from_id("note"),
+            None,
+        ));
+
+        assert!(session.find_comment_by_id("no-such-id").is_none());
     }
 
     #[test]

--- a/src/review_cli.rs
+++ b/src/review_cli.rs
@@ -11,6 +11,7 @@ use crate::config;
 use crate::error::{Result, TuicrError};
 use crate::model::comment::{self, CommentLifecycleState};
 use crate::model::{Comment, CommentType, LineRange, LineSide, ReviewSession};
+use crate::persistence::storage;
 use crate::review_store::{
     AddCommentRequest, CommentTarget, ReviewStore, SessionRef, SessionSummary,
 };
@@ -51,7 +52,31 @@ fn run_with_writer(command: ReviewCommand, out: &mut impl Write) -> Result<()> {
             out,
         ),
         ReviewCommand::Comments { session, repo } => show_comments(&session, &repo, out),
+        ReviewCommand::Delete {
+            session,
+            comment_id,
+            repo,
+        } => delete_comment(&session, &repo, &comment_id, out),
     }
+}
+
+fn delete_comment(
+    session: &str,
+    repo: &Path,
+    comment_id: &str,
+    out: &mut impl Write,
+) -> Result<()> {
+    let store = ReviewStore::new();
+    let session_ref = resolve_session_ref(&store, repo, session)?;
+    if !store.delete_comment(&session_ref, comment_id)? {
+        return Err(TuicrError::InvalidInput(format!(
+            "no comment with id '{comment_id}' in session '{session}'"
+        )));
+    }
+    storage::delete_session_if_empty(session_ref.path())?;
+    serde_json::to_writer_pretty(&mut *out, &serde_json::json!({ "deleted": comment_id }))?;
+    writeln!(out)?;
+    Ok(())
 }
 
 fn list_sessions(repo: &Path, all: bool, out: &mut impl Write) -> Result<()> {

--- a/src/review_cli.rs
+++ b/src/review_cli.rs
@@ -10,7 +10,7 @@ use crate::cli::{LineSideArg, ReviewCommand};
 use crate::config;
 use crate::error::{Result, TuicrError};
 use crate::model::comment::{self, CommentLifecycleState};
-use crate::model::{Comment, CommentType, LineRange, LineSide, ReviewSession};
+use crate::model::{ClearScope, Comment, CommentType, LineRange, LineSide, ReviewSession};
 use crate::persistence::storage;
 use crate::review_store::{
     AddCommentRequest, CommentTarget, ReviewStore, SessionRef, SessionSummary,
@@ -57,7 +57,31 @@ fn run_with_writer(command: ReviewCommand, out: &mut impl Write) -> Result<()> {
             comment_id,
             repo,
         } => delete_comment(&session, &repo, &comment_id, out),
+        ReviewCommand::Clearc { session, repo } => {
+            clear_comments(&session, &repo, ClearScope::CommentsOnly, out)
+        }
+        ReviewCommand::Clear { session, repo } => {
+            clear_comments(&session, &repo, ClearScope::CommentsAndReviewed, out)
+        }
     }
+}
+
+fn clear_comments(
+    session: &str,
+    repo: &Path,
+    scope: ClearScope,
+    out: &mut impl Write,
+) -> Result<()> {
+    let store = ReviewStore::new();
+    let session_ref = resolve_session_ref(&store, repo, session)?;
+    let (cleared, unreviewed) = store.clear_comments(&session_ref, scope)?;
+    storage::delete_session_if_empty(session_ref.path())?;
+    serde_json::to_writer_pretty(
+        &mut *out,
+        &serde_json::json!({ "cleared": cleared, "unreviewed": unreviewed }),
+    )?;
+    writeln!(out)?;
+    Ok(())
 }
 
 fn delete_comment(

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 
 use crate::error::{Result, TuicrError};
-use crate::model::{Comment, CommentType, LineRange, LineSide, ReviewSession};
+use crate::model::{ClearScope, Comment, CommentType, LineRange, LineSide, ReviewSession};
 use crate::persistence::manifest::{ManifestEntry, ManifestKind};
 use crate::persistence::storage;
 
@@ -94,6 +94,20 @@ impl ReviewStore {
                 Ok(session.remove_comment(&location))
             })?;
         Ok(removed)
+    }
+
+    /// Clear comments from a persisted session.
+    pub fn clear_comments(
+        &self,
+        session_ref: &SessionRef,
+        scope: ClearScope,
+    ) -> Result<(usize, usize)> {
+        let reviews_dir = self.reviews_dir()?;
+        let (_session, counts) =
+            storage::update_session_in_dir(session_ref.path(), &reviews_dir, |session| {
+                Ok(session.clear_comments(scope))
+            })?;
+        Ok(counts)
     }
 
     /// Save a session through this store's storage root.
@@ -319,6 +333,56 @@ mod tests {
         let loaded = store.get_review(&session_ref).unwrap();
         assert!(loaded.review_comments.is_empty());
         assert!(!store.delete_comment(&session_ref, &comment_id).unwrap());
+    }
+
+    #[test]
+    fn should_clear_comments_keeping_review_marks() {
+        let temp = tempdir().unwrap();
+        let store = ReviewStore::with_reviews_dir(temp.path().join("reviews"));
+        let mut session = test_session(PathBuf::from("/repo"));
+        session.review_comments.push(Comment::new(
+            "note".to_string(),
+            CommentType::from_id("note"),
+            None,
+        ));
+        let path = PathBuf::from("src/main.rs");
+        session.files.get_mut(&path).unwrap().reviewed = true;
+        let session_ref = store.save_review(&session).unwrap();
+
+        let (cleared, unreviewed) = store
+            .clear_comments(&session_ref, ClearScope::CommentsOnly)
+            .unwrap();
+
+        assert_eq!(cleared, 1);
+        assert_eq!(unreviewed, 0);
+        let loaded = store.get_review(&session_ref).unwrap();
+        assert!(loaded.review_comments.is_empty());
+        assert!(loaded.files.get(&path).unwrap().reviewed);
+    }
+
+    #[test]
+    fn should_clear_comments_and_review_marks() {
+        let temp = tempdir().unwrap();
+        let store = ReviewStore::with_reviews_dir(temp.path().join("reviews"));
+        let mut session = test_session(PathBuf::from("/repo"));
+        session.review_comments.push(Comment::new(
+            "note".to_string(),
+            CommentType::from_id("note"),
+            None,
+        ));
+        let path = PathBuf::from("src/main.rs");
+        session.files.get_mut(&path).unwrap().reviewed = true;
+        let session_ref = store.save_review(&session).unwrap();
+
+        let (cleared, unreviewed) = store
+            .clear_comments(&session_ref, ClearScope::CommentsAndReviewed)
+            .unwrap();
+
+        assert_eq!(cleared, 1);
+        assert_eq!(unreviewed, 1);
+        let loaded = store.get_review(&session_ref).unwrap();
+        assert!(loaded.review_comments.is_empty());
+        assert!(!loaded.files.get(&path).unwrap().reviewed);
     }
 
     #[test]

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -91,7 +91,18 @@ impl ReviewStore {
                 let Some(location) = session.find_comment_by_id(comment_id) else {
                     return Ok(false);
                 };
-                Ok(session.remove_comment(&location))
+                if session.remove_comment(&location) {
+                    Ok(true)
+                } else {
+                    let forge = session
+                        .pr_session_key
+                        .as_ref()
+                        .map(|key| key.repository.display_name())
+                        .unwrap_or_else(|| "the forge".to_string());
+                    Err(TuicrError::InvalidInput(format!(
+                        "Comment already pushed to {forge} — read only in tuicr"
+                    )))
+                }
             })?;
         Ok(removed)
     }
@@ -303,6 +314,7 @@ fn file_review_mut<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::comment::CommentLifecycleState;
     use crate::model::{FileStatus, SessionDiffSource};
     use tempfile::tempdir;
 
@@ -383,6 +395,24 @@ mod tests {
         let loaded = store.get_review(&session_ref).unwrap();
         assert!(loaded.review_comments.is_empty());
         assert!(!loaded.files.get(&path).unwrap().reviewed);
+    }
+
+    #[test]
+    fn should_refuse_to_delete_pushed_comment() {
+        let temp = tempdir().unwrap();
+        let store = ReviewStore::with_reviews_dir(temp.path().join("reviews"));
+        let mut session = test_session(PathBuf::from("/repo"));
+        let mut comment = Comment::new("note".to_string(), CommentType::from_id("note"), None);
+        comment.lifecycle_state = CommentLifecycleState::PushedDraft;
+        let comment_id = comment.id.clone();
+        session.review_comments.push(comment);
+        let session_ref = store.save_review(&session).unwrap();
+
+        let result = store.delete_comment(&session_ref, &comment_id);
+
+        assert!(matches!(result, Err(TuicrError::InvalidInput(_))));
+        let loaded = store.get_review(&session_ref).unwrap();
+        assert_eq!(loaded.review_comments.len(), 1);
     }
 
     #[test]

--- a/src/review_store.rs
+++ b/src/review_store.rs
@@ -83,6 +83,19 @@ impl ReviewStore {
         Ok(comment)
     }
 
+    /// Delete one comment by id from a persisted session.
+    pub fn delete_comment(&self, session_ref: &SessionRef, comment_id: &str) -> Result<bool> {
+        let reviews_dir = self.reviews_dir()?;
+        let (_session, removed) =
+            storage::update_session_in_dir(session_ref.path(), &reviews_dir, |session| {
+                let Some(location) = session.find_comment_by_id(comment_id) else {
+                    return Ok(false);
+                };
+                Ok(session.remove_comment(&location))
+            })?;
+        Ok(removed)
+    }
+
     /// Save a session through this store's storage root.
     pub fn save_review(&self, session: &ReviewSession) -> Result<SessionRef> {
         let reviews_dir = self.reviews_dir()?;
@@ -277,6 +290,7 @@ fn file_review_mut<'a>(
 mod tests {
     use super::*;
     use crate::model::{FileStatus, SessionDiffSource};
+    use tempfile::tempdir;
 
     fn test_session(repo_path: PathBuf) -> ReviewSession {
         let mut session = ReviewSession::new(
@@ -287,6 +301,24 @@ mod tests {
         );
         session.add_file(PathBuf::from("src/main.rs"), FileStatus::Modified, 0);
         session
+    }
+
+    #[test]
+    fn should_delete_comment_by_id_through_store() {
+        let temp = tempdir().unwrap();
+        let store = ReviewStore::with_reviews_dir(temp.path().join("reviews"));
+        let mut session = test_session(PathBuf::from("/repo"));
+        let comment = Comment::new("note".to_string(), CommentType::from_id("note"), None);
+        let comment_id = comment.id.clone();
+        session.review_comments.push(comment);
+        let session_ref = store.save_review(&session).unwrap();
+
+        let deleted = store.delete_comment(&session_ref, &comment_id).unwrap();
+
+        assert!(deleted);
+        let loaded = store.get_review(&session_ref).unwrap();
+        assert!(loaded.review_comments.is_empty());
+        assert!(!store.delete_comment(&session_ref, &comment_id).unwrap());
     }
 
     #[test]


### PR DESCRIPTION
Add `tuicr review delete`, `clearc`, and `clear` (#699)

Three new review CLI commands close the add/comments loop for scripts and
agents: comments could previously only be deleted inside the TUI, and sessions
whose scope is currently empty were unreachable there at all.

- `delete --session <slug> --comment-id <id>` removes one comment from
  whichever bucket holds it (review, file, or line level)
- `clearc --session <slug>` clears all comments, keeping review marks
- `clear --session <slug>` clears comments and resets review marks
- all three remove the session itself when nothing is left (no comments and no
  review marks), matching TUI exit cleanup
- each writes JSON to stdout like the existing review commands

Supporting refactor, behavior-preserving: `CommentLocation` moved into the
model and the TUI `dd` removal logic extracted into
`ReviewSession::remove_comment`, now shared by `dd` and the CLI. The TUI path
is unchanged (full test suite green); the File arm additionally gained a
bounds check the inline code lacked.

6 new tests. `cargo fmt` and `cargo clippy` clean.

Closes #699