### PR TITLE
feat(forge): sync file-reviewed markers with GitHub's Viewed checkbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ src/
 │   │   ├── pr_info.rs   # Extended `gh pr view --json` parsing for PR description panel
 │   │   ├── review_threads.rs # GraphQL query for existing review threads
 │   │   ├── review_metadata.rs # GraphQL review commit metadata for since-last-review scoping
+│   │   ├── viewed_files.rs # GraphQL per-file viewerViewedState for the reviewed-marker sync
 │   │   └── submit.rs    # build_review_payload, create_review wiring
 │   ├── gitlab/          # GitLab backend via `glab` CLI
 │   │   ├── mod.rs       # GitLabGlabBackend export
@@ -252,6 +253,8 @@ Forge selection is host-driven: `parse_any_remote_url` tries Bitbucket (`bitbuck
 - `list_review_threads` — existing forge comments + resolved/outdated state.
 - `fetch_file_lines` — remote context expansion in the diff view.
 - `create_review` — POST a review with inline comments via `CreateReviewRequest`.
+- `set_file_viewed` — tick or clear the viewer's per-file viewed state (GitHub's "Viewed" checkbox). Defaults to `UnsupportedOperation`; only GitHub implements it.
+- `list_viewed_files` — paths the viewer has already marked viewed. Defaults to an empty list, which reads the same as a forge without the concept.
 
 ### Async pattern
 
@@ -263,6 +266,8 @@ Network calls run on a background thread. Parsing + state mutation run on the ma
 4. The main-thread `finish_*` function parses the diff and builds the `ReviewSession`. `SyntaxHighlighter` is not trivially `Send`, so parsing has to happen on the main thread.
 
 In-flight requests carry an identity tuple (repo, PR#, head SHA). A late result is discarded if the user has since opened a different PR.
+
+The viewed-state sync (`src/app/viewed_sync.rs`) is the one long-lived worker: it holds its own `ForgeBackend` for the life of a PR session so the node id its GraphQL mutations need is resolved once, and takes toggles over an `mpsc` sender instead of spawning per update. Both it and its one-shot companion read start from `poll_viewed_sync_events()` in the main loop rather than from the PR-open paths, because `App::forge_config` is applied after `App::new` returns — work started at open time cannot see `[forge] sync_viewed`.
 
 ### Session key + lifecycle
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ comment_vim = false           # vim modal editing in the review comment box
 relative_line_numbers = false # show rendered-row distances in the diff gutter
 
 [forge]
-sync_viewed = false           # mirror `r` onto GitHub's per-file Viewed checkbox
+sync_viewed = false           # sync `r` with GitHub's per-file Viewed checkbox
 
 [[comment_types]]
 id = "issue"
@@ -298,7 +298,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `I` / `E` (file tree) | Clear the include / exclude filter |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |
-| `r` | Toggle file reviewed (mirrors GitHub's *Viewed* checkbox with `[forge] sync_viewed`) |
+| `r` | Toggle file reviewed (syncs with GitHub's *Viewed* checkbox via `[forge] sync_viewed`) |
 | `R` | Toggle hunk reviewed |
 | `e` | Open focused file in `$EDITOR` |
 | `y` | Copy review to clipboard |

--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ editor = "nvim"               # editor for `e` / `:edit`; overrides $EDITOR
 comment_vim = false           # vim modal editing in the review comment box
 relative_line_numbers = false # show rendered-row distances in the diff gutter
 
+[forge]
+sync_viewed = false           # mirror `r` onto GitHub's per-file Viewed checkbox
+
 [[comment_types]]
 id = "issue"
 color = "red"
@@ -295,7 +298,7 @@ A first-session cheatsheet. Press `?` inside tuicr for the full reference.
 | `I` / `E` (file tree) | Clear the include / exclude filter |
 | `c` / `C` | Add line / file comment |
 | `v` / `V` | Visual mode (range comment) |
-| `r` | Toggle file reviewed |
+| `r` | Toggle file reviewed (mirrors GitHub's *Viewed* checkbox with `[forge] sync_viewed`) |
 | `R` | Toggle hunk reviewed |
 | `e` | Open focused file in `$EDITOR` |
 | `y` | Copy review to clipboard |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -244,7 +244,7 @@ comment_type_prefix = false
 | Key                   | Default | Description                                                                                                                                                                 |
 | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `comment_type_prefix` | `true`  | Prepend `[TYPE] ` to comment bodies on submit (e.g. `[ISSUE] Magic number should be a constant`). The tag uses the type's `label`, uppercased — the same text the TUI badge and export show. Set to `false` to send the raw comment body without a classification tag. |
-| `sync_viewed`         | `false` | Mirror `r` (toggle file reviewed) onto GitHub's per-file **Viewed** checkbox while reviewing a pull request. GitHub only; see [Viewed state](#viewed-state). |
+| `sync_viewed`         | `false` | Keep `r` (toggle file reviewed) and GitHub's per-file **Viewed** checkbox in step while reviewing a pull request, in both directions. GitHub only; see [Viewed state](#viewed-state). |
 
 When enabled (the default), submitted comments look like:
 
@@ -266,10 +266,16 @@ This applies to inline line comments, file-level comments, and review-level comm
 
 ### Viewed state
 
-With `sync_viewed = true`, marking a file reviewed in a GitHub pull request also
-ticks that file's **Viewed** checkbox on github.com, and unmarking it clears the
-checkbox. It is off by default because it turns a local marker into a write to
-GitHub under your account.
+With `sync_viewed = true`, tuicr's file-reviewed markers and GitHub's per-file
+**Viewed** checkboxes track each other on a pull request:
+
+- Marking a file reviewed with `r` ticks that file's checkbox on github.com,
+  and unmarking it clears the checkbox.
+- Files you already ticked on github.com open as reviewed here — collapsed in
+  the diff and counted in the tree's `reviewed/total`.
+
+It is off by default because it turns a local marker into a write to GitHub
+under your account.
 
 ```toml
 [forge]
@@ -279,15 +285,20 @@ sync_viewed = true
 Details worth knowing:
 
 - **GitHub pull requests only.** Local diffs, commit ranges, and GitLab,
-  Bitbucket, and Azure DevOps pull requests ignore the setting — none of them
-  expose a per-viewer file state.
+  Bitbucket, Gitea, and Azure DevOps pull requests ignore the setting — none of
+  them expose a per-viewer file state.
 - **Files, not hunks.** `R` (toggle hunk reviewed) has no GitHub equivalent and
   never syncs.
-- **Nothing blocks on the network.** The update is pushed on a background
-  worker; the local marker applies immediately and stays applied even if the
-  push fails. Failures appear once in the status bar.
-- **The sync is one-way.** Files you marked viewed on github.com before opening
-  tuicr do not come back as reviewed markers.
+- **The read only adds markers.** A file reviewed here stays reviewed even when
+  GitHub reports it unticked, so a failed push — or unticking a box on the web
+  by accident — never throws away local review progress. GitHub's `DISMISSED`
+  state (viewed, then changed by a later commit) does not count as viewed.
+- **The read runs once per session**, shortly after the PR opens, and again on
+  `:reload`. Paths the review does not cover, because `.tuicrignore` filtered
+  them or the commit selector narrowed the range, are skipped.
+- **Nothing blocks on the network.** Pushes run on a background worker and the
+  read on its own thread; local markers apply immediately and stay applied even
+  if the forge call fails. Failures appear once in the status bar.
 - Requires `gh` authenticated to the host with the `repo` scope, the same as
   `:submit`.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -60,6 +60,7 @@ comment_types = [
 
 [forge]
 comment_type_prefix = true
+sync_viewed = false
 
 [export]
 intro = "I reviewed your code and have the following comments. Please address them."
@@ -243,6 +244,7 @@ comment_type_prefix = false
 | Key                   | Default | Description                                                                                                                                                                 |
 | --------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `comment_type_prefix` | `true`  | Prepend `[TYPE] ` to comment bodies on submit (e.g. `[ISSUE] Magic number should be a constant`). The tag uses the type's `label`, uppercased — the same text the TUI badge and export show. Set to `false` to send the raw comment body without a classification tag. |
+| `sync_viewed`         | `false` | Mirror `r` (toggle file reviewed) onto GitHub's per-file **Viewed** checkbox while reviewing a pull request. GitHub only; see [Viewed state](#viewed-state). |
 
 When enabled (the default), submitted comments look like:
 
@@ -261,6 +263,33 @@ This module could use a doc comment
 ```
 
 This applies to inline line comments, file-level comments, and review-level comments pushed via `:submit`. The prefix works the same way on GitLab MR and Bitbucket PR submissions.
+
+### Viewed state
+
+With `sync_viewed = true`, marking a file reviewed in a GitHub pull request also
+ticks that file's **Viewed** checkbox on github.com, and unmarking it clears the
+checkbox. It is off by default because it turns a local marker into a write to
+GitHub under your account.
+
+```toml
+[forge]
+sync_viewed = true
+```
+
+Details worth knowing:
+
+- **GitHub pull requests only.** Local diffs, commit ranges, and GitLab,
+  Bitbucket, and Azure DevOps pull requests ignore the setting — none of them
+  expose a per-viewer file state.
+- **Files, not hunks.** `R` (toggle hunk reviewed) has no GitHub equivalent and
+  never syncs.
+- **Nothing blocks on the network.** The update is pushed on a background
+  worker; the local marker applies immediately and stays applied even if the
+  push fails. Failures appear once in the status bar.
+- **The sync is one-way.** Files you marked viewed on github.com before opening
+  tuicr do not come back as reviewed markers.
+- Requires `gh` authenticated to the host with the `repo` scope, the same as
+  `:submit`.
 
 ## Export
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -131,7 +131,7 @@ Shown below the file tree when local comments or visible remote PR threads exist
 
 | Key | Action |
 |-----|--------|
-| `r` | Toggle file reviewed |
+| `r` | Toggle file reviewed (syncs with GitHub's *Viewed* checkbox via `[forge] sync_viewed`) |
 | `R` | Toggle hunk reviewed |
 | `c` | Add line comment (or file comment if not on a diff line) |
 | `C` | Add file comment |
@@ -150,6 +150,30 @@ take over the screen and tuicr reloads the diff once they exit. Windowed editors
 screen; reload with `:e` after editing. Adding `--wait` to the editor command opts a
 windowed editor back into the blocking behaviour. Set the `editor` config key to
 override `$EDITOR`.
+
+### Syncing `r` with GitHub's Viewed checkbox
+
+`sync_viewed = true` under `[forge]` in `config.toml` makes `r` and GitHub's
+per-file **Viewed** checkbox track each other on a pull request: marking a file
+reviewed ticks the box on github.com, unmarking clears it, and files you ticked
+on the web open here already reviewed — collapsed, and counted in the tree's
+`reviewed/total`. Without it `r` stays local, which is the default: the sync
+turns a keystroke into a write to GitHub under your account.
+
+GitHub pull requests only. Local diffs, commit ranges, and GitLab, Bitbucket,
+Gitea, and Azure DevOps pull requests ignore the setting, because none of them
+expose a per-viewer file state. `R` never syncs either — a hunk has no GitHub
+equivalent.
+
+Two things stay deliberately unaffected. Nothing blocks on the network: the
+local marker applies the moment you press `r` and stays applied even if the
+push fails, so walking a file list never stalls mid-keystroke — a failure
+surfaces once in the status bar, and `:e` resyncs. And the read only ever
+*adds* markers: a file reviewed here is never un-reviewed by what GitHub
+reports, since unticking a box on the web is easy to do by accident and a lost
+marker is the one direction `r` cannot undo. GitHub's `DISMISSED` state —
+viewed, then changed by a later commit — does not count as viewed. See
+[Viewed state](CONFIG.md#viewed-state) for the config details.
 
 ## Visual mode
 

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -554,6 +554,8 @@ impl App {
             pr_threads_rx: None,
             viewed_sync: None,
             viewed_sync_rx: None,
+            viewed_seeded: None,
+            viewed_seed_rx: None,
             forge_config: crate::config::ForgeConfig::default(),
             username: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             submit_state: None,

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -552,6 +552,8 @@ impl App {
             forge_review_summaries: Vec::new(),
             forge_review_threads_loading: false,
             pr_threads_rx: None,
+            viewed_sync: None,
+            viewed_sync_rx: None,
             forge_config: crate::config::ForgeConfig::default(),
             username: crate::model::comment::DEFAULT_AUTHOR.to_string(),
             submit_state: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1011,6 +1011,17 @@ pub enum ViewedSyncEvent {
     },
 }
 
+/// Viewed state read back from the forge when a PR session opens.
+#[derive(Debug)]
+pub enum ViewedSeedEvent {
+    Done {
+        /// Session the read was started for; a result that outlives its
+        /// session is discarded rather than applied to another PR.
+        key: crate::forge::traits::PrSessionKey,
+        result: std::result::Result<Vec<PathBuf>, String>,
+    },
+}
+
 /// Live viewed-state worker for one PR session. Dropping the sender ends the
 /// thread, so switching PRs needs no explicit shutdown.
 #[derive(Debug)]
@@ -1299,6 +1310,11 @@ pub struct App {
     /// Failures reported by that worker; drained by
     /// `poll_viewed_sync_events`.
     pub viewed_sync_rx: Option<std::sync::mpsc::Receiver<ViewedSyncEvent>>,
+    /// PR session whose remote viewed state has already been requested. The
+    /// read happens once per session, on the first tick after it opens.
+    pub viewed_seeded: Option<crate::forge::traits::PrSessionKey>,
+    /// That read while it is in flight.
+    pub viewed_seed_rx: Option<std::sync::mpsc::Receiver<ViewedSeedEvent>>,
 
     /// `[forge]` section settings resolved at startup. Drives the body/footer
     /// formatting on submit. Defaults to `ForgeConfig::default()` when the

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -994,6 +994,33 @@ pub enum PrThreadsEvent {
     },
 }
 
+/// A viewed-state push queued for the background worker.
+#[derive(Debug)]
+pub enum ViewedSyncRequest {
+    Set { path: PathBuf, viewed: bool },
+}
+
+/// Failure reported back by the viewed-state worker. Successes stay silent —
+/// the local marker the user already sees is the confirmation.
+#[derive(Debug)]
+pub enum ViewedSyncEvent {
+    Failed {
+        path: PathBuf,
+        viewed: bool,
+        error: String,
+    },
+}
+
+/// Live viewed-state worker for one PR session. Dropping the sender ends the
+/// thread, so switching PRs needs no explicit shutdown.
+#[derive(Debug)]
+pub struct ViewedSyncWorker {
+    /// PR the worker was started for. A toggle belonging to a different
+    /// session replaces it rather than writing to the wrong pull request.
+    pub key: crate::forge::traits::PrSessionKey,
+    pub tx: std::sync::mpsc::Sender<ViewedSyncRequest>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffViewMode {
     Unified,
@@ -1264,6 +1291,14 @@ pub struct App {
     /// Background-thread channel that delivers remote-thread fetch results.
     /// `Receiver` is only present while a fetch is in flight.
     pub pr_threads_rx: Option<std::sync::mpsc::Receiver<PrThreadsEvent>>,
+    /// Background worker mirroring file-reviewed toggles onto GitHub's
+    /// per-file viewed checkbox. Spawned lazily on the first toggle of a PR
+    /// session (config `[forge] sync_viewed`), so it never starts for local
+    /// diffs or for users who leave the setting off.
+    pub viewed_sync: Option<ViewedSyncWorker>,
+    /// Failures reported by that worker; drained by
+    /// `poll_viewed_sync_events`.
+    pub viewed_sync_rx: Option<std::sync::mpsc::Receiver<ViewedSyncEvent>>,
 
     /// `[forge]` section settings resolved at startup. Drives the body/footer
     /// formatting on submit. Defaults to `ForgeConfig::default()` when the
@@ -1812,6 +1847,7 @@ mod session;
 pub mod sessions_tab;
 mod submit;
 mod tree;
+mod viewed_sync;
 mod visual;
 
 #[cfg(test)]

--- a/src/app/pr.rs
+++ b/src/app/pr.rs
@@ -1059,6 +1059,9 @@ impl App {
     ) {
         self.forge_review_threads.clear();
         self.forge_review_threads_loading = true;
+        // Remote viewed state is part of the PR's remote state, so a reload
+        // re-reads it too; the next tick starts that read.
+        self.viewed_seeded = None;
 
         let (tx, rx) = std::sync::mpsc::channel();
         self.pr_threads_rx = Some(rx);

--- a/src/app/reviewed.rs
+++ b/src/app/reviewed.rs
@@ -194,7 +194,11 @@ impl App {
         self.revealed_reviewed_file = None;
         if let Some(review) = self.session.get_file_mut(&path) {
             review.reviewed = !review.reviewed;
+            let now_reviewed = review.reviewed;
             self.dirty = true;
+            // Fire-and-forget: GitHub's viewed checkbox follows the local
+            // marker, it never gates it.
+            self.push_viewed_state(&path, now_reviewed);
 
             // Update current_file_idx before rebuilding annotations:
             // single-file view filters annotations against it.

--- a/src/app/tests/mod.rs
+++ b/src/app/tests/mod.rs
@@ -20,4 +20,5 @@ mod single_file_view_tests;
 mod submit_flow_tests;
 mod target_selector_tests;
 mod tree_tests;
+mod viewed_sync_tests;
 mod visual_selection_tests;

--- a/src/app/tests/viewed_sync_tests.rs
+++ b/src/app/tests/viewed_sync_tests.rs
@@ -70,6 +70,10 @@ fn file(path: &str) -> DiffFile {
 }
 
 fn app() -> App {
+    app_with(&["src/main.rs"])
+}
+
+fn app_with(paths: &[&str]) -> App {
     let vcs_info = VcsInfo {
         root_path: PathBuf::from("/tmp"),
         head_commit: "head".into(),
@@ -88,7 +92,7 @@ fn app() -> App {
         crate::theme::Theme::dark(),
         None,
         false,
-        vec![file("src/main.rs")],
+        paths.iter().map(|p| file(p)).collect(),
         session,
         DiffSource::WorkingTree,
         InputMode::Normal,
@@ -184,4 +188,87 @@ fn should_ignore_viewed_sync_results_with_no_worker() {
 
     // when/then — no channel, no repaint, no panic
     assert!(!app.poll_viewed_sync_events());
+}
+
+#[test]
+fn should_not_read_viewed_state_for_local_diffs() {
+    // given — the sync is on, but there is no pull request behind this review
+    let mut app = app();
+    app.forge_config.sync_viewed = true;
+
+    // when — the main loop pumps the sync on every tick
+    let redraw = app.poll_viewed_sync_events();
+
+    // then — no read was started
+    assert!(!redraw);
+    assert!(app.viewed_seeded.is_none());
+    assert!(app.viewed_seed_rx.is_none());
+}
+
+#[test]
+fn should_not_read_viewed_state_when_disabled_in_config() {
+    // given — a GitHub PR with the sync left off
+    let mut app = app();
+    enter_pr_mode(
+        &mut app,
+        ForgeRepository::github("github.com", "agavra", "tuicr"),
+    );
+
+    // when
+    app.poll_viewed_sync_events();
+
+    // then
+    assert!(app.viewed_seeded.is_none());
+}
+
+#[test]
+fn should_mark_files_the_forge_reports_as_viewed() {
+    // given — two files, neither reviewed locally
+    let mut app = app_with(&["src/main.rs", "src/lib.rs"]);
+
+    // when — GitHub says one of them is already ticked
+    let redraw = app.apply_remote_viewed_state(&[PathBuf::from("src/lib.rs")]);
+
+    // then
+    assert!(redraw);
+    assert!(app.session.is_file_reviewed(&PathBuf::from("src/lib.rs")));
+    assert!(!app.session.is_file_reviewed(&PathBuf::from("src/main.rs")));
+    // and — the seeded markers are worth persisting
+    assert!(app.dirty);
+}
+
+#[test]
+fn should_not_clear_local_markers_the_forge_does_not_report() {
+    // given — a file reviewed here but not ticked on GitHub, which is what a
+    // failed push, or a marker made before the sync was switched on, leaves
+    // behind
+    let mut app = app_with(&["src/main.rs", "src/lib.rs"]);
+    app.toggle_reviewed_for_file_idx(0, false);
+    assert!(app.session.is_file_reviewed(&PathBuf::from("src/main.rs")));
+
+    // when — the forge reports only the other file
+    app.apply_remote_viewed_state(&[PathBuf::from("src/lib.rs")]);
+
+    // then — the read adds markers, it never takes them away
+    assert!(app.session.is_file_reviewed(&PathBuf::from("src/main.rs")));
+    assert!(app.session.is_file_reviewed(&PathBuf::from("src/lib.rs")));
+}
+
+#[test]
+fn should_ignore_viewed_paths_outside_the_review() {
+    // given — the PR covers files this session filtered out, so GitHub
+    // reports paths the review knows nothing about
+    let mut app = app_with(&["src/main.rs"]);
+
+    // when
+    let redraw = app.apply_remote_viewed_state(&[PathBuf::from("docs/ignored.md")]);
+
+    // then — nothing marked, nothing to repaint, no session entry invented
+    assert!(!redraw);
+    assert!(!app.dirty);
+    assert!(
+        !app.session
+            .files
+            .contains_key(&PathBuf::from("docs/ignored.md"))
+    );
 }

--- a/src/app/tests/viewed_sync_tests.rs
+++ b/src/app/tests/viewed_sync_tests.rs
@@ -1,0 +1,187 @@
+//! Guards on when a file-reviewed toggle is allowed to reach the forge.
+//!
+//! The positive path is covered at the backend seam
+//! (`forge::github::gh::tests`); here we only prove the worker never starts
+//! where it must not, because starting it means shelling out to `gh`.
+
+use crate::app::*;
+use crate::forge::traits::{ForgeRepository, PullRequestDetails, PullRequestInfo};
+use crate::model::{DiffFile, DiffHunk, DiffLine, FileStatus, LineOrigin};
+use crate::vcs::traits::{VcsBackend, VcsInfo, VcsType};
+use std::path::PathBuf;
+
+struct StubVcs(VcsInfo);
+impl VcsBackend for StubVcs {
+    fn info(&self) -> &VcsInfo {
+        &self.0
+    }
+    fn get_working_tree_diff(
+        &self,
+        _hl: &crate::syntax::SyntaxHighlighter,
+    ) -> crate::error::Result<Vec<DiffFile>> {
+        Ok(Vec::new())
+    }
+    fn fetch_context_lines(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+        _start: u32,
+        _end: u32,
+    ) -> crate::error::Result<Vec<DiffLine>> {
+        Ok(Vec::new())
+    }
+    fn file_line_count(
+        &self,
+        _path: &std::path::Path,
+        _status: FileStatus,
+        _ref_commit: Option<&str>,
+    ) -> crate::error::Result<u32> {
+        Ok(0)
+    }
+}
+
+fn file(path: &str) -> DiffFile {
+    let hunks = vec![DiffHunk {
+        header: "@@ -1,1 +1,1 @@".to_string(),
+        lines: vec![DiffLine {
+            origin: LineOrigin::Addition,
+            content: "added".to_string(),
+            old_lineno: None,
+            new_lineno: Some(1),
+            highlighted_spans: None,
+        }],
+        old_start: 1,
+        old_count: 0,
+        new_start: 1,
+        new_count: 1,
+    }];
+    let content_hash = DiffFile::compute_content_hash(&hunks);
+    DiffFile {
+        old_path: None,
+        new_path: Some(PathBuf::from(path)),
+        status: FileStatus::Added,
+        hunks,
+        is_binary: false,
+        is_too_large: false,
+        is_commit_message: false,
+        content_hash,
+    }
+}
+
+fn app() -> App {
+    let vcs_info = VcsInfo {
+        root_path: PathBuf::from("/tmp"),
+        head_commit: "head".into(),
+        branch_name: Some("main".into()),
+        vcs_type: VcsType::Git,
+    };
+    let session = ReviewSession::new(
+        vcs_info.root_path.clone(),
+        vcs_info.head_commit.clone(),
+        vcs_info.branch_name.clone(),
+        SessionDiffSource::WorkingTree,
+    );
+    App::build(
+        Box::new(StubVcs(vcs_info.clone())),
+        vcs_info,
+        crate::theme::Theme::dark(),
+        None,
+        false,
+        vec![file("src/main.rs")],
+        session,
+        DiffSource::WorkingTree,
+        InputMode::Normal,
+        Vec::new(),
+        None,
+        None,
+    )
+    .expect("build app")
+}
+
+fn details(repository: ForgeRepository) -> PullRequestDetails {
+    PullRequestDetails {
+        repository,
+        number: 125,
+        title: "Add a thing".into(),
+        url: "https://example.test/pull/125".into(),
+        state: "OPEN".into(),
+        is_draft: false,
+        author: None,
+        head_ref_name: "feature".into(),
+        base_ref_name: "main".into(),
+        head_sha: "headsha".into(),
+        base_sha: "basesha".into(),
+        body: String::new(),
+        updated_at: None,
+        closed: false,
+        merged_at: None,
+        diff_start_sha: None,
+    }
+}
+
+/// Put `app` into PR mode against `repository` without touching the network.
+fn enter_pr_mode(app: &mut App, repository: ForgeRepository) {
+    let details = details(repository);
+    app.diff_source =
+        DiffSource::PullRequest(Box::new(PullRequestDiffSource::from_details(&details)));
+    app.pr_info = Some(PullRequestInfo::from_details(details));
+}
+
+#[test]
+fn should_not_start_viewed_sync_for_local_diffs() {
+    // given — a working-tree review with the sync switched on
+    let mut app = app();
+    app.forge_config.sync_viewed = true;
+
+    // when
+    app.toggle_reviewed_for_file_idx(0, false);
+
+    // then — nothing to push to; there is no pull request
+    assert!(app.session.is_file_reviewed(&PathBuf::from("src/main.rs")));
+    assert!(app.viewed_sync.is_none());
+}
+
+#[test]
+fn should_not_start_viewed_sync_when_disabled_in_config() {
+    // given — a GitHub PR, sync left at its default (off)
+    let mut app = app();
+    enter_pr_mode(
+        &mut app,
+        ForgeRepository::github("github.com", "agavra", "tuicr"),
+    );
+
+    // when
+    app.toggle_reviewed_for_file_idx(0, false);
+
+    // then
+    assert!(app.session.is_file_reviewed(&PathBuf::from("src/main.rs")));
+    assert!(app.viewed_sync.is_none());
+}
+
+#[test]
+fn should_not_start_viewed_sync_on_forges_without_viewed_state() {
+    // given — GitLab has no per-viewer file state, so the backend would only
+    // answer `UnsupportedOperation`; don't spawn a worker to find that out.
+    let mut app = app();
+    app.forge_config.sync_viewed = true;
+    enter_pr_mode(
+        &mut app,
+        ForgeRepository::gitlab("gitlab.com", "agavra", "tuicr"),
+    );
+
+    // when
+    app.toggle_reviewed_for_file_idx(0, false);
+
+    // then
+    assert!(app.viewed_sync.is_none());
+}
+
+#[test]
+fn should_ignore_viewed_sync_results_with_no_worker() {
+    // given — polling is unconditional in the main loop
+    let mut app = app();
+
+    // when/then — no channel, no repaint, no panic
+    assert!(!app.poll_viewed_sync_events());
+}

--- a/src/app/viewed_sync.rs
+++ b/src/app/viewed_sync.rs
@@ -1,0 +1,150 @@
+//! Mirror local file-reviewed markers onto the forge's per-file viewed state.
+//!
+//! GitHub's "Viewed" checkbox on a pull request file is the same idea as
+//! tuicr's `r`, so a toggle here can tick it there. The push runs on a worker
+//! thread: every update is a `gh api graphql` process spawn, and the diff has
+//! to stay responsive while the user walks the file list marking files.
+
+use super::*;
+use crate::forge::traits::{ForgeKind, PrSessionKey, PullRequestDetails};
+
+impl App {
+    /// Queue a viewed-state push for `path`, spawning the worker on the first
+    /// toggle of a session. Does nothing when the sync is off, the review is
+    /// not a GitHub pull request, or the PR details are missing.
+    pub(in crate::app) fn push_viewed_state(&mut self, path: &Path, viewed: bool) {
+        let Some((key, details)) = self.viewed_sync_target() else {
+            return;
+        };
+
+        // A worker is bound to the PR session it was started for; opening a
+        // different PR — or the same one at a new head — replaces it.
+        if self
+            .viewed_sync
+            .as_ref()
+            .is_none_or(|worker| worker.key != key)
+        {
+            self.spawn_viewed_sync(key, details);
+        }
+
+        let Some(worker) = self.viewed_sync.as_ref() else {
+            return;
+        };
+        let request = ViewedSyncRequest::Set {
+            path: path.to_path_buf(),
+            viewed,
+        };
+        if worker.tx.send(request).is_err() {
+            // The worker is gone; its last failure was already reported.
+            self.viewed_sync = None;
+        }
+    }
+
+    /// The PR this session should push viewed state to, if any.
+    fn viewed_sync_target(&self) -> Option<(PrSessionKey, PullRequestDetails)> {
+        if !self.forge_config.sync_viewed {
+            return None;
+        }
+        let DiffSource::PullRequest(pr) = &self.diff_source else {
+            return None;
+        };
+        // Only GitHub exposes a per-viewer file state; the other backends
+        // return `UnsupportedOperation`, so don't even start a worker.
+        if pr.key.repository.kind != ForgeKind::GitHub {
+            return None;
+        }
+        let details = self.pr_info.as_ref()?.details.clone();
+        // `pr_info` is refreshed alongside `diff_source` on every open and
+        // reload. Should the two ever disagree, this check keeps the push
+        // from landing on a pull request the user is no longer looking at.
+        (details.repository == pr.key.repository && details.number == pr.key.number)
+            .then(|| (pr.key.clone(), details))
+    }
+
+    fn spawn_viewed_sync(&mut self, key: PrSessionKey, details: PullRequestDetails) {
+        let (request_tx, request_rx) = std::sync::mpsc::channel::<ViewedSyncRequest>();
+        let (event_tx, event_rx) = std::sync::mpsc::channel::<ViewedSyncEvent>();
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+        let show_pr_checks = self.show_pr_checks;
+        let show_pr_comments = self.show_pr_comments;
+
+        std::thread::spawn(move || {
+            // The worker owns its backend: `App::forge_backend` cannot cross
+            // threads, and a long-lived instance here keeps the PR node id
+            // the GraphQL mutation needs cached for the whole session.
+            let backend = create_forge_backend(
+                &details.repository,
+                local_checkout,
+                show_pr_checks,
+                show_pr_comments,
+            );
+            // Ends when the App drops the sender: session replaced, or exit.
+            while let Ok(ViewedSyncRequest::Set { path, viewed }) = request_rx.recv() {
+                if let Err(error) = backend.set_file_viewed(&details, &path, viewed) {
+                    let failure = ViewedSyncEvent::Failed {
+                        path,
+                        viewed,
+                        error: error.to_string(),
+                    };
+                    if event_tx.send(failure).is_err() {
+                        return;
+                    }
+                }
+            }
+        });
+
+        self.viewed_sync = Some(ViewedSyncWorker {
+            key,
+            tx: request_tx,
+        });
+        self.viewed_sync_rx = Some(event_rx);
+    }
+
+    /// Drain viewed-state failures into the status bar. Returns whether a
+    /// repaint is needed.
+    pub fn poll_viewed_sync_events(&mut self) -> bool {
+        let Some(rx) = self.viewed_sync_rx.as_ref() else {
+            return false;
+        };
+
+        // Only the newest failure is shown. A dead token or a revoked scope
+        // fails every queued push, and one warning says as much as twenty.
+        let mut warning = None;
+        loop {
+            match rx.try_recv() {
+                Ok(ViewedSyncEvent::Failed {
+                    path,
+                    viewed,
+                    error,
+                }) => {
+                    let verb = if viewed { "mark" } else { "unmark" };
+                    // The local marker stays as the user left it: losing a
+                    // toggle under the cursor is worse than a stale checkbox
+                    // on GitHub, which `:reload` will resync anyway.
+                    warning = Some(format!(
+                        "GitHub: could not {verb} {} as viewed \u{00b7} {error}",
+                        path.display()
+                    ));
+                }
+                Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                    self.viewed_sync_rx = None;
+                    self.viewed_sync = None;
+                    break;
+                }
+            }
+        }
+
+        match warning {
+            Some(text) => {
+                self.set_warning(text);
+                true
+            }
+            None => false,
+        }
+    }
+}

--- a/src/app/viewed_sync.rs
+++ b/src/app/viewed_sync.rs
@@ -1,9 +1,13 @@
 //! Mirror local file-reviewed markers onto the forge's per-file viewed state.
 //!
 //! GitHub's "Viewed" checkbox on a pull request file is the same idea as
-//! tuicr's `r`, so a toggle here can tick it there. The push runs on a worker
-//! thread: every update is a `gh api graphql` process spawn, and the diff has
-//! to stay responsive while the user walks the file list marking files.
+//! tuicr's `r`, so the two are kept in step: a toggle here ticks the checkbox
+//! there, and files already ticked there open as reviewed here.
+//!
+//! Both directions run off the main thread. Every push is a `gh api graphql`
+//! process spawn, and the diff has to stay responsive while the user walks
+//! the file list marking files; the read is one more paged query on top of
+//! everything a PR open already fetches.
 
 use super::*;
 use crate::forge::traits::{ForgeKind, PrSessionKey, PullRequestDetails};
@@ -13,7 +17,7 @@ impl App {
     /// toggle of a session. Does nothing when the sync is off, the review is
     /// not a GitHub pull request, or the PR details are missing.
     pub(in crate::app) fn push_viewed_state(&mut self, path: &Path, viewed: bool) {
-        let Some((key, details)) = self.viewed_sync_target() else {
+        let Some(key) = self.viewed_sync_key().cloned() else {
             return;
         };
 
@@ -24,6 +28,9 @@ impl App {
             .as_ref()
             .is_none_or(|worker| worker.key != key)
         {
+            let Some((key, details)) = self.viewed_sync_target() else {
+                return;
+            };
             self.spawn_viewed_sync(key, details);
         }
 
@@ -40,8 +47,9 @@ impl App {
         }
     }
 
-    /// The PR this session should push viewed state to, if any.
-    fn viewed_sync_target(&self) -> Option<(PrSessionKey, PullRequestDetails)> {
+    /// The PR session viewed state should sync with, if any. Borrows rather
+    /// than clones: the main loop asks this on every tick.
+    fn viewed_sync_key(&self) -> Option<&PrSessionKey> {
         if !self.forge_config.sync_viewed {
             return None;
         }
@@ -49,16 +57,20 @@ impl App {
             return None;
         };
         // Only GitHub exposes a per-viewer file state; the other backends
-        // return `UnsupportedOperation`, so don't even start a worker.
-        if pr.key.repository.kind != ForgeKind::GitHub {
-            return None;
-        }
+        // answer `UnsupportedOperation`, so don't even start a worker.
+        (pr.key.repository.kind == ForgeKind::GitHub).then_some(&pr.key)
+    }
+
+    /// That session together with the PR details a worker needs in order to
+    /// talk to the forge.
+    fn viewed_sync_target(&self) -> Option<(PrSessionKey, PullRequestDetails)> {
+        let key = self.viewed_sync_key()?.clone();
         let details = self.pr_info.as_ref()?.details.clone();
         // `pr_info` is refreshed alongside `diff_source` on every open and
-        // reload. Should the two ever disagree, this check keeps the push
-        // from landing on a pull request the user is no longer looking at.
-        (details.repository == pr.key.repository && details.number == pr.key.number)
-            .then(|| (pr.key.clone(), details))
+        // reload. Should the two ever disagree, this check keeps the sync off
+        // a pull request the user is no longer looking at.
+        (details.repository == key.repository && details.number == key.number)
+            .then_some((key, details))
     }
 
     fn spawn_viewed_sync(&mut self, key: PrSessionKey, details: PullRequestDetails) {
@@ -104,9 +116,130 @@ impl App {
         self.viewed_sync_rx = Some(event_rx);
     }
 
-    /// Drain viewed-state failures into the status bar. Returns whether a
-    /// repaint is needed.
+    /// Pump both directions of the viewed-state sync: start this session's
+    /// one-time read of the forge's state, then drain whatever came back.
+    /// Returns whether a repaint is needed.
     pub fn poll_viewed_sync_events(&mut self) -> bool {
+        let mut needs_redraw = self.start_viewed_seed();
+        needs_redraw |= self.drain_viewed_seed();
+        needs_redraw |= self.drain_viewed_failures();
+        needs_redraw
+    }
+
+    /// Read the forge's viewed state once per PR session.
+    ///
+    /// This runs from the main loop rather than from the PR-open paths
+    /// because `App::forge_config` is applied *after* `App::new` returns: a
+    /// read started at open time would never see `sync_viewed`.
+    fn start_viewed_seed(&mut self) -> bool {
+        // Cheap gate first — this is asked on every tick of the main loop.
+        match self.viewed_sync_key() {
+            Some(key) if self.viewed_seeded.as_ref() != Some(key) => {}
+            _ => return false,
+        }
+        let Some((key, details)) = self.viewed_sync_target() else {
+            return false;
+        };
+        // Claim the session before spawning: the read happens once even if it
+        // fails, so a PR whose files GitHub will not report does not queue a
+        // fresh request on every tick.
+        self.viewed_seeded = Some(key.clone());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.viewed_seed_rx = Some(rx);
+
+        let local_checkout = self
+            .forge_backend
+            .as_deref()
+            .and_then(|backend| backend.local_checkout_path());
+        let show_pr_checks = self.show_pr_checks;
+        let show_pr_comments = self.show_pr_comments;
+
+        std::thread::spawn(move || {
+            let backend = create_forge_backend(
+                &details.repository,
+                local_checkout,
+                show_pr_checks,
+                show_pr_comments,
+            );
+            let result = backend
+                .list_viewed_files(&details)
+                .map_err(|error| error.to_string());
+            let _ = tx.send(ViewedSeedEvent::Done { key, result });
+        });
+
+        false
+    }
+
+    /// Apply a finished read, if one has landed.
+    fn drain_viewed_seed(&mut self) -> bool {
+        let Some(rx) = self.viewed_seed_rx.as_ref() else {
+            return false;
+        };
+        let event = match rx.try_recv() {
+            Ok(event) => event,
+            Err(std::sync::mpsc::TryRecvError::Empty) => return false,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                self.viewed_seed_rx = None;
+                return false;
+            }
+        };
+        self.viewed_seed_rx = None;
+
+        let ViewedSeedEvent::Done { key, result } = event;
+        // Drop a read that landed after the user opened a different PR.
+        if self.viewed_sync_key() != Some(&key) {
+            return false;
+        }
+
+        match result {
+            Ok(paths) => self.apply_remote_viewed_state(&paths),
+            Err(error) => {
+                self.set_warning(format!(
+                    "GitHub: could not read viewed state \u{00b7} {error}"
+                ));
+                true
+            }
+        }
+    }
+
+    /// Mark locally the files the forge reports as already viewed.
+    ///
+    /// Additive on purpose. A marker the user made here is never cleared by
+    /// what GitHub reports: unticking a box on the web is easy to do by
+    /// accident, and silently throwing away review progress is the one
+    /// direction no keystroke can undo.
+    pub(in crate::app) fn apply_remote_viewed_state(&mut self, paths: &[PathBuf]) -> bool {
+        let mut marked = 0;
+        for path in paths {
+            // Only files this review actually covers — a path filtered out by
+            // `.tuicrignore` or outside the selected commit range has no
+            // session entry, and `get_file_mut` does not create one.
+            if let Some(review) = self.session.get_file_mut(path)
+                && !review.reviewed
+            {
+                review.reviewed = true;
+                marked += 1;
+            }
+        }
+        if marked == 0 {
+            return false;
+        }
+
+        self.dirty = true;
+        // Newly reviewed files collapse, which can leave the cursor past the
+        // end of the rebuilt diff.
+        self.rebuild_annotations();
+        self.diff_state.cursor_line = self.diff_state.cursor_line.min(self.max_cursor_line());
+        self.ensure_cursor_visible();
+        self.set_message(format!(
+            "{marked} file(s) already viewed on GitHub \u{00b7} marked reviewed"
+        ));
+        true
+    }
+
+    /// Drain push failures into the status bar.
+    fn drain_viewed_failures(&mut self) -> bool {
         let Some(rx) = self.viewed_sync_rx.as_ref() else {
             return false;
         };

--- a/src/app/viewed_sync.rs
+++ b/src/app/viewed_sync.rs
@@ -42,7 +42,6 @@ impl App {
             viewed,
         };
         if worker.tx.send(request).is_err() {
-            // The worker is gone; its last failure was already reported.
             self.viewed_sync = None;
         }
     }
@@ -140,9 +139,8 @@ impl App {
         let Some((key, details)) = self.viewed_sync_target() else {
             return false;
         };
-        // Claim the session before spawning: the read happens once even if it
-        // fails, so a PR whose files GitHub will not report does not queue a
-        // fresh request on every tick.
+        // Claim the session before spawning: the read happens once even if
+        // it fails, rather than requeueing on every tick.
         self.viewed_seeded = Some(key.clone());
 
         let (tx, rx) = std::sync::mpsc::channel();
@@ -255,9 +253,8 @@ impl App {
                     error,
                 }) => {
                     let verb = if viewed { "mark" } else { "unmark" };
-                    // The local marker stays as the user left it: losing a
-                    // toggle under the cursor is worse than a stale checkbox
-                    // on GitHub, which `:reload` will resync anyway.
+                    // The local marker stays as the user left it; `:reload`
+                    // resyncs the checkbox.
                     warning = Some(format!(
                         "GitHub: could not {verb} {} as viewed \u{00b7} {error}",
                         path.display()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -24,12 +24,17 @@ pub struct ForgeConfig {
     /// reader can see the comment classification at a glance. Defaults to
     /// `true`; set to `false` to send the raw comment body.
     pub comment_type_prefix: bool,
+    /// Mirror file-reviewed toggles (`r`) onto GitHub's per-file "Viewed"
+    /// checkbox while reviewing a pull request. Off by default: it turns a
+    /// local marker into a write to GitHub under your account.
+    pub sync_viewed: bool,
 }
 
 impl Default for ForgeConfig {
     fn default() -> Self {
         Self {
             comment_type_prefix: true,
+            sync_viewed: false,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -233,7 +233,7 @@ const KNOWN_KEYS: &[&str] = &[
     "export",
 ];
 
-const FORGE_KNOWN_KEYS: &[&str] = &["comment_type_prefix"];
+const FORGE_KNOWN_KEYS: &[&str] = &["comment_type_prefix", "sync_viewed"];
 
 const EXPORT_KNOWN_KEYS: &[&str] = &[
     "intro",
@@ -515,6 +515,11 @@ fn parse_forge(value: &Value, warnings: &mut Vec<String>) -> Option<ForgeConfig>
 
     if let Some(v) = read_section_bool(table, "forge", "comment_type_prefix", warnings) {
         cfg.comment_type_prefix = v;
+        any_override = true;
+    }
+
+    if let Some(v) = read_section_bool(table, "forge", "sync_viewed", warnings) {
+        cfg.sync_viewed = v;
         any_override = true;
     }
 
@@ -1624,6 +1629,26 @@ comment_type_prefix = false
             .and_then(|cfg| cfg.forge.clone())
             .expect("forge section should parse");
         assert!(!forge.comment_type_prefix);
+        assert!(outcome.warnings.is_empty());
+    }
+
+    #[test]
+    fn should_parse_sync_viewed_from_the_forge_section() {
+        // The `[forge]` table is read key by key, so a field added to
+        // `ForgeConfig` stays dead until it is listed here too.
+        let outcome = parse_config(
+            r#"[forge]
+sync_viewed = true
+"#,
+        );
+        let forge = outcome
+            .config
+            .as_ref()
+            .and_then(|cfg| cfg.forge.clone())
+            .expect("forge section should parse");
+        assert!(forge.sync_viewed);
+        // and — the default is untouched by naming only the one key
+        assert!(forge.comment_type_prefix);
         assert!(outcome.warnings.is_empty());
     }
 

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -563,6 +563,30 @@ where
         Ok(content.lines().count() as u32)
     }
 
+    fn list_viewed_files(&self, pr: &PullRequestDetails) -> Result<Vec<PathBuf>> {
+        let mut all: Vec<PathBuf> = Vec::new();
+        let mut cursor: Option<String> = None;
+        // Same bound as `list_review_threads`: 100 files * 100 pages is well
+        // past any real PR, and a cyclic cursor must not hang the worker.
+        for _ in 0..100 {
+            let args = self.build_viewed_files_args(pr, cursor.as_deref());
+            let output = self.run_gh(args, &pr.repository.host)?;
+            let parsed = super::viewed_files::parse_graphql_page(&output)?;
+            all.extend(parsed.viewed);
+            let Some(page_info) = parsed.page_info else {
+                break;
+            };
+            if !page_info.has_next_page {
+                break;
+            }
+            let Some(end_cursor) = page_info.end_cursor else {
+                break;
+            };
+            cursor = Some(end_cursor);
+        }
+        Ok(all)
+    }
+
     fn set_file_viewed(&self, pr: &PullRequestDetails, path: &Path, viewed: bool) -> Result<()> {
         let node_id = self.pull_request_node_id(pr)?;
         // `markFileAsViewed`/`unmarkFileAsViewed` have no REST equivalent, so
@@ -664,6 +688,14 @@ where
         cursor: Option<&str>,
     ) -> Vec<String> {
         self.build_graphql_args(pr, &super::review_metadata::build_query(cursor), cursor)
+    }
+
+    fn build_viewed_files_args(
+        &self,
+        pr: &PullRequestDetails,
+        cursor: Option<&str>,
+    ) -> Vec<String> {
+        self.build_graphql_args(pr, &super::viewed_files::build_query(cursor), cursor)
     }
 
     fn build_graphql_args(
@@ -1230,7 +1262,9 @@ index 1111111..2222222 100644
                         .find(|a| a.starts_with("query="))
                         .map(String::as_str)
                         .unwrap_or("");
-                    if query.contains("FileAsViewed(") {
+                    if query.contains("viewerViewedState") {
+                        Ok(VIEWED_FILES_JSON.to_string())
+                    } else if query.contains("FileAsViewed(") {
                         Ok(VIEWED_MUTATION_JSON.to_string())
                     } else if query.contains("pullRequest(number:$number){id}") {
                         Ok(PR_NODE_ID_JSON.to_string())
@@ -1334,6 +1368,22 @@ index 1111111..2222222 100644
 +    42
  }
 "##;
+
+    const VIEWED_FILES_JSON: &str = r##"{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "files": {
+          "pageInfo": { "hasNextPage": false, "endCursor": null },
+          "nodes": [
+            { "path": "src/lib.rs", "viewerViewedState": "VIEWED" },
+            { "path": "src/main.rs", "viewerViewedState": "UNVIEWED" }
+          ]
+        }
+      }
+    }
+  }
+}"##;
 
     const PR_NODE_ID_JSON: &str = r##"{
   "data": { "repository": { "pullRequest": { "id": "PR_kwDOABCD123" } } }
@@ -2075,6 +2125,32 @@ Match host github-work
             !mutation.iter().any(|a| a == "-F"),
             "viewed-state variables must be passed as strings with -f"
         );
+    }
+
+    #[test]
+    fn should_list_viewed_files_via_graphql_api_call() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+
+        // when
+        let viewed = backend.list_viewed_files(&details).unwrap();
+
+        // then — only the files this viewer has actually ticked
+        assert_eq!(viewed, vec![PathBuf::from("src/lib.rs")]);
+
+        // and — the query is scoped to the PR, with no cursor on page one
+        let calls = backend.runner.calls.borrow();
+        let call = graphql_calls(&calls)
+            .into_iter()
+            .find(|args| query_of(args).contains("viewerViewedState"))
+            .expect("expected a viewed-state graphql call");
+        assert!(call.iter().any(|a| a == "owner=agavra"));
+        assert!(call.iter().any(|a| a == "number=125"));
+        assert!(!call.iter().any(|a| a.starts_with("after=")));
     }
 
     #[test]

--- a/src/forge/github/gh.rs
+++ b/src/forge/github/gh.rs
@@ -1,6 +1,7 @@
 use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use crate::error::{Result, TuicrError};
 use crate::forge::remote_comments::{RemoteReviewSummary, RemoteReviewThread};
@@ -52,6 +53,13 @@ const PR_INFO_JSON_FIELDS_WITHOUT_CHECKS_OR_COMMENTS: &str = concat!(
     "number,title,url,state,isDraft,author,headRefName,baseRefName,",
     "headRefOid,baseRefOid,body,updatedAt,closed,mergedAt,",
     "reviewDecision,mergeable,mergeStateStatus,reviewRequests,latestReviews"
+);
+
+/// Minimal lookup for the PR's GraphQL node id, which the viewed-state
+/// mutations take instead of a number.
+const PR_NODE_ID_QUERY: &str = concat!(
+    "query($owner:String!,$name:String!,$number:Int!){",
+    "repository(owner:$owner,name:$name){pullRequest(number:$number){id}}}"
 );
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -162,6 +170,10 @@ pub struct GitHubGhBackend<R = SystemGhRunner> {
     /// Whether `get_pull_request_info` requests pull-request conversation
     /// comments from GitHub.
     show_pr_comments: bool,
+    /// PR node id resolved on demand for the viewed-state mutations, which
+    /// are GraphQL-only and take an `ID!` rather than a number. Cached so a
+    /// long-lived backend pays the lookup once per session.
+    pr_node_id: Arc<Mutex<Option<String>>>,
 }
 
 impl GitHubGhBackend<SystemGhRunner> {
@@ -172,6 +184,7 @@ impl GitHubGhBackend<SystemGhRunner> {
             local_checkout: None,
             show_pr_checks: false,
             show_pr_comments: true,
+            pr_node_id: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -192,6 +205,7 @@ where
             local_checkout: None,
             show_pr_checks: false,
             show_pr_comments: true,
+            pr_node_id: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -549,6 +563,42 @@ where
         Ok(content.lines().count() as u32)
     }
 
+    fn set_file_viewed(&self, pr: &PullRequestDetails, path: &Path, viewed: bool) -> Result<()> {
+        let node_id = self.pull_request_node_id(pr)?;
+        // `markFileAsViewed`/`unmarkFileAsViewed` have no REST equivalent, so
+        // this is GraphQL even though the rest of the file-level calls are not.
+        let mutation = if viewed {
+            concat!(
+                "mutation($pr:ID!,$path:String!){",
+                "markFileAsViewed(input:{pullRequestId:$pr,path:$path})",
+                "{clientMutationId}}"
+            )
+        } else {
+            concat!(
+                "mutation($pr:ID!,$path:String!){",
+                "unmarkFileAsViewed(input:{pullRequestId:$pr,path:$path})",
+                "{clientMutationId}}"
+            )
+        };
+        // `-f` keeps both variables strings; `-F` would coerce types and
+        // treat a leading `@` as a file read.
+        let mut args = vec![
+            "api".to_string(),
+            "graphql".to_string(),
+            "-f".to_string(),
+            format!("query={mutation}"),
+            "-f".to_string(),
+            format!("pr={node_id}"),
+            "-f".to_string(),
+            format!("path={}", path.to_string_lossy().replace('\\', "/")),
+        ];
+        if pr.repository.host != DEFAULT_GITHUB_HOST {
+            args.push("--hostname".to_string());
+            args.push(pr.repository.host.clone());
+        }
+        self.run_gh(args, &pr.repository.host).map(|_| ())
+    }
+
     fn create_review(
         &self,
         pr: &PullRequestDetails,
@@ -645,6 +695,29 @@ where
             args.push(pr.repository.host.clone());
         }
         args
+    }
+
+    /// Resolve (and memoize) the PR's GraphQL node id.
+    fn pull_request_node_id(&self, pr: &PullRequestDetails) -> Result<String> {
+        if let Some(id) = self.pr_node_id.lock().ok().and_then(|slot| slot.clone()) {
+            return Ok(id);
+        }
+        let args = self.build_graphql_args(pr, PR_NODE_ID_QUERY, None);
+        let output = self.run_gh(args, &pr.repository.host)?;
+        let payload: serde_json::Value = serde_json::from_str(&output)?;
+        let id = payload["data"]["repository"]["pullRequest"]["id"]
+            .as_str()
+            .ok_or_else(|| {
+                TuicrError::Forge(format!(
+                    "GitHub returned no node id for pull request #{}",
+                    pr.number
+                ))
+            })?
+            .to_string();
+        if let Ok(mut slot) = self.pr_node_id.lock() {
+            *slot = Some(id.clone());
+        }
+        Ok(id)
     }
 
     fn fetch_file_via_api(&self, request: &ForgeFileLinesRequest) -> Result<String> {
@@ -1157,7 +1230,11 @@ index 1111111..2222222 100644
                         .find(|a| a.starts_with("query="))
                         .map(String::as_str)
                         .unwrap_or("");
-                    if query.contains("reviewThreads(") {
+                    if query.contains("FileAsViewed(") {
+                        Ok(VIEWED_MUTATION_JSON.to_string())
+                    } else if query.contains("pullRequest(number:$number){id}") {
+                        Ok(PR_NODE_ID_JSON.to_string())
+                    } else if query.contains("reviewThreads(") {
                         Ok(REVIEW_THREADS_JSON.to_string())
                     } else if query.contains("viewer { login }") && query.contains("commit { oid }")
                     {
@@ -1257,6 +1334,14 @@ index 1111111..2222222 100644
 +    42
  }
 "##;
+
+    const PR_NODE_ID_JSON: &str = r##"{
+  "data": { "repository": { "pullRequest": { "id": "PR_kwDOABCD123" } } }
+}"##;
+
+    const VIEWED_MUTATION_JSON: &str = r##"{
+  "data": { "markFileAsViewed": { "clientMutationId": null } }
+}"##;
 
     const REVIEW_THREADS_JSON: &str = r##"{
         "data": {
@@ -1935,6 +2020,111 @@ Match host github-work
             .expect("expected review metadata graphql call");
         assert!(metadata_call.iter().any(|a| a == "owner=agavra"));
         assert!(metadata_call.iter().any(|a| a == "number=125"));
+    }
+
+    /// Returns the `gh api graphql` calls the backend placed, oldest first.
+    fn graphql_calls(calls: &[Vec<String>]) -> Vec<Vec<String>> {
+        calls
+            .iter()
+            .filter(|args| {
+                args.first().map(String::as_str) == Some("api")
+                    && args.get(1).map(String::as_str) == Some("graphql")
+            })
+            .cloned()
+            .collect()
+    }
+
+    fn query_of(args: &[String]) -> String {
+        args.iter()
+            .find(|a| a.starts_with("query="))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn should_mark_file_as_viewed_via_graphql_mutation() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+
+        // when
+        backend
+            .set_file_viewed(&details, Path::new("src/main.rs"), true)
+            .unwrap();
+
+        // then — the node id is resolved first, then the mutation carries it
+        // alongside the repo-relative path.
+        let calls = backend.runner.calls.borrow();
+        let graphql = graphql_calls(&calls);
+        assert_eq!(graphql.len(), 2, "expected a node-id lookup and a mutation");
+        assert!(query_of(&graphql[0]).contains("pullRequest(number:$number){id}"));
+
+        let mutation = &graphql[1];
+        let query = query_of(mutation);
+        assert!(
+            query.contains("markFileAsViewed(") && !query.contains("unmarkFileAsViewed("),
+            "expected the mark mutation, got {query}"
+        );
+        assert!(mutation.iter().any(|a| a == "pr=PR_kwDOABCD123"));
+        assert!(mutation.iter().any(|a| a == "path=src/main.rs"));
+        // `-F` would coerce types and read `@`-prefixed values from disk.
+        assert!(
+            !mutation.iter().any(|a| a == "-F"),
+            "viewed-state variables must be passed as strings with -f"
+        );
+    }
+
+    #[test]
+    fn should_unmark_file_as_viewed_via_graphql_mutation() {
+        // given
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+
+        // when
+        backend
+            .set_file_viewed(&details, Path::new("src/main.rs"), false)
+            .unwrap();
+
+        // then
+        let calls = backend.runner.calls.borrow();
+        let graphql = graphql_calls(&calls);
+        let query = query_of(graphql.last().expect("expected a mutation call"));
+        assert!(
+            query.contains("unmarkFileAsViewed("),
+            "expected the unmark mutation, got {query}"
+        );
+    }
+
+    #[test]
+    fn should_resolve_pull_request_node_id_once_across_viewed_updates() {
+        // given — marking a whole PR reviewed fires one update per file, and
+        // each extra `gh` spawn is a visible delay in the TUI.
+        let runner = FakeGhRunner::default();
+        let backend = GitHubGhBackend::with_runner(Some(repo()), runner);
+        let details = backend
+            .get_pull_request(parse_pull_request_target("125").unwrap())
+            .unwrap();
+
+        // when
+        for path in ["src/main.rs", "src/lib.rs", "README.md"] {
+            backend
+                .set_file_viewed(&details, Path::new(path), true)
+                .unwrap();
+        }
+
+        // then — one lookup, three mutations.
+        let calls = backend.runner.calls.borrow();
+        let lookups = graphql_calls(&calls)
+            .iter()
+            .filter(|args| query_of(args).contains("pullRequest(number:$number){id}"))
+            .count();
+        assert_eq!(lookups, 1, "node id should be cached after the first call");
     }
 
     #[test]

--- a/src/forge/github/mod.rs
+++ b/src/forge/github/mod.rs
@@ -5,3 +5,4 @@ pub mod review_metadata;
 pub mod review_summaries;
 pub mod review_threads;
 pub mod submit;
+pub mod viewed_files;

--- a/src/forge/github/viewed_files.rs
+++ b/src/forge/github/viewed_files.rs
@@ -1,0 +1,213 @@
+//! GraphQL parsing for GitHub's per-file viewed state.
+//!
+//! The "Viewed" checkbox on a pull request file is per-viewer state, and REST
+//! does not expose it at all — `viewerViewedState` lives on
+//! `PullRequestChangedFile` in the GraphQL schema, so this reads it the same
+//! way [`super::review_threads`] reads thread state.
+//!
+//! Payload shape (only the fields we read):
+//!
+//! ```json
+//! {
+//!   "data": {
+//!     "repository": {
+//!       "pullRequest": {
+//!         "files": {
+//!           "pageInfo": { "hasNextPage": false, "endCursor": null },
+//!           "nodes": [
+//!             { "path": "src/lib.rs", "viewerViewedState": "VIEWED" },
+//!             { "path": "src/main.rs", "viewerViewedState": "UNVIEWED" }
+//!           ]
+//!         }
+//!       }
+//!     }
+//!   }
+//! }
+//! ```
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::error::{Result, TuicrError};
+
+use super::review_threads::GhPageInfo;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhChangedFile {
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    viewer_viewed_state: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhFilesConn {
+    #[serde(default)]
+    page_info: Option<GhPageInfo>,
+    #[serde(default)]
+    nodes: Vec<GhChangedFile>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhPullRequest {
+    #[serde(default)]
+    files: Option<GhFilesConn>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhRepository {
+    #[serde(default, rename = "pullRequest")]
+    pull_request: Option<GhPullRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhData {
+    #[serde(default)]
+    repository: Option<GhRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhResponse {
+    #[serde(default)]
+    data: Option<GhData>,
+}
+
+/// Outcome of parsing a single GraphQL page.
+#[derive(Debug)]
+pub(crate) struct ParsedPage {
+    /// Paths the viewer has marked viewed on this page.
+    pub viewed: Vec<PathBuf>,
+    pub page_info: Option<GhPageInfo>,
+}
+
+/// Parse one page into the viewed paths it reports plus pagination info.
+/// Errors only on malformed JSON; missing optional fields are tolerated.
+pub(crate) fn parse_graphql_page(json: &str) -> Result<ParsedPage> {
+    let response: GhResponse = serde_json::from_str(json).map_err(|e| {
+        TuicrError::Forge(format!("Failed to parse GitHub viewed-state response: {e}"))
+    })?;
+
+    let conn = response
+        .data
+        .and_then(|d| d.repository)
+        .and_then(|r| r.pull_request)
+        .and_then(|p| p.files);
+
+    let Some(conn) = conn else {
+        return Ok(ParsedPage {
+            viewed: Vec::new(),
+            page_info: None,
+        });
+    };
+
+    let page_info = conn.page_info;
+    let viewed = conn
+        .nodes
+        .into_iter()
+        .filter(|file| {
+            // `FileViewedState` is VIEWED | UNVIEWED | DISMISSED. DISMISSED
+            // means "you viewed this, then it changed underneath you", which
+            // is not a reviewed file any more.
+            file.viewer_viewed_state.as_deref() == Some("VIEWED") && !file.path.is_empty()
+        })
+        .map(|file| PathBuf::from(file.path))
+        .collect();
+
+    Ok(ParsedPage { viewed, page_info })
+}
+
+/// Build the paged query. `after_cursor` continues a previous page.
+pub(crate) fn build_query(after_cursor: Option<&str>) -> String {
+    let (cursor_param, cursor_arg) = match after_cursor {
+        Some(_) => (", $after: String!", ", after: $after"),
+        None => ("", ""),
+    };
+    format!(
+        r#"query($owner: String!, $name: String!, $number: Int!{cursor_param}) {{
+  repository(owner: $owner, name: $name) {{
+    pullRequest(number: $number) {{
+      files(first: 100{cursor_arg}) {{
+        pageInfo {{ hasNextPage endCursor }}
+        nodes {{
+          path
+          viewerViewedState
+        }}
+      }}
+    }}
+  }}
+}}"#
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PAGE_JSON: &str = r##"{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "files": {
+          "pageInfo": { "hasNextPage": true, "endCursor": "Y3Vyc29yOjI=" },
+          "nodes": [
+            { "path": "src/lib.rs", "viewerViewedState": "VIEWED" },
+            { "path": "src/main.rs", "viewerViewedState": "UNVIEWED" },
+            { "path": "README.md", "viewerViewedState": "DISMISSED" }
+          ]
+        }
+      }
+    }
+  }
+}"##;
+
+    #[test]
+    fn should_keep_only_files_the_viewer_marked_viewed() {
+        // given/when
+        let page = parse_graphql_page(PAGE_JSON).unwrap();
+
+        // then — DISMISSED means the file changed after it was viewed, so it
+        // is no longer reviewed.
+        assert_eq!(page.viewed, vec![PathBuf::from("src/lib.rs")]);
+    }
+
+    #[test]
+    fn should_report_pagination_info() {
+        // given/when
+        let page = parse_graphql_page(PAGE_JSON).unwrap();
+
+        // then
+        let info = page.page_info.expect("expected pageInfo");
+        assert!(info.has_next_page);
+        assert_eq!(info.end_cursor.as_deref(), Some("Y3Vyc29yOjI="));
+    }
+
+    #[test]
+    fn should_tolerate_a_pull_request_with_no_files_connection() {
+        // given — a PR the token cannot see returns nulls rather than an error
+        let json = r##"{ "data": { "repository": { "pullRequest": null } } }"##;
+
+        // when
+        let page = parse_graphql_page(json).unwrap();
+
+        // then
+        assert!(page.viewed.is_empty());
+        assert!(page.page_info.is_none());
+    }
+
+    #[test]
+    fn should_declare_the_cursor_variable_only_when_paging() {
+        // given/when
+        let first = build_query(None);
+        let next = build_query(Some("Y3Vyc29yOjI="));
+
+        // then — GraphQL rejects a declared-but-unused variable, and an
+        // undeclared one used in the body.
+        assert!(!first.contains("$after"));
+        assert!(next.contains("$after: String!"));
+        assert!(next.contains("after: $after"));
+    }
+}

--- a/src/forge/submit.rs
+++ b/src/forge/submit.rs
@@ -1139,6 +1139,7 @@ mod tests {
         let comment = comment_with_line(LineSide::New, Some(11), None);
         let cfg = ForgeConfig {
             comment_type_prefix: false,
+            sync_viewed: false,
         };
         let mapped = map_comment(
             &comment,
@@ -1214,6 +1215,7 @@ mod tests {
     fn should_omit_type_prefix_in_body_when_disabled() {
         let cfg = ForgeConfig {
             comment_type_prefix: false,
+            sync_viewed: false,
         };
         let comments = vec![note("just text")];
         let body = build_review_body(&comments, &[], ctx_of(&cfg, &test_comment_types()));

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::Result;
 use crate::forge::remote_comments::RemoteReviewThread;
@@ -559,6 +559,17 @@ pub trait ForgeBackend {
     /// this path as the source of truth for PR contents.
     fn local_checkout_path(&self) -> Option<PathBuf> {
         None
+    }
+
+    /// Mirror the viewer's per-file "viewed" checkbox on the forge.
+    ///
+    /// `path` is the repository-relative path as it appears in the PR diff.
+    /// The default reports the operation as unsupported; only forges with a
+    /// per-viewer file state (GitHub) override it.
+    fn set_file_viewed(&self, _pr: &PullRequestDetails, _path: &Path, _viewed: bool) -> Result<()> {
+        Err(crate::error::TuicrError::UnsupportedOperation(
+            "This forge does not track per-file viewed state".into(),
+        ))
     }
 
     /// Create a review on the PR. The payload-building details (event field

--- a/src/forge/traits.rs
+++ b/src/forge/traits.rs
@@ -561,6 +561,13 @@ pub trait ForgeBackend {
         None
     }
 
+    /// Repository-relative paths the viewer has already marked viewed on
+    /// the forge. The default returns none, which reads as "nothing is
+    /// viewed" — the same answer a forge without the concept would give.
+    fn list_viewed_files(&self, _pr: &PullRequestDetails) -> Result<Vec<PathBuf>> {
+        Ok(Vec::new())
+    }
+
     /// Mirror the viewer's per-file "viewed" checkbox on the forge.
     ///
     /// `path` is the repository-relative path as it appears in the PR diff.

--- a/src/main.rs
+++ b/src/main.rs
@@ -428,6 +428,7 @@ fn main() -> anyhow::Result<()> {
         app.poll_pr_threads_events();
         app.poll_pr_submit_events();
         needs_redraw |= app.poll_editor_launches();
+        needs_redraw |= app.poll_viewed_sync_events();
         needs_redraw |= app.poll_persisted_session_changes();
         needs_redraw |= app.poll_diff_watch_changes();
         needs_redraw |= pr_pending;


### PR DESCRIPTION
GitHub's per-file **Viewed** checkbox is the same idea as `r`, but the two never
talked: marking a file reviewed in tuicr left the PR page unticked, and files
already ticked on github.com opened here as unreviewed, so a review resumed in
tuicr started over from the top. Reviewers kept both by hand.

With `[forge] sync_viewed = true`, the two track each other on a GitHub pull
request:

- Toggling a file reviewed calls `markFileAsViewed` / `unmarkFileAsViewed` for
  that path. The mutations are GraphQL-only and take the PR's node id, which the
  backend resolves once per session and caches.
- Once per PR session, and again on `:e`, the backend reads `viewerViewedState`
  off the PR's files and marks the matching review files reviewed, so they open
  collapsed and counted.

Off by default: it turns a local marker into a write to GitHub under your
account.

## Deliberate limits

- **GitHub pull requests only.** `set_file_viewed` and `list_viewed_files` are
  new `ForgeBackend` methods that default to `UnsupportedOperation` and an empty
  list, so GitLab, Bitbucket, Gitea, and Azure DevOps report the operation as
  unsupported and never start a worker. Local diffs and commit ranges are out
  too.
- **Files, not hunks.** `R` has no GitHub equivalent and never syncs.
- **The read only adds markers.** A file reviewed locally is never un-reviewed
  by what GitHub reports. Unticking a box on the web is easy to do by accident,
  and a lost marker is the one direction a keystroke cannot undo. `DISMISSED`
  (viewed, then changed by a later commit) does not count as viewed.
- **Paths the review does not cover are skipped**, not invented — a file
  filtered out by `.tuicrignore` or outside the selected commit range has no
  session entry.

## Threading

Per AGENTS.md's async pattern, nothing blocks on the network: walking a file
list with `r` must not stall. The local marker applies immediately and survives
a failed push — a stale checkbox on GitHub beats a toggle lost under the cursor
— with failures surfaced once in the status bar.

The push worker (`src/app/viewed_sync.rs`) is the one long-lived thread in the
codebase: it holds its own `ForgeBackend` for the life of a PR session so the
node id is resolved once, and takes toggles over an `mpsc` sender rather than
spawning per update. Both it and the one-shot read start from
`poll_viewed_sync_events()` in the main loop rather than the PR-open paths,
because `App::forge_config` is applied *after* `App::new` returns — work started
at open time cannot see `sync_viewed`. I've noted this as the documented
exception in AGENTS.md.

## Notes

- The `[forge]` table is parsed key by key against `FORGE_KNOWN_KEYS`, not by
  the serde derive on `ForgeConfig`. The first cut missed that, so
  `sync_viewed = true` warned `Unknown config key 'forge.sync_viewed'` and left
  the sync off with no way to switch it on. Folded into the same commit chain.
- Both GraphQL queries were verified against the live API; each returns the
  shape the parsers expect.

## Testing

`cargo check`, `cargo fmt --all --check`, `cargo clippy -- -D warnings`, and
`cargo test` all pass (1682 tests). Nine new tests cover the config gate, the
non-GitHub and local-diff paths, the additive read, paths outside the review,
and both GraphQL request shapes.

Docs updated per AGENTS.md's table: `README.md`, `docs/KEYBINDINGS.md`,
`docs/CONFIG.md` (Options row + Full example), and `AGENTS.md` (the two new
trait methods, the `github/` module map, and the long-lived-worker exception).
